### PR TITLE
OCPBUGS-90663: fix(test): use Eventually for auth-config ConfigMap assertions

### DIFF
--- a/test/e2e/v2/tests/hosted_cluster_external_oidc_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_external_oidc_test.go
@@ -168,66 +168,76 @@ func ExternalOIDCKASConfigTest(getTestCtx internal.TestContextGetter) {
 			tc := getTestCtx()
 			hc := tc.GetHostedCluster()
 
-			cm := &corev1.ConfigMap{}
-			err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
-				Namespace: tc.ControlPlaneNamespace,
-				Name:      "auth-config",
-			}, cm)
-			Expect(err).NotTo(HaveOccurred(),
-				"auth-config ConfigMap should exist in %s", tc.ControlPlaneNamespace)
-
-			authJSON, ok := cm.Data["auth.json"]
-			Expect(ok).To(BeTrue(), "auth-config ConfigMap should have auth.json key")
-
-			var authConfig map[string]interface{}
-			Expect(json.Unmarshal([]byte(authJSON), &authConfig)).To(Succeed())
-
-			jwtArray, ok := authConfig["jwt"].([]interface{})
-			Expect(ok).To(BeTrue(), "auth.json should have jwt array")
-			Expect(jwtArray).NotTo(BeEmpty(), "jwt array should not be empty")
-
-			// Dynamic assertion: compare against HC spec, not hardcoded values
 			expectedIssuerURL := hc.Spec.Configuration.Authentication.OIDCProviders[0].Issuer.URL
 			Expect(expectedIssuerURL).NotTo(BeEmpty(),
 				"OIDC provider issuer URL should not be empty on hosted cluster %s/%s", hc.Namespace, hc.Name)
 
-			firstJWT, ok := jwtArray[0].(map[string]interface{})
-			Expect(ok).To(BeTrue(), "first jwt entry should be a map")
-			issuer, ok := firstJWT["issuer"].(map[string]interface{})
-			Expect(ok).To(BeTrue(), "jwt entry should have issuer")
-			Expect(issuer["url"]).To(Equal(expectedIssuerURL),
-				"JWT issuer URL should match OIDC provider from hosted cluster spec")
+			// The auth-config ConfigMap is reconciled by CPO after the OIDC
+			// configuration is patched onto the HostedCluster. Poll until the
+			// JWT authenticator array is populated.
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+					Namespace: tc.ControlPlaneNamespace,
+					Name:      "auth-config",
+				}, cm)
+				g.Expect(err).NotTo(HaveOccurred(),
+					"auth-config ConfigMap should exist in %s", tc.ControlPlaneNamespace)
+
+				authJSON, ok := cm.Data["auth.json"]
+				g.Expect(ok).To(BeTrue(), "auth-config ConfigMap should have auth.json key")
+
+				var authConfig map[string]interface{}
+				g.Expect(json.Unmarshal([]byte(authJSON), &authConfig)).To(Succeed())
+
+				jwtArray, ok := authConfig["jwt"].([]interface{})
+				g.Expect(ok).To(BeTrue(), "auth.json should have jwt array")
+				g.Expect(jwtArray).NotTo(BeEmpty(), "jwt array should not be empty")
+
+				firstJWT, ok := jwtArray[0].(map[string]interface{})
+				g.Expect(ok).To(BeTrue(), "first jwt entry should be a map")
+				issuer, ok := firstJWT["issuer"].(map[string]interface{})
+				g.Expect(ok).To(BeTrue(), "jwt entry should have issuer")
+				g.Expect(issuer["url"]).To(Equal(expectedIssuerURL),
+					"JWT issuer URL should match OIDC provider from hosted cluster spec")
+			}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 		})
 
 		It("should have correct audiences in JWT config", func() {
 			tc := getTestCtx()
 			hc := tc.GetHostedCluster()
 
-			cm := &corev1.ConfigMap{}
-			Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
-				Namespace: tc.ControlPlaneNamespace,
-				Name:      "auth-config",
-			}, cm)).To(Succeed())
-
-			var authConfig map[string]interface{}
-			Expect(json.Unmarshal([]byte(cm.Data["auth.json"]), &authConfig)).To(Succeed())
-
-			jwtArray, ok := authConfig["jwt"].([]interface{})
-			Expect(ok).To(BeTrue(), "auth.json should have jwt array")
-			Expect(jwtArray).NotTo(BeEmpty(), "jwt array should not be empty")
-			firstJWT, ok := jwtArray[0].(map[string]interface{})
-			Expect(ok).To(BeTrue(), "first jwt entry should be a map")
-			issuer, ok := firstJWT["issuer"].(map[string]interface{})
-			Expect(ok).To(BeTrue(), "jwt entry should have issuer")
-			audiences, ok := issuer["audiences"].([]interface{})
-			Expect(ok).To(BeTrue(), "JWT issuer should have audiences array")
-			Expect(audiences).NotTo(BeEmpty(), "JWT audiences should not be empty")
-
 			expectedAudiences := hc.Spec.Configuration.Authentication.OIDCProviders[0].Issuer.Audiences
-			for _, expected := range expectedAudiences {
-				Expect(audiences).To(ContainElement(string(expected)),
-					"JWT audiences should contain %s from hosted cluster spec", expected)
-			}
+			Expect(expectedAudiences).NotTo(BeEmpty(),
+				"OIDC provider audiences should not be empty on hosted cluster %s/%s", hc.Namespace, hc.Name)
+
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+					Namespace: tc.ControlPlaneNamespace,
+					Name:      "auth-config",
+				}, cm)).To(Succeed())
+
+				var authConfig map[string]interface{}
+				g.Expect(json.Unmarshal([]byte(cm.Data["auth.json"]), &authConfig)).To(Succeed())
+
+				jwtArray, ok := authConfig["jwt"].([]interface{})
+				g.Expect(ok).To(BeTrue(), "auth.json should have jwt array")
+				g.Expect(jwtArray).NotTo(BeEmpty(), "jwt array should not be empty")
+
+				firstJWT, ok := jwtArray[0].(map[string]interface{})
+				g.Expect(ok).To(BeTrue(), "first jwt entry should be a map")
+				issuer, ok := firstJWT["issuer"].(map[string]interface{})
+				g.Expect(ok).To(BeTrue(), "jwt entry should have issuer")
+				audiences, ok := issuer["audiences"].([]interface{})
+				g.Expect(ok).To(BeTrue(), "JWT issuer should have audiences array")
+				g.Expect(audiences).NotTo(BeEmpty(), "JWT audiences should not be empty")
+
+				for _, expected := range expectedAudiences {
+					g.Expect(audiences).To(ContainElement(string(expected)),
+						"JWT audiences should contain %s from hosted cluster spec", expected)
+				}
+			}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 		})
 
 		It("should not have OAuth webhook authentication config", func() {


### PR DESCRIPTION
## What this PR does / why we need it:

The external OIDC auth-config tests (`[Feature:ExternalOIDC]`) were failing intermittently with an 85.71% pass rate (18/21), below the 95% threshold required by Component Readiness.

**Root cause**: Race condition between `postCreateExternalOIDC` patching OIDC configuration onto the HostedCluster spec and CPO reconciling the auth-config ConfigMap. The manifest template ships with `{"jwt":[]}`, so the ConfigMap exists immediately but has an empty JWT array until CPO processes the spec change via `adaptAuthConfig`. Tests that assert on the JWT array content right after the patch hit this window.

**Fix**: Wrap both auth-config `It` blocks in `Eventually()` with 2-minute timeout and 5-second polling, following the same pattern already used by the Keycloak auth test in the same file. All assertions are kept inside the `Eventually()` closure to avoid stale variable leaks across the convergence boundary.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-90663

## Special notes for your reviewer:

- The two modified `It` blocks are "should have auth-config ConfigMap with JWT authenticator matching the OIDC provider" and "should have correct audiences in JWT config"
- Expected values (issuerURL, audiences) are extracted from the HC spec **before** `Eventually()` since `sync.Once`-cached HC already has OIDCProviders at this point
- All ConfigMap Get + JSON parsing + JWT assertions are **inside** `Eventually()` so each poll gets a fresh ConfigMap
- This matches the existing pattern used by the Keycloak test at line 144 in the same file

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of OIDC authentication configuration validation tests by implementing polling-based assertions instead of single-time checks. Tests now wait for reconciliation before validating issuer URL and audience configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->