### PR TITLE
OCPBUGS-92013: MachineDeployment stale status

### DIFF
--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -149,6 +149,7 @@ func (c *CAPI) Reconcile(ctx context.Context) error {
 		} else {
 			log.Info("Reconciled MachineDeployment", "result", result)
 		}
+		c.reconcileMachineDeploymentStatus(ctx, log, md, template)
 	}
 
 	mhc := c.machineHealthCheck()
@@ -473,12 +474,7 @@ func (c *CAPI) reconcileMachineDeployment(ctx context.Context, log logr.Logger,
 	}
 
 	setMachineDeploymentReplicas(nodePool, machineDeployment)
-
-	if updated := c.propagateVersionAndTemplate(log, machineDeployment, machineTemplateCR); updated {
-		return nil
-	}
-
-	c.reconcileMachineDeploymentStatus(log, machineDeployment, machineTemplateCR)
+	c.propagateVersionAndTemplate(log, machineDeployment, machineTemplateCR)
 
 	return nil
 }
@@ -563,12 +559,11 @@ func (c *CAPI) propagateLabelsAndTaintsToMachines(ctx context.Context, log logr.
 	return nil
 }
 
-func (c *CAPI) propagateVersionAndTemplate(log logr.Logger, machineDeployment *capiv1.MachineDeployment, machineTemplateCR client.Object) bool {
+func (c *CAPI) propagateVersionAndTemplate(log logr.Logger, machineDeployment *capiv1.MachineDeployment, machineTemplateCR client.Object) {
 	nodePool := c.nodePool
 	userDataSecret := c.UserDataSecret()
 	targetVersion := c.Version()
 	targetConfigHash := c.HashWithoutVersion()
-	isUpdating := false
 
 	if userDataSecret.Name != ptr.Deref(machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName, "") {
 		log.Info("New user data Secret has been generated",
@@ -586,7 +581,6 @@ func (c *CAPI) propagateVersionAndTemplate(log logr.Logger, machineDeployment *c
 		}
 		machineDeployment.Spec.Template.Spec.Version = &targetVersion
 		machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName = ptr.To(userDataSecret.Name)
-		isUpdating = true
 	}
 
 	if machineTemplateCR.GetName() != machineDeployment.Spec.Template.Spec.InfrastructureRef.Name {
@@ -594,13 +588,10 @@ func (c *CAPI) propagateVersionAndTemplate(log logr.Logger, machineDeployment *c
 			"current", machineDeployment.Spec.Template.Spec.InfrastructureRef.Name,
 			"target", machineTemplateCR.GetName())
 		machineDeployment.Spec.Template.Spec.InfrastructureRef.Name = machineTemplateCR.GetName()
-		isUpdating = true
 	}
-
-	return isUpdating
 }
 
-func (c *CAPI) reconcileMachineDeploymentStatus(log logr.Logger, machineDeployment *capiv1.MachineDeployment, machineTemplateCR client.Object) {
+func (c *CAPI) reconcileMachineDeploymentStatus(ctx context.Context, log logr.Logger, machineDeployment *capiv1.MachineDeployment, machineTemplateCR client.Object) {
 	nodePool := c.nodePool
 	targetVersion := c.Version()
 	targetConfigHash := c.HashWithoutVersion()
@@ -608,7 +599,7 @@ func (c *CAPI) reconcileMachineDeploymentStatus(log logr.Logger, machineDeployme
 
 	// If the MachineDeployment is now processing we know
 	// is at the expected version (spec.version) and config (userData Secret) so we reconcile status and annotation.
-	if MachineDeploymentComplete(machineDeployment) {
+	if MachineDeploymentComplete(ctx, c.Client, machineDeployment, machineTemplateCR.GetName()) {
 		if nodePool.Status.Version != targetVersion {
 			log.Info("Version update complete",
 				"previous", nodePool.Status.Version, "new", targetVersion)

--- a/hypershift-operator/controllers/nodepool/capi_test.go
+++ b/hypershift-operator/controllers/nodepool/capi_test.go
@@ -1,6 +1,7 @@
 package nodepool
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -27,7 +28,6 @@ import (
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
-	"sigs.k8s.io/cluster-api/util/conversion"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -1341,6 +1341,9 @@ func TestCAPIReconcile(t *testing.T) {
 					Annotations: map[string]string{
 						nodePoolAnnotation: "test-namespace/test-nodepool",
 					},
+					Labels: map[string]string{
+						capiv1.MachineDeploymentNameLabel: "test-nodepool",
+					},
 				},
 				Spec: capiv1.MachineSetSpec{
 					Template: capiv1.MachineTemplateSpec{
@@ -1436,6 +1439,9 @@ func TestCAPIReconcile(t *testing.T) {
 					Namespace: "test-namespace-test-cluster",
 					Annotations: map[string]string{
 						nodePoolAnnotation: "test-namespace/test-nodepool",
+					},
+					Labels: map[string]string{
+						capiv1.MachineDeploymentNameLabel: "test-nodepool",
 					},
 				},
 				Spec: capiv1.MachineSetSpec{
@@ -1543,6 +1549,9 @@ func TestCAPIReconcile(t *testing.T) {
 					Namespace: "test-namespace-test-cluster",
 					Annotations: map[string]string{
 						nodePoolAnnotation: "test-namespace/test-nodepool",
+					},
+					Labels: map[string]string{
+						capiv1.MachineDeploymentNameLabel: "test-nodepool",
 					},
 				},
 				Spec: capiv1.MachineSetSpec{
@@ -2517,45 +2526,40 @@ func TestPropagateVersionAndTemplate(t *testing.T) {
 		templateName         string
 		currentInfraRefName  string
 		useDifferentUserData bool
-		expectedUpdating     bool
 		expectedInfraRefName string
 	}{
 		{
-			name:                 "When user data secret name differs from current bootstrap, it should propagate version and return true",
+			name:                 "When user data secret name differs from current bootstrap, it should propagate version",
 			currentBootstrapName: "old-userdata",
 			currentVersion:       "4.16.0",
 			templateName:         "template-1",
 			currentInfraRefName:  "template-1",
 			useDifferentUserData: true,
-			expectedUpdating:     true,
 			expectedInfraRefName: "template-1",
 		},
 		{
-			name:                 "When machine template name differs from infra ref, it should propagate template and return true",
+			name:                 "When machine template name differs from infra ref, it should propagate template",
 			currentBootstrapName: "", // will be set to match computed name
 			currentVersion:       "4.17.0",
 			templateName:         "new-template",
 			currentInfraRefName:  "old-template",
-			expectedUpdating:     true,
 			expectedInfraRefName: "new-template",
 		},
 		{
-			name:                 "When both user data and template differ, it should propagate both and return true",
+			name:                 "When both user data and template differ, it should propagate both",
 			currentBootstrapName: "old-userdata",
 			currentVersion:       "4.16.0",
 			templateName:         "new-template",
 			currentInfraRefName:  "old-template",
 			useDifferentUserData: true,
-			expectedUpdating:     true,
 			expectedInfraRefName: "new-template",
 		},
 		{
-			name:                 "When nothing differs, it should not update and return false",
+			name:                 "When nothing differs, it should not update",
 			currentBootstrapName: "", // will be set to match computed name
 			currentVersion:       "4.17.0",
 			templateName:         "same-template",
 			currentInfraRefName:  "same-template",
-			expectedUpdating:     false,
 			expectedInfraRefName: "same-template",
 		},
 	}
@@ -2620,12 +2624,10 @@ func TestPropagateVersionAndTemplate(t *testing.T) {
 				},
 			}
 
-			result := capi.propagateVersionAndTemplate(logr.Discard(), md, templateCR)
-			g.Expect(result).To(Equal(tc.expectedUpdating))
+			capi.propagateVersionAndTemplate(logr.Discard(), md, templateCR)
 			g.Expect(md.Spec.Template.Spec.InfrastructureRef.Name).To(Equal(tc.expectedInfraRefName))
 
-			if tc.expectedUpdating && tc.useDifferentUserData {
-				// When updating, bootstrap should be set to the computed user data name.
+			if tc.useDifferentUserData {
 				g.Expect(*md.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal(computedUserDataName))
 				g.Expect(*md.Spec.Template.Spec.Version).To(Equal("4.17.0"))
 			}
@@ -2637,6 +2639,7 @@ func TestReconcileMachineDeploymentStatus(t *testing.T) {
 	testCases := []struct {
 		name                         string
 		machineDeployment            *capiv1.MachineDeployment
+		extraObjects                 []client.Object
 		nodePoolVersion              string
 		nodePoolAnnotations          map[string]string
 		targetVersion                string
@@ -2650,7 +2653,7 @@ func TestReconcileMachineDeploymentStatus(t *testing.T) {
 		{
 			name: "When MachineDeployment is complete, it should update nodePool version and annotations",
 			machineDeployment: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				ObjectMeta: metav1.ObjectMeta{Name: "test-md", Namespace: "cp-ns", Generation: 1},
 				Spec: capiv1.MachineDeploymentSpec{
 					Replicas: ptr.To[int32](3),
 				},
@@ -2660,6 +2663,22 @@ func TestReconcileMachineDeploymentStatus(t *testing.T) {
 					ReadyReplicas:      3,
 					AvailableReplicas:  3,
 					ObservedGeneration: 1,
+				},
+			},
+			extraObjects: []client.Object{
+				&capiv1.MachineSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ms",
+						Namespace: "cp-ns",
+						Labels:    map[string]string{capiv1.MachineDeploymentNameLabel: "test-md"},
+					},
+					Spec: capiv1.MachineSetSpec{
+						Template: capiv1.MachineTemplateSpec{
+							Spec: capiv1.MachineSpec{
+								InfrastructureRef: corev1.ObjectReference{Name: "template-name"},
+							},
+						},
+					},
 				},
 			},
 			nodePoolVersion:            "",
@@ -2737,9 +2756,15 @@ func TestReconcileMachineDeploymentStatus(t *testing.T) {
 				},
 			}
 
+			clientBuilder := fake.NewClientBuilder().WithScheme(api.Scheme)
+			if len(tc.extraObjects) > 0 {
+				clientBuilder = clientBuilder.WithObjects(tc.extraObjects...)
+			}
+
 			capi := &CAPI{
 				Token: &Token{
 					ConfigGenerator: &ConfigGenerator{
+						Client:                clientBuilder.Build(),
 						nodePool:              nodePool,
 						controlplaneNamespace: "cp-ns",
 						rolloutConfig: &rolloutConfig{
@@ -2761,7 +2786,7 @@ func TestReconcileMachineDeploymentStatus(t *testing.T) {
 				},
 			}
 
-			capi.reconcileMachineDeploymentStatus(logr.Discard(), tc.machineDeployment, templateCR)
+			capi.reconcileMachineDeploymentStatus(t.Context(), logr.Discard(), tc.machineDeployment, templateCR)
 
 			g.Expect(nodePool.Status.Replicas).To(Equal(tc.expectedReplicas))
 			g.Expect(nodePool.Status.Version).To(Equal(tc.expectedVersion))
@@ -3281,142 +3306,254 @@ func TestNewCAPI(t *testing.T) {
 }
 
 func TestMachineDeploymentComplete(t *testing.T) {
-	two := int32(2)
-	three := int32(3)
-
-	conversionData := func(replicas, upToDate, available int32, observedGen int64) string {
-		data := map[string]any{
-			"apiVersion": "cluster.x-k8s.io/v1beta2",
-			"kind":       "MachineDeployment",
-			"spec":       map[string]any{"replicas": replicas},
-			"status": map[string]any{
-				"observedGeneration": observedGen,
-				"replicas":           replicas,
-				"upToDateReplicas":   upToDate,
-				"availableReplicas":  available,
-			},
-		}
-		raw, _ := json.Marshal(data)
-		return string(raw)
-	}
-
 	testCases := []struct {
-		name     string
-		md       *capiv1.MachineDeployment
-		expected bool
+		name                  string
+		md                    *capiv1.MachineDeployment
+		targetMachineTemplate string
+		extraObjects          []client.Object
+		expected              bool
 	}{
 		{
-			name: "When all v1beta1 and v1beta2 fields agree it should return true",
+			name: "When all fields match spec replicas and generation it should return true",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
-					Annotations: map[string]string{
-						conversion.DataAnnotation: conversionData(2, 2, 2, 2),
-					},
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: ptr.To[int32](2)},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+					ObservedGeneration: 2,
 				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2},
 			},
 			expected: true,
 		},
 		{
-			name: "When v1beta1 looks complete but v1beta2 upToDateReplicas disagrees it should return false",
+			name: "When availableReplicas is zero it should return false",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
-					Annotations: map[string]string{
-						conversion.DataAnnotation: conversionData(2, 0, 2, 2),
-					},
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: ptr.To[int32](2)},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  0,
+					ObservedGeneration: 2,
 				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2},
 			},
 			expected: false,
 		},
 		{
-			name: "When v1beta1 looks complete but v1beta2 replicas shows surge it should return false",
+			name: "When replicas shows surge it should return false",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
-					Annotations: map[string]string{
-						conversion.DataAnnotation: conversionData(3, 2, 2, 2),
-					},
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: ptr.To[int32](2)},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas:           3,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+					ObservedGeneration: 2,
 				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2},
 			},
 			expected: false,
 		},
 		{
-			name: "When v1beta1 looks complete but v1beta2 observedGeneration is stale it should return false",
+			name: "When observedGeneration is stale it should return false",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
-					Annotations: map[string]string{
-						conversion.DataAnnotation: conversionData(2, 2, 2, 1),
-					},
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: ptr.To[int32](2)},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+					ObservedGeneration: 1,
 				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2},
 			},
 			expected: false,
 		},
 		{
-			name: "When v1beta1 is not complete it should return false without checking conversion data",
+			name: "When AvailableReplicas does not match it should return false",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: ptr.To[int32](2)},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  1,
+					ObservedGeneration: 2,
 				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 3, UpdatedReplicas: 1, AvailableReplicas: 2, ObservedGeneration: 2},
 			},
 			expected: false,
 		},
 		{
-			name: "When no conversion-data annotation exists it should fall back to v1beta1 only",
+			name: "When spec replicas is zero it should return true",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 1,
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: ptr.To[int32](0)},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas:           0,
+					UpdatedReplicas:    0,
+					AvailableReplicas:  0,
+					ObservedGeneration: 1,
 				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 1},
 			},
 			expected: true,
 		},
 		{
-			name: "When conversion-data annotation is malformed it should fall back to v1beta1 result",
+			name: "When V1Beta2 is nil it should fall back to v1beta1 only",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 1,
-					Annotations: map[string]string{
-						conversion.DataAnnotation: "not-valid-json",
-					},
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: ptr.To[int32](2)},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+					ObservedGeneration: 2,
 				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &two},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 1},
 			},
 			expected: true,
 		},
 		{
-			name: "When v1beta1 replicas does not match spec it should return false",
+			name: "When V1Beta2 status matches it should return true",
 			md: &capiv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
-					Annotations: map[string]string{
-						conversion.DataAnnotation: conversionData(3, 2, 2, 2),
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: ptr.To[int32](2)},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+					ObservedGeneration: 2,
+					V1Beta2: &capiv1.MachineDeploymentV1Beta2Status{
+						AvailableReplicas: ptr.To[int32](2),
+						ReadyReplicas:     ptr.To[int32](2),
+						UpToDateReplicas:  ptr.To[int32](2),
 					},
 				},
-				Spec:   capiv1.MachineDeploymentSpec{Replicas: &three},
-				Status: capiv1.MachineDeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2, ObservedGeneration: 2},
+			},
+			expected: true,
+		},
+		{
+			name: "When v1beta1 complete but V1Beta2 UpToDateReplicas disagrees it should return false",
+			md: &capiv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: ptr.To[int32](2)},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+					ObservedGeneration: 2,
+					V1Beta2: &capiv1.MachineDeploymentV1Beta2Status{
+						AvailableReplicas: ptr.To[int32](2),
+						UpToDateReplicas:  ptr.To[int32](1),
+					},
+				},
 			},
 			expected: false,
+		},
+		{
+			name: "When v1beta1 complete but V1Beta2 AvailableReplicas disagrees it should return false",
+			md: &capiv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: ptr.To[int32](2)},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+					ObservedGeneration: 2,
+					V1Beta2: &capiv1.MachineDeploymentV1Beta2Status{
+						AvailableReplicas: ptr.To[int32](1),
+						UpToDateReplicas:  ptr.To[int32](2),
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "When v1beta1 complete but V1Beta2 fields are nil it should return false",
+			md: &capiv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: ptr.To[int32](2)},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+					ObservedGeneration: 2,
+					V1Beta2:            &capiv1.MachineDeploymentV1Beta2Status{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "When status looks complete but no MachineSet has target template it should return false",
+			md: &capiv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-md", Namespace: "cp-ns", Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: ptr.To[int32](2)},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+					ObservedGeneration: 2,
+				},
+			},
+			targetMachineTemplate: "new-template",
+			extraObjects: []client.Object{
+				&capiv1.MachineSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ms-old",
+						Namespace: "cp-ns",
+						Labels:    map[string]string{capiv1.MachineDeploymentNameLabel: "test-md"},
+					},
+					Spec: capiv1.MachineSetSpec{
+						Template: capiv1.MachineTemplateSpec{
+							Spec: capiv1.MachineSpec{
+								InfrastructureRef: corev1.ObjectReference{Name: "old-template"},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "When status is complete and MachineSet has target template it should return true",
+			md: &capiv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-md", Namespace: "cp-ns", Generation: 2},
+				Spec:       capiv1.MachineDeploymentSpec{Replicas: ptr.To[int32](2)},
+				Status: capiv1.MachineDeploymentStatus{
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+					ObservedGeneration: 2,
+				},
+			},
+			targetMachineTemplate: "new-template",
+			extraObjects: []client.Object{
+				&capiv1.MachineSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ms-new",
+						Namespace: "cp-ns",
+						Labels:    map[string]string{capiv1.MachineDeploymentNameLabel: "test-md"},
+					},
+					Spec: capiv1.MachineSetSpec{
+						Template: capiv1.MachineTemplateSpec{
+							Spec: capiv1.MachineSpec{
+								InfrastructureRef: corev1.ObjectReference{Name: "new-template"},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			g.Expect(MachineDeploymentComplete(tc.md)).To(Equal(tc.expected))
+			clientBuilder := fake.NewClientBuilder().WithScheme(api.Scheme)
+			if len(tc.extraObjects) > 0 {
+				clientBuilder = clientBuilder.WithObjects(tc.extraObjects...)
+			}
+			fakeClient := clientBuilder.Build()
+			g.Expect(MachineDeploymentComplete(context.Background(), fakeClient, tc.md, tc.targetMachineTemplate)).To(Equal(tc.expected))
 		})
 	}
 }

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -2,7 +2,6 @@ package nodepool
 
 import (
 	"context"
-	"encoding/json"
 	coreerrors "errors"
 	"fmt"
 	"os"
@@ -44,7 +43,6 @@ import (
 	capiopenstackv1beta1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -792,50 +790,69 @@ func defaultNodePoolGCPImage(specifiedArch string, releaseImage *releaseinfo.Rel
 // fields come from conversion. The converted v1beta1 fields (especially UpdatedReplicas,
 // which maps from deprecated.v1beta1.updatedReplicas rather than the native upToDateReplicas)
 // can transiently disagree with the v1beta2 native fields. To guard against this, when the
-// v1beta1 fields indicate completion we cross-check against the authoritative v1beta2 status
-// stored in the conversion-data annotation.
-func MachineDeploymentComplete(deployment *capiv1.MachineDeployment) bool {
+// v1beta1 fields indicate completion we cross-check against the v1beta2 status
+// stored in the Status.V1Beta2 field, which is kept current on every status-subresource write.
+//
+// When targetMachineTemplate is non-empty, it additionally verifies that at least one MachineSet
+// references that template. This guards against a race where CAPI updates ObservedGeneration
+// before recalculating replica counts after a spec change, causing status to briefly look complete
+// while still reflecting the old template.
+func MachineDeploymentComplete(ctx context.Context, c client.Reader, deployment *capiv1.MachineDeployment, targetMachineTemplate string) bool {
+	log := ctrl.LoggerFrom(ctx)
 	newStatus := &deployment.Status
 	v1beta1Complete := newStatus.UpdatedReplicas == *(deployment.Spec.Replicas) &&
 		newStatus.Replicas == *(deployment.Spec.Replicas) &&
 		newStatus.AvailableReplicas == *(deployment.Spec.Replicas) &&
 		newStatus.ObservedGeneration >= deployment.Generation
+
 	if !v1beta1Complete {
 		return false
 	}
-	return machineDeploymentCompleteFromConversionData(deployment)
+
+	if !machineDeploymentCompleteFromV1Beta2Status(deployment) {
+		return false
+	}
+
+	if targetMachineTemplate == "" {
+		return true
+	}
+
+	machineSets := &capiv1.MachineSetList{}
+	if err := c.List(ctx, machineSets,
+		client.InNamespace(deployment.Namespace),
+		client.MatchingLabels{capiv1.MachineDeploymentNameLabel: deployment.Name},
+	); err != nil {
+		log.Error(err, "Failed to list MachineSets for MachineDeployment, cannot verify completion")
+		return false
+	}
+
+	for i := range machineSets.Items {
+		if machineSets.Items[i].Spec.Template.Spec.InfrastructureRef.Name == targetMachineTemplate {
+			return true
+		}
+	}
+
+	log.Info("MachineDeployment reports complete but no MachineSet references target template yet, skipping",
+		"target", targetMachineTemplate, "machineSetCount", len(machineSets.Items))
+	return false
 }
 
-// machineDeploymentCompleteFromConversionData parses the v1beta2 conversion-data annotation
-// and verifies that the native v1beta2 status also indicates completion. If the annotation
-// is absent (e.g. CAPI < v1.11), returns true to preserve backwards compatibility.
-func machineDeploymentCompleteFromConversionData(deployment *capiv1.MachineDeployment) bool {
-	raw, ok := deployment.Annotations[conversion.DataAnnotation]
-	if !ok {
+// machineDeploymentCompleteFromV1Beta2Status verifies that the native v1beta2 status fields
+// also indicate completion. The v1beta1 Status.V1Beta2 field is populated by the v1beta2-to-v1beta1
+// conversion on every status-subresource write, so it is always current.
+// If V1Beta2 is nil (e.g. CAPI < v1.11), returns true to preserve backwards compatibility.
+func machineDeploymentCompleteFromV1Beta2Status(deployment *capiv1.MachineDeployment) bool {
+	v1beta2 := deployment.Status.V1Beta2
+	if v1beta2 == nil {
 		return true
 	}
-
-	var v1beta2MD struct {
-		Spec struct {
-			Replicas *int32 `json:"replicas"`
-		} `json:"spec"`
-		Status struct {
-			ObservedGeneration int64  `json:"observedGeneration"`
-			Replicas           *int32 `json:"replicas"`
-			AvailableReplicas  *int32 `json:"availableReplicas"`
-			UpToDateReplicas   *int32 `json:"upToDateReplicas"`
-		} `json:"status"`
+	if v1beta2.UpToDateReplicas == nil || v1beta2.AvailableReplicas == nil {
+		return false
 	}
-	if err := json.Unmarshal([]byte(raw), &v1beta2MD); err != nil {
-		ctrl.Log.WithName("nodepool").Error(err, "Failed to unmarshal conversion-data annotation, falling back to v1beta1 status")
-		return true
-	}
-
-	desired := ptr.Deref(v1beta2MD.Spec.Replicas, 0)
-	return ptr.Deref(v1beta2MD.Status.UpToDateReplicas, 0) == desired &&
-		ptr.Deref(v1beta2MD.Status.Replicas, 0) == desired &&
-		ptr.Deref(v1beta2MD.Status.AvailableReplicas, 0) == desired &&
-		v1beta2MD.Status.ObservedGeneration >= deployment.Generation
+	desired := ptr.Deref(deployment.Spec.Replicas, 0)
+	return ptr.Deref(v1beta2.UpToDateReplicas, 0) == desired &&
+		ptr.Deref(v1beta2.ReadyReplicas, 0) == desired &&
+		ptr.Deref(v1beta2.AvailableReplicas, 0) == desired
 }
 
 // GetHostedClusterByName finds and return a HostedCluster object using the specified params.


### PR DESCRIPTION
## What this PR does / why we need it:
MachineDeploymentComplete() has a regression when introducing v1beta2 where it has flakiness due to lossy conversion and stale status.

Replaced conversion-data annotation check with
deployment.Status.V1Beta2.

Additionally, guard against CAPI status race by adding a MachineSet template cross-verification to MachineDeploymentComplete, and move status reconciliation outside CreateOrPatch so it reads post-persist state.

## Which issue(s) this PR fixes:
Fixes [OCPBUGS-92013](https://redhat.atlassian.net/browse/OCPBUGS-92013)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node pool upgrade status tracking by reconciling MachineDeployment status immediately after updates during replace upgrades.
  * Reduced false “complete” signals by basing readiness on native status fields and only marking ready after confirming MachineSets reference the expected machine template.
  * Status/annotation updates now run more consistently and are gated on the updated completeness check, improving upgrade progress visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->