### PR TITLE
OTA-1956: Skip ConsolePlugin manifests during CVO bootstrap

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -136,6 +136,7 @@ spec:
           cp -R /manifests /var/payload/
           rm -f /var/payload/manifests/*_deployment.yaml
           rm -f /var/payload/manifests/*_servicemonitor.yaml
+          rm -f /var/payload/manifests/0000_50_cluster-update-console-plugin_*
           cp -R /release-manifests /var/payload/
           for file in $(find /var/payload/manifests/ -name "*.yaml"); do
               IFS=',' read -ra feature_sets <<< "$(cat $file | grep "release.openshift.io/feature-set:" | awk '{print $2}')"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -147,6 +147,7 @@ spec:
           cp -R /manifests /var/payload/
           rm -f /var/payload/manifests/*_deployment.yaml
           rm -f /var/payload/manifests/*_servicemonitor.yaml
+          rm -f /var/payload/manifests/0000_50_cluster-update-console-plugin_*
           cp -R /release-manifests /var/payload/
           for file in $(find /var/payload/manifests/ -name "*.yaml"); do
               IFS=',' read -ra feature_sets <<< "$(cat $file | grep "release.openshift.io/feature-set:" | awk '{print $2}')"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -136,6 +136,7 @@ spec:
           cp -R /manifests /var/payload/
           rm -f /var/payload/manifests/*_deployment.yaml
           rm -f /var/payload/manifests/*_servicemonitor.yaml
+          rm -f /var/payload/manifests/0000_50_cluster-update-console-plugin_*
           cp -R /release-manifests /var/payload/
           for file in $(find /var/payload/manifests/ -name "*.yaml"); do
               IFS=',' read -ra feature_sets <<< "$(cat $file | grep "release.openshift.io/feature-set:" | awk '{print $2}')"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -136,6 +136,7 @@ spec:
           cp -R /manifests /var/payload/
           rm -f /var/payload/manifests/*_deployment.yaml
           rm -f /var/payload/manifests/*_servicemonitor.yaml
+          rm -f /var/payload/manifests/0000_50_cluster-update-console-plugin_*
           cp -R /release-manifests /var/payload/
           for file in $(find /var/payload/manifests/ -name "*.yaml"); do
               IFS=',' read -ra feature_sets <<< "$(cat $file | grep "release.openshift.io/feature-set:" | awk '{print $2}')"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -136,6 +136,7 @@ spec:
           cp -R /manifests /var/payload/
           rm -f /var/payload/manifests/*_deployment.yaml
           rm -f /var/payload/manifests/*_servicemonitor.yaml
+          rm -f /var/payload/manifests/0000_50_cluster-update-console-plugin_*
           cp -R /release-manifests /var/payload/
           for file in $(find /var/payload/manifests/ -name "*.yaml"); do
               IFS=',' read -ra feature_sets <<< "$(cat $file | grep "release.openshift.io/feature-set:" | awk '{print $2}')"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
@@ -204,6 +204,7 @@ func preparePayloadScript(platformType hyperv1.PlatformType, oauthEnabled bool, 
 		fmt.Sprintf("cp -R /manifests %s/", payloadDir),
 		fmt.Sprintf("rm -f %s/manifests/*_deployment.yaml", payloadDir),
 		fmt.Sprintf("rm -f %s/manifests/*_servicemonitor.yaml", payloadDir),
+		fmt.Sprintf("rm -f %s/manifests/0000_50_cluster-update-console-plugin_*", payloadDir),
 		fmt.Sprintf("cp -R /release-manifests %s/", payloadDir),
 	)
 


### PR DESCRIPTION
## Summary

The CVO bootstrap init container in HyperShift gets stuck in an infinite retry loop trying to `kubectl apply` the `ConsolePlugin` manifest (`0000_50_cluster-update-console-plugin_90_consoleplugin.yaml`). The `ConsolePlugin` CRD (`console.openshift.io/v1`) is not available during bootstrap because the console operator hasn't started yet.

Add `*_consoleplugin.yaml` to the wildcard removals in `preparePayloadScript`, alongside the existing `*_deployment.yaml` and `*_servicemonitor.yaml` patterns that are already removed for the same reason (CRDs not available during bootstrap).

## Root cause

From [CVO PR #1398](https://github.com/openshift/cluster-version-operator/pull/1398) CI logs:
```
error: resource mapping not found for name: "openshift-cluster-update-console-plugin"
namespace: "" from "/var/payload/manifests/0000_50_cluster-update-console-plugin_90_consoleplugin.yaml":
no matches for kind "ConsolePlugin" in version "console.openshift.io/v1"
```

The bootstrap init container retries this indefinitely, preventing the CVO pod from starting.

## Related

- [openshift/cluster-version-operator#1398](https://github.com/openshift/cluster-version-operator/pull/1398) — adds the console plugin manifests to CVO
- [wking's analysis](https://github.com/openshift/cluster-version-operator/pull/1398#issuecomment-4803662563)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payload preparation by excluding console plugin manifest files matching `0000_50_cluster-update-console-plugin_*` from the copied `/var/payload/manifests/` content before the release workflow continues, preventing unintended console plugin resources from being processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->