### PR TITLE
OCPBUGS-92791: fix(configrefs): exclude componentRoutes secrets from management cluster sync

### DIFF
--- a/api/util/configrefs/refs.go
+++ b/api/util/configrefs/refs.go
@@ -25,7 +25,6 @@ func SecretRefs(cfg ClusterConfiguration) []string {
 	result := sets.NewString()
 	result = result.Union(apiServerSecretRefs(cfg.GetAPIServer()))
 	result = result.Union(authenticationSecretRefs(cfg.GetAuthentication()))
-	result = result.Union(ingressSecretRefs(cfg.GetIngress()))
 	result = result.Union(oauthSecretRefs(cfg.GetOAuth()))
 	return result.List()
 }
@@ -110,18 +109,6 @@ func authenticationConfigMapRefs(spec *configv1.AuthenticationSpec) sets.String 
 	return refs
 }
 
-func ingressSecretRefs(spec *configv1.IngressSpec) sets.String {
-	refs := sets.NewString()
-	if spec == nil {
-		return refs
-	}
-	for _, componentRoute := range spec.ComponentRoutes {
-		if len(componentRoute.ServingCertKeyPairSecret.Name) > 0 {
-			refs.Insert(componentRoute.ServingCertKeyPairSecret.Name)
-		}
-	}
-	return refs
-}
 
 func imageConfigMapRefs(spec *configv1.ImageSpec) sets.String {
 	refs := sets.NewString()

--- a/api/util/configrefs/refs_test.go
+++ b/api/util/configrefs/refs_test.go
@@ -277,6 +277,9 @@ func TestKnownSecretRefs(t *testing.T) {
 		".Authentication.WebhookTokenAuthenticator.KubeConfig",
 		".Authentication.WebhookTokenAuthenticators.KubeConfig",
 		".Authentication.OIDCProviders.OIDCClients.ClientSecret",
+		// ComponentRoutes secrets are intentionally excluded from SecretRefs — they are
+		// consumed by the guest cluster's ingress operator from openshift-config, not by
+		// any control plane component on the management cluster.
 		".Ingress.ComponentRoutes.ServingCertKeyPairSecret",
 		".OAuth.IdentityProviders.IdentityProviderConfig.BasicAuth.OAuthRemoteConnectionInfo.TLSClientCert",
 		".OAuth.IdentityProviders.IdentityProviderConfig.BasicAuth.OAuthRemoteConnectionInfo.TLSClientKey",
@@ -366,7 +369,7 @@ func TestSecretRefs(t *testing.T) {
 			refs: []string{"kubeconfig-ref1", "kubeconfig-ref2"},
 		},
 		{
-			name: "ingress component serving cert",
+			name: "When ingress componentRoutes have serving certs it should not include them",
 			config: &hyperv1.ClusterConfiguration{
 				Ingress: &configv1.IngressSpec{
 					ComponentRoutes: []configv1.ComponentRouteSpec{
@@ -383,7 +386,7 @@ func TestSecretRefs(t *testing.T) {
 					},
 				},
 			},
-			refs: []string{"serving-cert1", "serving-cert2"},
+			refs: []string{},
 		},
 		{
 			name: "oidc client secret",

--- a/vendor/github.com/openshift/hypershift/api/util/configrefs/refs.go
+++ b/vendor/github.com/openshift/hypershift/api/util/configrefs/refs.go
@@ -25,7 +25,6 @@ func SecretRefs(cfg ClusterConfiguration) []string {
 	result := sets.NewString()
 	result = result.Union(apiServerSecretRefs(cfg.GetAPIServer()))
 	result = result.Union(authenticationSecretRefs(cfg.GetAuthentication()))
-	result = result.Union(ingressSecretRefs(cfg.GetIngress()))
 	result = result.Union(oauthSecretRefs(cfg.GetOAuth()))
 	return result.List()
 }
@@ -110,18 +109,6 @@ func authenticationConfigMapRefs(spec *configv1.AuthenticationSpec) sets.String 
 	return refs
 }
 
-func ingressSecretRefs(spec *configv1.IngressSpec) sets.String {
-	refs := sets.NewString()
-	if spec == nil {
-		return refs
-	}
-	for _, componentRoute := range spec.ComponentRoutes {
-		if len(componentRoute.ServingCertKeyPairSecret.Name) > 0 {
-			refs.Insert(componentRoute.ServingCertKeyPairSecret.Name)
-		}
-	}
-	return refs
-}
 
 func imageConfigMapRefs(spec *configv1.ImageSpec) sets.String {
 	refs := sets.NewString()


### PR DESCRIPTION
## What this PR does / why we need it:

Removes `ingressSecretRefs()` from `SecretRefs()` so the HC controller no longer tries to find/copy componentRoutes TLS secrets on the management cluster.

ComponentRoutes `ServingCertKeyPairSecret` references are consumed by the hosted cluster's ingress operator from `openshift-config`, not by any control plane component on the management cluster. The HC controller was copying these secrets from the HC namespace to the CP namespace where nothing consumed them, and failing reconciliation when the secret did not exist in the HC namespace.

The secret name reference still propagates via `DeepCopy` through HC → HCP → HCCO → hosted cluster `ingresses.config.openshift.io/cluster`.

## Which issue(s) this PR fixes:

Fixes [OCPBUGS-92791](https://redhat.atlassian.net/browse/OCPBUGS-92791)

## Special notes for your reviewer:

- No API changes — all types remain identical
- No impact on existing clusters — no component in the CP namespace consumed the copied secret
- OAuth, APIServer, and authentication secret refs continue to be synced as before
- Verified end-to-end in integration: componentRoutes propagate from HC → HCP → HCCO → hosted cluster ingress config when the reconciliation blocker is removed

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted secret reference tracking so ingress serving certificate secrets are no longer included in the general secret list.
  * Updated expected results to reflect that component route secrets are intentionally excluded from secret reference collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->