### PR TITLE
NO-JIRA: fix(ci): add --verbose flag required by stream-json output format

### DIFF
--- a/.github/workflows/reusable-claude-on-pr.yaml
+++ b/.github/workflows/reusable-claude-on-pr.yaml
@@ -124,4 +124,4 @@ jobs:
           claude plugin marketplace add enxebre/ai-scripts
           claude plugin install git@enxebre
           claude --version
-          claude -p "$CLAUDE_PROMPT" --model claude-opus-4-6 --max-turns "$MAX_TURNS" --allowedTools "$ALLOWED_TOOLS" --output-format stream-json
+          claude -p "$CLAUDE_PROMPT" --model claude-opus-4-6 --max-turns "$MAX_TURNS" --allowedTools "$ALLOWED_TOOLS" --verbose --output-format stream-json


### PR DESCRIPTION
## What this PR does / why we need it:

Claude Code 2.1.185 now requires `--verbose` when using `--output-format=stream-json` with `--print` mode. Without it, the CLI exits with:

```
Error: When using --print, --output-format=stream-json requires --verbose
```

This broke all GHA workflows using the reusable workflow (e.g. address-review-comments).

## Which issue(s) this PR fixes:

Fixes https://github.com/openshift/hypershift/actions/runs/27954915889/job/82720724934

## Special notes for your reviewer:

One-line change adding `--verbose` to the claude CLI invocation.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development workflow configuration to enhance diagnostic output during code review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->