### PR TITLE
OCPBUGS-86415: fix(nodepool): use canonical image for kube-apiserver-proxy static pod

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -98,6 +98,11 @@ type NodePoolReconciler struct {
 	client.Client
 	recorder        record.EventRecorder
 	ReleaseProvider releaseinfo.Provider
+	// DataPlaneReleaseProvider looks up release images without applying
+	// management-cluster registry overrides. Images destined for the data plane
+	// ignition payload should be resolved through this provider so that CRI-O on
+	// the nodes can handle mirroring natively via registries.conf.
+	DataPlaneReleaseProvider releaseinfo.Provider
 	upsert.CreateOrUpdateProvider
 	HypershiftOperatorImage string
 	ImageMetadataProvider   supportutil.ImageMetadataProvider
@@ -1113,7 +1118,26 @@ func resolveHAProxyImage(nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedClu
 }
 
 func (r *NodePoolReconciler) generateHAProxyRawConfig(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, releaseImage *releaseinfo.ReleaseImage) (string, error) {
-	haProxyImage, err := resolveHAProxyImage(nodePool, hcluster, releaseImage)
+	// The HAProxy image is embedded in a static pod manifest in the ignition
+	// payload for data-plane nodes. Use the non-overridden release provider so
+	// the manifest contains the canonical image reference; CRI-O on the nodes
+	// handles mirroring natively via registries.conf.
+	dataPlaneReleaseImage := releaseImage
+	if r.DataPlaneReleaseProvider != nil {
+		pullSecretBytes, err := r.getPullSecretBytes(ctx, hcluster)
+		if err != nil {
+			return "", err
+		}
+		lookupCtx, lookupCancel := context.WithTimeout(ctx, 1*time.Minute)
+		defer lookupCancel()
+		dpImage, err := r.DataPlaneReleaseProvider.Lookup(lookupCtx, nodePool.Spec.Release.Image, pullSecretBytes)
+		if err != nil {
+			return "", fmt.Errorf("failed to look up data plane release image: %w", err)
+		}
+		dataPlaneReleaseImage = dpImage
+	}
+
+	haProxyImage, err := resolveHAProxyImage(nodePool, hcluster, dataPlaneReleaseImage)
 	if err != nil {
 		return "", err
 	}

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -2519,11 +2519,13 @@ func TestResolveHAProxyImage(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name                string
-		nodePoolAnnotations map[string]string
-		useSharedIngress    bool
-		envVarImage         string
-		expectedImage       string
+		name                     string
+		nodePoolAnnotations      map[string]string
+		useSharedIngress         bool
+		envVarImage              string
+		componentImage           string
+		dataPlaneComponentImage  string
+		expectedImage            string
 	}{
 		{
 			name: "When NodePool annotation is set it should use annotation image",
@@ -2577,6 +2579,13 @@ func TestResolveHAProxyImage(t *testing.T) {
 			},
 			useSharedIngress: false,
 			expectedImage:    testReleaseImage,
+		},
+		{
+			name:                    "When registry overrides are active it should use the canonical image from the data plane provider",
+			useSharedIngress:        false,
+			componentImage:          "mirror.mgmt.internal/openshift/haproxy-router:v4.16",
+			dataPlaneComponentImage: testReleaseImage,
+			expectedImage:           testReleaseImage,
 		},
 	}
 
@@ -2670,10 +2679,23 @@ kind: Config`),
 			c := fake.NewClientBuilder().WithObjects(objects...).Build()
 
 			// Create fake release provider with component images
+			haproxyImage := testReleaseImage
+			if tc.componentImage != "" {
+				haproxyImage = tc.componentImage
+			}
 			releaseProvider := &fakereleaseprovider.FakeReleaseProvider{
 				Components: map[string]string{
-					haproxy.HAProxyRouterImageName: testReleaseImage,
+					haproxy.HAProxyRouterImageName: haproxyImage,
 				},
+			}
+
+			var dataPlaneReleaseProvider *fakereleaseprovider.FakeReleaseProvider
+			if tc.dataPlaneComponentImage != "" {
+				dataPlaneReleaseProvider = &fakereleaseprovider.FakeReleaseProvider{
+					Components: map[string]string{
+						haproxy.HAProxyRouterImageName: tc.dataPlaneComponentImage,
+					},
+				}
 			}
 
 			// Create test HostedCluster
@@ -2735,6 +2757,9 @@ kind: Config`),
 						},
 					},
 				},
+			}
+			if dataPlaneReleaseProvider != nil {
+				reconciler.DataPlaneReleaseProvider = dataPlaneReleaseProvider
 			}
 
 			// Get release image using the fake provider

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -628,14 +628,15 @@ func setupNodePoolController(ctx context.Context, mgr ctrl.Manager, opts *StartO
 	}
 
 	if err := (&nodepool.NodePoolReconciler{
-		Client:                  mgr.GetClient(),
-		ReleaseProvider:         registryProvider.ReleaseProvider,
-		CreateOrUpdateProvider:  createOrUpdate,
-		HypershiftOperatorImage: operatorImage,
-		ImageMetadataProvider:   registryProvider.MetadataProvider,
-		KubevirtInfraClients:    kvinfra.NewKubevirtInfraClientMap(),
-		EC2Client:               ec2Client,
-		InstanceTypeProvider:    instanceTypeProvider,
+		Client:                   mgr.GetClient(),
+		ReleaseProvider:          registryProvider.ReleaseProvider,
+		DataPlaneReleaseProvider: registryProvider.DataPlaneReleaseProvider,
+		CreateOrUpdateProvider:   createOrUpdate,
+		HypershiftOperatorImage:  operatorImage,
+		ImageMetadataProvider:    registryProvider.MetadataProvider,
+		KubevirtInfraClients:     kvinfra.NewKubevirtInfraClientMap(),
+		EC2Client:                ec2Client,
+		InstanceTypeProvider:     instanceTypeProvider,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)
 	}

--- a/support/globalconfig/imagecontentsource.go
+++ b/support/globalconfig/imagecontentsource.go
@@ -220,6 +220,10 @@ type CommonRegistryProvider struct {
 	capChecker       capabilities.CapabiltyChecker
 	MetadataProvider *hyperutil.RegistryClientImageMetadataProvider
 	ReleaseProvider  *releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator
+	// DataPlaneReleaseProvider resolves release images without applying
+	// management-cluster registry overrides. Use this for image references
+	// embedded in data-plane ignition payloads where CRI-O handles mirroring.
+	DataPlaneReleaseProvider releaseinfo.Provider
 }
 
 // NewCommonRegistryProvider creates a CommonRegistryProvider
@@ -237,12 +241,14 @@ func NewCommonRegistryProvider(ctx context.Context, capChecker capabilities.Capa
 		}
 	}
 
+	cachedProvider := &releaseinfo.CachedProvider{
+		Inner: &releaseinfo.RegistryClientProvider{},
+		Cache: map[string]*releaseinfo.ReleaseImage{},
+	}
+
 	releaseProvider := &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{
 		Delegate: &releaseinfo.RegistryMirrorProviderDecorator{
-			Delegate: &releaseinfo.CachedProvider{
-				Inner: &releaseinfo.RegistryClientProvider{},
-				Cache: map[string]*releaseinfo.ReleaseImage{},
-			},
+			Delegate:          cachedProvider,
 			RegistryOverrides: registryOverrides,
 		},
 		OpenShiftImageRegistryOverrides: imageRegistryMirrors,
@@ -253,9 +259,10 @@ func NewCommonRegistryProvider(ctx context.Context, capChecker capabilities.Capa
 	}
 
 	provider := CommonRegistryProvider{
-		capChecker:       capChecker,
-		MetadataProvider: metadataProvider,
-		ReleaseProvider:  releaseProvider,
+		capChecker:               capChecker,
+		MetadataProvider:         metadataProvider,
+		ReleaseProvider:          releaseProvider,
+		DataPlaneReleaseProvider: cachedProvider,
 	}
 
 	return provider, nil


### PR DESCRIPTION
## Summary

- Fixes the kube-apiserver-proxy static pod image in the ignition payload being incorrectly rewritten by management-cluster registry overrides (`--registry-overrides` / ICSP / IDMS)
- Introduces a `DataPlaneReleaseProvider` that resolves release images without registry overrides, sharing the same `CachedProvider` (no extra network calls)
- The NodePool controller now uses this provider when resolving the HAProxy image for the static pod manifest, ensuring data-plane nodes receive the canonical image reference and CRI-O handles mirroring natively via `registries.conf`

## Test plan

- [x] New unit test: `TestResolveHAProxyImage/When_registry_overrides_are_active_it_should_use_the_canonical_image_from_the_data_plane_provider`
- [x] Existing `TestResolveHAProxyImage` tests pass (8/8)
- [x] Full `nodepool` controller test suite passes
- [ ] `e2e-aws-upgrade-hypershift-operator` (verifies no fleet-wide rollout regression)

Fixes: https://issues.redhat.com/browse/OCPBUGS-86415

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced image resolution for data-plane components and HAProxy with dedicated support for registry overrides. Enables canonical image references to be properly resolved for native mirroring via registries configuration, without applying management-cluster registry overrides. Maintains full backward compatibility with existing deployments and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->