### PR TITLE
CNTRLPLANE-3523: Retry on InvalidRouteTableId.NotFound during route creation

### DIFF
--- a/cmd/infra/aws/ec2.go
+++ b/cmd/infra/aws/ec2.go
@@ -443,7 +443,8 @@ func (o *CreateInfraOptions) CreatePrivateRouteTable(ctx context.Context, l logr
 		isRetriable := func(err error) bool {
 			var apiErr smithy.APIError
 			if errors.As(err, &apiErr) {
-				return strings.EqualFold(apiErr.ErrorCode(), invalidNATGatewayError)
+				return strings.EqualFold(apiErr.ErrorCode(), invalidNATGatewayError) ||
+					strings.EqualFold(apiErr.ErrorCode(), invalidRouteTableID)
 			}
 			return false
 		}
@@ -530,10 +531,20 @@ func (o *CreateInfraOptions) CreatePublicRouteTable(ctx context.Context, l logr.
 
 	// Create route to internet gateway
 	if !o.hasInternetGatewayRoute(routeTable, igwID) {
-		_, err = client.CreateRoute(ctx, &ec2.CreateRouteInput{
-			DestinationCidrBlock: aws.String("0.0.0.0/0"),
-			RouteTableId:         aws.String(tableID),
-			GatewayId:            aws.String(igwID),
+		isRetriable := func(err error) bool {
+			var apiErr smithy.APIError
+			if errors.As(err, &apiErr) {
+				return strings.EqualFold(apiErr.ErrorCode(), invalidRouteTableID)
+			}
+			return false
+		}
+		err = retry.OnError(retryBackoff, isRetriable, func() error {
+			_, err = client.CreateRoute(ctx, &ec2.CreateRouteInput{
+				DestinationCidrBlock: aws.String("0.0.0.0/0"),
+				RouteTableId:         aws.String(tableID),
+				GatewayId:            aws.String(igwID),
+			})
+			return err
 		})
 		if err != nil {
 			return "", fmt.Errorf("cannot create route to internet gateway: %w", err)

--- a/cmd/infra/aws/ec2.go
+++ b/cmd/infra/aws/ec2.go
@@ -466,7 +466,8 @@ func (o *CreateInfraOptions) CreatePrivateRouteTable(ctx context.Context, l logr
 		isRetriable := func(err error) bool {
 			var apiErr smithy.APIError
 			if errors.As(err, &apiErr) {
-				return strings.EqualFold(apiErr.ErrorCode(), invalidNATGatewayError)
+				return strings.EqualFold(apiErr.ErrorCode(), invalidNATGatewayError) ||
+					strings.EqualFold(apiErr.ErrorCode(), invalidRouteTableID)
 			}
 			return false
 		}
@@ -553,10 +554,20 @@ func (o *CreateInfraOptions) CreatePublicRouteTable(ctx context.Context, l logr.
 
 	// Create route to internet gateway
 	if !o.hasInternetGatewayRoute(routeTable, igwID) {
-		_, err = client.CreateRoute(ctx, &ec2.CreateRouteInput{
-			DestinationCidrBlock: aws.String("0.0.0.0/0"),
-			RouteTableId:         aws.String(tableID),
-			GatewayId:            aws.String(igwID),
+		isRetriable := func(err error) bool {
+			var apiErr smithy.APIError
+			if errors.As(err, &apiErr) {
+				return strings.EqualFold(apiErr.ErrorCode(), invalidRouteTableID)
+			}
+			return false
+		}
+		err = retry.OnError(retryBackoff, isRetriable, func() error {
+			_, err = client.CreateRoute(ctx, &ec2.CreateRouteInput{
+				DestinationCidrBlock: aws.String("0.0.0.0/0"),
+				RouteTableId:         aws.String(tableID),
+				GatewayId:            aws.String(igwID),
+			})
+			return err
 		})
 		if err != nil {
 			return "", fmt.Errorf("cannot create route to internet gateway: %w", err)

--- a/cmd/infra/aws/ec2_test.go
+++ b/cmd/infra/aws/ec2_test.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/onsi/gomega"
-	"github.com/openshift/hypershift/support/awsapi"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
 	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/hypershift/support/awsapi"
 	"go.uber.org/mock/gomock"
 )
 
@@ -92,7 +91,7 @@ func TestCreatePrivateRouteTable(t *testing.T) {
 		errorContains string
 	}{
 		{
-			name: "When route table exists and routes are already configured it should return the table ID without creating routes",
+			name: "When route table exists and routes are already configured, it should return the table ID without creating routes",
 			setupMock: func(m *awsapi.MockEC2API) {
 				existingRT := &ec2types.RouteTable{
 					RouteTableId: aws.String("rtb-existing"),
@@ -111,7 +110,7 @@ func TestCreatePrivateRouteTable(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "When CreateRoute fails with InvalidRouteTableId.NotFound it should retry until success",
+			name: "When CreateRoute fails with InvalidRouteTableId.NotFound, it should retry until success",
 			setupMock: func(m *awsapi.MockEC2API) {
 				newRT := &ec2types.RouteTable{
 					RouteTableId: aws.String("rtb-new"),
@@ -133,7 +132,7 @@ func TestCreatePrivateRouteTable(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "When CreateRoute fails with InvalidNatGatewayID.NotFound it should retry until success",
+			name: "When CreateRoute fails with InvalidNatGatewayID.NotFound, it should retry until success",
 			setupMock: func(m *awsapi.MockEC2API) {
 				newRT := &ec2types.RouteTable{
 					RouteTableId: aws.String("rtb-new"),
@@ -158,7 +157,7 @@ func TestCreatePrivateRouteTable(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "When CreateRoute fails with non-retriable error it should not retry",
+			name: "When CreateRoute fails with non-retriable error, it should not retry",
 			setupMock: func(m *awsapi.MockEC2API) {
 				newRT := &ec2types.RouteTable{
 					RouteTableId: aws.String("rtb-new"),
@@ -226,7 +225,7 @@ func TestCreatePublicRouteTable(t *testing.T) {
 		errorContains string
 	}{
 		{
-			name: "When CreateRoute for internet gateway fails with InvalidRouteTableId.NotFound it should retry until success",
+			name: "When CreateRoute for internet gateway fails with InvalidRouteTableId.NotFound, it should retry until success",
 			setupMock: func(m *awsapi.MockEC2API) {
 				newRT := &ec2types.RouteTable{
 					RouteTableId: aws.String("rtb-new"),
@@ -261,7 +260,7 @@ func TestCreatePublicRouteTable(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "When CreateRoute for internet gateway fails with non-retriable InvalidParameterValue error it should not retry",
+			name: "When CreateRoute for internet gateway fails with non-retriable InvalidParameterValue error, it should not retry",
 			setupMock: func(m *awsapi.MockEC2API) {
 				newRT := &ec2types.RouteTable{
 					RouteTableId: aws.String("rtb-new"),

--- a/cmd/infra/aws/ec2_test.go
+++ b/cmd/infra/aws/ec2_test.go
@@ -260,6 +260,42 @@ func TestCreatePublicRouteTable(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "When CreateRoute for internet gateway fails with non-retriable InvalidParameterValue error it should not retry",
+			setupMock: func(m *awsapi.MockEC2API) {
+				newRT := &ec2types.RouteTable{
+					RouteTableId: aws.String("rtb-new"),
+					Routes:       []ec2types.Route{},
+				}
+				mainRT := &ec2types.RouteTable{
+					RouteTableId: aws.String("rtb-main"),
+					Associations: []ec2types.RouteTableAssociation{
+						{
+							Main:                    aws.Bool(true),
+							RouteTableAssociationId: aws.String("rtbassoc-main"),
+						},
+					},
+				}
+				nonRetriableError := &smithy.GenericAPIError{
+					Code:    "InvalidParameterValue",
+					Message: "Invalid parameter",
+				}
+				gomock.InOrder(
+					m.EXPECT().DescribeRouteTables(gomock.Any(), gomock.Any()).
+						Return(&ec2.DescribeRouteTablesOutput{}, nil),
+					m.EXPECT().CreateRouteTable(gomock.Any(), gomock.Any()).
+						Return(&ec2.CreateRouteTableOutput{RouteTable: newRT}, nil),
+					m.EXPECT().DescribeRouteTables(gomock.Any(), gomock.Any()).
+						Return(&ec2.DescribeRouteTablesOutput{RouteTables: []ec2types.RouteTable{*mainRT}}, nil),
+					m.EXPECT().ReplaceRouteTableAssociation(gomock.Any(), gomock.Any()).
+						Return(&ec2.ReplaceRouteTableAssociationOutput{}, nil),
+					m.EXPECT().CreateRoute(gomock.Any(), gomock.Any()).
+						Return(nil, nonRetriableError).Times(1),
+				)
+			},
+			expectError:   true,
+			errorContains: "cannot create route to internet gateway",
+		},
 	}
 
 	for _, tc := range tests {

--- a/cmd/infra/aws/ec2_test.go
+++ b/cmd/infra/aws/ec2_test.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
 	"github.com/go-logr/logr"
-	. "github.com/onsi/gomega"
 	"github.com/openshift/hypershift/support/awsapi"
 	"go.uber.org/mock/gomock"
 )

--- a/cmd/infra/aws/ec2_test.go
+++ b/cmd/infra/aws/ec2_test.go
@@ -10,10 +10,9 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
 	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
 	"github.com/openshift/hypershift/support/awsapi"
 	"go.uber.org/mock/gomock"
-
-	. "github.com/onsi/gomega"
 )
 
 type testAPIError struct {

--- a/cmd/infra/aws/ec2_test.go
+++ b/cmd/infra/aws/ec2_test.go
@@ -10,9 +10,10 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
 	"github.com/go-logr/logr"
-	. "github.com/onsi/gomega"
 	"github.com/openshift/hypershift/support/awsapi"
 	"go.uber.org/mock/gomock"
+
+	. "github.com/onsi/gomega"
 )
 
 type testAPIError struct {

--- a/cmd/infra/aws/ec2_test.go
+++ b/cmd/infra/aws/ec2_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"

--- a/cmd/infra/aws/ec2_test.go
+++ b/cmd/infra/aws/ec2_test.go
@@ -1,12 +1,19 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/openshift/hypershift/support/awsapi"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
+	"github.com/go-logr/logr"
+	"go.uber.org/mock/gomock"
 )
 
 type testAPIError struct {
@@ -59,6 +66,233 @@ func TestIsRetriableVPCEndpointError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			g.Expect(isRetriableVPCEndpointError(tt.err)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func createEC2Options() *CreateInfraOptions {
+	return &CreateInfraOptions{
+		InfraID: testInfraID,
+		Region:  "us-east-1",
+	}
+}
+
+func invalidRouteTableIDError() error {
+	return &smithy.GenericAPIError{
+		Code:    "InvalidRouteTableId.NotFound",
+		Message: "The routeTable ID 'rtb-xxx' does not exist",
+	}
+}
+
+func TestCreatePrivateRouteTable(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func(*awsapi.MockEC2API)
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When route table exists and routes are already configured it should return the table ID without creating routes",
+			setupMock: func(m *awsapi.MockEC2API) {
+				existingRT := &ec2types.RouteTable{
+					RouteTableId: aws.String("rtb-existing"),
+					Routes: []ec2types.Route{
+						{
+							NatGatewayId:         aws.String("nat-123"),
+							DestinationCidrBlock: aws.String("0.0.0.0/0"),
+						},
+					},
+				}
+				m.EXPECT().DescribeRouteTables(gomock.Any(), gomock.Any()).
+					Return(&ec2.DescribeRouteTablesOutput{RouteTables: []ec2types.RouteTable{*existingRT}}, nil)
+				m.EXPECT().AssociateRouteTable(gomock.Any(), gomock.Any()).
+					Return(&ec2.AssociateRouteTableOutput{}, nil)
+			},
+			expectError: false,
+		},
+		{
+			name: "When CreateRoute fails with InvalidRouteTableId.NotFound it should retry until success",
+			setupMock: func(m *awsapi.MockEC2API) {
+				newRT := &ec2types.RouteTable{
+					RouteTableId: aws.String("rtb-new"),
+					Routes:       []ec2types.Route{},
+				}
+				gomock.InOrder(
+					m.EXPECT().DescribeRouteTables(gomock.Any(), gomock.Any()).
+						Return(&ec2.DescribeRouteTablesOutput{}, nil),
+					m.EXPECT().CreateRouteTable(gomock.Any(), gomock.Any()).
+						Return(&ec2.CreateRouteTableOutput{RouteTable: newRT}, nil),
+					m.EXPECT().CreateRoute(gomock.Any(), gomock.Any()).
+						Return(nil, invalidRouteTableIDError()),
+					m.EXPECT().CreateRoute(gomock.Any(), gomock.Any()).
+						Return(&ec2.CreateRouteOutput{}, nil),
+					m.EXPECT().AssociateRouteTable(gomock.Any(), gomock.Any()).
+						Return(&ec2.AssociateRouteTableOutput{}, nil),
+				)
+			},
+			expectError: false,
+		},
+		{
+			name: "When CreateRoute fails with InvalidNatGatewayID.NotFound it should retry until success",
+			setupMock: func(m *awsapi.MockEC2API) {
+				newRT := &ec2types.RouteTable{
+					RouteTableId: aws.String("rtb-new"),
+					Routes:       []ec2types.Route{},
+				}
+				gomock.InOrder(
+					m.EXPECT().DescribeRouteTables(gomock.Any(), gomock.Any()).
+						Return(&ec2.DescribeRouteTablesOutput{}, nil),
+					m.EXPECT().CreateRouteTable(gomock.Any(), gomock.Any()).
+						Return(&ec2.CreateRouteTableOutput{RouteTable: newRT}, nil),
+					m.EXPECT().CreateRoute(gomock.Any(), gomock.Any()).
+						Return(nil, &smithy.GenericAPIError{
+							Code:    "InvalidNatGatewayID.NotFound",
+							Message: "The NAT gateway ID does not exist",
+						}),
+					m.EXPECT().CreateRoute(gomock.Any(), gomock.Any()).
+						Return(&ec2.CreateRouteOutput{}, nil),
+					m.EXPECT().AssociateRouteTable(gomock.Any(), gomock.Any()).
+						Return(&ec2.AssociateRouteTableOutput{}, nil),
+				)
+			},
+			expectError: false,
+		},
+		{
+			name: "When CreateRoute fails with non-retriable error it should not retry",
+			setupMock: func(m *awsapi.MockEC2API) {
+				newRT := &ec2types.RouteTable{
+					RouteTableId: aws.String("rtb-new"),
+					Routes:       []ec2types.Route{},
+				}
+				nonRetriableError := &smithy.GenericAPIError{
+					Code:    "InvalidParameterValue",
+					Message: "Invalid parameter",
+				}
+				gomock.InOrder(
+					m.EXPECT().DescribeRouteTables(gomock.Any(), gomock.Any()).
+						Return(&ec2.DescribeRouteTablesOutput{}, nil),
+					m.EXPECT().CreateRouteTable(gomock.Any(), gomock.Any()).
+						Return(&ec2.CreateRouteTableOutput{RouteTable: newRT}, nil),
+					m.EXPECT().CreateRoute(gomock.Any(), gomock.Any()).
+						Return(nil, nonRetriableError).Times(1),
+				)
+			},
+			expectError:   true,
+			errorContains: "cannot create nat gateway route",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockEC2 := awsapi.NewMockEC2API(ctrl)
+			tc.setupMock(mockEC2)
+
+			opts := createEC2Options()
+			logger := logr.Discard()
+			ctx := context.Background()
+
+			routeTableID, err := opts.CreatePrivateRouteTable(
+				ctx,
+				logger,
+				mockEC2,
+				"vpc-123",
+				"nat-123",
+				"subnet-123",
+				"us-east-1a",
+			)
+
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tc.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tc.errorContains))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(routeTableID).NotTo(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestCreatePublicRouteTable(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func(*awsapi.MockEC2API)
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When CreateRoute for internet gateway fails with InvalidRouteTableId.NotFound it should retry until success",
+			setupMock: func(m *awsapi.MockEC2API) {
+				newRT := &ec2types.RouteTable{
+					RouteTableId: aws.String("rtb-new"),
+					Routes:       []ec2types.Route{},
+				}
+				mainRT := &ec2types.RouteTable{
+					RouteTableId: aws.String("rtb-main"),
+					Associations: []ec2types.RouteTableAssociation{
+						{
+							Main:                    aws.Bool(true),
+							RouteTableAssociationId: aws.String("rtbassoc-main"),
+						},
+					},
+				}
+				gomock.InOrder(
+					m.EXPECT().DescribeRouteTables(gomock.Any(), gomock.Any()).
+						Return(&ec2.DescribeRouteTablesOutput{}, nil),
+					m.EXPECT().CreateRouteTable(gomock.Any(), gomock.Any()).
+						Return(&ec2.CreateRouteTableOutput{RouteTable: newRT}, nil),
+					m.EXPECT().DescribeRouteTables(gomock.Any(), gomock.Any()).
+						Return(&ec2.DescribeRouteTablesOutput{RouteTables: []ec2types.RouteTable{*mainRT}}, nil),
+					m.EXPECT().ReplaceRouteTableAssociation(gomock.Any(), gomock.Any()).
+						Return(&ec2.ReplaceRouteTableAssociationOutput{}, nil),
+					m.EXPECT().CreateRoute(gomock.Any(), gomock.Any()).
+						Return(nil, invalidRouteTableIDError()),
+					m.EXPECT().CreateRoute(gomock.Any(), gomock.Any()).
+						Return(&ec2.CreateRouteOutput{}, nil),
+					m.EXPECT().AssociateRouteTable(gomock.Any(), gomock.Any()).
+						Return(&ec2.AssociateRouteTableOutput{}, nil).Times(2),
+				)
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockEC2 := awsapi.NewMockEC2API(ctrl)
+			tc.setupMock(mockEC2)
+
+			opts := createEC2Options()
+			logger := logr.Discard()
+			ctx := context.Background()
+
+			routeTableID, err := opts.CreatePublicRouteTable(
+				ctx,
+				logger,
+				mockEC2,
+				"vpc-123",
+				"igw-123",
+				[]string{"subnet-123", "subnet-456"},
+			)
+
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tc.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tc.errorContains))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(routeTableID).NotTo(BeEmpty())
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:

`hcp create cluster aws` fails with `InvalidRouteTableID.NotFound` due to a race condition with AWS eventual consistency. The CLI creates a route table and immediately tries to add routes before AWS has propagated the resource. This results in a 100% failure rate with no retry logic to handle the transient error.

This PR adds retry with exponential backoff on `InvalidRouteTableId.NotFound` errors when creating routes after route table creation, matching the existing pattern already used in `CreateVPCS3Endpoint`.

**Files changed:**
- `cmd/infra/aws/ec2.go` — `CreatePrivateRouteTable` and `CreatePublicRouteTable`

**Changes:**
- `CreatePrivateRouteTable`: Added `invalidRouteTableID` to the existing retriable error check alongside `invalidNATGatewayError`
- `CreatePublicRouteTable`: Wrapped the `CreateRoute` call in `retry.OnError` with backoff on `invalidRouteTableID`

Both use the existing `retryBackoff` (5 steps, 3s base, 3x factor) already defined and proven in production via `CreateVPCS3Endpoint`.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3523

## Special notes for your reviewer:

- The retry is idempotent — `CreateRoute` with the same destination CIDR on the same route table either succeeds or returns `RouteAlreadyExists`.
- The retry is narrowly scoped to only `InvalidRouteTableId.NotFound` — any other error fails immediately.
- The exact same pattern (retry on `invalidRouteTableID` with `retryBackoff`) is already used in `CreateVPCS3Endpoint` in the same file.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability during cloud infrastructure provisioning by retrying network route creation when route tables or NAT gateways are temporarily unavailable.
  * Reduced deployment interruptions caused by transient cloud API errors when configuring private and public network routes.
  * Improved handling of route-creation failures while preserving immediate reporting for errors that cannot be resolved through retrying.
  * Added clearer error reporting when routes cannot be created for the internet gateway.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->