### PR TITLE
OCPBUGS-89231: version-gate TestPullSecretUnavailable to 4.23+

### DIFF
--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -465,6 +465,7 @@ func testSingleMemberRecovery(parentCtx context.Context, client crclient.Client,
 // RequestServingNodeAdditionalSelector) to the HostedControlPlane even when the
 // pull secret is corrupted. This is a regression test for OCPBUGS-77268.
 func TestPullSecretUnavailable(t *testing.T) {
+	e2eutil.AtLeast(t, e2eutil.Version423)
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(testContext)


### PR DESCRIPTION
## What this PR does / why we need it:

Adds `e2eutil.AtLeast(t, e2eutil.Version423)` to `TestPullSecretUnavailable` so it skips on release branches older than 4.23.

The fix for OCPBUGS-77268 (PR #8352) is on `main` and `release-4.23` but not on `release-4.22` or older. Since `hypershift-tests:latest` is built from main and used by release branch CI jobs, the test runs against operators that don't have the fix — causing permafailures on release-4.22 periodic jobs.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/OCPBUGS-89231

## Special notes for your reviewer:

The test was introduced in #8352 alongside the operator fix. Since the fix was not backported to release-4.22 (and no backport is planned per OCPBUGS-77268), the test needs to be gated to avoid running against operators that lack the fix.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure requirements to ensure compatibility with newer e2e utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->