### PR TITLE
NO-JIRA: fix(ci): increase reusable workflow timeout to 90 minutes

### DIFF
--- a/.github/workflows/reusable-claude-on-pr.yaml
+++ b/.github/workflows/reusable-claude-on-pr.yaml
@@ -30,7 +30,7 @@ jobs:
       group: ${{ inputs.command-name }}-${{ github.event.issue.number }}
       cancel-in-progress: true
     runs-on: arc-runner-set
-    timeout-minutes: 45
+    timeout-minutes: 90
     env:
       HOME: /tmp
     steps:


### PR DESCRIPTION
## What this PR does / why we need it:

Increases the reusable Claude workflow job timeout from 45 to 90 minutes.
The pre-push hooks run `make verify` and `make test` sequentially (~25-35
min on ARC runners). Combined with Claude's PR analysis time, 45 minutes
is not enough.

## Which issue(s) this PR fixes:

Fixes https://github.com/openshift/hypershift/actions/runs/27961098795

## Special notes for your reviewer:

One-line change: `timeout-minutes: 45` -> `timeout-minutes: 90`

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->