### PR TITLE
OCPBUGS-89352: build(operator): drop hypershift-no-cgo from operator container images

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -5,15 +5,11 @@ WORKDIR /hypershift
 COPY --chown=default . .
 
 RUN make hypershift \
-  && make hypershift-no-cgo \
   && make hypershift-operator \
-  && make product-cli \
   && make karpenter-operator
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773204619
 COPY --from=builder /hypershift/bin/hypershift \
-  /hypershift/bin/hypershift-no-cgo \
-  /hypershift/bin/hcp \
   /hypershift/bin/hypershift-operator \
   /hypershift/bin/karpenter-operator \
   /usr/bin/


### PR DESCRIPTION
This is a cherry-pick of [PR #8601](https://github.com/openshift/hypershift/pull/8601) onto `release-4.22`.

## What this PR does / why we need it

Remove the `hypershift-no-cgo` statically compiled binary from `Containerfile.operator`. The non-FIPS binary causes Enterprise Contract FIPS violations in Konflux builds for MCE.

Fixes: OCPBUGS-89352
Upstream: https://github.com/openshift/hypershift/pull/8601

## Checklist
- [ ] Subject and description added to both commit and PR
- [ ] Relevant issues have been referenced

Made with [Cursor](https://cursor.com)