### PR TITLE
CNTRLPLANE-3722: updating context docs for agentic SDLC contextification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,33 +1,65 @@
 # Contributing to HyperShift
+
 Thank you for your interest in contributing to HyperShift! HyperShift enables running multiple OpenShift control planes as lightweight, cost-effective hosted clusters. Your contributions help improve this critical infrastructure technology.
 
 The following guidelines will help ensure a smooth contribution process for both contributors and maintainers.
 
+## Code Conventions
+
+We largely follow the [Kubernetes Code Conventions](https://github.com/kubernetes/community/blob/main/contributors/guide/coding-conventions.md#code-conventions).
+
+Review both the Kubernetes Code Conventions and the ones specified here.
+There will be some overlap. If any conventions are at odds with one another, prefer the conventions explicitly documented here.
+
+### Bash
+
+- Follow the [shell styleguide](https://google.github.io/styleguide/shellguide.html).
+- Use `[shellcheck](https://github.com/koalaman/shellcheck)` to identify common mistakes or caveats.
+- Ensure that all scripts run consistently across Linux and MacOS.
+
+### Golang (Go)
+
+- Review [Effective Go](https://go.dev/doc/effective_go).
+- Review common [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments).
+- Review and avoid [Go Landmines](https://gist.github.com/lavalamp/4bd23295a9f32706a48f)
+- Comment your code following the [Go comment conventions](https://go.dev/doc/comment).
+  - Comments should be meaningful and add context and/or explain choices that cannot be expressed through clear code.
+  - All exported types, functions, and methods must have descriptive comments.
+  - All unexported types, functions, and methods should have descriptive comments.
+- When adding command-line flags, use dashes/hyphens (`-`) and not underscores (`_`).
+- Naming
+  - Please consider package name when selecting an interface name, and avoid redundancy. For example, `storage.Interface` is better than `storage.StorageInterface`.
+  - Do not use uppercase characters, underscores, or dashes in package names.
+  - Please consider parent directory name when choosing a package name. For example, `pkg/controllers/autoscaler/foo.go` should say `package autoscaler` not `package autoscalercontroller`.
+    - Unless there's a good reason, the package foo line should match the name of the directory in which the .go file exists.
+    - Importers can use a different name if they need to disambiguate.
+  - Locks should be called `lock` and should never be embedded (always `lock sync.Mutex`). When multiple locks are present, give each lock a distinct name following Go conventions: `stateLock`, `mapLock` etc.
+- Error handling
+  - Wrap errors with meaningful context before returning or logging them.
+  - When logging, follow the [Kubernetes Logging Conventions](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-instrumentation/logging.md).
+  - When patching OpenShift-maintained forks of "upstream" repositories, patches should be as small as reasonably possible and should minimize touch points with code that is likely to change and impact the rebasing process.
+
 ## Prior to Submitting a Pull Request
+
 1. **Keep changes focused**: Scope commits to one thing and keep them minimal. Separate refactoring from logic changes, and save additional improvements for separate PRs.
-
 2. **Test your changes**: Run `make pre-commit` to update dependencies, build code, verify formatting, and run tests. This prevents CI failures on your PR.
-
 3. **Review before submitting**: Look at your changes from a reviewer's perspective and explain anything that might not be immediately clear in your PR description.
-
-4. **Use proper commit format**: 
-    1. Write commit subjects in [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) (e.g., "Fix bug" not "Fixed bug")
-    2. Follow [conventional commit format](https://www.conventionalcommits.org/) and include "Why" and "How" in commit messages
+4. **Use proper commit format**:
+  1. Write commit subjects in [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) (e.g., "Fix bug" not "Fixed bug")
+  2. Follow [conventional commit format](https://www.conventionalcommits.org/) and include "Why" and "How" in commit messages
 
 > **Tip: Install pre-commit hooks**
 >
 > Install `pre-commit` to automatically catch issues before committing. This helps catch spelling mistakes, formatting issues, and test failures early in your development process.
 >
-> * [Installation instructions](https://pre-commit.com/#install)
-> * [HyperShift-specific tips](docs/content/contribute/precommit-hook-help.md)
+> - [Installation instructions](https://pre-commit.com/#install)
+> - [HyperShift-specific tips](docs/content/contribute/precommit-hook-help.md)
 
 ## Creating a Pull Request
+
 1. **For small changes** (under 200 lines): Create your change and submit a pull request directly.
-
 2. **For larger changes** (200+ lines): Get feedback on your approach first by opening a GitHub issue or posting in the #project-hypershift Slack channel. This prevents situations where large changes get declined after significant work.
-
 3. **Write a clear PR title**: Prefix with your Jira ticket number (e.g., "OCPBUGS-12345: Fix memory leak in controller"). See [example PR](https://github.com/openshift/hypershift/pull/2233).
-
 4. **Explain the value**: Always describe how your change improves the project in the PR description.
 
 ### CI
@@ -48,11 +80,12 @@ Useful Prow commands:
 - `approved` - From an approver via `/approve`
 - `lgtm` - From a reviewer via `/lgtm`
 - `jira/valid-reference` - PR title contains a valid Jira ticket reference (or NO-JIRA if no associated issue)
-    **Note:** NO-JIRA should be used sparingly. Please have a Jira issue associated with your PR whenever possible.
-- `area/*` - Area label (e.g., `area/documentation`, `area/control-plane`)
+  **Note:** NO-JIRA should be used sparingly. Please have a Jira issue associated with your PR whenever possible.
+- `area/`* - Area label (e.g., `area/documentation`, `area/control-plane`)
 - `verified` - QA verification passed (for more information refer to the [documentation](https://docs.ci.openshift.org/docs/architecture/jira/#the-verified-label))
 
 **Conditionally required:**
+
 - `jira/valid-bug` - Required for bug fixes
 - `backport-risk-assessed` - Required for backports
 
@@ -80,18 +113,25 @@ Use these Prow commands to manage assignments:
 **Common scenarios:**
 
 1. **Auto-assigned reviewers are not suitable**:
-   - Use `/un-cc @reviewer` to remove them
-   - Run `/auto-cc` again for different suggestions
-
+  - Use `/un-cc @reviewer` to remove them
+  - Run `/auto-cc` again for different suggestions
 2. **Approver was also selected as reviewer**:
-   - Use `/un-cc @approver` to remove the approver from reviewers
-   - Run `/auto-cc` again to get additional reviewers
-
+  - Use `/un-cc @approver` to remove the approver from reviewers
+  - Run `/auto-cc` again to get additional reviewers
 3. **Need to change the approver**:
-   - Use `/unassign @current-approver`
-   - Use `/assign @new-approver`
+  - Use `/unassign @current-approver`
+  - Use `/assign @new-approver`
 
 Remember: If the openshift-ci assistant assigns unsuitable reviewers or approvers, don't hesitate to adjust the assignments. Being proactive helps ensure your PR gets timely and appropriate review.
+
+When interacting with reviewers/approvers:
+
+- Be professional.
+- Be respectful of differing opinions, viewpoints, and experiences.
+- Gracefully give and receive constructive feedback.
+- Focus on what is best for the product/organization, not just us as individuals.
+
+A special note on the usage of AI - to respect the time of those that are reviewing your contribution, please do not use AI to respond to review comments.
 
 ## Agentic Software Development
 


### PR DESCRIPTION

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
 This PR aims to update the HyperShift repo's contextification files in accordance with the Agentic SDLC context efforts for this Control Plane Shift Week.

- Add code conventions to CONTRIBUTING.md based on the new template found [here](https://docs.google.com/document/d/14-MqX0qoZeTO0X16b7sGQ5--lvAUaybLH5erQu-f3zk/edit?tab=t.0).
## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes [CNTRLPLANE-3722](https://redhat.atlassian.net/browse/CNTRLPLANE-3722)

## Special notes for your reviewer:

These changes are simple additions using some provided templates from the Control Plane team and may not be entirely necessary. I figured I would provide this PR anyway for feedback and thoughts from the team.

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contribution guidelines with a new code conventions section covering Bash and Go.
  * Updated section organization and formatting for easier reading.
  * Added clearer guidance on merge labels, including a note to use `NO-JIRA` sparingly.
  * Included an additional review note advising contributors not to use AI when responding to review comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->