### PR TITLE
GCP-841: remove ClusterResourceSet feature gate from CAPG manager args

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -197,14 +197,9 @@ func (p GCP) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hype
 		return nil, fmt.Errorf("no GCP CAPI provider image specified")
 	}
 
-	// GCP-specific feature gates based on payload version
+	// GCP-specific feature gates
 	featureGates := []string{
 		"MachinePool=false", // Disable for Phase 1
-	}
-
-	// Version-conditional feature gates (future-proofing)
-	if p.payloadVersion != nil && p.payloadVersion.Major == 4 && p.payloadVersion.Minor > 16 {
-		featureGates = append(featureGates, "ClusterResourceSet=false") // Example
 	}
 
 	args := []string{


### PR DESCRIPTION
## Summary

- Removes `ClusterResourceSet=false` from the `--feature-gates` arg passed to the CAPG manager
- `ClusterResourceSet` was promoted to GA in CAPI 1.10 and **removed** in CAPI 1.12 ([kubernetes-sigs/cluster-api#12950](https://github.com/kubernetes-sigs/cluster-api/pull/12950))
- OCP 4.22+ ships CAPG built against CAPI 1.12.8, causing the `capi-provider` pod to crash at startup with: `unrecognized feature gate: ClusterResourceSet`
- `MachinePool=false` is retained — still valid in CAPI 1.12 (Beta, default-on)

Fixes: https://redhat.atlassian.net/browse/GCP-841

## Test plan

- [ ] Existing unit tests pass (`go test ./hypershift-operator/controllers/hostedcluster/internal/platform/gcp/`)
- [ ] `periodic-ci-openshift-hypershift-release-4.23-periodics-e2e-v2-gke` no longer fails due to capi-provider crash
- [ ] `capi-provider` pod starts successfully on 4.22.x and 4.23.x without a CAPG image override

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified GCP controller feature gate configuration by removing version-dependent logic, now using a fixed set of feature gates instead of conditionally adjusting based on payload version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->