### PR TITLE
[WIP] CNTRLPLANE-3487: Multi-hop upgrade tests

### DIFF
--- a/test/e2e/multi_hop_upgrade_test.go
+++ b/test/e2e/multi_hop_upgrade_test.go
@@ -1,0 +1,169 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestMultiHopUpgrade(t *testing.T) {
+	t.Parallel()
+
+	imageChain := buildV1ReleaseImageChain()
+	if len(imageChain) < 3 {
+		t.Skipf("multi-hop upgrade requires at least 3 release images (got %d); set -e2e.n1-minor-release-image through -e2e.n3-minor-release-image", len(imageChain))
+	}
+
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
+
+	t.Logf("Multi-hop upgrade: %d hops planned across %d images", len(imageChain)-1, len(imageChain))
+	for i, img := range imageChain {
+		t.Logf("  image[%d]: %s", i, img)
+	}
+
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts.ReleaseImage = imageChain[0]
+	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
+
+	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+		guestClient := e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
+
+		var startingVersion string
+		if hostedCluster.Status.Version != nil && len(hostedCluster.Status.Version.History) > 0 {
+			startingVersion = hostedCluster.Status.Version.History[0].Version
+			t.Logf("Starting version: %s", startingVersion)
+		}
+
+		// Find the default NodePool created with the cluster.
+		npList := &hyperv1.NodePoolList{}
+		g.Expect(mgtClient.List(ctx, npList, crclient.InNamespace(hostedCluster.Namespace))).To(Succeed())
+		var defaultNP *hyperv1.NodePool
+		for i := range npList.Items {
+			if npList.Items[i].Spec.ClusterName == hostedCluster.Name {
+				defaultNP = &npList.Items[i]
+				break
+			}
+		}
+		g.Expect(defaultNP).NotTo(BeNil(), "default NodePool should exist for multi-hop upgrade")
+
+		upgradeTimeout := nodePoolUpgradeTimeout(hostedCluster.Spec.Platform.Type)
+
+		for i := 1; i < len(imageChain); i++ {
+			targetImage := imageChain[i]
+			hopNum := i
+			previousVersion := startingVersion
+
+			t.Logf("=== Hop %d/%d: upgrading to %s ===", hopNum, len(imageChain)-1, targetImage)
+
+			// Upgrade control plane.
+			t.Run(fmt.Sprintf("Hop%d/ControlPlaneUpgrade", hopNum), func(t *testing.T) {
+				err := e2eutil.UpdateObject(t, ctx, mgtClient, hostedCluster, func(obj *hyperv1.HostedCluster) {
+					obj.Spec.Release.Image = targetImage
+					if obj.Annotations == nil {
+						obj.Annotations = make(map[string]string)
+					}
+					obj.Annotations[hyperv1.ForceUpgradeToAnnotation] = targetImage
+				})
+				g.Expect(err).NotTo(HaveOccurred(), "hop %d: failed to update hosted cluster release image", hopNum)
+
+				e2eutil.WaitForControlPlaneComponentRollout(t, ctx, mgtClient, hostedCluster, previousVersion)
+				e2eutil.WaitForControlPlaneRollout(t, ctx, mgtClient, hostedCluster)
+				e2eutil.WaitForDataPlaneRollout(t, ctx, mgtClient, hostedCluster)
+			})
+
+			g.Expect(mgtClient.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)).To(Succeed())
+			if hostedCluster.Status.Version != nil && len(hostedCluster.Status.Version.History) > 0 {
+				startingVersion = hostedCluster.Status.Version.History[0].Version
+			}
+			t.Logf("Hop %d: control plane upgraded to version %s", hopNum, startingVersion)
+
+			// Upgrade NodePool.
+			t.Run(fmt.Sprintf("Hop%d/NodePoolUpgrade", hopNum), func(t *testing.T) {
+				g.Expect(mgtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), defaultNP)).To(Succeed())
+				original := defaultNP.DeepCopy()
+				defaultNP.Spec.Release.Image = targetImage
+				g.Expect(mgtClient.Patch(ctx, defaultNP, crclient.MergeFrom(original))).To(Succeed(),
+					"hop %d: failed to update NodePool release image", hopNum)
+
+				e2eutil.EventuallyObject(t, ctx,
+					fmt.Sprintf("NodePool %s/%s to start upgrading (hop %d)", defaultNP.Namespace, defaultNP.Name, hopNum),
+					func(ctx context.Context) (*hyperv1.NodePool, error) {
+						np := &hyperv1.NodePool{}
+						err := mgtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), np)
+						return np, err
+					},
+					[]e2eutil.Predicate[*hyperv1.NodePool]{
+						e2eutil.ConditionPredicate[*hyperv1.NodePool](e2eutil.Condition{
+							Type:   hyperv1.NodePoolUpdatingVersionConditionType,
+							Status: metav1.ConditionTrue,
+						}),
+					},
+				)
+
+				e2eutil.EventuallyObject(t, ctx,
+					fmt.Sprintf("NodePool %s/%s to finish upgrading (hop %d)", defaultNP.Namespace, defaultNP.Name, hopNum),
+					func(ctx context.Context) (*hyperv1.NodePool, error) {
+						np := &hyperv1.NodePool{}
+						err := mgtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), np)
+						return np, err
+					},
+					[]e2eutil.Predicate[*hyperv1.NodePool]{
+						e2eutil.ConditionPredicate[*hyperv1.NodePool](e2eutil.Condition{
+							Type:   hyperv1.NodePoolUpdatingVersionConditionType,
+							Status: metav1.ConditionFalse,
+						}),
+					},
+					e2eutil.WithTimeout(upgradeTimeout),
+				)
+
+				e2eutil.WaitForReadyNodesByNodePool(t, ctx, guestClient, defaultNP, hostedCluster.Spec.Platform.Type)
+			})
+
+			t.Logf("Hop %d: NodePool upgraded successfully", hopNum)
+		}
+
+		g.Expect(mgtClient.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)).To(Succeed())
+		if hostedCluster.Status.Version != nil && len(hostedCluster.Status.Version.History) > 0 {
+			t.Logf("Multi-hop upgrade complete. Final version: %s", hostedCluster.Status.Version.History[0].Version)
+		}
+
+		e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, mgtClient, guestClient, hostedCluster.Spec.Platform.Type, hostedCluster.Namespace)
+		e2eutil.EnsureNoCrashingPods(t, ctx, mgtClient, hostedCluster)
+	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "multi-hop-upgrade", globalOpts.ServiceAccountSigningKey)
+}
+
+func buildV1ReleaseImageChain() []string {
+	images := []string{
+		globalOpts.N3MinorReleaseImage,
+		globalOpts.N2MinorReleaseImage,
+		globalOpts.N1MinorReleaseImage,
+		globalOpts.LatestReleaseImage,
+	}
+
+	var chain []string
+	for _, img := range images {
+		if img != "" {
+			chain = append(chain, img)
+		}
+	}
+	return chain
+}
+
+func nodePoolUpgradeTimeout(platform hyperv1.PlatformType) time.Duration {
+	switch platform {
+	case hyperv1.AzurePlatform, hyperv1.KubevirtPlatform:
+		return 45 * time.Minute
+	default:
+		return 20 * time.Minute
+	}
+}

--- a/test/e2e/multi_hop_upgrade_test.go
+++ b/test/e2e/multi_hop_upgrade_test.go
@@ -31,6 +31,12 @@ func TestMultiHopUpgrade(t *testing.T) {
 		t.Logf("  image[%d]: %s", i, img)
 	}
 
+	// Set the release version to the starting image so version-gated condition
+	// checks in ValidateHostedClusterConditions use the correct thresholds.
+	if err := e2eutil.SetReleaseImageVersion(ctx, imageChain[0], globalOpts.ConfigurableClusterOptions.PullSecretFile); err != nil {
+		t.Fatalf("failed to set release image version for starting image: %v", err)
+	}
+
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.ReleaseImage = imageChain[0]
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)

--- a/test/e2e/multi_hop_upgrade_test.go
+++ b/test/e2e/multi_hop_upgrade_test.go
@@ -62,7 +62,7 @@ func TestMultiHopUpgrade(t *testing.T) {
 		}
 		g.Expect(defaultNP).NotTo(BeNil(), "default NodePool should exist for multi-hop upgrade")
 
-		upgradeTimeout := nodePoolUpgradeTimeout(hostedCluster.Spec.Platform.Type)
+		upgradeTimeout := 45 * time.Minute
 
 		for i := 1; i < len(imageChain); i++ {
 			targetImage := imageChain[i]
@@ -162,13 +162,4 @@ func buildV1ReleaseImageChain() []string {
 		}
 	}
 	return chain
-}
-
-func nodePoolUpgradeTimeout(platform hyperv1.PlatformType) time.Duration {
-	switch platform {
-	case hyperv1.AzurePlatform, hyperv1.KubevirtPlatform:
-		return 45 * time.Minute
-	default:
-		return 20 * time.Minute
-	}
 }

--- a/test/e2e/multi_hop_upgrade_test.go
+++ b/test/e2e/multi_hop_upgrade_test.go
@@ -83,7 +83,6 @@ func TestMultiHopUpgrade(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred(), "hop %d: failed to update hosted cluster release image", hopNum)
 
 				e2eutil.WaitForControlPlaneComponentRollout(t, ctx, mgtClient, hostedCluster, previousVersion)
-				e2eutil.WaitForControlPlaneRollout(t, ctx, mgtClient, hostedCluster)
 				e2eutil.WaitForDataPlaneRollout(t, ctx, mgtClient, hostedCluster)
 			})
 

--- a/test/e2e/v2/cmd/create-guests/main.go
+++ b/test/e2e/v2/cmd/create-guests/main.go
@@ -71,6 +71,7 @@ type envConfig struct {
 	artifactDir  string
 	releaseImage string
 	n1Image      string
+	n3Image      string
 
 	baseDomain  string
 	nodeCount   int
@@ -109,6 +110,7 @@ func loadEnvConfig() envConfig {
 		artifactDir:  mustGetenv("ARTIFACT_DIR"),
 		releaseImage: mustGetenv("RELEASE_IMAGE_LATEST"),
 		n1Image:      os.Getenv("OCP_IMAGE_N1"),
+		n3Image:      os.Getenv("OCP_IMAGE_N3"),
 
 		baseDomain:  envOrDefault("HYPERSHIFT_BASE_DOMAIN", platform.DefaultBaseDomain()),
 		nodeCount:   envOrDefaultInt("HYPERSHIFT_NODE_COUNT", 3),
@@ -125,12 +127,15 @@ func loadEnvConfig() envConfig {
 	if cfg.n1Image == "" {
 		cfg.n1Image = cfg.releaseImage
 	}
+	if cfg.n3Image == "" {
+		cfg.n3Image = cfg.n1Image
+	}
 
 	return cfg
 }
 
 func run(ctx context.Context, cfg envConfig) error {
-	specs := cfg.platform.ClusterSpecs(cfg.releaseImage, cfg.n1Image)
+	specs := cfg.platform.ClusterSpecs(cfg.releaseImage, cfg.n1Image, cfg.n3Image)
 
 	// Derive cluster names and build the name map.
 	named := make([]namedSpec, len(specs))

--- a/test/e2e/v2/cmd/destroy-guests/main.go
+++ b/test/e2e/v2/cmd/destroy-guests/main.go
@@ -52,7 +52,7 @@ func main() {
 		hypershiftBin = "hypershift"
 	}
 
-	specs := platform.ClusterSpecs("", "")
+	specs := platform.ClusterSpecs("", "", "")
 
 	log.Printf("Destroying %d clusters derived from PROW_JOB_ID=%s", len(specs), prowJobID)
 

--- a/test/e2e/v2/cmd/dump-guests/main.go
+++ b/test/e2e/v2/cmd/dump-guests/main.go
@@ -52,7 +52,7 @@ func main() {
 		log.Fatalf("Failed to initialize platform config: %v", err)
 	}
 
-	specs := platform.ClusterSpecs("", "")
+	specs := platform.ClusterSpecs("", "", "")
 	log.Printf("Dumping %d clusters derived from PROW_JOB_ID=%s", len(specs), prowJobID)
 
 	var wg sync.WaitGroup

--- a/test/e2e/v2/cmd/run-tests/main.go
+++ b/test/e2e/v2/cmd/run-tests/main.go
@@ -51,7 +51,11 @@ func main() {
 	// Let the platform set up any env vars it needs for tests.
 	platform.SetupTestEnv(sharedDir)
 
-	matrix := platform.TestMatrix(releaseImage)
+	n1Image := os.Getenv("OCP_IMAGE_N1")
+	n2Image := os.Getenv("OCP_IMAGE_N2")
+	n3Image := os.Getenv("OCP_IMAGE_N3")
+
+	matrix := platform.TestMatrix(releaseImage, n1Image, n2Image, n3Image)
 
 	var (
 		mu      sync.Mutex

--- a/test/e2e/v2/internal/env_vars.go
+++ b/test/e2e/v2/internal/env_vars.go
@@ -199,6 +199,11 @@ func init() {
 		false,
 	)
 	RegisterEnvVar(
+		"E2E_N3_RELEASE_IMAGE",
+		"N-3 minor release image for multi-hop upgrade tests.",
+		false,
+	)
+	RegisterEnvVar(
 		"E2E_AZURE_CREDENTIALS_FILE",
 		"Path to Azure service principal credentials JSON file for platform-specific tests (auto-repair, disk encryption).",
 		false,

--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -109,7 +109,7 @@ func (a *AzurePlatformConfig) DefaultBaseDomain() string {
 	return "hcp-sm-azure.azure.devcluster.openshift.com"
 }
 
-func (a *AzurePlatformConfig) ClusterSpecs(releaseImage, n1Image string) []ClusterSpec {
+func (a *AzurePlatformConfig) ClusterSpecs(releaseImage, n1Image, n3Image string) []ClusterSpec {
 	var publicExtraArgs []string
 	if a.encryptionKeyID != "" {
 		publicExtraArgs = append(publicExtraArgs, "--encryption-key-id="+a.encryptionKeyID)
@@ -138,6 +138,12 @@ func (a *AzurePlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Clust
 			Variant:      "upgrade",
 			OutputFile:   "cluster-name-upgrade",
 			ReleaseImage: n1Image,
+			ExtraArgs:    []string{"--control-plane-availability-policy=HighlyAvailable"},
+		},
+		{
+			Variant:      "multi-hop-upgrade",
+			OutputFile:   "cluster-name-multi-hop-upgrade",
+			ReleaseImage: n3Image,
 			ExtraArgs:    []string{"--control-plane-availability-policy=HighlyAvailable"},
 		},
 		{
@@ -327,7 +333,7 @@ func (a *AzurePlatformConfig) postCreateExternalOIDC(ctx context.Context, cl crc
 	return nil
 }
 
-func (a *AzurePlatformConfig) TestMatrix(releaseImage string) TestMatrix {
+func (a *AzurePlatformConfig) TestMatrix(releaseImage, n1Image, n2Image, n3Image string) TestMatrix {
 	return TestMatrix{
 		Parallel: []TestGroup{
 			{
@@ -378,6 +384,23 @@ func (a *AzurePlatformConfig) TestMatrix(releaseImage string) TestMatrix {
 						ClusterFile: "cluster-name-upgrade",
 						LabelFilter: "etcd-chaos",
 						JUnitFile:   "junit_lifecycle_etcd_chaos.xml",
+					},
+				},
+			},
+			{
+				Name: "multi-hop-upgrade",
+				Steps: []TestGroup{
+					{
+						Name:        "multi-hop-upgrade",
+						ClusterFile: "cluster-name-multi-hop-upgrade",
+						LabelFilter: "multi-hop-upgrade",
+						JUnitFile:   "junit_lifecycle_multi_hop_upgrade.xml",
+						ExtraEnv: []string{
+								fmt.Sprintf("E2E_LATEST_RELEASE_IMAGE=%s", releaseImage),
+								fmt.Sprintf("E2E_N1_RELEASE_IMAGE=%s", n1Image),
+								fmt.Sprintf("E2E_N2_RELEASE_IMAGE=%s", n2Image),
+								fmt.Sprintf("E2E_N3_RELEASE_IMAGE=%s", n3Image),
+							},
 					},
 				},
 			},

--- a/test/e2e/v2/lifecycle/platform.go
+++ b/test/e2e/v2/lifecycle/platform.go
@@ -55,9 +55,9 @@ type PlatformConfig interface {
 	DefaultBaseDomain() string
 
 	// ClusterSpecs returns the cluster variants this platform creates.
-	// The releaseImage and n1Image are the current and N-1 release
-	// images from the CI environment.
-	ClusterSpecs(releaseImage, n1Image string) []ClusterSpec
+	// The releaseImage is the current release, n1Image is N-1, and
+	// n3Image is N-3.
+	ClusterSpecs(releaseImage, n1Image, n3Image string) []ClusterSpec
 
 	// CreateArgs returns platform-specific args for
 	// "hypershift create cluster <platform>".
@@ -85,7 +85,8 @@ type PlatformConfig interface {
 	PostVersionRollout(ctx context.Context, cl crclient.WithWatch, namespace string, clusterNames map[string]string) error
 
 	// TestMatrix returns the test groups for this platform.
-	TestMatrix(releaseImage string) TestMatrix
+	// n1Image, n2Image, n3Image are the N-1, N-2, N-3 release images.
+	TestMatrix(releaseImage, n1Image, n2Image, n3Image string) TestMatrix
 
 	// SetupTestEnv sets platform-specific environment variables
 	// before test execution (e.g., reading subnet IDs from
@@ -95,7 +96,6 @@ type PlatformConfig interface {
 	// DestroyArgs returns platform-specific args for
 	// "hypershift destroy cluster <platform>".
 	DestroyArgs() []string
-
 }
 
 // NewPlatformConfig creates a PlatformConfig for the given platform
@@ -119,4 +119,3 @@ func DeriveClusterName(prowJobID, variant string) string {
 	hash := sha256.Sum256([]byte(prowJobID))
 	return variant + "-" + fmt.Sprintf("%x", hash)[:10]
 }
-

--- a/test/e2e/v2/tests/multi_hop_upgrade_test.go
+++ b/test/e2e/v2/tests/multi_hop_upgrade_test.go
@@ -79,9 +79,6 @@ func MultiHopUpgradeTest(getTestCtx internal.TestContextGetter) {
 			By(fmt.Sprintf("Hop %d/%d: waiting for control plane component rollout", hopNum, len(imageChain)-1))
 			e2eutil.WaitForControlPlaneComponentRollout(GinkgoTB(), ctx, testCtx.MgmtClient, hc, previousVersion)
 
-			By(fmt.Sprintf("Hop %d/%d: waiting for control plane version rollout", hopNum, len(imageChain)-1))
-			e2eutil.WaitForControlPlaneRollout(GinkgoTB(), ctx, testCtx.MgmtClient, hc)
-
 			By(fmt.Sprintf("Hop %d/%d: waiting for data plane rollout", hopNum, len(imageChain)-1))
 			e2eutil.WaitForDataPlaneRollout(GinkgoTB(), ctx, testCtx.MgmtClient, hc)
 

--- a/test/e2e/v2/tests/multi_hop_upgrade_test.go
+++ b/test/e2e/v2/tests/multi_hop_upgrade_test.go
@@ -1,0 +1,176 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// MultiHopUpgradeTest sequentially upgrades a HostedCluster's control plane
+// and NodePool through multiple minor versions from the oldest available
+// release image to the latest.
+func MultiHopUpgradeTest(getTestCtx internal.TestContextGetter) {
+	It("should upgrade control plane and NodePool through multiple minor versions", func() {
+		testCtx := getTestCtx()
+		testCtx.ValidateHostedClusterClient()
+		ctx := testCtx.Context
+		hc := testCtx.GetHostedCluster()
+		hcClient := testCtx.GetHostedClusterClient()
+
+		e2eutil.GinkgoAtLeast(e2eutil.Version420)
+
+		imageChain := buildReleaseImageChain()
+		if len(imageChain) < 3 {
+			Skip(fmt.Sprintf("multi-hop upgrade requires at least 3 release images (got %d); set E2E_N1_RELEASE_IMAGE through E2E_N3_RELEASE_IMAGE", len(imageChain)))
+		}
+
+		var startingVersion string
+		if hc.Status.Version != nil && len(hc.Status.Version.History) > 0 {
+			startingVersion = hc.Status.Version.History[0].Version
+		}
+		GinkgoWriter.Printf("Multi-hop upgrade: %d hops planned, starting from version %s\n", len(imageChain)-1, startingVersion)
+
+		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
+		Expect(defaultNP).NotTo(BeNil(), "default NodePool should exist for multi-hop upgrade")
+
+		upgradeTimeout := nodePoolUpgradeTimeout(hc.Spec.Platform.Type)
+
+		for i := 1; i < len(imageChain); i++ {
+			targetImage := imageChain[i]
+			hopNum := i
+			previousVersion := startingVersion
+
+			By(fmt.Sprintf("Hop %d/%d: upgrading control plane", hopNum, len(imageChain)-1))
+
+			err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+				obj.Spec.Release.Image = targetImage
+				if obj.Annotations == nil {
+					obj.Annotations = make(map[string]string)
+				}
+				obj.Annotations[hyperv1.ForceUpgradeToAnnotation] = targetImage
+			})
+			Expect(err).NotTo(HaveOccurred(), "hop %d: failed to update hosted cluster release image", hopNum)
+
+			By(fmt.Sprintf("Hop %d/%d: waiting for control plane component rollout", hopNum, len(imageChain)-1))
+			e2eutil.WaitForControlPlaneComponentRollout(GinkgoTB(), ctx, testCtx.MgmtClient, hc, previousVersion)
+
+			By(fmt.Sprintf("Hop %d/%d: waiting for control plane version rollout", hopNum, len(imageChain)-1))
+			e2eutil.WaitForControlPlaneRollout(GinkgoTB(), ctx, testCtx.MgmtClient, hc)
+
+			By(fmt.Sprintf("Hop %d/%d: waiting for data plane rollout", hopNum, len(imageChain)-1))
+			e2eutil.WaitForDataPlaneRollout(GinkgoTB(), ctx, testCtx.MgmtClient, hc)
+
+			Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), hc)).To(Succeed())
+			if hc.Status.Version != nil && len(hc.Status.Version.History) > 0 {
+				startingVersion = hc.Status.Version.History[0].Version
+			}
+			GinkgoWriter.Printf("Hop %d: control plane upgraded to version %s\n", hopNum, startingVersion)
+
+			By(fmt.Sprintf("Hop %d/%d: upgrading NodePool", hopNum, len(imageChain)-1))
+
+			Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), defaultNP)).To(Succeed())
+			Expect(e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, defaultNP, func(obj *hyperv1.NodePool) {
+				obj.Spec.Release.Image = targetImage
+			})).To(Succeed(), "hop %d: failed to update NodePool release image", hopNum)
+
+			Eventually(func(g Gomega) {
+				np := &hyperv1.NodePool{}
+				g.Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), np)).To(Succeed())
+				internal.ValidateConditions(g, np, []e2eutil.Condition{
+					{Type: hyperv1.NodePoolUpdatingVersionConditionType, Status: metav1.ConditionTrue},
+				})
+			}).WithTimeout(upgradeTimeout).WithPolling(10*time.Second).Should(Succeed(),
+				"hop %d: NodePool should start upgrading", hopNum)
+
+			Eventually(func(g Gomega) {
+				np := &hyperv1.NodePool{}
+				g.Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), np)).To(Succeed())
+				internal.ValidateConditions(g, np, []e2eutil.Condition{
+					{Type: hyperv1.NodePoolUpdatingVersionConditionType, Status: metav1.ConditionFalse},
+				})
+			}).WithTimeout(upgradeTimeout).WithPolling(30*time.Second).Should(Succeed(),
+				"hop %d: NodePool should finish upgrading", hopNum)
+
+			e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, defaultNP, hc.Spec.Platform.Type)
+
+			By(fmt.Sprintf("Hop %d/%d: verifying node health", hopNum, len(imageChain)-1))
+			Eventually(func(g Gomega) {
+				np := &hyperv1.NodePool{}
+				g.Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), np)).To(Succeed())
+				internal.ValidateConditions(g, np, []e2eutil.Condition{
+					{Type: hyperv1.NodePoolAllMachinesReadyConditionType, Status: metav1.ConditionTrue},
+					{Type: hyperv1.NodePoolAllNodesHealthyConditionType, Status: metav1.ConditionTrue},
+				})
+			}).WithTimeout(upgradeTimeout).WithPolling(30*time.Second).Should(Succeed(),
+				"hop %d: NodePool nodes should be healthy", hopNum)
+			GinkgoWriter.Printf("Hop %d: NodePool upgraded successfully\n", hopNum)
+		}
+
+		Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), hc)).To(Succeed())
+		if hc.Status.Version != nil && len(hc.Status.Version.History) > 0 {
+			GinkgoWriter.Printf("Multi-hop upgrade complete. Final version: %s\n", hc.Status.Version.History[0].Version)
+		}
+	})
+}
+
+// buildReleaseImageChain returns an ordered list of release images from oldest
+// to latest based on available E2E_N* environment variables. Empty entries are
+// skipped so the chain adapts to however many images CI provides.
+func buildReleaseImageChain() []string {
+	envVars := []string{
+		"E2E_N3_RELEASE_IMAGE",
+		"E2E_N2_RELEASE_IMAGE",
+		"E2E_N1_RELEASE_IMAGE",
+		"E2E_LATEST_RELEASE_IMAGE",
+	}
+
+	var chain []string
+	for _, envVar := range envVars {
+		image := internal.GetEnvVarValue(envVar)
+		if image != "" {
+			chain = append(chain, image)
+		}
+	}
+	return chain
+}
+
+// RegisterMultiHopUpgradeTests registers all multi-hop upgrade tests.
+func RegisterMultiHopUpgradeTests(getTestCtx internal.TestContextGetter) {
+	MultiHopUpgradeTest(getTestCtx)
+}
+
+var _ = Describe("Multi-Hop Upgrade", Label("lifecycle", "multi-hop-upgrade"), func() {
+	var testCtx *internal.TestContext
+
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+	})
+
+	RegisterMultiHopUpgradeTests(func() *internal.TestContext { return testCtx })
+})


### PR DESCRIPTION
## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3487

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new multi-hop upgrade e2e test that upgrades the HostedCluster control plane through multiple release-image hops and updates the NodePool image, validating rollout progress and node health at each step.
  * Extended test coverage to support N-3 (optional) upgrade chains via `E2E_N3_RELEASE_IMAGE` (with N1/N2 and latest).

* **Chores**
  * Updated e2e v2 execution to generate, destroy, and dump additional cluster-spec variants using both N1 and N3 images, and expanded the test matrix to accept N1/N2/N3 inputs.
  * Azure now includes a dedicated `multi-hop-upgrade` test group in its v2 lifecycle runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->