### PR TITLE
SPLAT-2743: aws/ccm - remove inline iam policy patch

### DIFF
--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -937,21 +937,11 @@ func (o *CreateIAMOptions) CreateOIDCResources(ctx context.Context, iamClient aw
 		ingressRoleName := output.Roles.IngressARN[strings.LastIndex(output.Roles.IngressARN, "/")+1:]
 
 		// Cloud Controller Manager's (CCM) managed policy needs to be updated on ROSA to allow new permissions downstream controllers to work.
-		// The permissions are:
-		// - elasticloadbalancing:DescribeTargetGroupAttributes
-		// - elasticloadbalancing:ModifyTargetGroupAttributes
-		// - elasticloadbalancing:SetSecurityGroups
-		//
-		// https://issues.redhat.com/browse/OCPBUGS-65885
-		//
 		// This inline policy must be removed when the following issue is resolved:
-		// https://issues.redhat.com/browse/SREP-2895
-		// https://redhat-internal.slack.com/archives/C03SZLX3A10/p1765396356482459
+		// elasticloadbalancing:SetSecurityGroups: https://redhat.atlassian.net/browse/SPLAT-2742
 		ccmPolicyStatement := `{
 				"Effect": "Allow",
 				"Action": [
-					"elasticloadbalancing:DescribeTargetGroupAttributes",
-					"elasticloadbalancing:ModifyTargetGroupAttributes",
 					"elasticloadbalancing:SetSecurityGroups"
 				],
 				"Resource": "*"


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

This PR removes inline policies added when the managed policies were not updated, now AWS has published the policy we don't need those permissions anymore. References:

- Managed policy update request:  https://redhat.atlassian.net/browse/ROSAENG-21795
- AWS Managed Policies: https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAKubeControllerPolicy.html
- This PR is blocked by CI issues reported in PR https://github.com/openshift/hypershift/pull/8401 (nice to have there merged first)

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AWS IAM permissions used during cluster setup for Cloud Controller Manager to better match current requirements, removing now-unneeded permissions related to target group attribute access and modification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->