### PR TITLE
CNTRLPLANE-3641: fix restructure-commits GHA to force push without confirmation

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -92,4 +92,4 @@ jobs:
           claude plugin marketplace add enxebre/ai-scripts
           claude plugin install git@enxebre
           claude --version
-          claude -p "Rebase this branch onto the latest main and force push. Steps: 1) git fetch origin main 2) git rebase origin/main 3) If there are conflicts, resolve them while preserving the intent of the PR changes 4) git push --force-with-lease. Report what was done." --model claude-opus-4-6 --max-turns 50 --allowedTools "Bash Read Write Edit Grep Glob"
+          claude -p "Rebase this branch onto the latest main and force push. You are running in CI. Force push with --force-with-lease when done without asking for confirmation. Steps: 1) git fetch origin main 2) git rebase origin/main 3) If there are conflicts, resolve them while preserving the intent of the PR changes 4) git push --force-with-lease. Report what was done." --model claude-opus-4-6 --max-turns 50 --allowedTools "Bash Read Write Edit Grep Glob"

--- a/.github/workflows/restructure-commits.yaml
+++ b/.github/workflows/restructure-commits.yaml
@@ -92,4 +92,4 @@ jobs:
           claude plugin marketplace add enxebre/ai-scripts
           claude plugin install git@enxebre
           claude --version
-          claude -p "/restructure-commits" --model claude-opus-4-6 --max-turns 200 --allowedTools "Bash Read Write Edit Grep Glob WebFetch"
+          claude -p "/restructure-commits -- You are running in CI. Force push with --force-with-lease when done without asking for confirmation." --model claude-opus-4-6 --max-turns 200 --allowedTools "Bash Read Write Edit Grep Glob WebFetch"


### PR DESCRIPTION
## What this PR does / why we need it:

Updates the `restructure-commits` GHA workflow to instruct Claude to force push without asking for confirmation. In CI there is no interactive user to respond, so Claude was stopping after restructuring commits with "Shall I run `git push --force-with-lease`?" and the job ended without pushing.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3641](https://redhat.atlassian.net/browse/CNTRLPLANE-3641)

## Special notes for your reviewer:

The original PR #8770 merged before this fix was included. This is a one-line change to the Claude prompt adding CI-specific instructions.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Chores**
  - Updated CI workflow prompts for “Restructure commits” and “Rebase onto main.”
  - CI now force-pushes using `--force-with-lease` automatically after commit restructuring/rebasing, without confirmation prompts.

This release contains no user-facing changes; updates are limited to internal development workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->