### PR TITLE
CNTRLPLANE-3641: add restructure-commits and rebase GHA workflows

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -1,0 +1,95 @@
+name: Rebase PR
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  rebase:
+    concurrency:
+      group: rebase-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/rebase') &&
+      (github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    runs-on: arc-runner-set
+    timeout-minutes: 45
+    env:
+      HOME: /tmp
+    steps:
+      - name: Link to run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "🤖 Rebasing PR onto main: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
+      - name: Get PR ref
+        id: pr
+        run: |
+          curl -fsSL -H "Authorization: token ${{ github.token }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}" > /tmp/pr.json
+          echo "branch=$(jq -r '.head.ref' /tmp/pr.json)" >> "$GITHUB_OUTPUT"
+          echo "repo=$(jq -r '.head.repo.full_name' /tmp/pr.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Select token for PR repo
+        id: token
+        env:
+          PR_REPO: ${{ steps.pr.outputs.repo }}
+        run: |
+          if [[ "$PR_REPO" == "hypershift-community/hypershift" ]]; then
+            echo "use_fork_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "use_fork_token=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.pr.outputs.branch }}
+          repository: ${{ steps.pr.outputs.repo }}
+          token: ${{ steps.token.outputs.use_fork_token == 'true' && secrets.COMMUNITY_FORK_TOKEN || github.token }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          project_id: hosted-control-planes
+          service_account: claude-gha@hosted-control-planes.iam.gserviceaccount.com
+          workload_identity_provider: projects/21066242673/locations/global/workloadIdentityPools/itpc-identity-pool/providers/github-com
+
+      - name: Install Claude Code
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install tool dependencies
+        run: |
+          go install golang.org/x/tools/gopls@latest
+          echo "$HOME/go/bin" >> $GITHUB_PATH
+          pip install --break-system-packages pre-commit
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Rebase onto main
+        env:
+          CLAUDE_CODE_USE_VERTEX: "1"
+          CLOUD_ML_REGION: global
+          ANTHROPIC_VERTEX_PROJECT_ID: hosted-control-planes
+          GH_TOKEN: ${{ steps.token.outputs.use_fork_token == 'true' && secrets.COMMUNITY_FORK_TOKEN || github.token }}
+        run: |
+          claude plugin marketplace add openshift-eng/ai-helpers
+          claude plugin install utils@ai-helpers
+          claude plugin install golang@ai-helpers
+          claude plugin marketplace add enxebre/ai-scripts
+          claude plugin install git@enxebre
+          claude --version
+          claude -p "Rebase this branch onto the latest main and force push. Steps: 1) git fetch origin main 2) git rebase origin/main 3) If there are conflicts, resolve them while preserving the intent of the PR changes 4) git push --force-with-lease. Report what was done." --model claude-opus-4-6 --max-turns 50 --allowedTools "Bash Read Write Edit Grep Glob"

--- a/.github/workflows/restructure-commits.yaml
+++ b/.github/workflows/restructure-commits.yaml
@@ -1,0 +1,95 @@
+name: Restructure Commits
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  restructure-commits:
+    concurrency:
+      group: restructure-commits-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/restructure-commits') &&
+      (github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    runs-on: arc-runner-set
+    timeout-minutes: 45
+    env:
+      HOME: /tmp
+    steps:
+      - name: Link to run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "🤖 Restructuring commits: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
+      - name: Get PR ref
+        id: pr
+        run: |
+          curl -fsSL -H "Authorization: token ${{ github.token }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}" > /tmp/pr.json
+          echo "branch=$(jq -r '.head.ref' /tmp/pr.json)" >> "$GITHUB_OUTPUT"
+          echo "repo=$(jq -r '.head.repo.full_name' /tmp/pr.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Select token for PR repo
+        id: token
+        env:
+          PR_REPO: ${{ steps.pr.outputs.repo }}
+        run: |
+          if [[ "$PR_REPO" == "hypershift-community/hypershift" ]]; then
+            echo "use_fork_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "use_fork_token=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.pr.outputs.branch }}
+          repository: ${{ steps.pr.outputs.repo }}
+          token: ${{ steps.token.outputs.use_fork_token == 'true' && secrets.COMMUNITY_FORK_TOKEN || github.token }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          project_id: hosted-control-planes
+          service_account: claude-gha@hosted-control-planes.iam.gserviceaccount.com
+          workload_identity_provider: projects/21066242673/locations/global/workloadIdentityPools/itpc-identity-pool/providers/github-com
+
+      - name: Install Claude Code
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install tool dependencies
+        run: |
+          go install golang.org/x/tools/gopls@latest
+          echo "$HOME/go/bin" >> $GITHUB_PATH
+          pip install --break-system-packages pre-commit
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Restructure commits
+        env:
+          CLAUDE_CODE_USE_VERTEX: "1"
+          CLOUD_ML_REGION: global
+          ANTHROPIC_VERTEX_PROJECT_ID: hosted-control-planes
+          GH_TOKEN: ${{ steps.token.outputs.use_fork_token == 'true' && secrets.COMMUNITY_FORK_TOKEN || github.token }}
+        run: |
+          claude plugin marketplace add openshift-eng/ai-helpers
+          claude plugin install utils@ai-helpers
+          claude plugin install golang@ai-helpers
+          claude plugin marketplace add enxebre/ai-scripts
+          claude plugin install git@enxebre
+          claude --version
+          claude -p "/restructure-commits" --model claude-opus-4-6 --max-turns 200 --allowedTools "Bash Read Write Edit Grep Glob WebFetch"


### PR DESCRIPTION
## What this PR does / why we need it:

Adds two new GitHub Actions workflows that can be triggered by PR comments:

- **`/restructure-commits`** — invokes the repo's `.claude/commands/restructure-commits.md` command via Claude to reorganize branch commits into logical, component-based commits matching HyperShift's architecture.
- **`/rebase`** — uses Claude to rebase the PR branch onto the latest main, resolve any merge conflicts, and force push.

Both workflows follow the same pattern as the existing `address-review-comments` workflow: concurrency grouping per PR number, member/owner/collaborator authorization, community fork token handling, GCP WIF authentication for Vertex AI, and the same tool dependency setup.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

Both workflows are modeled directly after `.github/workflows/address-review-comments.yaml` with minimal changes to the trigger command and Claude prompt.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PR rebase automation that runs when a qualifying “/rebase” command comment is posted.
  * Added commit restructuring automation that runs when a qualifying “/restructure-commits” command comment is posted.
  * Both automations report progress by commenting a link to the workflow run and execute the requested changes on the PR branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->