### PR TITLE
NO-JIRA: fix(ci): switch to openshift-developer plugin bundle for GHA workflows

### DIFF
--- a/.github/workflows/address-review-comments.yaml
+++ b/.github/workflows/address-review-comments.yaml
@@ -21,6 +21,6 @@ jobs:
     with:
       command-name: address-review-comments
       status-message: "Addressing review comments"
-      claude-prompt: "/utils:address-reviews ${{ github.event.issue.number }}"
+      claude-prompt: "/openshift-developer:address-review-pr ${{ github.event.issue.number }}"
       max-turns: 200
     secrets: inherit

--- a/.github/workflows/reusable-claude-on-pr.yaml
+++ b/.github/workflows/reusable-claude-on-pr.yaml
@@ -119,9 +119,6 @@ jobs:
           ALLOWED_TOOLS: ${{ inputs.allowed-tools }}
         run: |
           claude plugin marketplace add openshift-eng/ai-helpers
-          claude plugin install utils@ai-helpers
-          claude plugin install golang@ai-helpers
-          claude plugin marketplace add enxebre/ai-scripts
-          claude plugin install git@enxebre
+          claude plugin install openshift-developer@ai-helpers
           claude --version
           claude -p "$CLAUDE_PROMPT" --model claude-opus-4-6 --max-turns "$MAX_TURNS" --allowedTools "$ALLOWED_TOOLS" --verbose --output-format stream-json


### PR DESCRIPTION
## What this PR does / why we need it:

The `address-reviews` skill was moved upstream from the `utils` plugin to the `openshift-developer` plugin (as `address-review-pr`). This caused the `/address-review-comments` GHA job to fail with `Unknown command: /utils:address-reviews`.

This PR:
- Updates the `address-review-comments` workflow prompt to use `/openshift-developer:address-review-pr`
- Replaces individual plugin installs (`utils`, `golang`, `git` from `enxebre`) with the `openshift-developer` bundle, which auto-installs all dependencies (`jira`, `ci`, `golang`, `git`, `gopls-lsp`)

## Which issue(s) this PR fixes:

Fixes the `/address-review-comments` GHA command failing after the upstream skill migration.

## Special notes for your reviewer:

Verified locally that `claude plugin install openshift-developer@ai-helpers` auto-resolves all 5 dependencies without needing the `enxebre/ai-scripts` marketplace or individual plugin installs.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use new configurations for AI-assisted code review and pull request automation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->