### PR TITLE
OCPBUGS-88531: Remove CPO-side restart logic for CNO operands

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2021,30 +2021,6 @@ func (r *HostedControlPlaneReconciler) reconcileValidIDPConfigurationCondition(c
 }
 
 func (r *HostedControlPlaneReconciler) cleanupClusterNetworkOperatorResources(ctx context.Context, hcp *hyperv1.HostedControlPlane, hasRouteCap bool) error {
-	if restartAnnotation, ok := hcp.Annotations[hyperv1.RestartDateAnnotation]; ok {
-		// CNO manages overall multus-admission-controller deployment. CPO manages restarts.
-		// TODO: why is this not done in CNO?
-		// Only restart multus deployment if Multus is not disabled
-		if !netutil.IsDisableMultiNetwork(hcp) {
-			multusDeployment := manifests.MultusAdmissionControllerDeployment(hcp.Namespace)
-			if err := cnov2.SetRestartAnnotationAndPatch(ctx, r.Client, multusDeployment, restartAnnotation); err != nil {
-				return fmt.Errorf("failed to restart multus admission controller: %w", err)
-			}
-		}
-
-		// CNO manages overall network-node-identity deployment. CPO manages restarts.
-		networkNodeIdentityDeployment := manifests.NetworkNodeIdentityDeployment(hcp.Namespace)
-		if err := cnov2.SetRestartAnnotationAndPatch(ctx, r.Client, networkNodeIdentityDeployment, restartAnnotation); err != nil {
-			return fmt.Errorf("failed to restart network node identity: %w", err)
-		}
-
-		// CNO manages overall ovnkube-control-plane deployment. CPO manages restarts.  Note that cnov2.SetRestartAnnotationAndPatch just returns err == nil if the deployment isn't found (so if OVN isn't being used)
-		ovnKubeControlPlaneDeployment := manifests.OVNKubeControlPlaneDeployment(hcp.Namespace)
-		if err := cnov2.SetRestartAnnotationAndPatch(ctx, r.Client, ovnKubeControlPlaneDeployment, restartAnnotation); err != nil {
-			return fmt.Errorf("failed to restart ovnkube-control-plane: %w", err)
-		}
-	}
-
 	// Clean up ovnkube-sbdb Route if exists
 	if hasRouteCap {
 		if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, manifests.OVNKubeSBDBRoute(hcp.Namespace)); err != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/cno.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/cno.go
@@ -10,9 +10,6 @@ import (
 )
 
 const clusterNetworkOperator = "cluster-network-operator"
-const multusAdmissionController = "multus-admission-controller"
-const networkNodeIdentity = "network-node-identity"
-const ovnKubeControlPlane = "ovnkube-control-plane"
 
 func ClusterNetworkOperatorDeployment(ns string) *appsv1.Deployment {
 	return &appsv1.Deployment{
@@ -46,33 +43,6 @@ func ClusterNetworkOperatorServiceAccount(namespace string) *corev1.ServiceAccou
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      clusterNetworkOperator,
-		},
-	}
-}
-
-func MultusAdmissionControllerDeployment(namespace string) *appsv1.Deployment {
-	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      multusAdmissionController,
-		},
-	}
-}
-
-func NetworkNodeIdentityDeployment(namespace string) *appsv1.Deployment {
-	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      networkNodeIdentity,
-		},
-	}
-}
-
-func OVNKubeControlPlaneDeployment(namespace string) *appsv1.Deployment {
-	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      ovnKubeControlPlane,
 		},
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component.go
@@ -1,7 +1,6 @@
 package cno
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 
@@ -80,28 +78,6 @@ func NewComponent() component.ControlPlaneComponent {
 
 func isAroHCP(cpContext component.WorkloadContext) bool {
 	return azureutil.IsAroHCPByHCP(cpContext.HCP)
-}
-
-func SetRestartAnnotationAndPatch(ctx context.Context, crclient client.Client, dep *appsv1.Deployment, restartAnnotation string) error {
-	if err := crclient.Get(ctx, client.ObjectKeyFromObject(dep), dep); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed retrieve deployment: %w", err)
-	}
-
-	patch := dep.DeepCopy()
-	podMeta := patch.Spec.Template.ObjectMeta
-	if podMeta.Annotations == nil {
-		podMeta.Annotations = map[string]string{}
-	}
-	podMeta.Annotations[hyperv1.RestartDateAnnotation] = restartAnnotation
-
-	if err := crclient.Patch(ctx, patch, client.MergeFrom(dep)); err != nil {
-		return fmt.Errorf("failed to set restart annotation: %w", err)
-	}
-
-	return nil
 }
 
 type operand struct {


### PR DESCRIPTION
## Summary

- Remove redundant CPO-side restart-date annotation propagation for multus-admission-controller, network-node-identity, and ovnkube-control-plane
- CNO handles restart-date propagation to all its operands directly, making the CPO-side logic redundant

The `cleanupClusterNetworkOperatorResources` function previously contained logic to read `hypershift.openshift.io/restart-date` from the HCP and patch it onto CNO-managed deployments. CNO reads the annotation from HCP itself and sets it as a pod template annotation on all rendered workloads, so the CPO-side logic is unnecessary duplication.

## Test plan
Tested and verified. Test verification report here - https://bryan-cox.github.io/architectural-artifact-sharing/test-verification-report-ocpbugs-84239/index.html.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified cluster network operator resource cleanup by removing restart-annotation handling for CNO-managed components.
  * Cleanup now focuses directly on removing the `ovnkube-sbdb` Route when applicable, and deleting the `ovnkube-master-external` and `ovnkube-master-internal` Services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->