### PR TITLE
fix(ci): add missing plugin marketplaces for GHA workflows

### DIFF
--- a/.github/workflows/reusable-claude-on-pr.yaml
+++ b/.github/workflows/reusable-claude-on-pr.yaml
@@ -119,6 +119,8 @@ jobs:
           ALLOWED_TOOLS: ${{ inputs.allowed-tools }}
         run: |
           claude plugin marketplace add openshift-eng/ai-helpers
+          claude plugin marketplace add anthropics/claude-plugins-official
+          claude plugin marketplace add RedHatProductSecurity/prodsec-skills
           claude plugin install openshift-developer@ai-helpers
           claude --version
           claude -p "$CLAUDE_PROMPT" --model claude-opus-4-6 --max-turns "$MAX_TURNS" --allowedTools "$ALLOWED_TOOLS" --verbose --output-format stream-json


### PR DESCRIPTION
## What this PR does / why we need it:

Adds the `claude-plugins-official` and `prodsec-skills` marketplaces to the reusable GHA workflow. The `openshift-developer` plugin bundle (introduced in #8809) depends on plugins from these external marketplaces (`gopls-lsp` from `claude-plugins-official` and `prodsec-skills` from `RedHatProductSecurity/prodsec-skills`). Without them, the bundle fails to load with `dependency-unsatisfied` errors and its skills (including `address-review-pr`) are never registered.

## Which issue(s) this PR fixes:

Fixes the broken `/address-review-comments` GHA job after #8809 was merged.

## Special notes for your reviewer:

The failing GHA run: https://github.com/openshift/hypershift/actions/runs/28025683087/job/82952751320

The init JSON from that run shows the root cause:
```json
"plugin_errors":[
  {"plugin":"openshift-developer@ai-helpers","type":"dependency-unsatisfied","message":"Dependency \"prodsec-skills@prodsec-skills\" is not installed"},
  {"plugin":"golang@ai-helpers","type":"dependency-unsatisfied","message":"Dependency \"gopls-lsp@claude-plugins-official\" is not installed"}
]
```

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance automated code processing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->