### PR TITLE
OCPBUGS-89355: build(operator): drop hypershift-no-cgo from operator container images

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -5,18 +5,14 @@ WORKDIR /hypershift
 COPY --chown=default . .
 
 RUN make hypershift \
-  && make hypershift-no-cgo \
   && make hypershift-operator \
-  && make product-cli \
   && make karpenter-operator
 
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 COPY --from=builder /hypershift/bin/hypershift \
-                    /hypershift/bin/hypershift-no-cgo \
-                    /hypershift/bin/hcp \
-                    /hypershift/bin/hypershift-operator \
-                    /hypershift/bin/karpenter-operator \
-     /usr/bin/
+  /hypershift/bin/hypershift-operator \
+  /hypershift/bin/karpenter-operator \
+  /usr/bin/
 
 ENTRYPOINT ["/usr/bin/hypershift"]
 


### PR DESCRIPTION
This is a cherry-pick of [PR #8601](https://github.com/openshift/hypershift/pull/8601) onto `release-4.19`.

## What this PR does / why we need it

Remove the `hypershift-no-cgo` statically compiled binary from `Containerfile.operator`. The non-FIPS binary causes Enterprise Contract FIPS violations in Konflux builds for MCE.

Fixes: OCPBUGS-89355
Upstream: https://github.com/openshift/hypershift/pull/8601

Made with [Cursor](https://cursor.com)