### PR TITLE
OCPBUGS-92034: fix registry override matching for digest and tag separators

### DIFF
--- a/support/util/registryoverride/registryoverride.go
+++ b/support/util/registryoverride/registryoverride.go
@@ -12,8 +12,11 @@ import "strings"
 //
 // Matching is strict: an override applies only when the image reference is
 // exactly equal to the source key or starts with the source key followed by a
-// "/" separator. This prevents accidental substring matches (e.g. an override
-// for "quay.io" must not match "quay.io.example.com/foo").
+// valid image-reference separator ("/" for path components, "@" for digests,
+// or ":" for tags). This prevents accidental substring matches (e.g. an
+// override for "quay.io" must not match "quay.io.example.com/foo") while
+// correctly handling repository-level overrides against digest references
+// (e.g. "quay.io/org/repo" must match "quay.io/org/repo@sha256:abc").
 //
 // When several override keys match the same image, the longest key wins. This
 // makes the result deterministic regardless of map iteration order and lets
@@ -31,7 +34,7 @@ func Replace(image string, overrides map[string]string) string {
 		if source == "" {
 			continue
 		}
-		if image != source && !strings.HasPrefix(image, source+"/") {
+		if !matchesPrefix(image, source) {
 			continue
 		}
 		if len(source) > len(bestSource) {
@@ -42,4 +45,24 @@ func Replace(image string, overrides map[string]string) string {
 		return image
 	}
 	return bestTarget + image[len(bestSource):]
+}
+
+// matchesPrefix reports whether image is exactly source, or source is a prefix
+// of image followed by a valid separator. Valid separators are "/" (path) and
+// "@" (digest), always. ":" is accepted only when source contains a "/" (i.e.
+// includes a path component), where it denotes a tag boundary. Without a "/"
+// the source is a bare hostname and ":" would be a port separator, which must
+// not match (e.g. override "quay.io" must not match "quay.io:5000/foo").
+func matchesPrefix(image, source string) bool {
+	if image == source {
+		return true
+	}
+	if !strings.HasPrefix(image, source) {
+		return false
+	}
+	sep := image[len(source)]
+	if sep == '/' || sep == '@' {
+		return true
+	}
+	return sep == ':' && strings.ContainsRune(source, '/')
 }

--- a/support/util/registryoverride/registryoverride_test.go
+++ b/support/util/registryoverride/registryoverride_test.go
@@ -90,6 +90,45 @@ func TestReplace(t *testing.T) {
 			want:      "mirror.example.com/foo/bar:v1.2.3",
 		},
 		{
+			name:      "When source matches full repository with digest separator it should replace prefix",
+			image:     "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123",
+			overrides: map[string]string{"quay.io/openshift-release-dev/ocp-v4.0-art-dev": "mirror.example.com/art-dev"},
+			want:      "mirror.example.com/art-dev@sha256:abc123",
+		},
+		{
+			name:      "When source matches full repository with tag separator it should replace prefix",
+			image:     "quay.io/openshift-release-dev/ocp-v4.0-art-dev:latest",
+			overrides: map[string]string{"quay.io/openshift-release-dev/ocp-v4.0-art-dev": "mirror.example.com/art-dev"},
+			want:      "mirror.example.com/art-dev:latest",
+		},
+		{
+			name:  "When multiple overrides match with digest it should pick longest prefix",
+			image: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123",
+			overrides: map[string]string{
+				"quay.io": "broad.example.com",
+				"quay.io/openshift-release-dev/ocp-v4.0-art-dev": "narrow.example.com/art-dev",
+			},
+			want: "narrow.example.com/art-dev@sha256:abc123",
+		},
+		{
+			name:      "When source has trailing dash it should not match similar prefix (no false positive)",
+			image:     "quay.io/openshift-release-dev/ocp-v4.0-art-dev-extra@sha256:abc",
+			overrides: map[string]string{"quay.io/openshift-release-dev/ocp-v4.0-art-dev": "mirror/art-dev"},
+			want:      "quay.io/openshift-release-dev/ocp-v4.0-art-dev-extra@sha256:abc",
+		},
+		{
+			name:      "When host-only source matches host:port image it should not match (port is not a tag)",
+			image:     "quay.io:5000/org/repo@sha256:abc",
+			overrides: map[string]string{"quay.io": "mirror.example.com"},
+			want:      "quay.io:5000/org/repo@sha256:abc",
+		},
+		{
+			name:      "When host:port source matches host:port image it should match via slash",
+			image:     "myregistry:5000/org/repo@sha256:abc",
+			overrides: map[string]string{"myregistry:5000": "mirror.example.com"},
+			want:      "mirror.example.com/org/repo@sha256:abc",
+		},
+		{
 			name:      "empty image returns empty",
 			image:     "",
 			overrides: map[string]string{"quay.io": "mirror.example.com"},


### PR DESCRIPTION
## Summary
- Fix `registryoverride.Replace` to accept `@` (digest) and `:` (tag) as valid separators alongside `/`, so repository-level `--registry-overrides` work for digest-based images
- Add test cases covering digest separator, tag separator, longest-prefix with digest, and false-positive rejection

## Root Cause

PR #8509 introduced strict prefix matching in `registryoverride.Replace` that only checked for `/` as a valid separator after the source key. Release payload images use `@sha256:` digest references, so repository-level overrides like:

```
--registry-overrides=quay.io/openshift-release-dev/ocp-v4.0-art-dev=mirror.example.com/art-dev
```

failed to match `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123` because the character after the source prefix is `@`, not `/`.

This broke CAPI and all other component image rewrites in disconnected/air-gapped environments using repository-level overrides.

## Which issue(s) this PR fixes
Fixes [OCPBUGS-92034](https://issues.redhat.com/browse/OCPBUGS-92034)
Regression of [OCPBUGS-74247](https://issues.redhat.com/browse/OCPBUGS-74247) (PR #7575)

## Test plan
- [x] Unit tests for digest separator matching (`@sha256:`)
- [x] Unit tests for tag separator matching (`:latest`)
- [x] Unit tests for longest-prefix selection with digest references
- [x] Unit tests for false-positive rejection (trailing dash in repo name)
- [x] All existing `registryoverride`, `imageprovider`, and `registry_mirror_provider` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deterministic image override matching using stricter, separator-based prefix rules.
  * Reduced false positives for similarly named repositories.
  * Ensured the most specific (longest) matching override is applied.
  * Correctly handled tag/digest boundaries and `host:port` behavior.

* **Tests**
  * Expanded coverage for repository, tag, and digest match scenarios.
  * Added cases for longest-prefix selection and non-matching similar prefixes.
  * Added validation for `host:port` matching and correct boundary handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->