### PR TITLE
CNTRLPLANE-3615: add tls security profile configuration for the etcd

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -134,6 +134,10 @@ spec:
           value: "true"
         - name: ETCD_INITIAL_CLUSTER
           value: etcd-0=https://etcd-0.etcd-discovery.hcp-namespace.svc:2380,etcd-1=https://etcd-1.etcd-discovery.hcp-namespace.svc:2380,etcd-2=https://etcd-2.etcd-discovery.hcp-namespace.svc:2380
+        - name: ETCD_TLS_MIN_VERSION
+          value: TLS1.2
+        - name: ETCD_CIPHER_SUITES
+          value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         image: etcd
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -134,6 +134,10 @@ spec:
           value: "true"
         - name: ETCD_INITIAL_CLUSTER
           value: etcd-0=https://etcd-0.etcd-discovery.hcp-namespace.svc:2380,etcd-1=https://etcd-1.etcd-discovery.hcp-namespace.svc:2380,etcd-2=https://etcd-2.etcd-discovery.hcp-namespace.svc:2380
+        - name: ETCD_TLS_MIN_VERSION
+          value: TLS1.2
+        - name: ETCD_CIPHER_SUITES
+          value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         image: etcd
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -134,6 +134,10 @@ spec:
           value: "true"
         - name: ETCD_INITIAL_CLUSTER
           value: etcd-0=https://etcd-0.etcd-discovery.hcp-namespace.svc:2380,etcd-1=https://etcd-1.etcd-discovery.hcp-namespace.svc:2380,etcd-2=https://etcd-2.etcd-discovery.hcp-namespace.svc:2380
+        - name: ETCD_TLS_MIN_VERSION
+          value: TLS1.2
+        - name: ETCD_CIPHER_SUITES
+          value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         image: etcd
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -134,6 +134,10 @@ spec:
           value: "true"
         - name: ETCD_INITIAL_CLUSTER
           value: etcd-0=https://etcd-0.etcd-discovery.hcp-namespace.svc:2380,etcd-1=https://etcd-1.etcd-discovery.hcp-namespace.svc:2380,etcd-2=https://etcd-2.etcd-discovery.hcp-namespace.svc:2380
+        - name: ETCD_TLS_MIN_VERSION
+          value: TLS1.2
+        - name: ETCD_CIPHER_SUITES
+          value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         image: etcd
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -134,6 +134,10 @@ spec:
           value: "true"
         - name: ETCD_INITIAL_CLUSTER
           value: etcd-0=https://etcd-0.etcd-discovery.hcp-namespace.svc:2380,etcd-1=https://etcd-1.etcd-discovery.hcp-namespace.svc:2380,etcd-2=https://etcd-2.etcd-discovery.hcp-namespace.svc:2380
+        - name: ETCD_TLS_MIN_VERSION
+          value: TLS1.2
+        - name: ETCD_CIPHER_SUITES
+          value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         image: etcd
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/etcd_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/etcd_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
 
+	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 
@@ -211,6 +213,89 @@ func TestDefragControllerPredicate(t *testing.T) {
 			}
 
 			result := defragControllerPredicate(cpContext)
+			g.Expect(result).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestMinTLSVersion(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		profile  *configv1.TLSSecurityProfile
+		expected string
+	}{
+		{
+			name:     "When TLS profile is nil, it should return TLS 1.2",
+			profile:  nil,
+			expected: string(tlsutil.TLSVersion12),
+		},
+		{
+			name: "When TLS profile is Modern, it should return TLS 1.3",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expected: string(tlsutil.TLSVersion13),
+		},
+		{
+			name: "When TLS profile is Intermediate, it should return TLS 1.2",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expected: string(tlsutil.TLSVersion12),
+		},
+		{
+			name: "When TLS profile is Old, it should return TLS 1.2",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			expected: string(tlsutil.TLSVersion12),
+		},
+		{
+			name: "When TLS profile is Custom with TLS 1.3, it should return TLS 1.3",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS13,
+					},
+				},
+			},
+			expected: string(tlsutil.TLSVersion13),
+		},
+		{
+			name: "When TLS profile is Custom with TLS 1.2, it should return TLS 1.2",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expected: string(tlsutil.TLSVersion12),
+		},
+		{
+			name: "When TLS profile is Custom with unknown TLS version, it should return TLS 1.2",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "UnknownVersion",
+					},
+				},
+			},
+			expected: string(tlsutil.TLSVersion12),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			result := minTLSVersion(tc.profile)
 			g.Expect(result).To(Equal(tc.expected))
 		})
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"strings"
 
+	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/netutil"
 	"github.com/openshift/hypershift/support/podspec"
+	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -17,9 +20,21 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+// minTLSVersion assesses what is the minimum TLS version we should use. This
+// function takes into account that etcd supports only 1.2 and 1.3.
+func minTLSVersion(profile *configv1.TLSSecurityProfile) string {
+	switch config.MinTLSVersion(profile) {
+	case string(configv1.VersionTLS13):
+		return string(tlsutil.TLSVersion13)
+	default:
+		return string(tlsutil.TLSVersion12)
+	}
+}
+
 func adaptStatefulSet(cpContext component.WorkloadContext, sts *appsv1.StatefulSet) error {
 	hcp := cpContext.HCP
 	managedEtcdSpec := hcp.Spec.Etcd.Managed
+	profile := cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile()
 
 	ipv4, err := netutil.IsIPv4CIDR(hcp.Spec.Networking.ClusterNetwork[0].CIDR.String())
 	if err != nil {
@@ -39,6 +54,23 @@ func adaptStatefulSet(cpContext component.WorkloadContext, sts *appsv1.StatefulS
 				Value: strings.Join(members, ","),
 			},
 		)
+
+		tlsMinVersion := minTLSVersion(profile)
+
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
+			Name:  "ETCD_TLS_MIN_VERSION",
+			Value: tlsMinVersion,
+		})
+
+		// When TLS 1.3 is configured, etcd does not allow cipher suites to be specified
+		// as they are automatically selected. Only set ETCD_CIPHER_SUITES for TLS 1.2.
+		if tlsMinVersion != string(tlsutil.TLSVersion13) {
+			cipherSuites := config.SupportedEtcdCipherSuites(config.CipherSuites(profile))
+			podspec.UpsertEnvVar(c, corev1.EnvVar{
+				Name:  "ETCD_CIPHER_SUITES",
+				Value: strings.Join(cipherSuites, ","),
+			})
+		}
 
 		if !ipv4 {
 			podspec.UpsertEnvVar(c, corev1.EnvVar{

--- a/support/config/cipher.go
+++ b/support/config/cipher.go
@@ -5,6 +5,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/crypto"
+	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
 )
 
 // openSSLToIANACiphersMap maps OpenSSL cipher suite names to IANA names
@@ -71,6 +72,20 @@ func CipherSuites(securityProfile *configv1.TLSSecurityProfile) []string {
 		ciphers = configv1.TLSProfiles[securityProfile.Type].Ciphers
 	}
 	return OpenSSLToIANACipherSuites(ciphers)
+}
+
+// SupportedEtcdCipherSuites filters the input cipher suites to only those supported by etcd.
+// It validates each cipher against etcd's tlsutil.GetCipherSuite() and silently filters out
+// unsupported ciphers.
+func SupportedEtcdCipherSuites(cipherSuites []string) []string {
+	allowedCiphers := []string{}
+	for _, cipher := range cipherSuites {
+		if _, ok := tlsutil.GetCipherSuite(cipher); !ok {
+			continue
+		}
+		allowedCiphers = append(allowedCiphers, cipher)
+	}
+	return allowedCiphers
 }
 
 // SetMinTLSVersionUsingAPIServer returns a function capable of setting the min

--- a/support/config/cipher_test.go
+++ b/support/config/cipher_test.go
@@ -205,3 +205,52 @@ func TestSetCipherSuitesUsingAPIServer(t *testing.T) {
 		})
 	}
 }
+
+func TestSupportedEtcdCipherSuites(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name: "When all ciphers are supported, it should return all",
+			input: []string{
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			},
+			expected: []string{
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			},
+		},
+		{
+			name: "When cipher is unsupported, it should filter it out",
+			input: []string{
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"TLS_UNSUPPORTED_CIPHER",
+				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			},
+			expected: []string{
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			},
+		},
+		{
+			name:     "When all ciphers are unsupported, it should return empty",
+			input:    []string{"INVALID_1", "INVALID_2"},
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			result := SupportedEtcdCipherSuites(tc.input)
+			g.Expect(result).To(Equal(tc.expected))
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Configure the `etcd` to use the TLS security profile settings from the HostedCluster resource. This ensures the etcd uses ciphers and minimum TLS version that match the cluster's security requirements.

> [!NOTE]
> This implementation is largely inspired by similar implemenatation on https://github.com/openshift/cluster-etcd-operator. There we also have a minimal accepted TLS version of `v1.2`. You can validate this implementation against the one found in https://github.com/openshift/cluster-etcd-operator/blob/main/pkg/etcdenvvar/etcd_env.go.


## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced TLS configuration support for etcd with TLS 1.2 and TLS 1.3 profile handling.
  * Added cipher suite validation and filtering for security configuration.

* **Tests**
  * Added comprehensive test coverage for TLS version and cipher suite configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->