### PR TITLE
OCPBUGS-86669: fix(cli): make deleteCLISecrets non-fatal during cluster destroy

### DIFF
--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -116,12 +116,17 @@ func GetCluster(ctx context.Context, o *DestroyOptions) (*hyperv1.HostedCluster,
 }
 
 func DestroyCluster(ctx context.Context, hostedCluster *hyperv1.HostedCluster, o *DestroyOptions, destroyPlatformSpecifics DestroyPlatformSpecifics) error {
-	hostedClusterExists := hostedCluster != nil
-	shouldDestroyPlatformSpecifics := destroyPlatformSpecifics != nil
 	c, err := util.GetClientWithKubeconfig(o.Kubeconfig)
 	if err != nil {
 		return err
 	}
+	return destroyCluster(ctx, c, hostedCluster, o, destroyPlatformSpecifics)
+}
+
+func destroyCluster(ctx context.Context, c client.Client, hostedCluster *hyperv1.HostedCluster, o *DestroyOptions, destroyPlatformSpecifics DestroyPlatformSpecifics) error {
+	var err error
+	hostedClusterExists := hostedCluster != nil
+	shouldDestroyPlatformSpecifics := destroyPlatformSpecifics != nil
 
 	// If the hosted cluster exists, add a finalizer, delete it, and wait for
 	// the cluster to be cleaned up before destroying its infrastructure.
@@ -182,9 +187,12 @@ func DestroyCluster(ctx context.Context, hostedCluster *hyperv1.HostedCluster, o
 		return err
 	}
 
-	// clean up CLI generated secrets
+	// Non-fatal: CLI-created secrets are labeled with DeleteWithClusterLabelName: "true"
+	// and AutoInfraLabelName. The operator's reconcileCLISecrets sets the HostedCluster
+	// as their ownerRef, ensuring they are garbage-collected when the HC is deleted.
 	if err = deleteCLISecrets(ctx, o, c); err != nil {
-		return err
+		o.Log.Info("Failed to delete CLI generated secrets, skipping",
+			"error", err.Error(), "namespace", o.Namespace)
 	}
 
 	if shouldDestroyPlatformSpecifics && hostedClusterExists {

--- a/cmd/cluster/core/destroy_test.go
+++ b/cmd/cluster/core/destroy_test.go
@@ -14,8 +14,10 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
 	capzv1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -23,12 +25,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func TestDestroyCluster(t *testing.T) {
 	t.Run("When HostedCluster is nil and platform specifics provided it should call destroyPlatformSpecifics", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		t.Setenv("FAKE_CLIENT", "true")
 
 		platformSpecificsCalled := false
 		var receivedOpts *DestroyOptions
@@ -50,7 +52,8 @@ func TestDestroyCluster(t *testing.T) {
 			},
 		}
 
-		err := DestroyCluster(context.Background(), nil, opts, mockPlatformSpecifics)
+		c := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).Build()
+		err := destroyCluster(context.Background(), c, nil, opts, mockPlatformSpecifics)
 
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(platformSpecificsCalled).To(BeTrue())
@@ -60,7 +63,6 @@ func TestDestroyCluster(t *testing.T) {
 
 	t.Run("When kubeconfig is set it should use it for the client", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		t.Setenv("FAKE_CLIENT", "true")
 
 		platformSpecificsCalled := false
 		mockPlatformSpecifics := func(ctx context.Context, o *DestroyOptions) error {
@@ -77,7 +79,90 @@ func TestDestroyCluster(t *testing.T) {
 			Log:                log.Log,
 		}
 
-		err := DestroyCluster(context.Background(), nil, opts, mockPlatformSpecifics)
+		c := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).Build()
+		err := destroyCluster(context.Background(), c, nil, opts, mockPlatformSpecifics)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(platformSpecificsCalled).To(BeTrue())
+	})
+
+	t.Run("When destroying a hosted cluster with platform specifics, it should set the destroy finalizer and complete successfully", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// Start with a realistic HC: operator's finalizer present, no destroy finalizer yet.
+		// setFinalizer() inside destroyCluster will add "openshift.io/destroy-cluster".
+		hc := &hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "clusters",
+				Name:       "test-cluster",
+				Finalizers: []string{"hypershift.openshift.io/finalizer"},
+			},
+			Spec: hyperv1.HostedClusterSpec{
+				InfraID: "test-infra",
+			},
+		}
+
+		g.Expect(controllerutil.ContainsFinalizer(hc, destroyFinalizer)).To(BeFalse(),
+			"destroy finalizer should not be present before destroyCluster runs")
+
+		platformSpecificsCalled := false
+		mockPlatformSpecifics := func(ctx context.Context, o *DestroyOptions) error {
+			platformSpecificsCalled = true
+			return nil
+		}
+
+		opts := &DestroyOptions{
+			ClusterGracePeriod: 1 * time.Second,
+			Name:               "test-cluster",
+			Namespace:          "clusters",
+			InfraID:            "test-infra",
+			Log:                log.Log,
+		}
+
+		// Fake client store is intentionally empty — removeFinalizer() will get
+		// NotFound (the operator has already cleaned up) and return nil.
+		c := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).Build()
+		err := destroyCluster(context.Background(), c, hc, opts, mockPlatformSpecifics)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(platformSpecificsCalled).To(BeTrue())
+		// setFinalizer() should have added the destroy finalizer during the flow.
+		// removeFinalizer() handles it (returns nil on NotFound since the fake
+		// client has no HC in its store, which is the expected path when the
+		// operator has already cleaned up).
+		g.Expect(controllerutil.ContainsFinalizer(hc, destroyFinalizer)).To(BeTrue(),
+			"destroy finalizer should have been set by setFinalizer()")
+	})
+
+	t.Run("When deleteCLISecrets fails it should log and continue", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		c := fake.NewClientBuilder().
+			WithScheme(hyperapi.Scheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				DeleteAllOf: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteAllOfOption) error {
+					if _, ok := obj.(*corev1.Secret); ok {
+						return apierrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "", fmt.Errorf("access denied"))
+					}
+					return cl.DeleteAllOf(ctx, obj, opts...)
+				},
+			}).
+			Build()
+
+		platformSpecificsCalled := false
+		mockPlatformSpecifics := func(ctx context.Context, o *DestroyOptions) error {
+			platformSpecificsCalled = true
+			return nil
+		}
+
+		opts := &DestroyOptions{
+			ClusterGracePeriod: 1 * time.Second,
+			Name:               "test-cluster",
+			Namespace:          "clusters",
+			InfraID:            "test-infra",
+			Log:                log.Log,
+		}
+
+		err := destroyCluster(context.Background(), c, nil, opts, mockPlatformSpecifics)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(platformSpecificsCalled).To(BeTrue())
 	})


### PR DESCRIPTION
## What this PR does / why we need it:
- Make `deleteCLISecrets` non-fatal in the `DestroyCluster` CLI flow to prevent the
    `openshift.io/destroy-cluster` finalizer from getting stuck when the service account
    lacks `deletecollection` RBAC permission
- Register `hyperapi.Scheme` in the fake test client to enable unit tests with HyperShift types
- Add test coverage for the destroy finalizer lifecycle with a non-nil HostedCluster

## Problem

- When running `hcp destroy cluster`, the `openshift.io/destroy-cluster` finalizer is added early in the flow and removed at the very end. The `deleteCLISecrets` function sits between `destroyPlatformSpecifics` and `removeFinalizer`:
```
  setFinalizer()              ← finalizer added
  destroyPlatformSpecifics()  ← succeeds (AWS cleanup done)
  deleteCLISecrets()          ← FAILS (RBAC: deletecollection forbidden)
  removeFinalizer()           ← NEVER REACHED
```

 - `deleteCLISecrets` uses `DeleteAllOf`, which requires the `deletecollection` RBAC verb — a more elevated permission than standard CRUD. When the calling service account lacks this permission, the function returns an error, the CLI exits, and the finalizer is never removed. The HostedCluster remains stuck with `deletionTimestamp` set indefinitely.

## Special notes for your reviewer:
 **Why non-fatal instead of removing the finalizer entirely?**
  - The `openshift.io/destroy-cluster` finalizer keeps the HostedCluster alive while the CLI
  performs platform infrastructure teardown (VPCs, IAM, DNS, etc.). If `destroyPlatformSpecifics`
  fails, the HC staying around is valuable; it serves as the source of truth for InfraID,
  Region, and BaseDomain, allowing the user to simply re-run `hypershift destroy` without
  remembering those values. Removing the finalizer entirely would lose this recovery anchor.

  **Why is `deleteCLISecrets` safe to skip?**
 - The operator's `reconcileCLISecrets` (hostedcluster_controller.go) sets ownerRefs on
  CLI-created secrets pointing to the HostedCluster. When the finalizer is removed and the HC
  is fully deleted, Kubernetes garbage collection handles secret cleanup automatically. The
  CLI's explicit `DeleteAllOf` is redundant.

  **Why change the fake client scheme?**
 - `GetClient()` with `FAKE_CLIENT=true` previously returned `fake.NewFakeClient()` using only
  the default Kubernetes scheme. This prevented any test from working with HyperShift types
  (HostedCluster, NodePool, etc.), the existing test worked around this by passing `nil` for
  the HostedCluster. Registering `hyperapi.Scheme` is a superset (includes all standard k8s
  types plus HyperShift types), so existing tests are unaffected.

## Which issue(s) this PR fixes:
Fixes: [OCPBUGS-86669](https://issues.redhat.com/browse/OCPBUGS-86669)

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.
- [x] Existing test passes: `When HostedCluster is nil and platform specifics provided`
- [x] New test passes: `When destroying a hosted cluster with platform specifics, it should 
       set the destroy finalizer and complete successfully`
- [x] `make verify` passes
- [x] `make test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Cluster destruction now continues even if command secret cleanup fails, logging the issue and proceeding with the rest of the removal process.
* Destroy workflow finalizer behavior is validated more reliably before and after the operation.

## Tests
* Expanded destruction test coverage with a more realistic hosted cluster scenario and stronger assertions around destroy finalizer state.
* Added coverage to ensure destruction succeeds even when secret deletion is blocked (forbidden error).
* Improved test-mode fake client setup to use the correct API scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->