### PR TITLE
CNTRLPLANE-3624: add tls security profile configuration for the control-plane-pki-operator

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/AROSwift/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/AROSwift/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: tcp4
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: control-plane-pki-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/AROSwift/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/AROSwift/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_controlplanecomponent.yaml
@@ -19,6 +19,9 @@ status:
     status: "False"
     type: RolloutComplete
   resources:
+  - group: ""
+    kind: ConfigMap
+    name: control-plane-pki-operator-config
   - group: rbac.authorization.k8s.io
     kind: Role
     name: control-plane-pki-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/AROSwift/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/AROSwift/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: 1a4fc37c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: control-plane-pki-operator
@@ -67,6 +67,8 @@ spec:
         - operator
         - --namespace
         - $(HOSTED_CONTROL_PLANE_NAMESPACE)
+        - --config=/var/run/configmaps/control-plane-pki-operator-config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/control-plane-pki-operator-config/config.yaml
         command:
         - /usr/bin/control-plane-pki-operator
         env:
@@ -102,6 +104,9 @@ spec:
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: openshift-config-managed-trusted-ca-bundle
           readOnly: true
+        - mountPath: /var/run/configmaps/control-plane-pki-operator-config
+          name: control-plane-pki-operator-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -125,6 +130,10 @@ spec:
           name: openshift-config-managed-trusted-ca-bundle
           optional: true
         name: openshift-config-managed-trusted-ca-bundle
+      - configMap:
+          defaultMode: 420
+          name: control-plane-pki-operator-config
+        name: control-plane-pki-operator-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/GCP/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/GCP/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: tcp4
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: control-plane-pki-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/GCP/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/GCP/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_controlplanecomponent.yaml
@@ -19,6 +19,9 @@ status:
     status: "False"
     type: RolloutComplete
   resources:
+  - group: ""
+    kind: ConfigMap
+    name: control-plane-pki-operator-config
   - group: rbac.authorization.k8s.io
     kind: Role
     name: control-plane-pki-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/GCP/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/GCP/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: 1a4fc37c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: control-plane-pki-operator
@@ -67,6 +67,8 @@ spec:
         - operator
         - --namespace
         - $(HOSTED_CONTROL_PLANE_NAMESPACE)
+        - --config=/var/run/configmaps/control-plane-pki-operator-config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/control-plane-pki-operator-config/config.yaml
         command:
         - /usr/bin/control-plane-pki-operator
         env:
@@ -107,6 +109,9 @@ spec:
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: openshift-config-managed-trusted-ca-bundle
           readOnly: true
+        - mountPath: /var/run/configmaps/control-plane-pki-operator-config
+          name: control-plane-pki-operator-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -130,6 +135,10 @@ spec:
           name: openshift-config-managed-trusted-ca-bundle
           optional: true
         name: openshift-config-managed-trusted-ca-bundle
+      - configMap:
+          defaultMode: 420
+          name: control-plane-pki-operator-config
+        name: control-plane-pki-operator-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: tcp4
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: control-plane-pki-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_controlplanecomponent.yaml
@@ -19,6 +19,9 @@ status:
     status: "False"
     type: RolloutComplete
   resources:
+  - group: ""
+    kind: ConfigMap
+    name: control-plane-pki-operator-config
   - group: rbac.authorization.k8s.io
     kind: Role
     name: control-plane-pki-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: 1a4fc37c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: control-plane-pki-operator
@@ -67,6 +67,8 @@ spec:
         - operator
         - --namespace
         - $(HOSTED_CONTROL_PLANE_NAMESPACE)
+        - --config=/var/run/configmaps/control-plane-pki-operator-config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/control-plane-pki-operator-config/config.yaml
         command:
         - /usr/bin/control-plane-pki-operator
         env:
@@ -102,6 +104,9 @@ spec:
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: openshift-config-managed-trusted-ca-bundle
           readOnly: true
+        - mountPath: /var/run/configmaps/control-plane-pki-operator-config
+          name: control-plane-pki-operator-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -125,6 +130,10 @@ spec:
           name: openshift-config-managed-trusted-ca-bundle
           optional: true
         name: openshift-config-managed-trusted-ca-bundle
+      - configMap:
+          defaultMode: 420
+          name: control-plane-pki-operator-config
+        name: control-plane-pki-operator-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: tcp4
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: control-plane-pki-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_controlplanecomponent.yaml
@@ -19,6 +19,9 @@ status:
     status: "False"
     type: RolloutComplete
   resources:
+  - group: ""
+    kind: ConfigMap
+    name: control-plane-pki-operator-config
   - group: rbac.authorization.k8s.io
     kind: Role
     name: control-plane-pki-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: 1a4fc37c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: control-plane-pki-operator
@@ -67,6 +67,8 @@ spec:
         - operator
         - --namespace
         - $(HOSTED_CONTROL_PLANE_NAMESPACE)
+        - --config=/var/run/configmaps/control-plane-pki-operator-config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/control-plane-pki-operator-config/config.yaml
         command:
         - /usr/bin/control-plane-pki-operator
         env:
@@ -102,6 +104,9 @@ spec:
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: openshift-config-managed-trusted-ca-bundle
           readOnly: true
+        - mountPath: /var/run/configmaps/control-plane-pki-operator-config
+          name: control-plane-pki-operator-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -125,6 +130,10 @@ spec:
           name: openshift-config-managed-trusted-ca-bundle
           optional: true
         name: openshift-config-managed-trusted-ca-bundle
+      - configMap:
+          defaultMode: 420
+          name: control-plane-pki-operator-config
+        name: control-plane-pki-operator-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: tcp4
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: control-plane-pki-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_controlplanecomponent.yaml
@@ -19,6 +19,9 @@ status:
     status: "False"
     type: RolloutComplete
   resources:
+  - group: ""
+    kind: ConfigMap
+    name: control-plane-pki-operator-config
   - group: rbac.authorization.k8s.io
     kind: Role
     name: control-plane-pki-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: 1a4fc37c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: control-plane-pki-operator
@@ -67,6 +67,8 @@ spec:
         - operator
         - --namespace
         - $(HOSTED_CONTROL_PLANE_NAMESPACE)
+        - --config=/var/run/configmaps/control-plane-pki-operator-config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/control-plane-pki-operator-config/config.yaml
         command:
         - /usr/bin/control-plane-pki-operator
         env:
@@ -102,6 +104,9 @@ spec:
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: openshift-config-managed-trusted-ca-bundle
           readOnly: true
+        - mountPath: /var/run/configmaps/control-plane-pki-operator-config
+          name: control-plane-pki-operator-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -125,6 +130,10 @@ spec:
           name: openshift-config-managed-trusted-ca-bundle
           optional: true
         name: openshift-config-managed-trusted-ca-bundle
+      - configMap:
+          defaultMode: 420
+          name: control-plane-pki-operator-config
+        name: control-plane-pki-operator-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/control-plane-pki-operator/controller-config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/control-plane-pki-operator/controller-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: control-plane-pki-operator-config
+data:
+  config.yaml: |-
+    apiVersion: config.openshift.io/v1
+    kind: GenericControllerConfig
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: tcp4

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/control-plane-pki-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/control-plane-pki-operator/deployment.yaml
@@ -23,6 +23,8 @@ spec:
         - operator
         - --namespace
         - $(HOSTED_CONTROL_PLANE_NAMESPACE)
+        - --config=/var/run/configmaps/control-plane-pki-operator-config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/control-plane-pki-operator-config/config.yaml
         command:
         - /usr/bin/control-plane-pki-operator
         env:
@@ -54,6 +56,9 @@ spec:
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: openshift-config-managed-trusted-ca-bundle
           readOnly: true
+        - mountPath: /var/run/configmaps/control-plane-pki-operator-config
+          name: control-plane-pki-operator-config
+          readOnly: true
       serviceAccount: control-plane-pki-operator
       serviceAccountName: control-plane-pki-operator
       volumes:
@@ -65,3 +70,6 @@ spec:
           name: openshift-config-managed-trusted-ca-bundle
           optional: true
         name: openshift-config-managed-trusted-ca-bundle
+      - configMap:
+          name: control-plane-pki-operator-config
+        name: control-plane-pki-operator-config

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/pkioperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/pkioperator/component.go
@@ -38,6 +38,10 @@ func NewComponent(certRotationScale time.Duration) component.ControlPlaneCompone
 	}
 	return component.NewDeploymentComponent(ComponentName, operator).
 		WithAdaptFunction(operator.adaptDeployment).
+		WithManifestAdapter(
+			"controller-config.yaml",
+			component.WithAdaptFunction(adaptControllerConfig),
+		).
 		WithPredicate(predicate).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/pkioperator/configmap.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/pkioperator/configmap.go
@@ -1,0 +1,57 @@
+package pkioperator
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/openshift/hypershift/support/config"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/yaml"
+)
+
+// adaptControllerConfig uses the HostedControlPlane to derive the PKI
+// operator controller configuration. We mostly worry about making sure
+// that the operator is using the correct TLS profile settings.
+func adaptControllerConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap) error {
+	profile := cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile()
+	controllerConfig := configv1.GenericControllerConfig{
+		ServingInfo: configv1.HTTPServingInfo{
+			ServingInfo: configv1.ServingInfo{
+				BindAddress:   "0.0.0.0:8443",
+				BindNetwork:   "tcp4",
+				CipherSuites:  config.CipherSuites(profile),
+				MinTLSVersion: config.MinTLSVersion(profile),
+			},
+		},
+	}
+
+	asJSON, err := json.Marshal(controllerConfig)
+	if err != nil {
+		return fmt.Errorf("failed to json marshal config: %w", err)
+	}
+
+	asMap := map[string]any{}
+	if err := json.Unmarshal(asJSON, &asMap); err != nil {
+		return fmt.Errorf("failed to json unmarshal config: %w", err)
+	}
+
+	asMap["apiVersion"] = configv1.GroupVersion.String()
+	asMap["kind"] = "GenericControllerConfig"
+
+	data, err := yaml.Marshal(asMap)
+	if err != nil {
+		return fmt.Errorf("failed to yaml marshal config: %w", err)
+	}
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+
+	cm.Data["config.yaml"] = string(data)
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/pkioperator/configmap_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/pkioperator/configmap_test.go
@@ -1,0 +1,145 @@
+package pkioperator
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/yaml"
+)
+
+func Test_adaptControllerConfig(t *testing.T) {
+	intermediate := &configv1.TLSSecurityProfile{
+		Type:         configv1.TLSProfileIntermediateType,
+		Intermediate: &configv1.IntermediateTLSProfile{},
+	}
+
+	modern := &configv1.TLSSecurityProfile{
+		Type:   configv1.TLSProfileModernType,
+		Modern: &configv1.ModernTLSProfile{},
+	}
+
+	old := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileOldType,
+		Old:  &configv1.OldTLSProfile{},
+	}
+
+	custom := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-RSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES256-GCM-SHA384",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name              string
+		tlsProfile        *configv1.TLSSecurityProfile
+		existingData      map[string]string
+		expectedCiphers   []string
+		expectedMinTLS    configv1.TLSProtocolVersion
+		shouldPreserveKey string
+	}{
+		{
+			name:            "When TLS profile is Intermediate it should use Intermediate ciphers and TLS 1.2",
+			tlsProfile:      intermediate,
+			expectedCiphers: config.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers),
+			expectedMinTLS:  configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion,
+		},
+		{
+			name:           "When TLS profile is Modern it should use TLS 1.3 with empty cipher list",
+			tlsProfile:     modern,
+			expectedMinTLS: configv1.TLSProfiles[configv1.TLSProfileModernType].MinTLSVersion,
+		},
+		{
+			name:            "When TLS profile is Old it should use Old ciphers and TLS 1.0",
+			tlsProfile:      old,
+			expectedCiphers: config.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileOldType].Ciphers),
+			expectedMinTLS:  configv1.TLSProfiles[configv1.TLSProfileOldType].MinTLSVersion,
+		},
+		{
+			name:            "When TLS profile is Custom it should use custom ciphers and TLS version",
+			tlsProfile:      custom,
+			expectedCiphers: config.OpenSSLToIANACipherSuites(custom.Custom.Ciphers),
+			expectedMinTLS:  custom.Custom.MinTLSVersion,
+		},
+		{
+			name:              "When ConfigMap has existing data it should preserve other keys",
+			tlsProfile:        intermediate,
+			existingData:      map[string]string{"other-key": "other-value"},
+			expectedCiphers:   config.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers),
+			expectedMinTLS:    configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion,
+			shouldPreserveKey: "other-key",
+		},
+		{
+			name:            "When TLS profile is nil it should use Intermediate profile",
+			expectedCiphers: config.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers),
+			expectedMinTLS:  configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: tt.tlsProfile,
+						},
+					},
+				},
+			}
+
+			cm := &corev1.ConfigMap{Data: tt.existingData}
+			cpContext := component.WorkloadContext{HCP: hcp}
+
+			err := adaptControllerConfig(cpContext, cm)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(cm.Data).To(HaveKey("config.yaml"))
+			configYAML := cm.Data["config.yaml"]
+
+			var controllerConfig map[string]any
+			err = yaml.Unmarshal([]byte(configYAML), &controllerConfig)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(controllerConfig).To(HaveKeyWithValue("apiVersion", configv1.GroupVersion.String()))
+			g.Expect(controllerConfig).To(HaveKeyWithValue("kind", "GenericControllerConfig"))
+
+			servingInfo := controllerConfig["servingInfo"].(map[string]any)
+			g.Expect(servingInfo).To(HaveKeyWithValue("bindAddress", "0.0.0.0:8443"))
+			g.Expect(servingInfo).To(HaveKeyWithValue("minTLSVersion", string(tt.expectedMinTLS)))
+
+			if tt.shouldPreserveKey != "" {
+				g.Expect(cm.Data).To(HaveKeyWithValue(tt.shouldPreserveKey, tt.existingData[tt.shouldPreserveKey]))
+			}
+
+			if tt.expectedCiphers == nil {
+				g.Expect(servingInfo).ToNot(HaveKey("cipherSuites"))
+				return
+			}
+
+			cipherSuites := servingInfo["cipherSuites"].([]any)
+			cipherStrings := make([]string, len(cipherSuites))
+			for i, cipher := range cipherSuites {
+				cipherStrings[i] = cipher.(string)
+			}
+			g.Expect(cipherStrings).To(Equal(tt.expectedCiphers))
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Configure the `control-plane-pki-operator` to use the TLS security profile settings from the HostedCluster resource. This ensures the operator's metric endpoint uses ciphers and minimum TLS version that match the cluster's security requirements.

Implementation:

> [!NOTE]
> This follows what has been done for the Image Registry Operator, almost verbatim.

- Add ConfigMap adapter to generate `configv1.GenericControllerConfig` with TLS settings derived from `hcp.spec.configuration.apiServer.tlsSecurityProfile`.
- Mount the config and use it via `--config` flag on the operator deployment.
- Reuse existing `config.CipherSuites()` and `config.minTLSVersion()` helper functions for consistency with other control plane components.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PKI operator now generates TLS serving settings (bind address, minimum TLS version, and applicable cipher suites) from the HostedControlPlane TLS security profile via a ConfigMap-backed configuration.
* **Chores**
  * Updated the PKI operator Deployment to load configuration from a mounted, read-only ConfigMap file using explicit startup arguments.
* **Tests**
  * Added unit tests covering multiple TLS security profile scenarios, defaulting behavior, and ensuring unrelated ConfigMap data remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->