### PR TITLE
OCPBUGS-89356: build(operator): drop hypershift-no-cgo from operator container images

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -8,8 +8,6 @@ RUN make build
 
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 COPY --from=builder /hypershift/bin/hypershift \
-                    /hypershift/bin/hypershift-no-cgo \
-                    /hypershift/bin/hcp \
                     /hypershift/bin/hypershift-operator \
                     /hypershift/bin/control-plane-operator \
                     /hypershift/bin/control-plane-pki-operator \


### PR DESCRIPTION
This is a cherry-pick of [PR #8601](https://github.com/openshift/hypershift/pull/8601) onto `release-4.18`.

## What this PR does / why we need it

Remove the `hypershift-no-cgo` and `hcp` binaries from `Containerfile.operator`. The non-FIPS binary causes Enterprise Contract FIPS violations in Konflux builds for MCE.

Fixes: OCPBUGS-89356
Upstream: https://github.com/openshift/hypershift/pull/8601

Made with [Cursor](https://cursor.com)