### PR TITLE
ROSA-712: migrate default ARM64 instance type from m6g to m8g

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -383,7 +383,7 @@ func (o *CreateOptions) GenerateNodePools(constructor core.DefaultNodePoolConstr
 		case hyperv1.ArchitectureAMD64:
 			instanceType = "m5.large"
 		case hyperv1.ArchitectureARM64:
-			instanceType = "m6g.large"
+			instanceType = "m8g.large"
 		}
 	}
 

--- a/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.aws.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.aws.testsuite.yaml
@@ -509,7 +509,7 @@ tests:
         platform:
           aws:
             instanceProfile: a-profile
-            instanceType: m6g.large
+            instanceType: m8g.large
             rootVolume:
               size: 120
               type: gp3
@@ -557,7 +557,7 @@ tests:
         platform:
           aws:
             instanceProfile: a-profile
-            instanceType: m6g.large
+            instanceType: m8g.large
             rootVolume:
               size: 120
               type: gp3
@@ -633,7 +633,7 @@ tests:
         platform:
           aws:
             instanceProfile: a-profile
-            instanceType: m6g.large
+            instanceType: m8g.large
             rootVolume:
               size: 120
               type: gp3

--- a/cmd/nodepool/aws/create.go
+++ b/cmd/nodepool/aws/create.go
@@ -149,7 +149,7 @@ func (o *CompletedAWSPlatformCreateOptions) UpdateNodePool(ctx context.Context, 
 		case "amd64":
 			instanceType = "m5.large"
 		case "arm64":
-			instanceType = "m6g.large"
+			instanceType = "m8g.large"
 		}
 	}
 

--- a/cmd/nodepool/aws/create_test.go
+++ b/cmd/nodepool/aws/create_test.go
@@ -39,7 +39,7 @@ func TestCreateNodePool_When_flags_are_parsed_it_should_generate_correct_nodepoo
 		{
 			name: "custom root volume configuration",
 			args: []string{
-				"--instance-type=m6g.large",
+				"--instance-type=m8g.large",
 				"--subnet-id=subnet-arm64",
 				"--root-volume-type=io2",
 				"--root-volume-size=200",
@@ -249,7 +249,7 @@ func TestUpdateNodePool_When_instance_type_is_empty_it_should_default_based_on_a
 		expectedInstanceType string
 	}{
 		{"amd64", "m5.large"},
-		{"arm64", "m6g.large"},
+		{"arm64", "m8g.large"},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/nodepool/aws/testdata/zz_fixture_TestCreateNodePool_When_flags_are_parsed_it_should_generate_correct_nodepool_custom_root_volume_configuration.yaml
+++ b/cmd/nodepool/aws/testdata/zz_fixture_TestCreateNodePool_When_flags_are_parsed_it_should_generate_correct_nodepool_custom_root_volume_configuration.yaml
@@ -1,5 +1,5 @@
 instanceProfile: test-infra-worker
-instanceType: m6g.large
+instanceType: m8g.large
 rootVolume:
   iops: 10000
   size: 200

--- a/hypershift-operator/controllers/nodepool/instancetype/aws/provider_test.go
+++ b/hypershift-operator/controllers/nodepool/instancetype/aws/provider_test.go
@@ -268,9 +268,9 @@ func TestTransformInstanceTypeInfo_WhenValidInput_ItShouldTransformCorrectly(t *
 		},
 		{
 			name:  "When instance is ARM it should set correct architecture",
-			input: makeInstanceTypeInfo("m6g.xlarge", string(ec2types.ArchitectureTypeArm64), 4, 16384, 0),
+			input: makeInstanceTypeInfo("m8g.xlarge", string(ec2types.ArchitectureTypeArm64), 4, 16384, 0),
 			expected: &instancetype.InstanceTypeInfo{
-				InstanceType:    "m6g.xlarge",
+				InstanceType:    "m8g.xlarge",
 				VCPU:            4,
 				MemoryMb:        16384,
 				GPU:             0,

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -288,7 +288,7 @@ func testARM64Provisioning(ctx context.Context, guestClient crclient.Client, hos
 
 		armNodePool := baseNodePool("arm-nodepool", armNodeClass.Name)
 		armNodePool.Spec.Template.Spec.Requirements = []karpenterv1.NodeSelectorRequirementWithMinValues{
-			{Key: "node.kubernetes.io/instance-type", Operator: corev1.NodeSelectorOpIn, Values: []string{"m6g.xlarge"}},
+			{Key: "node.kubernetes.io/instance-type", Operator: corev1.NodeSelectorOpIn, Values: []string{"m8g.xlarge"}},
 			{Key: "kubernetes.io/arch", Operator: corev1.NodeSelectorOpIn, Values: []string{"arm64"}},
 			{Key: karpenterv1.CapacityTypeLabelKey, Operator: corev1.NodeSelectorOpIn, Values: []string{karpenterv1.CapacityTypeOnDemand}},
 		}

--- a/test/e2e/nodepool_arm64_create_test.go
+++ b/test/e2e/nodepool_arm64_create_test.go
@@ -37,7 +37,7 @@ func (arm64np *NodePoolArm64CreateTest) BuildNodePoolManifest(defaultNodepool hy
 	nodePool.Spec.Replicas = &oneReplicas
 	nodePool.Spec.Arch = "arm64"
 	if nodePool.Spec.Platform.Type == hyperv1.AWSPlatform {
-		nodePool.Spec.Platform.AWS.InstanceType = "m6g.large"
+		nodePool.Spec.Platform.AWS.InstanceType = "m8g.large"
 	} else if nodePool.Spec.Platform.Type == hyperv1.AzurePlatform {
 		nodePool.Spec.Platform.Azure.VMSize = "Standard_D4ps_v5"
 		nodePool.Spec.Platform.Azure.Image.Type = hyperv1.AzureMarketplace


### PR DESCRIPTION
## What this PR does / why we need it:

Migrates the default ARM64 (Graviton) instance type from `m6g` to `m8g` (Graviton4) across all defaults, tests, and e2e fixtures.

Graviton4 (`m8g`) offers ~30% better performance at the same price point compared to Graviton2 (`m6g`) and is available in all ROSA regions and AZs.

### Changes:
- **Production defaults**: `cmd/cluster/aws/create.go` and `cmd/nodepool/aws/create.go` — default ARM64 instance type updated from `m6g.large` to `m8g.large`
- **Unit tests**: nodepool create test cases and fixtures updated
- **CRD envtest suite**: ARM64 nodepool test cases updated
- **Instance type provider test**: ARM architecture test updated from `m6g.xlarge` to `m8g.xlarge`
- **E2E tests**: Karpenter ARM64 provisioning and NodePool ARM64 create tests updated

## Which issue(s) this PR fixes:

Fixes [ROSA-712](https://redhat.atlassian.net/browse/ROSA-712)

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.