### PR TITLE
CNTRLPLANE-3774: fix: control-plane-operator: improve opaque conditions

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1,11 +1,13 @@
 package hostedcontrolplane
 
 import (
+	"bufio"
 	"context"
 	crand "crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
 	"os"
@@ -978,9 +980,16 @@ func (r *HostedControlPlaneReconciler) healthCheckKASLoadBalancers(ctx context.C
 		if err := r.Get(ctx, client.ObjectKeyFromObject(svc), svc); err != nil {
 			return fmt.Errorf("failed to get kube apiserver service: %w", err)
 		}
-		if len(svc.Status.LoadBalancer.Ingress) == 0 ||
-			svc.Status.LoadBalancer.Ingress[0].Hostname == "" && svc.Status.LoadBalancer.Ingress[0].IP == "" {
-			return fmt.Errorf("APIServer load balancer is not provisioned")
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			msg, err := k8sutil.CollectLBMessageIfNotProvisioned(svc, events.NewMessageCollector(ctx, r.Client))
+			if err != nil {
+				return fmt.Errorf("%s; additionally: %w", msg, err)
+			}
+			return fmt.Errorf("%s", msg)
+		}
+		if svc.Status.LoadBalancer.Ingress[0].Hostname == "" && svc.Status.LoadBalancer.Ingress[0].IP == "" {
+			return fmt.Errorf("APIServer load balancer %s/%s has ingress entry with no hostname or IP",
+				svc.Namespace, svc.Name)
 		}
 		LBIngress := svc.Status.LoadBalancer.Ingress[0]
 		ingressPoint := ""
@@ -995,7 +1004,7 @@ func (r *HostedControlPlaneReconciler) healthCheckKASLoadBalancers(ctx context.C
 }
 
 func healthCheckKASEndpoint(ctx context.Context, ingressPoint string, port int) error {
-	healthEndpoint := fmt.Sprintf("https://%s:%d/healthz", ingressPoint, port)
+	healthEndpoint := fmt.Sprintf("https://%s:%d/healthz?verbose", ingressPoint, port)
 
 	httpClient := util.InsecureHTTPClient()
 	httpClient.Timeout = 10 * time.Second
@@ -1005,14 +1014,41 @@ func healthCheckKASEndpoint(ctx context.Context, ingressPoint string, port int) 
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("health check to APIServer endpoint %s failed: %w", ingressPoint, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("APIServer endpoint %s is not healthy", ingressPoint)
+		failingChecks := parseFailingHealthChecks(resp.Body)
+		if len(failingChecks) > 0 {
+			return fmt.Errorf("APIServer endpoint %s is not healthy (status %d): failing health checks: %s",
+				ingressPoint, resp.StatusCode, strings.Join(failingChecks, ", "))
+		}
+		return fmt.Errorf("APIServer endpoint %s is not healthy (status %d)", ingressPoint, resp.StatusCode)
 	}
 	return nil
+}
+
+// parseFailingHealthChecks reads a verbose /healthz response body and returns
+// the names of checks that are marked as failing (lines starting with "[-]").
+func parseFailingHealthChecks(body io.Reader) []string {
+	var failing []string
+	scanner := bufio.NewScanner(body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "[-]") {
+			// Format: "[-]<name> failed: reason withheld"
+			name := strings.TrimPrefix(line, "[-]")
+			if idx := strings.Index(name, " failed:"); idx > 0 {
+				name = name[:idx]
+			}
+			failing = append(failing, name)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		failing = append(failing, fmt.Sprintf("(error reading response: %v)", err))
+	}
+	return failing
 }
 
 // controlPlaneComponentsAvailable checks that all ControlPlaneComponents in the namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -4458,12 +4458,24 @@ func TestHealthCheckKASEndpoint(t *testing.T) {
 			},
 		},
 		{
-			name: "When endpoint returns 503, it should return an unhealthy error",
+			name: "When endpoint returns 503, it should return an unhealthy error with status code",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusServiceUnavailable)
 			},
 			wantErr:   true,
-			errSubstr: "is not healthy",
+			errSubstr: "is not healthy (status 503)",
+		},
+		{
+			name: "When endpoint returns 503 with failing checks, it should include check names",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				fmt.Fprintln(w, "[+]ping ok")
+				fmt.Fprintln(w, "[-]etcd failed: reason withheld")
+				fmt.Fprintln(w, "[-]kms-provider-0 failed: reason withheld")
+				fmt.Fprintln(w, "healthz check failed")
+			},
+			wantErr:   true,
+			errSubstr: "failing health checks: etcd, kms-provider-0",
 		},
 		{
 			name: "When context is canceled, it should return an error",

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
@@ -194,11 +194,12 @@ func (r *Reconciler) AdmitHCPManagedRoutes(ctx context.Context, hcp *hyperv1.Hos
 			}
 		}
 		if route.Annotations[netutil.RouteStatusWriterAnnotation] != "hcp-router" {
+			routeBeforeAnnotation := route.DeepCopy()
 			if route.Annotations == nil {
 				route.Annotations = map[string]string{}
 			}
 			route.Annotations[netutil.RouteStatusWriterAnnotation] = "hcp-router"
-			if err := r.Client.Patch(ctx, route, client.MergeFrom(originalRoute)); err != nil {
+			if err := r.Client.Patch(ctx, route, client.MergeFrom(routeBeforeAnnotation)); err != nil {
 				return fmt.Errorf("failed to update route %s status-writer annotation: %w", route.Name, err)
 			}
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
@@ -193,6 +193,15 @@ func (r *Reconciler) AdmitHCPManagedRoutes(ctx context.Context, hcp *hyperv1.Hos
 				return fmt.Errorf("failed to update route %s status: %w", route.Name, err)
 			}
 		}
+		if route.Annotations[netutil.RouteStatusWriterAnnotation] != "hcp-router" {
+			if route.Annotations == nil {
+				route.Annotations = map[string]string{}
+			}
+			route.Annotations[netutil.RouteStatusWriterAnnotation] = "hcp-router"
+			if err := r.Client.Patch(ctx, route, client.MergeFrom(originalRoute)); err != nil {
+				return fmt.Errorf("failed to update route %s status-writer annotation: %w", route.Name, err)
+			}
+		}
 	}
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -113,6 +113,14 @@ func ReconcileRouteStatus(route *routev1.Route, externalHostname, internalHostna
 		canonicalHostName = externalHostname
 	}
 
+	// When the router host is not yet known, we must not write route status with
+	// an empty RouterCanonicalHostname. Doing so overwrites a previously-valid
+	// value and causes health checks to report "route not admitted", flapping the
+	// HostedCluster Available condition.
+	if canonicalHostName == "" {
+		return
+	}
+
 	// Skip reconciliation if ingress status.ingress has already been populated and canonical hostname is the same
 	if len(route.Status.Ingress) > 0 && route.Status.Ingress[0].RouterCanonicalHostname == canonicalHostName {
 		return

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
@@ -16,8 +16,9 @@ import (
 // GetHealthcheckEndpoint determines the appropriate endpoint and port for healthcheck based on the route and configuration
 func GetHealthcheckEndpointForRoute(externalRoute *routev1.Route, hcp *hyperv1.HostedControlPlane) (endpoint string, port int, err error) {
 	if len(externalRoute.Status.Ingress) == 0 {
-		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: route has no ingress status",
-			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host)
+		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: route has no ingress status; last status writer: %s",
+			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host,
+			externalRoute.Annotations[netutil.RouteStatusWriterAnnotation])
 	}
 	if externalRoute.Status.Ingress[0].RouterCanonicalHostname == "" {
 		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: %s; last status writer: %s",

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
@@ -15,16 +15,20 @@ import (
 
 // GetHealthcheckEndpoint determines the appropriate endpoint and port for healthcheck based on the route and configuration
 func GetHealthcheckEndpointForRoute(externalRoute *routev1.Route, hcp *hyperv1.HostedControlPlane) (endpoint string, port int, err error) {
+	statusWriter := externalRoute.Annotations[netutil.RouteStatusWriterAnnotation]
+	if statusWriter == "" {
+		statusWriter = "(none)"
+	}
 	if len(externalRoute.Status.Ingress) == 0 {
 		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: route has no ingress status; last status writer: %s",
 			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host,
-			externalRoute.Annotations[netutil.RouteStatusWriterAnnotation])
+			statusWriter)
 	}
 	if externalRoute.Status.Ingress[0].RouterCanonicalHostname == "" {
 		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: %s; last status writer: %s",
 			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host,
 			routeIngressDiagnostic(externalRoute.Status.Ingress[0]),
-			externalRoute.Annotations[netutil.RouteStatusWriterAnnotation])
+			statusWriter)
 	}
 
 	endpoint = externalRoute.Status.Ingress[0].RouterCanonicalHostname

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
@@ -20,9 +20,10 @@ func GetHealthcheckEndpointForRoute(externalRoute *routev1.Route, hcp *hyperv1.H
 			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host)
 	}
 	if externalRoute.Status.Ingress[0].RouterCanonicalHostname == "" {
-		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: %s",
+		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: %s; last status writer: %s",
 			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host,
-			routeIngressDiagnostic(externalRoute.Status.Ingress[0]))
+			routeIngressDiagnostic(externalRoute.Status.Ingress[0]),
+			externalRoute.Annotations[netutil.RouteStatusWriterAnnotation])
 	}
 
 	endpoint = externalRoute.Status.Ingress[0].RouterCanonicalHostname

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
@@ -2,6 +2,7 @@ package kas
 
 import (
 	"fmt"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -14,8 +15,14 @@ import (
 
 // GetHealthcheckEndpoint determines the appropriate endpoint and port for healthcheck based on the route and configuration
 func GetHealthcheckEndpointForRoute(externalRoute *routev1.Route, hcp *hyperv1.HostedControlPlane) (endpoint string, port int, err error) {
-	if len(externalRoute.Status.Ingress) == 0 || externalRoute.Status.Ingress[0].RouterCanonicalHostname == "" {
-		return "", 0, fmt.Errorf("APIServer external route not admitted")
+	if len(externalRoute.Status.Ingress) == 0 {
+		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: route has no ingress status",
+			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host)
+	}
+	if externalRoute.Status.Ingress[0].RouterCanonicalHostname == "" {
+		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: %s",
+			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host,
+			routeIngressDiagnostic(externalRoute.Status.Ingress[0]))
 	}
 
 	endpoint = externalRoute.Status.Ingress[0].RouterCanonicalHostname
@@ -35,4 +42,23 @@ func GetHealthcheckEndpointForRoute(externalRoute *routev1.Route, hcp *hyperv1.H
 	}
 
 	return endpoint, port, nil
+}
+
+// routeIngressDiagnostic produces a human-readable summary of a RouteIngress
+// entry that has been populated but lacks a RouterCanonicalHostname.
+func routeIngressDiagnostic(ingress routev1.RouteIngress) string {
+	parts := []string{
+		fmt.Sprintf("router %q has not set a canonical hostname", ingress.RouterName),
+	}
+	for _, cond := range ingress.Conditions {
+		detail := fmt.Sprintf("%s=%s", cond.Type, cond.Status)
+		if cond.Reason != "" {
+			detail += fmt.Sprintf(" reason=%s", cond.Reason)
+		}
+		if cond.Message != "" {
+			detail += fmt.Sprintf(" message=%q", cond.Message)
+		}
+		parts = append(parts, detail)
+	}
+	return strings.Join(parts, "; ")
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck_test.go
@@ -12,30 +12,83 @@ import (
 	"github.com/openshift/hypershift/support/config"
 
 	routev1 "github.com/openshift/api/route/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetHealthcheckEndpoint(t *testing.T) {
 	tests := []struct {
-		name             string
-		route            *routev1.Route
-		hcp              *hyperv1.HostedControlPlane
-		useSharedIngress bool
-		expectedEndpoint string
-		expectedPort     int
-		expectedError    string
+		name                    string
+		route                   *routev1.Route
+		hcp                     *hyperv1.HostedControlPlane
+		useSharedIngress        bool
+		expectedEndpoint        string
+		expectedPort            int
+		expectedErrorSubstrings []string
 	}{
 		{
-			name: "when route is not admitted, it should return error",
+			name: "When route has no ingress status, it should return error with no ingress detail",
 			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver",
+					Namespace: "clusters-test",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "api.test.example.com",
+				},
 				Status: routev1.RouteStatus{
 					Ingress: []routev1.RouteIngress{},
 				},
 			},
-			hcp:           &hyperv1.HostedControlPlane{},
-			expectedError: "APIServer external route not admitted",
+			hcp: &hyperv1.HostedControlPlane{},
+			expectedErrorSubstrings: []string{
+				"clusters-test/kube-apiserver",
+				"api.test.example.com",
+				"route has no ingress status",
+			},
 		},
 		{
-			name: "when route is admitted without shared ingress, it should return canonical hostname",
+			name: "When route has ingress but no canonical hostname, it should return error with router diagnostic",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver",
+					Namespace: "clusters-test",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "api.test.example.com",
+				},
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							RouterName:              "default",
+							RouterCanonicalHostname: "",
+							Conditions: []routev1.RouteIngressCondition{
+								{
+									Type:    routev1.RouteAdmitted,
+									Status:  corev1.ConditionFalse,
+									Reason:  "HostAlreadyClaimed",
+									Message: "route foo already exposes api.test.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{},
+			expectedErrorSubstrings: []string{
+				"clusters-test/kube-apiserver",
+				"api.test.example.com",
+				"not admitted",
+				"default",
+				"has not set a canonical hostname",
+				"Admitted=False",
+				"HostAlreadyClaimed",
+				"route foo already exposes",
+			},
+		},
+		{
+			name: "When route is admitted without shared ingress, it should return canonical hostname",
 			route: &routev1.Route{
 				Status: routev1.RouteStatus{
 					Ingress: []routev1.RouteIngress{
@@ -51,7 +104,7 @@ func TestGetHealthcheckEndpoint(t *testing.T) {
 			expectedPort:     443,
 		},
 		{
-			name: "when using shared ingress, it should return route host",
+			name: "When using shared ingress, it should return route host",
 			route: &routev1.Route{
 				Spec: routev1.RouteSpec{
 					Host: "route.example.com",
@@ -87,7 +140,7 @@ func TestGetHealthcheckEndpoint(t *testing.T) {
 			expectedPort:     sharedingress.ExternalDNSLBPort,
 		},
 		{
-			name: "when using shared ingress with CIDR blocks, it should return KAS service",
+			name: "When using shared ingress with CIDR blocks, it should return KAS service",
 			route: &routev1.Route{
 				Spec: routev1.RouteSpec{
 					Host: "route.example.com",
@@ -140,9 +193,11 @@ func TestGetHealthcheckEndpoint(t *testing.T) {
 
 			endpoint, port, err := GetHealthcheckEndpointForRoute(tc.route, tc.hcp)
 
-			if tc.expectedError != "" {
+			if len(tc.expectedErrorSubstrings) > 0 {
 				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).To(Equal(tc.expectedError))
+				for _, substr := range tc.expectedErrorSubstrings {
+					g.Expect(err.Error()).To(ContainSubstring(substr))
+				}
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(endpoint).To(Equal(tc.expectedEndpoint))

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck_test.go
@@ -46,6 +46,7 @@ func TestGetHealthcheckEndpoint(t *testing.T) {
 				"clusters-test/kube-apiserver",
 				"api.test.example.com",
 				"route has no ingress status",
+				"last status writer:",
 			},
 		},
 		{

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck_test.go
@@ -85,6 +85,7 @@ func TestGetHealthcheckEndpoint(t *testing.T) {
 				"Admitted=False",
 				"HostAlreadyClaimed",
 				"route foo already exposes",
+				"last status writer:",
 			},
 		},
 		{

--- a/hypershift-operator/controllers/sharedingress/router_test.go
+++ b/hypershift-operator/controllers/sharedingress/router_test.go
@@ -4,6 +4,9 @@ import (
 	"reflect"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
+	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/hypershift/support/config"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -139,4 +142,73 @@ func TestReconcileRouterPodDisruptionBudget(t *testing.T) {
 			t.Errorf("Expected unhealthyPodEvictionPolicy to be AlwaysAllow, got %v", *pdb.Spec.UnhealthyPodEvictionPolicy)
 		}
 	})
+}
+
+func TestReconcileRouteStatus(t *testing.T) {
+	tests := []struct {
+		name              string
+		route             *routev1.Route
+		canonicalHostname string
+		expectUpdate      bool
+		expectedHostname  string
+	}{
+		{
+			name: "When canonical hostname is set, it should update route ingress",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{Host: "api.test.example.com"},
+			},
+			canonicalHostname: "lb.example.com",
+			expectUpdate:      true,
+			expectedHostname:  "lb.example.com",
+		},
+		{
+			name: "When canonical hostname matches existing, it should not update",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{Host: "api.test.example.com"},
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							RouterCanonicalHostname: "lb.example.com",
+							RouterName:              "router",
+						},
+					},
+				},
+			},
+			canonicalHostname: "lb.example.com",
+			expectUpdate:      false,
+			expectedHostname:  "lb.example.com",
+		},
+		{
+			name: "When canonical hostname changes, it should update route ingress",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{Host: "api.test.example.com"},
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							RouterCanonicalHostname: "old-lb.example.com",
+							RouterName:              "router",
+						},
+					},
+				},
+			},
+			canonicalHostname: "new-lb.example.com",
+			expectUpdate:      true,
+			expectedHostname:  "new-lb.example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			original := tc.route.DeepCopy()
+			ReconcileRouteStatus(tc.route, tc.canonicalHostname)
+			if tc.expectUpdate {
+				g.Expect(tc.route.Status.Ingress).To(HaveLen(1))
+				g.Expect(tc.route.Status.Ingress[0].RouterCanonicalHostname).To(Equal(tc.expectedHostname))
+				g.Expect(tc.route.Status.Ingress[0].RouterName).To(Equal("router"))
+			} else {
+				g.Expect(tc.route.Status).To(Equal(original.Status))
+			}
+		})
+	}
 }

--- a/hypershift-operator/controllers/sharedingress/router_test.go
+++ b/hypershift-operator/controllers/sharedingress/router_test.go
@@ -6,8 +6,9 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/hypershift/support/config"
+
+	routev1 "github.com/openshift/api/route/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
+++ b/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
@@ -222,8 +222,15 @@ func (r *SharedIngressReconciler) reconcileRouter(ctx context.Context, pullSecre
 	// and causes the CPO health check to report "route not admitted", flapping the
 	// HostedCluster Available condition.
 	if canonicalHostname == "" {
-		log.Log.Info("shared ingress LB has no hostname or IP; skipping route status reconciliation",
-			"service", client.ObjectKeyFromObject(svc))
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			log.Log.Info("shared ingress LB is not provisioned; skipping route status reconciliation",
+				"service", client.ObjectKeyFromObject(svc),
+				"serviceSince", svc.CreationTimestamp.Time)
+		} else {
+			log.Log.Info("shared ingress LB has ingress entry with no hostname or IP; skipping route status reconciliation",
+				"service", client.ObjectKeyFromObject(svc),
+				"ingressEntries", len(svc.Status.LoadBalancer.Ingress))
+		}
 		return nil
 	}
 

--- a/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
+++ b/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
@@ -253,11 +253,12 @@ func (r *SharedIngressReconciler) reconcileRouter(ctx context.Context, pullSecre
 			}
 		}
 		if route.Annotations[netutil.RouteStatusWriterAnnotation] != "shared-ingress" {
+			routeBeforeAnnotation := route.DeepCopy()
 			if route.Annotations == nil {
 				route.Annotations = map[string]string{}
 			}
 			route.Annotations[netutil.RouteStatusWriterAnnotation] = "shared-ingress"
-			if err := r.Client.Patch(ctx, &route, client.MergeFrom(originalRoute)); err != nil {
+			if err := r.Client.Patch(ctx, &route, client.MergeFrom(routeBeforeAnnotation)); err != nil {
 				return fmt.Errorf("failed to update route %s status-writer annotation: %w", route.Name, err)
 			}
 		}

--- a/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
+++ b/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
@@ -217,6 +217,16 @@ func (r *SharedIngressReconciler) reconcileRouter(ctx context.Context, pullSecre
 		}
 	}
 
+	// When the LB has no hostname or IP, we must not write route status with an
+	// empty RouterCanonicalHostname. Doing so overwrites a previously-valid value
+	// and causes the CPO health check to report "route not admitted", flapping the
+	// HostedCluster Available condition.
+	if canonicalHostname == "" {
+		log.Log.Info("shared ingress LB has no hostname or IP; skipping route status reconciliation",
+			"service", client.ObjectKeyFromObject(svc))
+		return nil
+	}
+
 	routeList := &routev1.RouteList{}
 	// If the hypershift.openshift.io/hosted-control-plane label is not present,
 	// then it means the route should be fulfilled by the management cluster's router.

--- a/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
+++ b/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
@@ -252,6 +252,15 @@ func (r *SharedIngressReconciler) reconcileRouter(ctx context.Context, pullSecre
 				return fmt.Errorf("failed to update route %s status: %w", route.Name, err)
 			}
 		}
+		if route.Annotations[netutil.RouteStatusWriterAnnotation] != "shared-ingress" {
+			if route.Annotations == nil {
+				route.Annotations = map[string]string{}
+			}
+			route.Annotations[netutil.RouteStatusWriterAnnotation] = "shared-ingress"
+			if err := r.Client.Patch(ctx, &route, client.MergeFrom(originalRoute)); err != nil {
+				return fmt.Errorf("failed to update route %s status-writer annotation: %w", route.Name, err)
+			}
+		}
 	}
 
 	routerDeploymentOwnerRef := supportconfig.OwnerRefFrom(deployment)

--- a/support/netutil/route.go
+++ b/support/netutil/route.go
@@ -17,6 +17,12 @@ import (
 const HCPRouteLabel = "hypershift.openshift.io/hosted-control-plane"
 const InternalRouteLabel = "hypershift.openshift.io/internal-route"
 
+// RouteStatusWriterAnnotation identifies which controller last wrote a route's
+// Status.Ingress. Both the shared ingress controller and the CPO's HCP router
+// use RouterName "router", making their writes indistinguishable from the route
+// object alone. This annotation resolves that ambiguity for diagnosis.
+const RouteStatusWriterAnnotation = "hypershift.openshift.io/route-status-writer"
+
 // RemoveLabelMarker is a sentinel value that can be set on a label to indicate
 // that the label should be removed during metadata preservation in ApplyManifest.
 // This allows adapt functions to explicitly request label removal even when using


### PR DESCRIPTION
# INFO

Consider all commits in this PR as *proposals* - we see a serious gap in observability in this space, but I am not married to any of these individual approaches as long as we see the gap closed. I am happy to edit, redo, omit, etc, any of these changes as requested.

---

fix: control-plane-operator: improve opaque conditions

When we have the context on *why* something is not progressing or
presenting the way we expected it to be, we should say so. Users will be
thrilled to not need to learn about which code flows might have been
triggered and think through the implicit reasoning behind why a
condition is failing.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

fix(sharedingress): skip route status reconciliation when LB has no hostname

When the shared ingress LB service has no hostname or IP, the controller
was writing an empty RouterCanonicalHostname to all HCP-labeled routes.
This overwrites any previously-valid value and causes the CPO health
check to report "route not admitted", flapping the HostedCluster
Available condition every reconcile cycle.

Skip route status reconciliation entirely when the canonical hostname
is empty, preserving the last-known-good route status.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>
Commit-Message-Assisted-by: Claude (via Claude Code)

---

fix(sharedingress): distinguish LB not provisioned vs empty ingress in logs

Differentiate the two sub-cases when skipping route status
reconciliation: LB has no ingress entries at all (not yet provisioned,
includes creation timestamp) vs LB has ingress entries with no
hostname or IP. This lets operators diagnose the root cause from shared
ingress controller logs alone.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>
Commit-Message-Assisted-by: Claude (via Claude Code)

---

fix: annotate routes with which controller last wrote status

Both the shared ingress controller and the CPO HCP router write route
Status.Ingress with RouterName "router", making their writes
indistinguishable when diagnosing route status flapping.

Add a hypershift.openshift.io/route-status-writer annotation set to
"shared-ingress" or "hcp-router" by the respective controllers, and
include its value in the CPO health check error message.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>
Commit-Message-Assisted-by: Claude (via Claude Code)

---

fix(cpo): include last status writer in "no ingress" health check error

The "route has no ingress status" case previously gave no indication of
whether the route was never admitted or had its admission cleared. By
including the route-status-writer annotation value, operators can tell
from the HostedCluster condition message alone which controller last
touched the route, without needing to inspect the route object.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>
Commit-Message-Assisted-by: Claude (via Claude Code)
Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced KubeAPI health checks to use verbose output, surfacing which specific health checks are failing and adding endpoint context on request failures.
  * Improved load balancer and endpoint health diagnostics, distinguishing “not yet provisioned” from “missing ingress hostname/IP” and improving unhealthy error messages (including for HTTP 503).
  * Expanded Route-based readiness errors with richer ingress/admission condition details when required routing attributes are absent.
  * More reliable Route status reconciliation by preventing overwrites when router hostnames aren’t known and by attributing status writes to avoid conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->