### PR TITLE
OCPBUGS-90521: fix(nodepool): don't explicitly set the MinReadySeconds default

### DIFF
--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -419,11 +419,6 @@ func (c *CAPI) reconcileMachineDeployment(ctx context.Context, log logr.Logger,
 	}
 	machineDeployment.Labels[capiv1.ClusterNameLabel] = capiClusterName
 
-	// Set defaults. These are normally set by the CAPI machinedeployment webhook.
-	// However, since we don't run the webhook, CAPI updates the machinedeployment
-	// after it has been created with defaults.
-	machineDeployment.Spec.MinReadySeconds = ptr.To[int32](0)
-
 	machineDeployment.Spec.ClusterName = capiClusterName
 	if machineDeployment.Spec.Selector.MatchLabels == nil {
 		machineDeployment.Spec.Selector.MatchLabels = map[string]string{}
@@ -880,7 +875,6 @@ func (c *CAPI) reconcileMachineSet(ctx context.Context,
 	machineSet.Labels[capiv1.ClusterNameLabel] = capiClusterName
 
 	resourcesName := generateName(capiClusterName, nodePool.Spec.ClusterName, nodePool.GetName())
-	machineSet.Spec.MinReadySeconds = int32(0)
 
 	gvk, err := apiutil.GVKForObject(machineTemplateCR, api.Scheme)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Remove unconditional `MinReadySeconds` defaulting from MachineDeployment and MachineSet reconciliation, matching what PR #8594 (CAPI 1.11 upgrade) already did on `main`.

## Problem

The `e2e-aws-upgrade-hypershift-operator` test on `release-4.22` has been **100% broken** for all PRs since PR #8594 merged to `main` on June 3.

The upgrade test installs the pre-upgrade operator from `hypershift/hypershift-operator:latest` (built from `main`), which after #8594 no longer sets `MinReadySeconds` on MachineDeployments. It then upgrades to the `release-4.22` operator, which unconditionally sets `MinReadySeconds = *int32(0)`. This causes a spec change (`nil` → `*int32(0)`) on every MachineDeployment, bumping `.metadata.generation` from 1 to 2, and failing the upgrade invariant check:

```
Pre-upgrade and post-upgrade MachineDeployment generations should match
Expected <int64>: 2 to equal <int64>: 1
```

## Fix

Remove the explicit `MinReadySeconds` defaulting from both `reconcileMachineDeployment()` and `reconcileMachineSet()` in `capi.go`. The CAPI controller applies its own defaults, making the explicit setting unnecessary — as recognized by the removal in #8594 on `main`.

## Test plan

- [ ] `e2e-aws-upgrade-hypershift-operator` should pass on `release-4.22`
- [ ] Unit tests pass (`go test ./hypershift-operator/controllers/nodepool/...`)

## References

- Root cause PR (CAPI 1.11 on main): https://github.com/openshift/hypershift/pull/8594
- Example failing run: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/8625/pull-ci-openshift-hypershift-release-4.22-e2e-aws-upgrade-hypershift-operator/2063882654004023296

🤖 Generated with [Claude Code](https://claude.com/claude-code)