### PR TITLE
CNTRLPLANE-3686: feat(api,cpo): add observedGeneration to ControlPlaneComponentStatus

### DIFF
--- a/api/hypershift/v1beta1/controlplanecomponent_types.go
+++ b/api/hypershift/v1beta1/controlplanecomponent_types.go
@@ -54,7 +54,7 @@ type ControlPlaneComponentStatus struct {
 	// conditions contains details for the current state of the ControlPlane Component.
 	// If there is an error, then the Available condition will be false.
 	//
-	// Current condition types are: "Available"
+	// Current condition types are: "Available", "RolloutComplete"
 	// +optional
 	// +listType=map
 	// +listMapKey=type
@@ -72,6 +72,12 @@ type ControlPlaneComponentStatus struct {
 	// +optional
 	// +kubebuilder:validation:MaxItems=100
 	Resources []ComponentResource `json:"resources,omitempty"`
+
+	// observedGeneration reports which generation of the HostedControlPlane spec has been reconciled by this component.
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=9007199254740992
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -80,9 +86,9 @@ type ControlPlaneComponentStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="Version"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].status",description="Available"
-// +kubebuilder:printcolumn:name="Progressing",type="string",JSONPath=".status.conditions[?(@.type==\"Progressing\")].status",description="Progressing"
+// +kubebuilder:printcolumn:name="RolloutComplete",type="string",JSONPath=".status.conditions[?(@.type==\"RolloutComplete\")].status",description="RolloutComplete"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].message",description="Message"
-// +kubebuilder:printcolumn:name="ProgressingMessage",type="string",priority=1,JSONPath=".status.conditions[?(@.type==\"Progressing\")].message",description="ProgressingMessage"
+// +kubebuilder:printcolumn:name="RolloutCompleteMessage",type="string",priority=1,JSONPath=".status.conditions[?(@.type==\"RolloutComplete\")].message",description="RolloutCompleteMessage"
 // ControlPlaneComponent specifies the state of a ControlPlane Component
 type ControlPlaneComponent struct {
 	metav1.TypeMeta `json:",inline"`

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests.yaml
@@ -103,17 +103,17 @@ controlplanecomponents.hypershift.openshift.io:
     jsonPath: .status.conditions[?(@.type=="Available")].status
     name: Available
     type: string
-  - description: Progressing
-    jsonPath: .status.conditions[?(@.type=="Progressing")].status
-    name: Progressing
+  - description: RolloutComplete
+    jsonPath: .status.conditions[?(@.type=="RolloutComplete")].status
+    name: RolloutComplete
     type: string
   - description: Message
     jsonPath: .status.conditions[?(@.type=="Available")].message
     name: Message
     type: string
-  - description: ProgressingMessage
-    jsonPath: .status.conditions[?(@.type=="Progressing")].message
-    name: ProgressingMessage
+  - description: RolloutCompleteMessage
+    jsonPath: .status.conditions[?(@.type=="RolloutComplete")].message
+    name: RolloutCompleteMessage
     priority: 1
     type: string
   Scope: Namespaced

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/controlplanecomponents.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/controlplanecomponents.hypershift.openshift.io/AAA_ungated.yaml
@@ -25,17 +25,17 @@ spec:
       jsonPath: .status.conditions[?(@.type=="Available")].status
       name: Available
       type: string
-    - description: Progressing
-      jsonPath: .status.conditions[?(@.type=="Progressing")].status
-      name: Progressing
+    - description: RolloutComplete
+      jsonPath: .status.conditions[?(@.type=="RolloutComplete")].status
+      name: RolloutComplete
       type: string
     - description: Message
       jsonPath: .status.conditions[?(@.type=="Available")].message
       name: Message
       type: string
-    - description: ProgressingMessage
-      jsonPath: .status.conditions[?(@.type=="Progressing")].message
-      name: ProgressingMessage
+    - description: RolloutCompleteMessage
+      jsonPath: .status.conditions[?(@.type=="RolloutComplete")].message
+      name: RolloutCompleteMessage
       priority: 1
       type: string
     name: v1beta1
@@ -71,7 +71,7 @@ spec:
                   conditions contains details for the current state of the ControlPlane Component.
                   If there is an error, then the Available condition will be false.
 
-                  Current condition types are: "Available"
+                  Current condition types are: "Available", "RolloutComplete"
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -131,6 +131,13 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              observedGeneration:
+                description: observedGeneration reports which generation of the HostedControlPlane
+                  spec has been reconciled by this component.
+                format: int64
+                maximum: 9007199254740992
+                minimum: 1
+                type: integer
               resources:
                 description: resources is a list of the resources reconciled by this
                   component.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/controlplanecomponents.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/controlplanecomponents.crd.yaml
@@ -27,17 +27,17 @@ spec:
       jsonPath: .status.conditions[?(@.type=="Available")].status
       name: Available
       type: string
-    - description: Progressing
-      jsonPath: .status.conditions[?(@.type=="Progressing")].status
-      name: Progressing
+    - description: RolloutComplete
+      jsonPath: .status.conditions[?(@.type=="RolloutComplete")].status
+      name: RolloutComplete
       type: string
     - description: Message
       jsonPath: .status.conditions[?(@.type=="Available")].message
       name: Message
       type: string
-    - description: ProgressingMessage
-      jsonPath: .status.conditions[?(@.type=="Progressing")].message
-      name: ProgressingMessage
+    - description: RolloutCompleteMessage
+      jsonPath: .status.conditions[?(@.type=="RolloutComplete")].message
+      name: RolloutCompleteMessage
       priority: 1
       type: string
     name: v1beta1
@@ -73,7 +73,7 @@ spec:
                   conditions contains details for the current state of the ControlPlane Component.
                   If there is an error, then the Available condition will be false.
 
-                  Current condition types are: "Available"
+                  Current condition types are: "Available", "RolloutComplete"
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -133,6 +133,13 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              observedGeneration:
+                description: observedGeneration reports which generation of the HostedControlPlane
+                  spec has been reconciled by this component.
+                format: int64
+                maximum: 9007199254740992
+                minimum: 1
+                type: integer
               resources:
                 description: resources is a list of the resources reconciled by this
                   component.

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -42951,7 +42951,7 @@ ControlPlaneComponentStatus
 <em>(Optional)</em>
 <p>conditions contains details for the current state of the ControlPlane Component.
 If there is an error, then the Available condition will be false.</p>
-<p>Current condition types are: &ldquo;Available&rdquo;</p>
+<p>Current condition types are: &ldquo;Available&rdquo;, &ldquo;RolloutComplete&rdquo;</p>
 </td>
 </tr>
 <tr>
@@ -42978,6 +42978,18 @@ string
 <td>
 <em>(Optional)</em>
 <p>resources is a list of the resources reconciled by this component.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>observedGeneration reports which generation of the HostedControlPlane spec has been reconciled by this component.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -6478,7 +6478,7 @@ ControlPlaneComponentStatus
 <em>(Optional)</em>
 <p>conditions contains details for the current state of the ControlPlane Component.
 If there is an error, then the Available condition will be false.</p>
-<p>Current condition types are: &ldquo;Available&rdquo;</p>
+<p>Current condition types are: &ldquo;Available&rdquo;, &ldquo;RolloutComplete&rdquo;</p>
 </td>
 </tr>
 <tr>
@@ -6505,6 +6505,18 @@ string
 <td>
 <em>(Optional)</em>
 <p>resources is a list of the resources reconciled by this component.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>observedGeneration reports which generation of the HostedControlPlane spec has been reconciled by this component.</p>
 </td>
 </tr>
 </tbody>

--- a/support/controlplane-component/status.go
+++ b/support/controlplane-component/status.go
@@ -134,6 +134,8 @@ func (c *controlPlaneWorkload[T]) reconcileComponentStatus(cpContext ControlPlan
 		component.Status.Version = cpContext.ReleaseImageProvider.Version()
 	}
 
+	component.Status.ObservedGeneration = cpContext.HCP.Generation
+
 	return nil
 }
 

--- a/support/controlplane-component/status_test.go
+++ b/support/controlplane-component/status_test.go
@@ -194,11 +194,13 @@ func TestReconcileComponentStatus(t *testing.T) {
 				WithObjects(tc.deployment).
 				Build()
 
+			var hcpGeneration int64 = 5
 			cpContext := ControlPlaneContext{
 				Client: client,
 				HCP: &hyperv1.HostedControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: namespace,
+						Namespace:  namespace,
+						Generation: hcpGeneration,
 					},
 				},
 				ReleaseImageProvider: testutil.FakeImageProvider(),
@@ -235,6 +237,9 @@ func TestReconcileComponentStatus(t *testing.T) {
 
 			// Check version
 			g.Expect(componentStatus.Status.Version).To(Equal(tc.expectedVersion))
+
+			// Check observedGeneration is always set to the HCP generation
+			g.Expect(componentStatus.Status.ObservedGeneration).To(Equal(hcpGeneration))
 		})
 	}
 }

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/controlplanecomponent_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/controlplanecomponent_types.go
@@ -54,7 +54,7 @@ type ControlPlaneComponentStatus struct {
 	// conditions contains details for the current state of the ControlPlane Component.
 	// If there is an error, then the Available condition will be false.
 	//
-	// Current condition types are: "Available"
+	// Current condition types are: "Available", "RolloutComplete"
 	// +optional
 	// +listType=map
 	// +listMapKey=type
@@ -72,6 +72,12 @@ type ControlPlaneComponentStatus struct {
 	// +optional
 	// +kubebuilder:validation:MaxItems=100
 	Resources []ComponentResource `json:"resources,omitempty"`
+
+	// observedGeneration reports which generation of the HostedControlPlane spec has been reconciled by this component.
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=9007199254740992
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -80,9 +86,9 @@ type ControlPlaneComponentStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="Version"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].status",description="Available"
-// +kubebuilder:printcolumn:name="Progressing",type="string",JSONPath=".status.conditions[?(@.type==\"Progressing\")].status",description="Progressing"
+// +kubebuilder:printcolumn:name="RolloutComplete",type="string",JSONPath=".status.conditions[?(@.type==\"RolloutComplete\")].status",description="RolloutComplete"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].message",description="Message"
-// +kubebuilder:printcolumn:name="ProgressingMessage",type="string",priority=1,JSONPath=".status.conditions[?(@.type==\"Progressing\")].message",description="ProgressingMessage"
+// +kubebuilder:printcolumn:name="RolloutCompleteMessage",type="string",priority=1,JSONPath=".status.conditions[?(@.type==\"RolloutComplete\")].message",description="RolloutCompleteMessage"
 // ControlPlaneComponent specifies the state of a ControlPlane Component
 type ControlPlaneComponent struct {
 	metav1.TypeMeta `json:",inline"`

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests.yaml
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests.yaml
@@ -103,17 +103,17 @@ controlplanecomponents.hypershift.openshift.io:
     jsonPath: .status.conditions[?(@.type=="Available")].status
     name: Available
     type: string
-  - description: Progressing
-    jsonPath: .status.conditions[?(@.type=="Progressing")].status
-    name: Progressing
+  - description: RolloutComplete
+    jsonPath: .status.conditions[?(@.type=="RolloutComplete")].status
+    name: RolloutComplete
     type: string
   - description: Message
     jsonPath: .status.conditions[?(@.type=="Available")].message
     name: Message
     type: string
-  - description: ProgressingMessage
-    jsonPath: .status.conditions[?(@.type=="Progressing")].message
-    name: ProgressingMessage
+  - description: RolloutCompleteMessage
+    jsonPath: .status.conditions[?(@.type=="RolloutComplete")].message
+    name: RolloutCompleteMessage
     priority: 1
     type: string
   Scope: Namespaced


### PR DESCRIPTION
## Summary

- Adds `observedGeneration` field to `ControlPlaneComponentStatus` to track which HostedControlPlane generation each component last reconciled
- Closes the gap where a component reports `RolloutComplete=True` from a previous reconcile while the CPO hasn't yet processed a new HCP spec change
- The field is set unconditionally at the end of `reconcileComponentStatus` — conditions (`RolloutComplete`, `Available`) communicate success/failure, while `observedGeneration` signals "I've processed this generation"

## Test plan

- [x] Unit tests updated — `TestReconcileComponentStatus` asserts `ObservedGeneration` equals HCP generation in all test cases
- [x] `make api` regenerated CRDs, deepcopy, clients, docs
- [x] `make api-lint-fix` passes with 0 issues
- [ ] `make verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Control plane component status now reports `observedGeneration`, indicating which Hosted Control Plane spec generation has been reconciled.
  * Control Plane Component CRD status output now emphasizes rollout completion with `RolloutComplete` and `RolloutCompleteMessage` (replacing progressing-focused columns).

* **Bug Fixes**
  * Component status reconciliation now correctly sets `observedGeneration` based on the Hosted Control Plane’s current `generation`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->