### PR TITLE
CNTRLPLANE-3352: force HTTPS for GHA plugin dependency clones

### DIFF
--- a/.github/workflows/reusable-claude-on-pr.yaml
+++ b/.github/workflows/reusable-claude-on-pr.yaml
@@ -117,6 +117,9 @@ jobs:
           CLAUDE_PROMPT: ${{ inputs.claude-prompt }}
           MAX_TURNS: ${{ inputs.max-turns }}
           ALLOWED_TOOLS: ${{ inputs.allowed-tools }}
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: "url.https://github.com/.insteadOf"
+          GIT_CONFIG_VALUE_0: "git@github.com:"
         run: |
           claude plugin marketplace add openshift-eng/ai-helpers
           claude plugin install openshift-developer@ai-helpers


### PR DESCRIPTION
## What this PR does / why we need it:

The `claude plugin install openshift-developer@ai-helpers` step in the
reusable GHA workflow fails because plugin dependencies with external
source repos (`prodsec-skills`, `gopls-lsp`) are cloned via SSH. The
GHA runners don't have SSH keys for GitHub, so the clone fails with
`Host key verification failed`.

This adds `GIT_CONFIG` env vars to redirect all `git@github.com:` URLs
to `https://github.com/`, which is the standard pattern for CI
environments without SSH access.

Evidence of failure: https://github.com/openshift/hypershift/actions/runs/28036121179/job/82989822214
```
✘ Failed to install plugin "openshift-developer@ai-helpers":
  Failed to clone repository: Host key verification failed.
```

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3352](https://redhat.atlassian.net/browse/CNTRLPLANE-3352)

## Special notes for your reviewer:

The external plugin dependencies (`gopls-lsp`, `prodsec-skills`) were
bundled into the ai-helpers marketplace in openshift-eng/ai-helpers#565,
so only the `ai-helpers` marketplace needs to be added. But the source
repos still need to be cloned during install, which is what this SSH→HTTPS
redirect fixes.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.