### PR TITLE
OCPBUGS-44164: Fix TestNodePoolReplaceUpgrade flaky timeout on OpenStack

### DIFF
--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -188,7 +188,7 @@ func (ru *NodePoolUpgradeTest) Run(t *testing.T, nodePool hyperv1.NodePool, node
 				return nodePool.Status.Version == previousReleaseInfo.ObjectMeta.Name, fmt.Sprintf("wanted version %s, got %s", previousReleaseInfo.ObjectMeta.Name, nodePool.Status.Version), nil
 			},
 		},
-		e2eutil.WithTimeout(10*time.Second),
+		e2eutil.WithTimeout(2*time.Minute),
 	)
 
 	// Validate NodesInfo is populated with the previous version before upgrade.


### PR DESCRIPTION
## What this PR does / why we need it:

Increases the pre-upgrade version check timeout in `TestNodePoolReplaceUpgrade` from 10 seconds to 2 minutes. On fast platforms like OpenStack, the image rollout completes instantly, giving the controller very little time to set `nodePool.Status.Version` before the check runs. The 10-second retry window introduced in 72c70116c reduced flakiness but was still too short — 30% of recent OpenStack `e2e-openstack-aws` runs still fail on this check.

The new timeout matches the `NodesInfo` check that immediately follows (also 2 minutes).

**Files changed:**
- `test/e2e/nodepool_upgrade_test.go` — `WithTimeout(10*time.Second)` → `WithTimeout(2*time.Minute)`

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-44164

## Special notes for your reviewer:

- Parent bug OCPBUGS-43943 was fixed by Patryk Stefanski (72c70116c) by replacing a hard assertion with `EventuallyObject` + 10s timeout. That reduced the flake rate but didn't eliminate it on OpenStack.
- The clone OCPBUGS-44164 has been open and unassigned since Nov 2024.
- Recent Prow data confirms 3/10 `e2e-openstack-aws` runs in the last 14 days still fail on this test (all from PR #8687).

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by allowing more time for node pool upgrade validation to complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->