### PR TITLE
CNTRLPLANE-3030: feat(nodepool,ignition-server): consume os-stream

### DIFF
--- a/hypershift-operator/controllers/nodepool/osstream_test.go
+++ b/hypershift-operator/controllers/nodepool/osstream_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestGetRHELStreamForBootImage(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name           string
 		nodePool       *hyperv1.NodePool
@@ -246,6 +247,7 @@ func TestGetRHELStreamForBootImage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
 
 			objs := make([]client.Object, 0, len(tc.configs))
@@ -265,6 +267,7 @@ func TestGetRHELStreamForBootImage(t *testing.T) {
 }
 
 func TestValidateOSImageStream(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name         string
 		nodePool     *hyperv1.NodePool
@@ -374,6 +377,7 @@ func TestValidateOSImageStream(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
 
 			objs := make([]client.Object, 0, len(tc.configs))

--- a/ignition-server/cmd/run_local_ignitionprovider.go
+++ b/ignition-server/cmd/run_local_ignitionprovider.go
@@ -111,7 +111,8 @@ func (o *RunLocalIgnitionProviderOptions) Run(ctx context.Context) error {
 		FeatureGateManifest:   o.FeatureGateManifest,
 	}
 
-	payload, err := p.GetPayload(ctx, o.Image, config.String(), "", "", "")
+	osStream := string(token.Data[controllers.TokenSecretOSStreamKey])
+	payload, err := p.GetPayload(ctx, o.Image, config.String(), "", "", "", osStream)
 	if err != nil {
 		return err
 	}

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -607,7 +607,7 @@ func (p *LocalIgnitionProvider) runMCSAndFetchPayload(ctx context.Context, dirs 
 	return payload, err
 }
 
-func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, customConfig, pullSecretHash, additionalTrustBundleHash, hcConfigurationHash string) ([]byte, error) {
+func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, customConfig, pullSecretHash, additionalTrustBundleHash, hcConfigurationHash, osStream string) ([]byte, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -644,16 +644,11 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, cu
 		return nil, err
 	}
 
-	imageProvider, err := func() (*imageprovider.SimpleReleaseImageProvider, error) {
-		img, err := p.ReleaseProvider.Lookup(ctx, releaseImage, pullSecret)
-		if err != nil {
-			return nil, fmt.Errorf("failed to look up release image metadata: %w", err)
-		}
-		return imageprovider.New(img), nil
-	}()
+	img, err := p.ReleaseProvider.Lookup(ctx, releaseImage, pullSecret)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get component images: %w", err)
+		return nil, fmt.Errorf("failed to look up release image metadata: %w", err)
 	}
+	imageProvider := imageprovider.New(img)
 
 	mcoImage, err := p.resolveMCOImage(ctx, imageProvider, pullSecret)
 	if err != nil {
@@ -691,17 +686,11 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, cu
 		return nil, err
 	}
 
-	err = func() error {
-		start := time.Now()
-		if err := registryclient.ExtractImageFilesToDir(ctx, mcoImage, pullSecret, "etc/mcc/templates/*", dirs.mccDir); err != nil {
-			return fmt.Errorf("failed to extract mcc templates: %w", err)
-		}
-		log.Info("extracted templates", "time", time.Since(start).Round(time.Second).String())
-		return nil
-	}()
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract templates from image: %w", err)
+	templateStart := time.Now()
+	if err := registryclient.ExtractImageFilesToDir(ctx, mcoImage, pullSecret, "etc/mcc/templates/*", dirs.mccDir); err != nil {
+		return nil, fmt.Errorf("failed to extract mcc templates from image: %w", err)
 	}
+	log.Info("extracted templates", "time", time.Since(templateStart).Round(time.Second).String())
 
 	payloadVersion, err := semver.Parse(imageProvider.Version())
 	if err != nil {
@@ -739,6 +728,17 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, cu
 	// First, run the MCO using templates and image refs as input. This generates output for the MCC.
 	if err := p.runMCO(ctx, dirs, releaseImage, pullSecret, mcsConfig, imageProvider, payloadVersion); err != nil {
 		return nil, fmt.Errorf("failed to execute machine-config-operator: %w", err)
+	}
+
+	// Write the OSImageStream CR to mccDir so the MCC bootstrap can discover
+	// and select the requested RHEL stream. When osStream is empty (feature
+	// gate disabled or pre-5.0 payload), skip — the MCC uses the default
+	// BaseOSContainerImage from ControllerConfig.
+	if osStream != "" {
+		if err := writeOSImageStreamManifest(dirs.mccDir, osStream); err != nil {
+			return nil, fmt.Errorf("failed to write OSImageStream manifest: %w", err)
+		}
+		log.Info("wrote OSImageStream manifest", "stream", osStream)
 	}
 
 	// Next, run the MCC using templates and MCO output as input, producing output for the MCS.
@@ -786,6 +786,20 @@ func (r *LocalIgnitionProvider) reconcileValidReleaseInfoCondition(ctx context.C
 	}
 
 	return r.Client.Status().Patch(ctx, &hostedControlPlane, client.MergeFromWithOptions(originalHCP, client.MergeFromWithOptimisticLock{}))
+}
+
+// writeOSImageStreamManifest writes a 99_osimagestream.yaml manifest to mccDir.
+// The MCC bootstrap reads this CR to discover available RHEL streams from OCI
+// labels and select the requested stream for OS image resolution.
+func writeOSImageStreamManifest(mccDir, osStream string) error {
+	manifest := fmt.Sprintf(`apiVersion: machineconfiguration.openshift.io/v1alpha1
+kind: OSImageStream
+metadata:
+  name: cluster
+spec:
+  defaultStream: %q
+`, osStream)
+	return os.WriteFile(filepath.Join(mccDir, "99_osimagestream.yaml"), []byte(manifest), 0644)
 }
 
 // copyFile copies a file named src to dst, preserving attributes.

--- a/ignition-server/controllers/local_ignitionprovider_test.go
+++ b/ignition-server/controllers/local_ignitionprovider_test.go
@@ -24,6 +24,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	sigs_yaml "sigs.k8s.io/yaml"
 
 	"github.com/blang/semver"
 )
@@ -1333,6 +1334,66 @@ func TestWriteInitialFilesMultipleConfigEntries(t *testing.T) {
 		_, err = os.Stat(filepath.Join(dirs.configDir, "configuration-hash"))
 		g.Expect(os.IsNotExist(err)).To(BeTrue())
 	})
+}
+
+func TestWriteOSImageStreamManifest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		osStream              string
+		expectedAPIVersion    string
+		expectedKind          string
+		expectedName          string
+		expectedDefaultStream string
+	}{
+		{
+			name:                  "When osStream is rhel-10 it should write a valid OSImageStream CR with defaultStream rhel-10",
+			osStream:              "rhel-10",
+			expectedAPIVersion:    "machineconfiguration.openshift.io/v1alpha1",
+			expectedKind:          "OSImageStream",
+			expectedName:          "cluster",
+			expectedDefaultStream: "rhel-10",
+		},
+		{
+			name:                  "When osStream is rhel-9 it should write a valid OSImageStream CR with defaultStream rhel-9",
+			osStream:              "rhel-9",
+			expectedAPIVersion:    "machineconfiguration.openshift.io/v1alpha1",
+			expectedKind:          "OSImageStream",
+			expectedName:          "cluster",
+			expectedDefaultStream: "rhel-9",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			mccDir := t.TempDir()
+			err := writeOSImageStreamManifest(mccDir, tt.osStream)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			content, err := os.ReadFile(filepath.Join(mccDir, "99_osimagestream.yaml"))
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// Parse the YAML to verify structure.
+			var obj map[string]any
+			err = sigs_yaml.Unmarshal(content, &obj)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(obj["apiVersion"]).To(Equal(tt.expectedAPIVersion))
+			g.Expect(obj["kind"]).To(Equal(tt.expectedKind))
+
+			metadata, ok := obj["metadata"].(map[string]any)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(metadata["name"]).To(Equal(tt.expectedName))
+
+			spec, ok := obj["spec"].(map[string]any)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(spec["defaultStream"]).To(Equal(tt.expectedDefaultStream))
+		})
+	}
 }
 
 func TestCopyMCOOutputToMCCMixedContent(t *testing.T) {

--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -37,9 +37,12 @@ const (
 	TokenSecretAdditionalTrustBundleHashKey = "additional-trust-bundle-hash"
 	InvalidConfigReason                     = "InvalidConfig"
 	TokenSecretReasonKey                    = "reason"
-	TokenSecretAnnotation                   = "hypershift.openshift.io/ignition-config"
-	TokenSecretNodePoolUpgradeType          = "hypershift.openshift.io/node-pool-upgrade-type"
-	TokenSecretTokenGenerationTime          = "hypershift.openshift.io/last-token-generation-time"
+	// TokenSecretOSStreamKey is intentionally duplicated from nodepool/token.go
+	// to avoid a dependency from ignition-server → hypershift-operator.
+	TokenSecretOSStreamKey         = "os-stream"
+	TokenSecretAnnotation          = "hypershift.openshift.io/ignition-config"
+	TokenSecretNodePoolUpgradeType = "hypershift.openshift.io/node-pool-upgrade-type"
+	TokenSecretTokenGenerationTime = "hypershift.openshift.io/last-token-generation-time"
 	// Set the ttl 1h above the reconcile resync period so every existing
 	// token Secret has the chance to rotate their token ID during a reconciliation cycle
 	// while the expired ones get eventually garbageCollected.
@@ -80,10 +83,12 @@ func NewPayloadStore() *ExpiringCache {
 
 // IgnitionProvider can build ignition payload contents
 // for a given release image.
+// TODO(sdminonne): replace positional string parameters in GetPayload with a PayloadRequest
+// struct to make call sites self-documenting and avoid silent argument swaps.
 type IgnitionProvider interface {
 	// GetPayload returns the ignition payload content for
 	// the provided release image and a config string containing 0..N MachineConfig yaml definitions.
-	GetPayload(ctx context.Context, payloadImage, config, pullSecretHash, additionalTrustBundleHash, hcConfigurationHash string) ([]byte, error)
+	GetPayload(ctx context.Context, payloadImage, config, pullSecretHash, additionalTrustBundleHash, hcConfigurationHash, osStream string) ([]byte, error)
 }
 
 // TokenSecretReconciler watches token Secrets
@@ -271,9 +276,10 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	pullSecretHash := string(tokenSecret.Data[TokenSecretPullSecretHashKey])
 	hcConfigurationHash := string(tokenSecret.Data[TokenSecretHCConfigurationHashKey])
 	additionalTrustBundleHash := string(tokenSecret.Data[TokenSecretAdditionalTrustBundleHashKey])
+	osStream := string(tokenSecret.Data[TokenSecretOSStreamKey])
 	payload, err := func() ([]byte, error) {
 		start := time.Now()
-		payload, err := r.IgnitionProvider.GetPayload(ctx, releaseImage, config.String(), pullSecretHash, additionalTrustBundleHash, hcConfigurationHash)
+		payload, err := r.IgnitionProvider.GetPayload(ctx, releaseImage, config.String(), pullSecretHash, additionalTrustBundleHash, hcConfigurationHash, osStream)
 		if err != nil {
 			return nil, fmt.Errorf("error getting ignition payload: %w", err)
 		}

--- a/ignition-server/controllers/tokensecret_controller_test.go
+++ b/ignition-server/controllers/tokensecret_controller_test.go
@@ -30,7 +30,7 @@ var (
 
 type fakeIgnitionProvider struct{}
 
-func (p *fakeIgnitionProvider) GetPayload(ctx context.Context, releaseImage, config, pullSecretHash, additionalTrustBundleHash, hcConfigurationHash string) (payload []byte, err error) {
+func (p *fakeIgnitionProvider) GetPayload(ctx context.Context, releaseImage, config, pullSecretHash, additionalTrustBundleHash, hcConfigurationHash, osStream string) (payload []byte, err error) {
 	return []byte(fakePayload), nil
 }
 
@@ -685,6 +685,93 @@ func TestHasSameReasonAndMessage(t *testing.T) {
 			g := NewWithT(t)
 			result := hasSameReasonAndMessage(tc.secret, tc.reason, tc.message)
 			g.Expect(result).To(Equal(tc.expected))
+		})
+	}
+}
+
+// osStreamCapturingProvider captures the osStream parameter passed to GetPayload.
+type osStreamCapturingProvider struct {
+	capturedOSStream string
+}
+
+func (p *osStreamCapturingProvider) GetPayload(_ context.Context, _, _, _, _, _, osStream string) ([]byte, error) {
+	p.capturedOSStream = osStream
+	return []byte(fakePayload), nil
+}
+
+func TestReconcileOSStreamPropagation(t *testing.T) {
+	t.Parallel()
+	compressedConfig, err := util.CompressAndEncode([]byte("compressedConfig"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		name               string
+		osStream           string
+		includeOSStreamKey bool
+		expectedOSStream   string
+	}{
+		{
+			name:               "When os-stream is set to rhel-10 it should pass rhel-10 to GetPayload",
+			osStream:           "rhel-10",
+			includeOSStreamKey: true,
+			expectedOSStream:   "rhel-10",
+		},
+		{
+			name:               "When os-stream is set to rhel-9 it should pass rhel-9 to GetPayload",
+			osStream:           "rhel-9",
+			includeOSStreamKey: true,
+			expectedOSStream:   "rhel-9",
+		},
+		{
+			name:               "When os-stream is empty it should pass empty string to GetPayload",
+			osStream:           "",
+			includeOSStreamKey: true,
+			expectedOSStream:   "",
+		},
+		{
+			name:               "When os-stream key is absent it should pass empty string to GetPayload",
+			includeOSStreamKey: false,
+			expectedOSStream:   "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			provider := &osStreamCapturingProvider{}
+			data := map[string][]byte{
+				TokenSecretTokenKey:                     []byte(uuid.New().String()),
+				TokenSecretReleaseKey:                   []byte("release"),
+				TokenSecretConfigKey:                    compressedConfig.Bytes(),
+				TokenSecretPullSecretHashKey:            []byte("pull-hash"),
+				TokenSecretHCConfigurationHashKey:       []byte("hc-hash"),
+				TokenSecretAdditionalTrustBundleHashKey: []byte("bundle-hash"),
+			}
+			if tc.includeOSStreamKey {
+				data[TokenSecretOSStreamKey] = []byte(tc.osStream)
+			}
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						TokenSecretAnnotation: "true",
+					},
+					CreationTimestamp: metav1.Now(),
+				},
+				Data: data,
+			}
+			r := TokenSecretReconciler{
+				Client:           fake.NewClientBuilder().WithObjects(secret).Build(),
+				IgnitionProvider: provider,
+				PayloadStore:     NewPayloadStore(),
+			}
+			_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(secret)})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(provider.capturedOSStream).To(Equal(tc.expectedOSStream))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

This PR implements the **consumer side** of dual-stream RHEL NodePool support ([enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/hypershift/dual-stream-rhel-nodepool.md)), enabling the ignition server to inject an `OSImageStream` custom resource into the ignition payload based on the `os-stream` key written to the token secret by the NodePool controller.

> **Builds on:** #8730 (merged) — the NodePool controller side that writes `os-stream` to the token secret.

### Changes

**Ignition server — `os-stream` consumption (InPlace)**

Reads the `os-stream` key from the token secret (written by the NodePool controller in #8730) and injects an `OSImageStream` CR manifest (`99_osimagestream.yaml`) into the MCC input directory between `runMCO()` and `runMCC()`. This is the mechanism by which InPlace nodes learn which RHEL stream to rebase to.

Changes:
- `tokensecret_controller.go` — reads `os-stream` from token secret, passes it to `GetPayload()`
- `local_ignitionprovider.go` — accepts `osStream` param, writes `OSImageStream` CR via `writeOSImageStreamManifest()`
- `run_local_ignitionprovider.go` — reads `os-stream` from token secret for the debug path
- Also cleans up unnecessary IIFEs in `GetPayload`
- Tests for both the manifest writing and end-to-end token secret propagation

Note: `osImageStream.Name` validation is already enforced at the API level via CEL, so no additional controller-side condition is needed.

## Upgrade strategy coverage

### Replace (AWS, Azure)
No ignition-server involvement — boot images are selected by the NodePool controller (#8730) via `resolvedRHELStreamForBootImage`. This PR does not affect the Replace path.

### InPlace
The `os-stream` key flows: NodePool controller (#8730) → token secret → ignition server (this PR) → `OSImageStream` CR → MCC bootstrap → node OS rebase.

## Test plan

- [x] Unit tests for `writeOSImageStreamManifest` (YAML structure verification for rhel-9, rhel-10)
- [x] Unit tests for `os-stream` propagation through `TokenSecretReconciler` → `GetPayload` (set, empty, absent key)
- [ ] E2E: `e2e-aws-upgrade-hypershift-operator` (no config hash impact — `os-stream` is not part of the hash)