### PR TITLE
CNTRLPLANE-3640: Fix address-review-comments GHA credential file deleted during run

### DIFF
--- a/.github/workflows/address-review-comments.yaml
+++ b/.github/workflows/address-review-comments.yaml
@@ -59,11 +59,19 @@ jobs:
           fetch-depth: 0
 
       - name: Authenticate to GCP via WIF
+        id: gcp-auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: hosted-control-planes
           service_account: claude-gha@hosted-control-planes.iam.gserviceaccount.com
           workload_identity_provider: projects/21066242673/locations/global/workloadIdentityPools/itpc-identity-pool/providers/github-com
+
+      - name: Move GCP credentials out of workspace
+        run: |
+          install -m 0600 "${{ steps.gcp-auth.outputs.credentials_file_path }}" "$RUNNER_TEMP/gcp-credentials.json"
+          echo "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=$RUNNER_TEMP/gcp-credentials.json" >> "$GITHUB_ENV"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/gcp-credentials.json" >> "$GITHUB_ENV"
+          echo "GOOGLE_GHA_CREDS_PATH=$RUNNER_TEMP/gcp-credentials.json" >> "$GITHUB_ENV"
 
       - name: Install Claude Code
         run: |


### PR DESCRIPTION
## What this PR does / why we need it:

The `address-review-comments` GitHub Actions workflow frequently fails with:
```
API Error: The file at /home/runner/_work/hypershift/hypershift/gha-creds-*.json does not exist, or it is not a file.
```

The `google-github-actions/auth` action writes the GCP WIF credentials file into the workspace root. During the ~30 minute Claude Code run, git operations (checkout, clean, worktree creation) delete this untracked file. When Claude Code later tries to authenticate to Vertex AI, `GOOGLE_APPLICATION_CREDENTIALS` still points to the deleted path.

This PR copies the credentials file to `$RUNNER_TEMP` after auth completes and overrides the environment variables to point there. `$RUNNER_TEMP` is outside the workspace and safe from git operations.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-3640

## Special notes for your reviewer:

Example failed run: https://github.com/openshift/hypershift/actions/runs/27537699767/job/81391254040

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.