### PR TITLE
OCPBUGS-91656: fix(test): add retry logic to GetLogs in Karpenter kubelet propagatio…

### DIFF
--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -1325,13 +1325,19 @@ func testKubeletPropagation(ctx context.Context, mgtClient, guestClient crclient
 			g.Expect(p.Status.Phase).To(BeElementOf(corev1.PodSucceeded, corev1.PodFailed))
 		}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 
-		// Always fetch and log the pod output so it's visible in the test run
-		logReq := guestClientset.CoreV1().Pods(checkerPod.Namespace).GetLogs(checkerPod.Name, &corev1.PodLogOptions{Container: "checker"})
-		logStream, err := logReq.Stream(ctx)
-		g.Expect(err).NotTo(HaveOccurred())
-		defer logStream.Close()
-		logBytes, err := io.ReadAll(logStream)
-		g.Expect(err).NotTo(HaveOccurred())
+		// Fetch pod output with retries — the kubelet serving cert on freshly
+		// provisioned Karpenter nodes may not be ready immediately after the
+		// node is marked Ready, causing transient TLS or HTTP/2 errors on the
+		// proxied log request.
+		var logBytes []byte
+		g.Eventually(func(g Gomega) {
+			logReq := guestClientset.CoreV1().Pods(checkerPod.Namespace).GetLogs(checkerPod.Name, &corev1.PodLogOptions{Container: "checker"})
+			logStream, err := logReq.Stream(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			defer logStream.Close()
+			logBytes, err = io.ReadAll(logStream)
+			g.Expect(err).NotTo(HaveOccurred())
+		}).WithTimeout(2 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 		t.Logf("kubelet-config-checker output:\n%s", string(logBytes))
 
 		// Assert the pod succeeded (grep chain exited 0 = all fields found)


### PR DESCRIPTION
…n test

## What this PR does / why we need it:

The kubelet serving certificate on freshly provisioned Karpenter nodes may not be ready immediately after the node is marked Ready, causing transient "tls: internal error" or "http2: client connection lost" failures on the proxied log request. Wrap the GetLogs call in g.Eventually with a 2-minute timeout to tolerate this window.

## Which issue(s) this PR fixes:
Fixes https://redhat.atlassian.net/browse/OCPBUGS-91656

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of node provisioning tests on newly provisioned clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->