### PR TITLE
CNTRLPLANE-3352: fix GHA reusable workflow for fork PRs

### DIFF
--- a/.github/workflows/reusable-claude-on-pr.yaml
+++ b/.github/workflows/reusable-claude-on-pr.yaml
@@ -112,11 +112,15 @@ jobs:
           CLAUDE_CODE_USE_VERTEX: "1"
           CLOUD_ML_REGION: global
           ANTHROPIC_VERTEX_PROJECT_ID: hosted-control-planes
-          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
           CLAUDE_PROMPT: ${{ inputs.claude-prompt }}
           MAX_TURNS: ${{ inputs.max-turns }}
           ALLOWED_TOOLS: ${{ inputs.allowed-tools }}
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: "url.https://github.com/.insteadOf"
+          GIT_CONFIG_VALUE_0: "git@github.com:"
         run: |
           claude plugin marketplace add openshift-eng/ai-helpers
           claude plugin install openshift-developer@ai-helpers


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes three issues in the reusable Claude GHA workflow that prevented it
from working on community fork PRs:

1. **SSH clone failure**: Plugin dependencies with external source repos
   are cloned via SSH, which fails on GHA runners without SSH keys
   (`Host key verification failed`). Adds `GIT_CONFIG` env vars to
   redirect `git@github.com:` to `https://github.com/`.

2. **Fork PR resolution failure**: For PRs from community forks
   (`hypershift-community/hypershift`), the checkout sets `origin` to the
   fork. The `gh` CLI then resolves PR numbers against the fork instead
   of `openshift/hypershift`, causing `Could not resolve to a PullRequest`
   errors. Adds `GH_REPO: ${{ github.repository }}` so `gh` always
   targets the upstream repo.

3. **Fork token can't write to upstream**: `GH_TOKEN` was set to the
   fork app token for community PRs, but `gh pr comment` needs write
   access to `openshift/hypershift`. Changed `GH_TOKEN` to
   `github.token` which has `pull-requests: write` on the upstream repo.
   Git push still works because `actions/checkout` persists the app token
   via `persist-credentials: true`.

Evidence:
- SSH failure: https://github.com/openshift/hypershift/actions/runs/28036121179/job/82989822214
- Fork resolution failure: https://github.com/openshift/hypershift/actions/runs/28039505619/job/83001781412

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3352](https://redhat.atlassian.net/browse/CNTRLPLANE-3352)

## Special notes for your reviewer:

Depends on openshift-eng/ai-helpers#565 (already merged).

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI/CD “Run Claude” step to improve pull request review reliability by adjusting repository URL handling for git operations and simplifying how the token is sourced during the workflow run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->