### PR TITLE
OCPBUGS-92086: GetVnetID is empty when running setup_all.sh in Managed AKS

### DIFF
--- a/contrib/managed-azure/create_basic_hosted_cluster.sh
+++ b/contrib/managed-azure/create_basic_hosted_cluster.sh
@@ -42,7 +42,7 @@ az group create --name "${CUSTOMER_NSG_RG_NAME}" --location ${LOCATION}
 az network nsg create --resource-group "${CUSTOMER_NSG_RG_NAME}" --name "${CUSTOMER_NSG}"
 
 # Get customer nsg ID
-GetNsgID=$(az network nsg list --query "[?name=='${CUSTOMER_NSG}'].id" -o tsv)
+GetNsgID=$(az network nsg show --resource-group "${CUSTOMER_NSG_RG_NAME}" --name "${CUSTOMER_NSG}" --query id -o tsv)
 
 # Create customer vnet in customer resource group
 az network vnet create \
@@ -54,7 +54,7 @@ az network vnet create \
     --nsg "${GetNsgID}"
 
 # Get customer vnet ID
-GetVnetID=$(az network vnet list --query "[?name=='${CUSTOMER_VNET_NAME}'].id" -o tsv)
+GetVnetID=$(az network vnet show --resource-group "${CUSTOMER_VNET_RG_NAME}" --name "${CUSTOMER_VNET_NAME}" --query id -o tsv)
 
 # Get customer subnet ID
 GetSubnetID=$(az network vnet subnet show --vnet-name "${CUSTOMER_VNET_NAME}" --name "${CUSTOMER_VNET_SUBNET1}" --resource-group "${CUSTOMER_VNET_RG_NAME}" --query id --output tsv)


### PR DESCRIPTION


<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
This PR adds the `--resource-group` flag to network NSG and VNet list commands in the since the Azure CLI now requires this for `az network vnet list`, which fixes issue where `GetVnetID` becomes empty on basic HC creation.

This flag was originally optional but was changed to required in commit [2ff0af0](https://github.com/Azure/azure-cli/commit/2ff0af0e8aafb911031c13d27f8e7f7b32b1a2e4#diff-7a8a76ef4f98e3adff3986e16fc37c038d85c3fd6a94f70d716f17b7988702a6L55-R56) in the [Azure/azure-cli repo](https://github.com/Azure/azure-cli) repo (PR #[33241](https://github.com/Azure/azure-cli/pull/33241)). This is still compatible with older versions with the `azure-cli`.
## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes [#OCPBUGS-92086](https://redhat.atlassian.net/browse/OCPBUGS-92086)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure resource lookup accuracy by limiting network security group and virtual network searches to the intended resource groups.
  * Reduced the risk of selecting the wrong network resources during cluster setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->