### PR TITLE
NO-JIRA: Add Sippy/CR test name annotations to v2 e2e tests

### DIFF
--- a/docs/content/how-to/ci/v2-testing/writing-tests.md
+++ b/docs/content/how-to/ci/v2-testing/writing-tests.md
@@ -94,7 +94,7 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
     })
 }
 
-var _ = Describe("Control Plane Workloads", Label("control-plane-workloads"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneWorkloads] Control Plane Workloads", Label("control-plane-workloads"), func() {
     var testCtx *internal.TestContext
     BeforeEach(func() {
         testCtx = internal.GetTestContext()
@@ -161,6 +161,52 @@ Sequential: []SequentialGroup{
 
 !!! tip "Adding a test with an existing label"
     If your test uses a label already in a filter expression (e.g., `hosted-cluster-health`), it runs automatically in the appropriate CI jobs. If you introduce a new label, you must add it to existing filter expressions in the TestMatrix configuration in the hypershift repository (not the release repository).
+
+## Sippy/CR test name annotations
+
+All test name strings must include annotations for [Sippy Component Readiness](https://sippy.dptools.openshift.org) (CR) mapping. These are parsed from the full Ginkgo test path and enable automatic Jira component assignment and per-feature regression tracking.
+
+**Required annotations:**
+
+1. **`[sig-hypershift][Jira:Hypershift]`** — on every top-level `Describe` block. Maps all tests to the Hypershift Jira component.
+2. **`[Feature:XYZ]`** — maps to a specific feature/capability. Placement depends on the file:
+    - **On the `Describe`** when the entire file tests one cohesive feature (most files).
+    - **On individual `Context`/`When` blocks** when a file covers multiple distinct capabilities.
+
+Feature names use PascalCase with no spaces (e.g., `BackupRestore`, `AzurePrivateLink`, `NodePoolLifecycle`).
+
+**Single-feature file:**
+
+```go
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Health] Hosted Cluster Health", Label("hosted-cluster-health"), func() {
+    // all tests in this file map to Feature:Health
+})
+```
+
+**Multi-feature file** (e.g., platform-specific files covering multiple capabilities):
+
+```go
+var _ = Describe("[sig-hypershift][Jira:Hypershift] Hosted Cluster Azure", Label("hosted-cluster-azure"), func() {
+    // Jira component set at Describe level, Feature set per Context
+})
+
+Context("[Feature:AzureWorkloadIdentity] Azure Public Cluster", Label("Azure"), func() {
+    It("should mutate pods with workload identity federated credentials", func() { ... })
+})
+
+Context("[Feature:AzurePrivateLink] Azure Private Topology", Label("Azure"), func() {
+    It("should create AzurePrivateLinkService CR with PLS alias", func() { ... })
+})
+```
+
+!!! warning "Do not rename tests after Sippy import"
+    Renaming tests after Sippy imports them loses historical data and requires manual re-mapping. Add annotations before tests are imported.
+
+Check existing Feature names before adding new ones:
+
+```bash
+grep -r '\[Feature:' test/e2e/v2/tests/
+```
 
 ## Platform guards
 
@@ -266,7 +312,7 @@ Lifecycle tests may modify cluster state but must:
 - Check `IsNotFound()` in cleanup to handle missing resources gracefully
 
 ```go
-var _ = Describe("NodePool Lifecycle", Label("lifecycle", "nodepool-lifecycle"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolLifecycle] NodePool Lifecycle", Label("lifecycle", "nodepool-lifecycle"), func() {
     var originalReplicas int32
     BeforeEach(func() {
         // Capture original state

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -14699,7 +14699,7 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
     })
 }
 
-var _ = Describe("Control Plane Workloads", Label("control-plane-workloads"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneWorkloads] Control Plane Workloads", Label("control-plane-workloads"), func() {
     var testCtx *internal.TestContext
     BeforeEach(func() {
         testCtx = internal.GetTestContext()
@@ -14766,6 +14766,52 @@ Sequential: []SequentialGroup{
 
 !!! tip "Adding a test with an existing label"
     If your test uses a label already in a filter expression (e.g., `hosted-cluster-health`), it runs automatically in the appropriate CI jobs. If you introduce a new label, you must add it to existing filter expressions in the TestMatrix configuration in the hypershift repository (not the release repository).
+
+## Sippy/CR test name annotations
+
+All test name strings must include annotations for Sippy Component Readiness (CR) mapping. These are parsed from the full Ginkgo test path and enable automatic Jira component assignment and per-feature regression tracking.
+
+**Required annotations:**
+
+1. **`[sig-hypershift][Jira:Hypershift]`** — on every top-level `Describe` block. Maps all tests to the Hypershift Jira component.
+2. **`[Feature:XYZ]`** — maps to a specific feature/capability. Placement depends on the file:
+    - **On the `Describe`** when the entire file tests one cohesive feature (most files).
+    - **On individual `Context`/`When` blocks** when a file covers multiple distinct capabilities.
+
+Feature names use PascalCase with no spaces (e.g., `BackupRestore`, `AzurePrivateLink`, `NodePoolLifecycle`).
+
+**Single-feature file:**
+
+```go
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Health] Hosted Cluster Health", Label("hosted-cluster-health"), func() {
+    // all tests in this file map to Feature:Health
+})
+```
+
+**Multi-feature file** (e.g., platform-specific files covering multiple capabilities):
+
+```go
+var _ = Describe("[sig-hypershift][Jira:Hypershift] Hosted Cluster Azure", Label("hosted-cluster-azure"), func() {
+    // Jira component set at Describe level, Feature set per Context
+})
+
+Context("[Feature:AzureWorkloadIdentity] Azure Public Cluster", Label("Azure"), func() {
+    It("should mutate pods with workload identity federated credentials", func() { ... })
+})
+
+Context("[Feature:AzurePrivateLink] Azure Private Topology", Label("Azure"), func() {
+    It("should create AzurePrivateLinkService CR with PLS alias", func() { ... })
+})
+```
+
+!!! warning "Do not rename tests after Sippy import"
+    Renaming tests after Sippy imports them loses historical data and requires manual re-mapping. Add annotations before tests are imported.
+
+Check existing Feature names before adding new ones:
+
+```bash
+grep -r '\Feature:' test/e2e/v2/tests/
+```
 
 ## Platform guards
 
@@ -14854,7 +14900,7 @@ Eventually(func() bool {
 }).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(BeTrue())
 ```
 
-For pointer safety, vacuous pass prevention, IPv6 URL construction, and the non-lifecycle vs. lifecycle mutation rule, see AGENTS.md conventions #11, #13, #15, #16.
+For pointer safety, vacuous pass prevention, IPv6 URL construction, and the non-lifecycle vs. lifecycle mutation rule, see [AGENTS.md conventions #11, #13, #15, #16.
 
 ## Lifecycle vs non-lifecycle tests
 
@@ -14871,7 +14917,7 @@ Lifecycle tests may modify cluster state but must:
 - Check `IsNotFound()` in cleanup to handle missing resources gracefully
 
 ```go
-var _ = Describe("NodePool Lifecycle", Label("lifecycle", "nodepool-lifecycle"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolLifecycle] NodePool Lifecycle", Label("lifecycle", "nodepool-lifecycle"), func() {
     var originalReplicas int32
     BeforeEach(func() {
         // Capture original state

--- a/test/e2e/v2/AGENTS.md
+++ b/test/e2e/v2/AGENTS.md
@@ -39,7 +39,7 @@ func RegisterControlPlaneWorkloadsTests(getTestCtx internal.TestContextGetter) {
     // ...
 }
 
-var _ = Describe("Control Plane Workloads", Label("control-plane-workloads"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneWorkloads] Control Plane Workloads", Label("control-plane-workloads"), func() {
     // BeforeEach gets TestContext, then calls RegisterControlPlaneWorkloadsTests
 })
 ```
@@ -202,6 +202,47 @@ g.Expect(ic.Spec.EndpointPublishingStrategy.Type).To(Equal(operatorv1.LoadBalanc
 // RIGHT — compare against the extracted expectation
 g.Expect(ic.Spec.EndpointPublishingStrategy.Type).To(Equal(expectedStrategy.Type))
 ```
+
+### 19. Sippy/CR Test Name Annotations
+
+All test name strings must include annotations for Sippy Component Readiness (CR) mapping. These annotations are parsed from the full Ginkgo test path and enable automatic Jira component assignment and per-feature regression tracking.
+
+**Required annotations:**
+
+1. **`[sig-hypershift][Jira:Hypershift]`** — on every top-level `Describe` block. Maps all tests to the Hypershift Jira component.
+
+2. **`[Feature:XYZ]`** — maps to a specific feature/capability. Placement depends on the file:
+   - **On the `Describe`** when the entire file tests one cohesive feature (most files).
+   - **On individual `Context`/`When` blocks** when a file covers multiple distinct capabilities.
+
+Feature names use PascalCase with no spaces (e.g., `BackupRestore`, `AzurePrivateLink`, `NodePoolLifecycle`).
+
+**Single-feature file example:**
+
+```go
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Health] Hosted Cluster Health", Label("hosted-cluster-health"), func() {
+    // all tests in this file map to Feature:Health
+})
+```
+
+**Multi-feature file example:**
+
+```go
+var _ = Describe("[sig-hypershift][Jira:Hypershift] Hosted Cluster Azure", Label("hosted-cluster-azure"), func() {
+    // Jira component set at Describe level, Feature set per Context
+})
+
+// In the registration function:
+Context("[Feature:AzureWorkloadIdentity] Azure Public Cluster", Label("Azure", "self-managed-azure-public"), func() {
+    It("should mutate pods with workload identity federated credentials", func() { ... })
+})
+
+Context("[Feature:AzurePrivateLink] Azure Private Topology", Label("Azure", "self-managed-azure-private"), func() {
+    It("should create AzurePrivateLinkService CR with PLS alias", func() { ... })
+})
+```
+
+**When adding new test files:** Choose a Feature name that maps to a distinct capability. Check existing Feature names in the codebase (`grep -r '\[Feature:' test/e2e/v2/tests/`) to avoid duplicates.
 
 ## Expanding v2
 

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -99,7 +99,7 @@ var backupRestorePlatforms = map[hyperv1.PlatformType]backupRestorePlatformConfi
 	},
 }
 
-var _ = Describe("BackupRestore", Label("backup-restore"), Ordered, Serial, func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] BackupRestore", Label("backup-restore"), Ordered, Serial, func() {
 
 	var (
 		platformCfg        backupRestorePlatformConfig
@@ -380,7 +380,7 @@ func validatePostRestoreControlPlane(testCtx *internal.TestContext, excludeWorkl
 	}
 }
 
-var _ = Describe("BackupRestoreEtcdSnapshot", Label("backup-restore", "etcd-snapshot"), Ordered, Serial, func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] BackupRestoreEtcdSnapshot", Label("backup-restore", "etcd-snapshot"), Ordered, Serial, func() {
 
 	var (
 		platformCfg        backupRestorePlatformConfig

--- a/test/e2e/v2/tests/control_plane_infrastructure_test.go
+++ b/test/e2e/v2/tests/control_plane_infrastructure_test.go
@@ -187,7 +187,7 @@ func RegisterControlPlaneInfrastructureTests(getTestCtx internal.TestContextGett
 	InfrastructureResourceRequestsTest(getTestCtx)
 }
 
-var _ = Describe("Control Plane Infrastructure Workloads", Label("control-plane-workloads"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneInfrastructure] Control Plane Infrastructure Workloads", Label("control-plane-workloads"), func() {
 	var testCtx *internal.TestContext
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()

--- a/test/e2e/v2/tests/control_plane_upgrade_test.go
+++ b/test/e2e/v2/tests/control_plane_upgrade_test.go
@@ -81,7 +81,7 @@ func RegisterControlPlaneUpgradeTests(getTestCtx internal.TestContextGetter) {
 	ControlPlaneUpgradeTest(getTestCtx)
 }
 
-var _ = Describe("Control Plane Upgrade", Label("lifecycle", "control-plane-upgrade"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneUpgrade] Control Plane Upgrade", Label("lifecycle", "control-plane-upgrade"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -1065,7 +1065,7 @@ func RegisterControlPlaneWorkloadsTests(getTestCtx internal.TestContextGetter) {
 	SecurityContextUIDTest(getTestCtx)
 }
 
-var _ = Describe("Control Plane Workloads", Label("control-plane-workloads"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneWorkloads] Control Plane Workloads", Label("control-plane-workloads"), func() {
 	var (
 		testCtx *internal.TestContext
 	)

--- a/test/e2e/v2/tests/etcd_chaos_test.go
+++ b/test/e2e/v2/tests/etcd_chaos_test.go
@@ -52,7 +52,7 @@ func RegisterEtcdChaosTests(getTestCtx internal.TestContextGetter) {
 	EtcdMissingMemberRecoveryTest(getTestCtx)
 }
 
-var _ = Describe("Etcd Chaos", Label("lifecycle", "etcd-chaos"), Ordered, func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdResilience] Etcd Chaos", Label("lifecycle", "etcd-chaos"), Ordered, func() {
 	var testCtx *internal.TestContext
 
 	BeforeAll(func() {

--- a/test/e2e/v2/tests/hosted_cluster_aws_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_aws_test.go
@@ -45,7 +45,7 @@ func RegisterHostedClusterAWSTests(getTestCtx internal.TestContextGetter) {
 }
 
 func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
-	When("a day-2 resource tag is added to the HostedCluster spec", func() {
+	When("[Feature:AWSSecurityGroups] a day-2 resource tag is added to the HostedCluster spec", func() {
 		It("should apply the tag to the default worker security group via AWS API", Label("AWS"), func() {
 			tc := getTestCtx()
 			if e2eutil.IsLessThan(e2eutil.Version420) {
@@ -127,7 +127,7 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 }
 
 func AWSCCMWithCustomizationsTest(getTestCtx internal.TestContextGetter) {
-	Context("AWS CCM NLB Security Group", Label("AWS", "CCM"), func() {
+	Context("[Feature:AWSNLB] AWS CCM NLB Security Group", Label("AWS", "CCM"), func() {
 		BeforeEach(func() {
 			tc := getTestCtx()
 			if e2eutil.IsLessThan(e2eutil.Version423) {
@@ -275,7 +275,7 @@ func extractLBNameFromHostname(hostname string) string {
 	return firstLabel[:lastHyphen]
 }
 
-var _ = Describe("Hosted Cluster AWS", Label("lifecycle", "hosted-cluster-aws"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift] Hosted Cluster AWS", Label("lifecycle", "hosted-cluster-aws"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_azure_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_azure_test.go
@@ -41,7 +41,7 @@ import (
 // These tests verify workload identity, KAS allowed CIDRs, and ingress operator configuration
 // on Azure platform clusters.
 func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
-	Context("Azure Public Cluster", Label("Azure", "self-managed-azure-public"), func() {
+	Context("[Feature:AzureWorkloadIdentity] Azure Public Cluster", Label("Azure", "self-managed-azure-public"), func() {
 		BeforeEach(func() {
 			testCtx := getTestCtx()
 			hc := testCtx.GetHostedCluster()
@@ -88,7 +88,7 @@ func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
 // These tests verify private-router Service annotation, PrivateLinkService CRs, and DNS zone configuration
 // on Azure clusters with Private topology.
 func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
-	Context("Azure Private Topology", Label("Azure", "self-managed-azure-private"), Ordered, func() {
+	Context("[Feature:AzurePrivateLink] Azure Private Topology", Label("Azure", "self-managed-azure-private"), Ordered, func() {
 		var testCtx *internal.TestContext
 		var controlPlaneNamespace string
 
@@ -227,7 +227,7 @@ func listPLS(ctx context.Context, client crclient.Client, namespace string) ([]*
 // These tests verify that OAuth is properly exposed via a LoadBalancer Service and that the
 // OAuth token flow works through that endpoint.
 func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
-	Context("Azure OAuth LoadBalancer", Label("Azure", "self-managed-azure-oauth-lb"), func() {
+	Context("[Feature:AzureOAuth] Azure OAuth LoadBalancer", Label("Azure", "self-managed-azure-oauth-lb"), func() {
 		BeforeEach(func() {
 			testCtx := getTestCtx()
 			hc := testCtx.GetHostedCluster()
@@ -293,7 +293,7 @@ func RegisterHostedClusterAzureTests(getTestCtx internal.TestContextGetter) {
 	AzureOAuthLoadBalancerTest(getTestCtx)
 }
 
-var _ = Describe("Hosted Cluster Azure", Label("hosted-cluster-azure"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift] Hosted Cluster Azure", Label("hosted-cluster-azure"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_ccm_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ccm_test.go
@@ -105,7 +105,7 @@ func RegisterHostedClusterCCMTests(getTestCtx internal.TestContextGetter) {
 	GCPCloudControllerManagerTest(getTestCtx)
 }
 
-var _ = Describe("Hosted Cluster CCM", Label("hosted-cluster-ccm"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:CloudControllerManager] Hosted Cluster CCM", Label("hosted-cluster-ccm"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_compliance_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_compliance_test.go
@@ -68,7 +68,7 @@ func EnsureAllRoutesUseHCPRouterTest(getTestCtx internal.TestContextGetter) {
 	})
 }
 
-var _ = Describe("Hosted Cluster Compliance", Label("hosted-cluster-compliance"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Compliance] Hosted Cluster Compliance", Label("hosted-cluster-compliance"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_cpo_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_cpo_test.go
@@ -91,7 +91,7 @@ func VerifyCPOOverrideImageTest(getTestCtx internal.TestContextGetter) {
 	})
 }
 
-var _ = Describe("Hosted Cluster CPO", Label("hosted-cluster-cpo"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneOperator] Hosted Cluster CPO", Label("hosted-cluster-cpo"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_dns_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_dns_test.go
@@ -68,7 +68,7 @@ func EnsureKubeAPIDNSNameCustomCertTest(getTestCtx internal.TestContextGetter) {
 	})
 }
 
-var _ = Describe("Hosted Cluster DNS", Label("hosted-cluster-dns"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:DNS] Hosted Cluster DNS", Label("hosted-cluster-dns"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_external_oidc_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_external_oidc_test.go
@@ -56,7 +56,7 @@ func RegisterExternalOIDCTests(getTestCtx internal.TestContextGetter) {
 	ExternalOIDCKeycloakAuthTest(getTestCtx)
 }
 
-var _ = Describe("External OIDC", Label("external-oidc"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ExternalOIDC] External OIDC", Label("external-oidc"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_health_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_health_test.go
@@ -186,7 +186,7 @@ func ValidateConfigurationStatusTest(getTestCtx internal.TestContextGetter) {
 	})
 }
 
-var _ = Describe("Hosted Cluster Health", Label("hosted-cluster-health"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Health] Hosted Cluster Health", Label("hosted-cluster-health"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_image_registry_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_image_registry_test.go
@@ -279,7 +279,7 @@ func verifyExternalAccountCred(credData []byte, key, expectedEmail string) {
 		"service_account_impersonation_url should reference the imageRegistry GSA email %s", expectedEmail)
 }
 
-var _ = Describe("Hosted Cluster Image Registry", Label("hosted-cluster-image-registry"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ImageRegistry] Hosted Cluster Image Registry", Label("hosted-cluster-image-registry"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_ingress_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ingress_test.go
@@ -76,7 +76,7 @@ func ValidateIngressOperatorConfigurationTest(getTestCtx internal.TestContextGet
 	})
 }
 
-var _ = Describe("Hosted Cluster Ingress", Label("hosted-cluster-ingress"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Ingress] Hosted Cluster Ingress", Label("hosted-cluster-ingress"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_metrics_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_metrics_test.go
@@ -308,7 +308,7 @@ func EnsureNodeTuningOperatorMetricsEndpointTest(getTestCtx internal.TestContext
 	})
 }
 
-var _ = Describe("Hosted Cluster Metrics", Label("hosted-cluster-metrics"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Metrics] Hosted Cluster Metrics", Label("hosted-cluster-metrics"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
@@ -67,7 +67,7 @@ func EnsureNodeCommunicationTest(getTestCtx internal.TestContextGetter) {
 	})
 }
 
-var _ = Describe("Hosted Cluster Node Communication", Label("hosted-cluster-node-communication"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodeCommunication] Hosted Cluster Node Communication", Label("hosted-cluster-node-communication"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
@@ -343,7 +343,7 @@ func verifyDaemonSetsReady(tc *internal.TestContext, hcClient crclient.Client, n
 	}
 }
 
-var _ = Describe("Global Pull Secret", Label("lifecycle", "global-pull-secret"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:GlobalPullSecret] Global Pull Secret", Label("lifecycle", "global-pull-secret"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
@@ -149,7 +149,7 @@ func RegisterHostedClusterSecretEncryptionTests(getTestCtx internal.TestContextG
 	KMSFunctionalValidationTest(getTestCtx)
 }
 
-var _ = Describe("Hosted Cluster Secret Encryption", Label("secret-encryption"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:SecretEncryption] Hosted Cluster Secret Encryption", Label("secret-encryption"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/hosted_cluster_security_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_security_test.go
@@ -51,7 +51,7 @@ func RegisterHostedClusterSecurityTests(getTestCtx internal.TestContextGetter) {
 }
 
 func EnsureHostedClusterWebhooksValidatedTest(getTestCtx internal.TestContextGetter) {
-	When("a webhook targeting a control plane service is created in the hosted cluster", func() {
+	When("[Feature:WebhookValidation] a webhook targeting a control plane service is created in the hosted cluster", func() {
 		It("should be automatically deleted", func() {
 			tc := getTestCtx()
 			tc.ValidateHostedClusterClient()
@@ -101,7 +101,7 @@ func EnsureHostedClusterWebhooksValidatedTest(getTestCtx internal.TestContextGet
 }
 
 func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
-	When("checking admission policies on a public hosted cluster", Ordered, func() {
+	When("[Feature:AdmissionPolicies] checking admission policies on a public hosted cluster", Ordered, func() {
 		var tc *internal.TestContext
 		var hcClient crclient.Client
 		var hostedCluster *hyperv1.HostedCluster
@@ -212,7 +212,7 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 }
 
 func EnsureNetworkPoliciesTest(getTestCtx internal.TestContextGetter) {
-	When("checking network policies on an AWS hosted cluster", func() {
+	When("[Feature:NetworkPolicies] checking network policies on an AWS hosted cluster", func() {
 		BeforeEach(func() {
 			tc := getTestCtx()
 			hostedCluster := tc.GetHostedCluster()
@@ -327,7 +327,7 @@ func EnsureNetworkPoliciesTest(getTestCtx internal.TestContextGetter) {
 	})
 }
 
-var _ = Describe("Hosted Cluster Security", Label("hosted-cluster-security"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift] Hosted Cluster Security", Label("hosted-cluster-security"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/nodepool_autoscaling_test.go
+++ b/test/e2e/v2/tests/nodepool_autoscaling_test.go
@@ -385,7 +385,7 @@ func RegisterNodePoolAutoscalingTests(getTestCtx internal.TestContextGetter) {
 	AutoscalingBalancingTest(getTestCtx)
 }
 
-var _ = Describe("NodePool Autoscaling", Label("lifecycle", "nodepool-autoscaling"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolAutoscaling] NodePool Autoscaling", Label("lifecycle", "nodepool-autoscaling"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/nodepool_lifecycle_test.go
+++ b/test/e2e/v2/tests/nodepool_lifecycle_test.go
@@ -67,7 +67,7 @@ func RegisterNodePoolLifecycleTests(getTestCtx internal.TestContextGetter) {
 	NodePoolDiskEncryptionTest(getTestCtx)
 }
 
-var _ = Describe("NodePool Lifecycle", Label("lifecycle", "nodepool-lifecycle"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolLifecycle] NodePool Lifecycle", Label("lifecycle", "nodepool-lifecycle"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/suite_test.go
+++ b/test/e2e/v2/tests/suite_test.go
@@ -46,7 +46,7 @@ func TestE2EV2(t *testing.T) {
 	RegisterFailHandler(internal.InformingAwareFailHandler)
 
 	// Run the ginkgo test suite
-	RunSpecs(t, "HyperShift End To End Test Suite")
+	RunSpecs(t, "hypershift-e2e")
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
## What this PR does / why we need it:

Adds `[Jira:Hypershift]` and `[Feature:XYZ]` annotations to all 22 v2 e2e test files for Sippy Component Readiness (CR) mapping. These annotations enable automatic Jira component assignment and per-feature regression tracking in CR dashboards.

The e2e-azure-v2-self-managed job was promoted to standard tier in CR via [sippy#3613](https://github.com/openshift/sippy/pull/3613), but without these annotations tests won't be mapped to Jira components or features. Test names must be annotated before Sippy imports them — renaming after import loses historical data.

**Annotation strategy:**
- Single-feature files: both `[Jira:Hypershift]` and `[Feature:XYZ]` on the `Describe` block
- Multi-feature files (AWS, Azure, Security): `[Jira:Hypershift]` on the `Describe`, `[Feature:XYZ]` on individual `Context`/`When` blocks

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

No logic changes — only string edits to Ginkgo test name strings and documentation updates. Build verified with `make e2ev2`.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/expanded v2 e2e writing guidelines for Sippy/CR test name annotations, including required `[sig-hypershift][Jira:Hypershift]` and `[Feature:XYZ]` formats, placement rules for single- vs multi-feature files, and updated examples.

* **Tests**
  * Updated v2 e2e suite and block title strings to consistently include Jira/feature metadata prefixes (while preserving existing suite labels and test behavior).
  * Renamed the v2 E2E suite runner name to `"hypershift-e2e"`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->