### PR TITLE
OCPBUGS-88757: Align HCCO CatalogSource registryPoll interval with OCP defaults

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/catalogs.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/catalogs.go
@@ -41,8 +41,8 @@ func reconcileCatalogSource(cs *operatorsv1alpha1.CatalogSource, address string,
 		Priority:  priority,
 		UpdateStrategy: &operatorsv1alpha1.UpdateStrategy{
 			RegistryPoll: &operatorsv1alpha1.RegistryPoll{
-				RawInterval: "10m",
-				Interval:    &metav1.Duration{Duration: 10 * time.Minute},
+				RawInterval: "240m",
+				Interval:    &metav1.Duration{Duration: 240 * time.Minute},
 			},
 		},
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/catalogs_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/catalogs_test.go
@@ -1,0 +1,164 @@
+package olm
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+)
+
+func TestReconcileCertifiedOperatorsCatalogSource(t *testing.T) {
+	testsCases := []struct {
+		name      string
+		placement hyperv1.OLMCatalogPlacement
+		params    *OperatorLifecycleManagerParams
+	}{
+		{
+			name:      "when placement is Management it should set Address",
+			placement: hyperv1.ManagementOLMCatalogPlacement,
+			params: &OperatorLifecycleManagerParams{
+				CertifiedOperatorsImage: "registry.example.com/certified:latest",
+				OLMCatalogPlacement:     hyperv1.ManagementOLMCatalogPlacement,
+			},
+		},
+		{
+			name:      "when placement is Guest it should set Image",
+			placement: hyperv1.GuestOLMCatalogPlacement,
+			params: &OperatorLifecycleManagerParams{
+				CertifiedOperatorsImage: "registry.example.com/certified:latest",
+				OLMCatalogPlacement:     hyperv1.GuestOLMCatalogPlacement,
+			},
+		},
+	}
+
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cs := &operatorsv1alpha1.CatalogSource{}
+
+			ReconcileCertifiedOperatorsCatalogSource(cs, tc.params)
+
+			// Verify common fields
+			g.Expect(cs.Spec.SourceType).To(Equal(operatorsv1alpha1.SourceTypeGrpc))
+			g.Expect(cs.Spec.DisplayName).To(Equal("Certified Operators"))
+			g.Expect(cs.Spec.Publisher).To(Equal("Red Hat"))
+			g.Expect(cs.Spec.Priority).To(Equal(-200))
+			g.Expect(cs.Spec.GrpcPodConfig.SecurityContextConfig).To(Equal(operatorsv1alpha1.Restricted))
+			g.Expect(cs.Annotations).To(HaveKeyWithValue("target.workload.openshift.io/management", `{"effect": "PreferredDuringScheduling"}`))
+
+			// Verify RegistryPoll interval is 240 minutes
+			g.Expect(cs.Spec.UpdateStrategy).ToNot(BeNil())
+			g.Expect(cs.Spec.UpdateStrategy.RegistryPoll).ToNot(BeNil())
+			g.Expect(cs.Spec.UpdateStrategy.RegistryPoll.Interval).ToNot(BeNil())
+			g.Expect(cs.Spec.UpdateStrategy.RegistryPoll.RawInterval).To(Equal("240m"))
+			g.Expect(cs.Spec.UpdateStrategy.RegistryPoll.Interval.Duration).To(Equal(240 * time.Minute))
+
+			// Verify placement-specific fields
+			if tc.placement == hyperv1.ManagementOLMCatalogPlacement {
+				g.Expect(cs.Spec.Address).To(Equal("certified-operators:50051"))
+				g.Expect(cs.Spec.Image).To(BeEmpty())
+			} else {
+				g.Expect(cs.Spec.Image).To(Equal("registry.example.com/certified:latest"))
+				g.Expect(cs.Spec.Address).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestReconcileCommunityOperatorsCatalogSource(t *testing.T) {
+	g := NewWithT(t)
+
+	params := &OperatorLifecycleManagerParams{
+		CommunityOperatorsImage: "registry.example.com/community:latest",
+		OLMCatalogPlacement:     hyperv1.GuestOLMCatalogPlacement,
+	}
+
+	cs := &operatorsv1alpha1.CatalogSource{}
+	ReconcileCommunityOperatorsCatalogSource(cs, params)
+
+	// Verify RegistryPoll interval is 240 minutes
+	g.Expect(cs.Spec.UpdateStrategy).ToNot(BeNil())
+	g.Expect(cs.Spec.UpdateStrategy.RegistryPoll).ToNot(BeNil())
+	g.Expect(cs.Spec.UpdateStrategy.RegistryPoll.Interval).ToNot(BeNil())
+	g.Expect(cs.Spec.UpdateStrategy.RegistryPoll.RawInterval).To(Equal("240m"))
+	g.Expect(cs.Spec.UpdateStrategy.RegistryPoll.Interval.Duration).To(Equal(240 * time.Minute))
+
+	g.Expect(cs.Spec.DisplayName).To(Equal("Community Operators"))
+	g.Expect(cs.Spec.Priority).To(Equal(-400))
+	g.Expect(cs.Spec.Image).To(Equal("registry.example.com/community:latest"))
+}
+
+func TestReconcileRedHatMarketplaceCatalogSource(t *testing.T) {
+	g := NewWithT(t)
+
+	params := &OperatorLifecycleManagerParams{
+		RedHatMarketplaceImage: "registry.example.com/marketplace:latest",
+		OLMCatalogPlacement:    hyperv1.ManagementOLMCatalogPlacement,
+	}
+
+	cs := &operatorsv1alpha1.CatalogSource{}
+	ReconcileRedHatMarketplaceCatalogSource(cs, params)
+
+	// Verify RegistryPoll interval is 240 minutes
+	g.Expect(cs.Spec.UpdateStrategy).ToNot(BeNil())
+	g.Expect(cs.Spec.UpdateStrategy.RegistryPoll).ToNot(BeNil())
+	g.Expect(cs.Spec.UpdateStrategy.RegistryPoll.Interval).ToNot(BeNil())
+	g.Expect(cs.Spec.UpdateStrategy.RegistryPoll.RawInterval).To(Equal("240m"))
+	g.Expect(cs.Spec.UpdateStrategy.RegistryPoll.Interval.Duration).To(Equal(240 * time.Minute))
+
+	g.Expect(cs.Spec.DisplayName).To(Equal("Red Hat Marketplace"))
+	g.Expect(cs.Spec.Priority).To(Equal(-300))
+	g.Expect(cs.Spec.Address).To(Equal("redhat-marketplace:50051"))
+}
+
+func TestReconcileRedHatOperatorsCatalogSource(t *testing.T) {
+	g := NewWithT(t)
+
+	params := &OperatorLifecycleManagerParams{
+		RedHatOperatorsImage: "registry.example.com/redhat-operators:latest",
+		OLMCatalogPlacement:  hyperv1.GuestOLMCatalogPlacement,
+	}
+
+	cs := &operatorsv1alpha1.CatalogSource{}
+	ReconcileRedHatOperatorsCatalogSource(cs, params)
+
+	// Verify RegistryPoll interval is 240 minutes
+	g.Expect(cs.Spec.UpdateStrategy).ToNot(BeNil())
+	g.Expect(cs.Spec.UpdateStrategy.RegistryPoll).ToNot(BeNil())
+	g.Expect(cs.Spec.UpdateStrategy.RegistryPoll.Interval).ToNot(BeNil())
+	g.Expect(cs.Spec.UpdateStrategy.RegistryPoll.RawInterval).To(Equal("240m"))
+	g.Expect(cs.Spec.UpdateStrategy.RegistryPoll.Interval.Duration).To(Equal(240 * time.Minute))
+
+	g.Expect(cs.Spec.DisplayName).To(Equal("Red Hat Operators"))
+	g.Expect(cs.Spec.Priority).To(Equal(-100))
+	g.Expect(cs.Spec.Image).To(Equal("registry.example.com/redhat-operators:latest"))
+}
+
+func TestReconcileCatalogSourcePreservesExistingAnnotations(t *testing.T) {
+	g := NewWithT(t)
+
+	params := &OperatorLifecycleManagerParams{
+		RedHatOperatorsImage: "registry.example.com/redhat-operators:latest",
+		OLMCatalogPlacement:  hyperv1.GuestOLMCatalogPlacement,
+	}
+
+	cs := &operatorsv1alpha1.CatalogSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"existing-annotation": "existing-value",
+			},
+		},
+	}
+
+	ReconcileRedHatOperatorsCatalogSource(cs, params)
+
+	// Verify existing annotation is preserved and management annotation is added
+	g.Expect(cs.Annotations).To(HaveKeyWithValue("existing-annotation", "existing-value"))
+	g.Expect(cs.Annotations).To(HaveKeyWithValue("target.workload.openshift.io/management", `{"effect": "PreferredDuringScheduling"}`))
+}


### PR DESCRIPTION
## Summary

Updates the HCCO-managed CatalogSource `registryPoll.interval` from `10m` to `240m` to align with standard OCP 4.18+ defaults established by operator-marketplace.

## Context

In standard OCP clusters (4.18+), the operator-marketplace component sets the default `registryPoll` interval to 240 minutes (4 hours) to address performance issues including unbounded etcd growth and high I/O on control plane nodes (see [operator-marketplace PR #695](https://github.com/operator-framework/operator-marketplace/pull/695) and OCPBUGS-69441).

In HyperShift/HCP hosted clusters, the Hosted Cluster Config Operator (HCCO) manages CatalogSources independently with its own reconciliation logic in `catalogs.go`, which still hardcodes the interval to 10 minutes. This creates inconsistency between standard OCP and HCP behavior.

## Changes

- Updated `RawInterval` from `"10m"` to `"240m"` in `catalogs.go`
- Updated `Interval` duration from `10 * time.Minute` to `240 * time.Minute`

## Benefits

- **Reduced control plane resource consumption**: Less CPU/memory/network for catalog polling
- **Lower etcd churn**: Fewer updates to CatalogSource status means less etcd I/O and storage growth
- **Better scalability**: Management clusters hosting many HCP clusters see 24x reduction in aggregate polling load (4 catalogs × 6 polls/hour → 4 catalogs × 0.25 polls/hour per hosted cluster)
- **Consistency with standard OCP**: HCP clusters behave the same as OCP 4.18+ clusters

## Trade-offs

- **Catalog update discovery latency**: When a new operator catalog image is pushed to the registry, discovery time increases from up to 10 minutes to up to 4 hours
- **Mitigation**: Users can manually trigger refresh by deleting the CatalogSource pod or updating the `spec.image` field

## Related Issues

- OCPBUGS-88757 - HyperShift HCCO hardcodes CatalogSource registryPoll interval to 10m instead of 240m
- OCPBUGS-88758 - Audit HyperShift HCCO for divergences from standard OCP component defaults
- OCPBUGS-69441 - Original issue for standard OCP (fixed in operator-marketplace)

## Testing

- Code change is straightforward and low-risk (2 lines)
- No functional behavior change, only timing adjustment
- Follows established pattern from operator-marketplace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the OLM `CatalogSource` registry polling interval from 10 minutes to 240 minutes (4 hours) to reduce how frequently catalogs are checked.
  * Updated repo ignore rules to exclude `.mcp.json` files.
* **Tests**
  * Added `CatalogSource` reconciliation tests validating default spec settings (including the 240-minute polling interval), management vs. guest placement behavior, and preservation/merging of existing annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->