### PR TITLE
OCPBUGS-86648: move IP addresses from dnsNames to ips in etcd peer cert

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/pki/etcd.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/etcd.go
@@ -45,12 +45,10 @@ func ReconcileEtcdPeerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef
 	dnsNames := []string{
 		fmt.Sprintf("*.etcd-discovery.%s.svc", secret.Namespace),
 		fmt.Sprintf("*.etcd-discovery.%s.svc.cluster.local", secret.Namespace),
-		// etcd-client uses a ClusterIP service (not headless), so it does not create per-pod
-		// PTR records and cannot cause reverse DNS ambiguity during peer TLS verification.
-		// TODO(OCPBUGS-86648): move IPs to the ips parameter of reconcileSignedCertWithKeysAndAddresses.
-		"127.0.0.1",
-		"::1",
 	}
+	// etcd-client uses a ClusterIP service (not headless), so it does not create per-pod
+	// PTR records and cannot cause reverse DNS ambiguity during peer TLS verification.
+	ips := []string{"127.0.0.1", "::1"}
 
-	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, "etcd-discovery", []string{"kubernetes"}, X509UsageClientServerAuth, EtcdPeerCrtKey, EtcdPeerKeyKey, "", dnsNames, nil, "")
+	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, "etcd-discovery", []string{"kubernetes"}, X509UsageClientServerAuth, EtcdPeerCrtKey, EtcdPeerKeyKey, "", dnsNames, ips, "")
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/etcd_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/etcd_test.go
@@ -3,6 +3,7 @@ package pki
 import (
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"net"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -32,7 +33,7 @@ func TestReconcileEtcdPeerSecret(t *testing.T) {
 		},
 	}
 
-	t.Run("When reconciling etcd peer secret it should include etcd-discovery SANs", func(t *testing.T) {
+	t.Run("When reconciling etcd peer secret it should place DNS names and IPs in correct cert fields", func(t *testing.T) {
 		g := NewWithT(t)
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -52,11 +53,15 @@ func TestReconcileEtcdPeerSecret(t *testing.T) {
 		g.Expect(cert.DNSNames).To(ContainElements(
 			"*.etcd-discovery.clusters-test.svc",
 			"*.etcd-discovery.clusters-test.svc.cluster.local",
-			// TODO(OCPBUGS-86648): assert on cert.IPAddresses instead once IPs are moved out of dnsNames.
-			"127.0.0.1",
-			"::1",
+		))
+
+		g.Expect(cert.IPAddresses).To(ContainElements(
+			net.IPv4(127, 0, 0, 1).To4(),
+			net.ParseIP("::1"),
 		))
 		g.Expect(cert.DNSNames).ToNot(ContainElement(ContainSubstring("etcd-client")))
+		g.Expect(cert.DNSNames).ToNot(ContainElement("127.0.0.1"))
+		g.Expect(cert.DNSNames).ToNot(ContainElement("::1"))
 	})
 
 	t.Run("When reconciling etcd peer secret it should have client and server auth usage", func(t *testing.T) {


### PR DESCRIPTION
## What this PR does / why we need it:

Follow-up to #8479 (OCPBUGS-76530), which switched `etcd-client` from headless to ClusterIP to fix dual-PTR reverse DNS ambiguity in peer TLS verification. That PR noted as tech debt that `127.0.0.1` and `::1` were being passed in the `dnsNames` slice instead of the `ips` parameter.

This PR fixes that: it moves `127.0.0.1` and `::1` from `dnsNames` to the `ips` parameter of `reconcileSignedCertWithKeysAndAddresses`, so they appear in the x509 `IPAddresses` extension where IP addresses belong, rather than in `DNSNames`.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-86648

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.