### PR TITLE
CNTRLPLANE-2916: restore conditional deletion of openshift-ingress NetworkPolicy

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/hypershift/support/awsutil"
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/netutil"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/upsert"
@@ -43,15 +44,11 @@ const (
 func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, log logr.Logger, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, version semver.Version, controlPlaneOperatorAppliesManagementKASNetworkPolicyLabel bool) error {
 	controlPlaneNamespaceName := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 
-	// Reconcile openshift-ingress Network Policy
-	policy := networkpolicy.OpenshiftIngressNetworkPolicy(controlPlaneNamespaceName)
-	if _, err := createOrUpdate(ctx, r.Client, policy, func() error {
-		return reconcileOpenshiftIngressNetworkPolicy(policy)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile ingress network policy: %w", err)
+	if err := r.reconcileIngressNetworkPolicy(ctx, createOrUpdate, hcp, controlPlaneNamespaceName); err != nil {
+		return err
 	}
 
-	policy = networkpolicy.SameNamespaceNetworkPolicy(controlPlaneNamespaceName)
+	policy := networkpolicy.SameNamespaceNetworkPolicy(controlPlaneNamespaceName)
 	if _, err := createOrUpdate(ctx, r.Client, policy, func() error {
 		return reconcileSameNamespaceNetworkPolicy(policy)
 	}); err != nil {
@@ -101,6 +98,24 @@ func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, 
 	}
 
 	return r.reconcileServiceNetworkPolicies(ctx, createOrUpdate, hcluster, controlPlaneNamespaceName)
+}
+
+func (r *HostedClusterReconciler) reconcileIngressNetworkPolicy(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcp *hyperv1.HostedControlPlane, controlPlaneNamespaceName string) error {
+	// Only needed when routes are served by the management cluster's default ingress controller,
+	// i.e., when routes are NOT labeled for the HCP router.
+	policy := networkpolicy.OpenshiftIngressNetworkPolicy(controlPlaneNamespaceName)
+	if !netutil.LabelHCPRoutes(hcp) {
+		if _, err := createOrUpdate(ctx, r.Client, policy, func() error {
+			return reconcileOpenshiftIngressNetworkPolicy(policy)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile ingress network policy: %w", err)
+		}
+	} else {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, policy); err != nil {
+			return fmt.Errorf("failed to delete ingress network policy: %w", err)
+		}
+	}
+	return nil
 }
 
 func (r *HostedClusterReconciler) getManagementClusterNetwork(ctx context.Context) (*configv1.Network, error) {

--- a/hypershift-operator/controllers/hostedcluster/network_policies_test.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies_test.go
@@ -266,14 +266,12 @@ func TestGCPPrivateRouterNetworkPolicy_IngressOnly(t *testing.T) {
 }
 
 func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
-	// The openshift-ingress NetworkPolicy must always be created regardless of
-	// platform, endpoint access mode, or KAS publishing strategy.
-	// Removing it triggers an OVN-Kubernetes bug where port group references
-	// become stale during MC KAS rollouts. See OCPBUGS-87018.
 	tests := []struct {
-		name     string
-		hcluster *hyperv1.HostedCluster
-		hcp      *hyperv1.HostedControlPlane
+		name          string
+		hcluster      *hyperv1.HostedCluster
+		hcp           *hyperv1.HostedControlPlane
+		expectCreated bool
+		expectDeleted bool
 	}{
 		{
 			name: "When AWS public cluster uses KAS LoadBalancer it should create policy",
@@ -294,9 +292,10 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 					},
 				},
 			},
+			expectCreated: true,
 		},
 		{
-			name: "When AWS private cluster uses KAS LoadBalancer it should create policy",
+			name: "When AWS private cluster uses KAS LoadBalancer it should delete policy",
 			hcluster: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
 				Spec: hyperv1.HostedClusterSpec{
@@ -314,9 +313,31 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 					},
 				},
 			},
+			expectDeleted: true,
 		},
 		{
-			name: "When AWS public cluster uses KAS Route with hostname it should create policy",
+			name: "When AWS PublicAndPrivate cluster uses KAS LoadBalancer it should create policy",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform, AWS: &hyperv1.AWSPlatformSpec{EndpointAccess: hyperv1.PublicAndPrivate}},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
+					},
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform, AWS: &hyperv1.AWSPlatformSpec{EndpointAccess: hyperv1.PublicAndPrivate}},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
+					},
+				},
+			},
+			expectCreated: true,
+		},
+		{
+			name: "When AWS public cluster uses KAS Route with hostname it should delete policy",
 			hcluster: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
 				Spec: hyperv1.HostedClusterSpec{
@@ -340,9 +361,31 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 					},
 				},
 			},
+			expectDeleted: true,
 		},
 		{
-			name: "When GCP private cluster uses KAS LoadBalancer it should create policy",
+			name: "When GCP PublicAndPrivate cluster uses KAS LoadBalancer it should create policy",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.GCPPlatform, GCP: &hyperv1.GCPPlatformSpec{EndpointAccess: hyperv1.GCPEndpointAccessPublicAndPrivate}},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
+					},
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.GCPPlatform, GCP: &hyperv1.GCPPlatformSpec{EndpointAccess: hyperv1.GCPEndpointAccessPublicAndPrivate}},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
+					},
+				},
+			},
+			expectCreated: true,
+		},
+		{
+			name: "When GCP private cluster uses KAS LoadBalancer it should delete policy",
 			hcluster: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
 				Spec: hyperv1.HostedClusterSpec{
@@ -360,9 +403,52 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 					},
 				},
 			},
+			expectDeleted: true,
 		},
 		{
-			name: "When Agent cluster uses KAS Route with hostname it should create policy",
+			name: "When IBM Cloud cluster uses KAS Route it should create policy",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.IBMCloudPlatform},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route}},
+					},
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.IBMCloudPlatform},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route}},
+					},
+				},
+			},
+			expectCreated: true,
+		},
+		{
+			name: "When Agent cluster uses KAS LoadBalancer it should create policy",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.AgentPlatform},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
+					},
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.AgentPlatform},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
+					},
+				},
+			},
+			expectCreated: true,
+		},
+		{
+			name: "When Agent cluster uses KAS Route with hostname it should delete policy",
 			hcluster: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
 				Spec: hyperv1.HostedClusterSpec{
@@ -386,6 +472,28 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 					},
 				},
 			},
+			expectDeleted: true,
+		},
+		{
+			name: "When KubeVirt cluster uses KAS LoadBalancer it should create policy",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.KubevirtPlatform, Kubevirt: &hyperv1.KubevirtPlatformSpec{}},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
+					},
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.KubevirtPlatform, Kubevirt: &hyperv1.KubevirtPlatformSpec{}},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
+					},
+				},
+			},
+			expectCreated: true,
 		},
 	}
 
@@ -427,6 +535,15 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 			}
 
 			objs := []client.Object{kubernetesEndpoint, managementClusterNetwork}
+
+			// For deletion tests, pre-create the openshift-ingress NetworkPolicy
+			if tc.expectDeleted {
+				existingPolicy := networkpolicy.OpenshiftIngressNetworkPolicy(controlPlaneNamespaceName)
+				existingPolicy.Spec.PodSelector = metav1.LabelSelector{}
+				existingPolicy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
+				objs = append(objs, existingPolicy)
+			}
+
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 
 			reconciler := &HostedClusterReconciler{
@@ -454,8 +571,20 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 				t.Fatalf("reconcileNetworkPolicies failed: %v", err)
 			}
 
-			if _, policyCreated := createdNetworkPolicies["openshift-ingress"]; !policyCreated {
+			_, policyCreated := createdNetworkPolicies["openshift-ingress"]
+			if tc.expectCreated && !policyCreated {
 				t.Error("Expected openshift-ingress NetworkPolicy to be created, but it was not")
+			}
+			if !tc.expectCreated && policyCreated {
+				t.Error("Expected openshift-ingress NetworkPolicy to NOT be created, but it was")
+			}
+
+			if tc.expectDeleted {
+				policyObj := networkpolicy.OpenshiftIngressNetworkPolicy(controlPlaneNamespaceName)
+				err := fakeClient.Get(ctx, client.ObjectKeyFromObject(policyObj), policyObj)
+				if !apierrors.IsNotFound(err) {
+					t.Error("Expected openshift-ingress NetworkPolicy to be deleted from the cluster, but it still exists")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Reverts the revert PR #8662 to restore the original PR #7872 behavior
- Conditionally creates or deletes the `openshift-ingress` NetworkPolicy based on whether routes are labeled for the HCP router (`LabelHCPRoutes`)
- The OVN-Kubernetes port group race that prompted the revert is being properly addressed via #8689 (`--hcp-egress-block-cidrs` flag), making the blanket always-create workaround unnecessary

## Test plan

- [ ] Unit tests restored with full coverage of create/delete scenarios across AWS, GCP, IBM Cloud, Agent, and KubeVirt platforms
- [ ] Verify in conjunction with #8689 that MC KAS rollouts do not cause HC API blackouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of the ingress network policy. The “openshift-ingress” policy is now conditionally created or removed based on your route labeling configuration, better aligning network isolation with your ingress controller setup.

* **Tests**
  * Expanded coverage for ingress network policy behavior across more platform and publishing scenarios, including validation of both creation and deletion outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->