### PR TITLE
CORENET-7114: Add HostedCluster RBAC permissions for CNO

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_network_operator_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_network_operator_role.yaml
@@ -76,3 +76,11 @@ rules:
   - hostedcontrolplanes/status
   verbs:
   - '*'
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedclusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_network_operator_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_network_operator_role.yaml
@@ -76,3 +76,11 @@ rules:
   - hostedcontrolplanes/status
   verbs:
   - '*'
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedclusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_network_operator_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_network_operator_role.yaml
@@ -76,3 +76,11 @@ rules:
   - hostedcontrolplanes/status
   verbs:
   - '*'
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedclusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_network_operator_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_network_operator_role.yaml
@@ -76,3 +76,11 @@ rules:
   - hostedcontrolplanes/status
   verbs:
   - '*'
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedclusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents_cluster_network_operator_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents_cluster_network_operator_role.yaml
@@ -76,3 +76,11 @@ rules:
   - hostedcontrolplanes/status
   verbs:
   - '*'
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedclusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-network-operator/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-network-operator/role.yaml
@@ -55,3 +55,11 @@ rules:
   - hostedcontrolplanes/status
   verbs:
   - '*'
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedclusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/rbac.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/rbac.go
@@ -88,6 +88,17 @@ func adaptRole(cpContext component.WorkloadContext, role *rbacv1.Role) error {
 			},
 			Verbs: []string{"*"},
 		},
+		{
+			APIGroups: []string{hyperv1.GroupVersion.Group},
+			Resources: []string{
+				"hostedclusters",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
 	}
 
 	return nil


### PR DESCRIPTION
CNO needs to read `hostedclusters.hypershift.openshift.io` resources to fetch TLS security profile configuration from the `HostedCluster` spec. This was added to both the static _role.yaml_ (for when `networkType`
is `OVNKubernetes`) and the `adaptRole()` function (which replaces the rules otherwise).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RBAC permissions for cluster networking components to allow reading hosted cluster information (`get`, `list`, `watch`) when using non-OVN Kubernetes network configurations.
  * This ensures networking features can reliably access the hosted cluster details they need to operate correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->