### PR TITLE
OCPBUGS-91650: bump consolidateAfter to 60s in karpenter e2e base NodePool

### DIFF
--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -1738,7 +1738,10 @@ func baseNodePool(name, nodeClassName string) *karpenterv1.NodePool {
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: karpenterv1.NodePoolSpec{
 			Disruption: karpenterv1.Disruption{
-				ConsolidateAfter: karpenterv1.MustParseNillableDuration("0s"),
+				// 60s mitigates the risk of consolidation from racing with drift
+				// the default setting of 0s can cause replacement nodes to be deleted
+				// before the drift drain begins.
+				ConsolidateAfter: karpenterv1.MustParseNillableDuration("60s"),
 			},
 			Template: karpenterv1.NodeClaimTemplate{
 				ObjectMeta: karpenterv1.ObjectMeta{


### PR DESCRIPTION
With consolidateAfter set to 0s, drift replacement nodes become consolidation-eligible the instant they initialize. The emptiness controller can delete them before the drift command drains the source, causing the upgrade test to fail (OCPBUGS-91650).

60s gives the drift command time to begin eviction after the replacement is ready.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated node pool disruption consolidation configuration to use a 60-second delay instead of immediate consolidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->