### PR TITLE
ci: stream Claude output in GHA workflow logs

### DIFF
--- a/.github/workflows/reusable-claude-on-pr.yaml
+++ b/.github/workflows/reusable-claude-on-pr.yaml
@@ -124,4 +124,4 @@ jobs:
           claude plugin marketplace add enxebre/ai-scripts
           claude plugin install git@enxebre
           claude --version
-          claude -p "$CLAUDE_PROMPT" --model claude-opus-4-6 --max-turns "$MAX_TURNS" --allowedTools "$ALLOWED_TOOLS"
+          claude -p "$CLAUDE_PROMPT" --model claude-opus-4-6 --max-turns "$MAX_TURNS" --allowedTools "$ALLOWED_TOOLS" --output-format stream-json


### PR DESCRIPTION
## What this PR does / why we need it:

Adds `--output-format stream-json` to the Claude Code invocation in the reusable GHA workflow. Without this flag, Claude produces no stdout output until it finishes — if the job times out or gets stuck, the logs are empty and there's no way to diagnose what happened.

With `stream-json`, each tool call and message is written to stdout in real time, so the GHA logs show exactly what Claude was doing.

## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

Single-line change in `reusable-claude-on-pr.yaml`.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to improve automated processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->