### PR TITLE
OCPBUGS-92013: fix NodePool stuck in UpdatingVersion/UpdatingConfig due to stale conversion-data annotation

### DIFF
--- a/hypershift-operator/controllers/nodepool/capi_test.go
+++ b/hypershift-operator/controllers/nodepool/capi_test.go
@@ -27,7 +27,6 @@ import (
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
-	"sigs.k8s.io/cluster-api/util/conversion"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -3284,22 +3283,6 @@ func TestMachineDeploymentComplete(t *testing.T) {
 	two := int32(2)
 	three := int32(3)
 
-	conversionData := func(replicas, upToDate, available int32, observedGen int64) string {
-		data := map[string]any{
-			"apiVersion": "cluster.x-k8s.io/v1beta2",
-			"kind":       "MachineDeployment",
-			"spec":       map[string]any{"replicas": replicas},
-			"status": map[string]any{
-				"observedGeneration": observedGen,
-				"replicas":           replicas,
-				"upToDateReplicas":   upToDate,
-				"availableReplicas":  available,
-			},
-		}
-		raw, _ := json.Marshal(data)
-		return string(raw)
-	}
-
 	testCases := []struct {
 		name     string
 		md       *capiv1.MachineDeployment
@@ -3308,106 +3291,92 @@ func TestMachineDeploymentComplete(t *testing.T) {
 		{
 			name: "When all v1beta1 and v1beta2 fields agree it should return true",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
-					Annotations: map[string]string{
-						conversion.DataAnnotation: conversionData(2, 2, 2, 2),
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: &two},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2,
+					V1Beta2: &capiv1.MachineDeploymentV1Beta2Status{
+						UpToDateReplicas:  ptr.To(int32(2)),
+						AvailableReplicas: ptr.To(int32(2)),
 					},
 				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2},
 			},
 			expected: true,
 		},
 		{
 			name: "When v1beta1 looks complete but v1beta2 upToDateReplicas disagrees it should return false",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
-					Annotations: map[string]string{
-						conversion.DataAnnotation: conversionData(2, 0, 2, 2),
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: &two},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2,
+					V1Beta2: &capiv1.MachineDeploymentV1Beta2Status{
+						UpToDateReplicas:  ptr.To(int32(0)),
+						AvailableReplicas: ptr.To(int32(2)),
 					},
 				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2},
 			},
 			expected: false,
 		},
 		{
-			name: "When v1beta1 looks complete but v1beta2 replicas shows surge it should return false",
+			name: "When v1beta1 looks complete but v1beta2 availableReplicas disagrees it should return false",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
-					Annotations: map[string]string{
-						conversion.DataAnnotation: conversionData(3, 2, 2, 2),
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: &two},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2,
+					V1Beta2: &capiv1.MachineDeploymentV1Beta2Status{
+						UpToDateReplicas:  ptr.To(int32(2)),
+						AvailableReplicas: ptr.To(int32(1)),
 					},
 				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2},
 			},
 			expected: false,
 		},
 		{
-			name: "When v1beta1 looks complete but v1beta2 observedGeneration is stale it should return false",
+			name: "When v1beta1 is not complete it should return false without checking v1beta2",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
-					Annotations: map[string]string{
-						conversion.DataAnnotation: conversionData(2, 2, 2, 1),
-					},
-				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2},
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: &two},
+				Status:     capiv1.MachineDeploymentStatus{Replicas: 3, UpdatedReplicas: 1, AvailableReplicas: 2, ObservedGeneration: 2},
 			},
 			expected: false,
 		},
 		{
-			name: "When v1beta1 is not complete it should return false without checking conversion data",
+			name: "When v1beta2 status is nil it should fall back to v1beta1 only",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
-				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 3, UpdatedReplicas: 1, AvailableReplicas: 2, ObservedGeneration: 2},
-			},
-			expected: false,
-		},
-		{
-			name: "When no conversion-data annotation exists it should fall back to v1beta1 only",
-			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 1,
-				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 1},
-			},
-			expected: true,
-		},
-		{
-			name: "When conversion-data annotation is malformed it should fall back to v1beta1 result",
-			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 1,
-					Annotations: map[string]string{
-						conversion.DataAnnotation: "not-valid-json",
-					},
-				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 1},
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: &two},
+				Status:     capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 1},
 			},
 			expected: true,
 		},
 		{
 			name: "When v1beta1 replicas does not match spec it should return false",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
-					Annotations: map[string]string{
-						conversion.DataAnnotation: conversionData(3, 2, 2, 2),
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: &three},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2,
+					V1Beta2: &capiv1.MachineDeploymentV1Beta2Status{
+						UpToDateReplicas:  ptr.To(int32(2)),
+						AvailableReplicas: ptr.To(int32(2)),
 					},
 				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &three},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2},
+			},
+			expected: false,
+		},
+		{
+			name: "When v1beta2 upToDateReplicas is nil it should return false",
+			md: &capiv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: &two},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2,
+					V1Beta2: &capiv1.MachineDeploymentV1Beta2Status{
+						AvailableReplicas: ptr.To(int32(2)),
+					},
+				},
 			},
 			expected: false,
 		},

--- a/hypershift-operator/controllers/nodepool/capi_test.go
+++ b/hypershift-operator/controllers/nodepool/capi_test.go
@@ -3380,6 +3380,35 @@ func TestMachineDeploymentComplete(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "When v1beta2 availableReplicas is nil it should return false",
+			md: &capiv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: &two},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2,
+					V1Beta2: &capiv1.MachineDeploymentV1Beta2Status{
+						UpToDateReplicas: ptr.To(int32(2)),
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "When desired replicas is zero and v1beta2 fields are nil it should return false",
+			md: func() *capiv1.MachineDeployment {
+				zero := int32(0)
+				return &capiv1.MachineDeployment{
+					ObjectMeta: metav1.ObjectMeta{Generation: 2},
+					Spec:       capiv1.MachineDeploymentSpec{Replicas: &zero},
+					Status: capiv1.MachineDeploymentStatus{
+						Replicas: 0, UpdatedReplicas: 0, AvailableReplicas: 0, ObservedGeneration: 2,
+						V1Beta2: &capiv1.MachineDeploymentV1Beta2Status{},
+					},
+				}
+			}(),
+			expected: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -2,7 +2,6 @@ package nodepool
 
 import (
 	"context"
-	"encoding/json"
 	coreerrors "errors"
 	"fmt"
 	"os"
@@ -44,7 +43,6 @@ import (
 	capiopenstackv1beta1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -792,8 +790,8 @@ func defaultNodePoolGCPImage(specifiedArch string, releaseImage *releaseinfo.Rel
 // fields come from conversion. The converted v1beta1 fields (especially UpdatedReplicas,
 // which maps from deprecated.v1beta1.updatedReplicas rather than the native upToDateReplicas)
 // can transiently disagree with the v1beta2 native fields. To guard against this, when the
-// v1beta1 fields indicate completion we cross-check against the authoritative v1beta2 status
-// stored in the conversion-data annotation.
+// v1beta1 fields indicate completion we cross-check against the v1beta2 status stored in the
+// Status.V1Beta2 field, which is kept current on every status-subresource write.
 func MachineDeploymentComplete(deployment *capiv1.MachineDeployment) bool {
 	newStatus := &deployment.Status
 	v1beta1Complete := newStatus.UpdatedReplicas == *(deployment.Spec.Replicas) &&
@@ -803,39 +801,21 @@ func MachineDeploymentComplete(deployment *capiv1.MachineDeployment) bool {
 	if !v1beta1Complete {
 		return false
 	}
-	return machineDeploymentCompleteFromConversionData(deployment)
+	return machineDeploymentCompleteFromV1Beta2Status(deployment)
 }
 
-// machineDeploymentCompleteFromConversionData parses the v1beta2 conversion-data annotation
-// and verifies that the native v1beta2 status also indicates completion. If the annotation
-// is absent (e.g. CAPI < v1.11), returns true to preserve backwards compatibility.
-func machineDeploymentCompleteFromConversionData(deployment *capiv1.MachineDeployment) bool {
-	raw, ok := deployment.Annotations[conversion.DataAnnotation]
-	if !ok {
+// machineDeploymentCompleteFromV1Beta2Status verifies that the native v1beta2 status fields
+// also indicate completion. The v1beta1 Status.V1Beta2 field is populated by the v1beta2-to-v1beta1
+// conversion on every status-subresource write, so it is always current.
+// If V1Beta2 is nil (e.g. CAPI < v1.11), returns true to preserve backwards compatibility.
+func machineDeploymentCompleteFromV1Beta2Status(deployment *capiv1.MachineDeployment) bool {
+	v1beta2 := deployment.Status.V1Beta2
+	if v1beta2 == nil {
 		return true
 	}
-
-	var v1beta2MD struct {
-		Spec struct {
-			Replicas *int32 `json:"replicas"`
-		} `json:"spec"`
-		Status struct {
-			ObservedGeneration int64  `json:"observedGeneration"`
-			Replicas           *int32 `json:"replicas"`
-			AvailableReplicas  *int32 `json:"availableReplicas"`
-			UpToDateReplicas   *int32 `json:"upToDateReplicas"`
-		} `json:"status"`
-	}
-	if err := json.Unmarshal([]byte(raw), &v1beta2MD); err != nil {
-		ctrl.Log.WithName("nodepool").Error(err, "Failed to unmarshal conversion-data annotation, falling back to v1beta1 status")
-		return true
-	}
-
-	desired := ptr.Deref(v1beta2MD.Spec.Replicas, 0)
-	return ptr.Deref(v1beta2MD.Status.UpToDateReplicas, 0) == desired &&
-		ptr.Deref(v1beta2MD.Status.Replicas, 0) == desired &&
-		ptr.Deref(v1beta2MD.Status.AvailableReplicas, 0) == desired &&
-		v1beta2MD.Status.ObservedGeneration >= deployment.Generation
+	desired := ptr.Deref(deployment.Spec.Replicas, 0)
+	return ptr.Deref(v1beta2.UpToDateReplicas, 0) == desired &&
+		ptr.Deref(v1beta2.AvailableReplicas, 0) == desired
 }
 
 // GetHostedClusterByName finds and return a HostedCluster object using the specified params.

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -813,9 +813,12 @@ func machineDeploymentCompleteFromV1Beta2Status(deployment *capiv1.MachineDeploy
 	if v1beta2 == nil {
 		return true
 	}
+	if v1beta2.UpToDateReplicas == nil || v1beta2.AvailableReplicas == nil {
+		return false
+	}
 	desired := ptr.Deref(deployment.Spec.Replicas, 0)
-	return ptr.Deref(v1beta2.UpToDateReplicas, 0) == desired &&
-		ptr.Deref(v1beta2.AvailableReplicas, 0) == desired
+	return *v1beta2.UpToDateReplicas == desired &&
+		*v1beta2.AvailableReplicas == desired
 }
 
 // GetHostedClusterByName finds and return a HostedCluster object using the specified params.


### PR DESCRIPTION
## Summary

- Replaces the `cluster.x-k8s.io/conversion-data` annotation-based v1beta2 cross-check in `MachineDeploymentComplete` with a direct read of `Status.V1Beta2` fields
- Fixes a permanent deadlock where NodePools get stuck reporting `UpdatingVersion=True` and `UpdatingConfig=True` after a rollout completes

### Root cause

The conversion-data annotation is **metadata**. When CAPI updates MachineDeployment status via the v1beta2 status subresource, the API server's `PrepareForUpdate` preserves metadata from etcd — so the annotation is never refreshed by status writes. If the last main-resource v1beta2 write captured mid-rollout state (e.g. `replicas: 4, upToDateReplicas: null`), the annotation becomes permanently stale. `machineDeploymentCompleteFromConversionData` then returns `false` forever, preventing `reconcileMachineDeploymentStatus` from updating `nodePool.Status.Version` and the config annotation.

### Fix

The v1beta1 `MachineDeploymentStatus` already has a `V1Beta2` nested field that stores the v1beta2-native replica counters (`UpToDateReplicas`, `AvailableReplicas`). These fields are **part of the status** (not metadata), so they are correctly updated on every status-subresource write via `Convert_v1beta2_MachineDeploymentStatus_To_v1beta1_MachineDeploymentStatus`.

The new `machineDeploymentCompleteFromV1Beta2Status` reads these fields directly instead of parsing the stale annotation.

Jira: https://issues.redhat.com/browse/OCPBUGS-92013

## Test plan

- [x] Unit tests updated (`TestMachineDeploymentComplete` — 7 cases covering v1beta2 disagreement, nil V1Beta2, nil UpToDateReplicas, v1beta1-only fallback)
- [x] Full nodepool test suite passes (`go test ./hypershift-operator/controllers/nodepool/`)
- [ ] e2e-aws-upgrade-hypershift-operator (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MachineDeployment completion detection to rely on native status replica fields instead of conversion-data annotation parsing, resulting in more reliable readiness checks.
  * Preserved backward-compatible behavior when newer status details are unavailable.
  * Enhanced handling of replica edge cases, including scenarios where replica fields are nil.
* **Tests**
  * Updated and expanded unit tests to validate completion logic using the v1beta2 status replica fields, including explicit nil pointer cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->