### PR TITLE
CNTRLPLANE-3733: add --blog flag to /pr-report skill

### DIFF
--- a/.claude/commands/pr-report.md
+++ b/.claude/commands/pr-report.md
@@ -1,6 +1,6 @@
 ---
 description: "PR Report Generator"
-argument-hint: "[--start YYYY-MM-DD] [--end YYYY-MM-DD] [--deep] [--progress-report] - Date range with optional deep analysis and progress report"
+argument-hint: "[--start YYYY-MM-DD] [--end YYYY-MM-DD] [--deep] [--progress-report] [--blog] - Date range with optional deep analysis, progress report, and blog post"
 ---
 
 # PR Report Generator
@@ -16,6 +16,7 @@ Generate comprehensive PR reports for openshift/hypershift, openshift-eng/ai-hel
 /pr-report --start 2026-02-05 --end 2026-02-12 --deep  # With deep code analysis
 /pr-report --start 2026-02-05 --end 2026-02-12 --deep --progress-report # Deep analysis + progress report
 /pr-report --start 2026-02-05 --end 2026-02-12 --deep --breaking-changes # Deep analysis + breaking change report
+/pr-report --start 2026-05-14 --end 2026-06-22 --deep --progress-report --blog # Deep + progress report + blog post
 ```
 
 **Parameters:**
@@ -25,6 +26,7 @@ Generate comprehensive PR reports for openshift/hypershift, openshift-eng/ai-hel
 - `--deep` (optional): Enable deep analysis mode that fetches and analyzes actual code diffs.
 - `--progress-report` (optional): Generate a narrative blog-style progress report (Dolphin Emulator style). **Requires `--deep`.**
 - `--breaking-changes` (optional): Generate a detailed breaking change assessment report for management cluster operators and senior SREs. **Requires `--deep`.**
+- `--blog` (optional): Generate a Material-styled blog post in `docs/content/blog/` and update `docs/mkdocs.yml` nav. **Requires `--progress-report`.**
 - `--output-dir` (optional): Directory for output files. If not specified, ask the user with AskUserQuestion.
 
 ## What This Command Does
@@ -68,6 +70,14 @@ This command generates **two reports** (with two optional additions):
 - Identifies bridge nodes who connect clusters
 - Super short format: one paragraph per cluster
 
+### 7. Blog Post (--blog, docs-ready Material-styled post)
+- Converts progress report to MkDocs Material blog post with grid stat cards, admonitions, and icons
+- Generates sortable contributor table with per-repo linked PR counts and bugfix column
+- Creates/updates `docs/content/blog/index.md` landing page
+- Updates `docs/mkdocs.yml` nav with new post entry
+- Runs `make docs-aggregate` for verification
+- Applies sensitive content filtering for public blog (no S360/SFDC references)
+
 ## Output Files
 
 | File | Description |
@@ -83,6 +93,7 @@ This command generates **two reports** (with two optional additions):
 | `$OUTPUT_DIR/hypershift_progress_report_YYYY-MM-DD.md` | (--progress-report) Narrative progress report (blog-style) |
 | `$OUTPUT_DIR/breaking_changes_report_YYYY-MM-DD.md` | (--breaking-changes) Breaking change assessment for SREs |
 | `$OUTPUT_DIR/collaboration_report_YYYY-MM-DD.md` | (--deep) Contributor collaboration clusters |
+| `docs/content/blog/YYYY-MM-progress-report.md` | (--blog) Material-styled blog post for docs site |
 
 ## Implementation
 
@@ -90,6 +101,9 @@ This command generates **two reports** (with two optional additions):
 
 If `--progress-report` is specified without `--deep`, stop and inform the user:
 `--progress-report requires --deep mode for code-level analysis. Please add --deep to your command.`
+
+If `--blog` is specified without `--progress-report`, stop and inform the user:
+`--blog requires --progress-report mode to generate the blog source content. Please add --progress-report (and --deep) to your command.`
 
 ### Step 1: Run the Python script to fetch PRs
 
@@ -100,6 +114,7 @@ Parse the arguments and run the script. The script accepts:
 ```bash
 # Parse ARGUMENTS which may contain: --start YYYY-MM-DD --end YYYY-MM-DD --deep --output-dir DIR
 # Example: python3 contrib/repo_metrics/weekly_pr_report.py 2026-02-05 --end 2026-02-12 --output-dir /tmp
+# If --blog is specified, also pass --blog-data to generate blog_data.json
 
 python3 contrib/repo_metrics/weekly_pr_report.py $ARGUMENTS --output-dir $OUTPUT_DIR
 ```
@@ -107,6 +122,8 @@ python3 contrib/repo_metrics/weekly_pr_report.py $ARGUMENTS --output-dir $OUTPUT
 Note: The script's positional argument is the start date. The `--start` flag in the skill
 is mapped to this positional argument when invoking the script. `$OUTPUT_DIR` is the
 directory chosen by the user. All output file paths below use this directory.
+When `--blog` is active, include `--blog-data` in the script arguments to generate
+`$OUTPUT_DIR/blog_data.json` with contributor table, metrics, and pre-rendered markdown.
 
 ### Step 2: Jira Enrichment (Conditional)
 
@@ -687,6 +704,104 @@ bridge nodes (people who connect clusters).
 4. List the members in bold, then one sentence describing what they worked on together
 5. End with a "Bridge nodes" line identifying contributors who span multiple clusters
 
+### Step 5d: Generate Blog Post (--blog mode only)
+
+If `--blog` flag is specified, generate a Material-styled blog post from the progress report.
+Use `docs/content/blog/2026-06-progress-report.md` as the canonical template reference for
+styling decisions.
+
+#### Step 5d-1: Generate blog data
+
+The Python script handles all the deterministic work (contributor counting, URL generation,
+table rendering, metrics). It was already invoked with `--blog-data` alongside the other flags
+in Step 1. Verify `$OUTPUT_DIR/blog_data.json` exists. If not, re-run:
+
+```bash
+python3 contrib/repo_metrics/weekly_pr_report.py $SINCE_DATE --end $END_DATE \
+    --blog-data --resume --output-dir $OUTPUT_DIR
+```
+
+The script uses `OWNERS_ALIASES` to determine the HyperShift team for ai-helpers inclusion
+(formula: `(core-approvers ∪ core-reviewers ∪ konflux-approvers) - gcp-reviewers`).
+
+**Spot-check release-only contributors:** `blog_data.json` flags contributors with
+`"release_only": true` and includes their PR numbers in `"release_pr_numbers"`. For each,
+verify their release PRs touch HyperShift-specific paths:
+
+```bash
+gh pr view openshift/release#NNNNN --json files --jq '.files[].path'
+```
+
+If their PRs are broad CI sweeps (not HyperShift-specific), exclude them from the
+contributor table by removing their entry before generating the blog post.
+
+#### Step 5d-2: Transform progress report to blog post
+
+Read `$OUTPUT_DIR/hypershift_progress_report_YYYY-MM-DD.md` and apply Material styling.
+Write to `docs/content/blog/YYYY-MM-progress-report.md`.
+
+**Pre-rendered markdown from `blog_data.json`** — insert these directly:
+- `markdown.stats_cards` → after the H1 title
+- `markdown.metrics_table` → in the "By the Numbers" section
+- `markdown.top_reviewers_table` → after the metrics table
+- `markdown.contributor_table` → in the "Contributors" section
+
+**Content preservation rules (do NOT alter these):**
+- Preserve all existing PR links (`[PR #NNNN](url)` and `[#NNNN](url)`) — do not strip URLs
+- Preserve em dashes (`—`). If the source uses `--`, convert to `—`
+- Preserve the intro paragraph's detailed statistics (merge time, high-impact count, etc.)
+  but update contributor count to match `blog_data.json → stats.contributor_count`
+- Preserve enhancement proposal links and Jira links that are already in the source
+
+**Title format:** Use `{Month} {Year} Progress Report` (e.g., "June 2026 Progress Report"),
+not "HyperShift Progress Report: June 2026". Keep it short. No quotes in YAML frontmatter
+values unless they contain special characters.
+
+**LLM styling transforms:**
+- Add YAML frontmatter (`title`, `description` with PR count and contributor count)
+- Remove "Story N:" prefixes from section headings
+- Add Material icons to section headings (choose contextually: `:material-swap-horizontal:`
+  for migrations, `:material-linux:` for OS, `:material-lan-disconnect:` for networking, etc.)
+- Convert only clearly-marked callout paragraphs to admonitions — look for explicit
+  "Key Takeaway", "Production Impact", "Lesson Learned" markers in the source. Do NOT
+  wrap regular narrative paragraphs in admonitions. When in doubt, leave as prose.
+- Ensure `@username` mentions use `[@username](https://github.com/username)` linking
+- Add "By the Numbers" section (`:material-chart-bar:`) with pre-rendered metrics and
+  top reviewers tables
+- Add "Contributors" section (`:octicons-people-24:`) with header text "Click any column
+  header to sort. Each number links to the contributor's PRs in that repository."
+  and the pre-rendered contributor table
+- Add "What's Next" section from the progress report with `:material-crystal-ball:` icon
+
+**Sensitive content filtering (blog is public):**
+- S360 references → "compliance"
+- Remove SFDC case count/link references
+- Don't include internal-only Jira links for non-public tickets
+- Don't mention specific customer names
+
+#### Step 5d-3: Update blog index and mkdocs.yml nav
+
+Read `docs/content/blog/index.md`. Add a new card entry at the TOP of the grid cards div
+(newest first). Create the file if it doesn't exist. Card template:
+
+```markdown
+-   :material-newspaper-variant-outline:{ .lg .middle } **{Month} {Year} Progress Report**
+
+    ---
+
+    {description}. {total_prs} PRs from {contributor_count} contributors.
+
+    [:octicons-arrow-right-24: Read the report]({filename})
+```
+
+Read `docs/mkdocs.yml`, find `- 'Blog':` section, add new entry. If no Blog section
+exists, create one before `- 'Videos':`.
+
+#### Step 5d-4: Verify and preview
+
+Run `make docs-aggregate` (blog excluded by `/blog/` filter in `hack/tools/docs-aggregator/main.go`).
+Start `mkdocs serve` from `docs/` for user preview before committing.
+
 ### Step 6: Present Results
 
 After generating reports, provide the user with:
@@ -698,6 +813,9 @@ After generating reports, provide the user with:
 5. (--progress-report mode) Mention the progress report location
 6. (--breaking-changes mode) Summarize breaking changes found and their severity
 7. (--deep mode) Mention the collaboration report location
+8. (--blog mode) Mention the blog post at `docs/content/blog/YYYY-MM-progress-report.md`,
+   suggest running `cd docs && mkdocs serve` to preview, and note that `make docs-aggregate`
+   was run successfully
 
 ## Script Features
 

--- a/contrib/repo_metrics/pyproject.toml
+++ b/contrib/repo_metrics/pyproject.toml
@@ -3,7 +3,9 @@ name = "repo-metrics"
 version = "0.1.0"
 description = "Repository metrics and analysis tools"
 requires-python = ">=3.9"
-dependencies = []
+dependencies = [
+    "PyYAML>=6.0",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/contrib/repo_metrics/weekly_pr_report.py
+++ b/contrib/repo_metrics/weekly_pr_report.py
@@ -400,7 +400,7 @@ class PRReportGenerator:
         self.repo_fetch_status: Dict[str, str] = {}  # repo -> "ok" | "failed"
 
     BOT_PATTERNS = ['-bot', '-robot', '[bot]']
-    BOT_LOGINS = {'coderabbitai', 'hypershift-jira-solve-ci'}
+    BOT_LOGINS = {'coderabbitai', 'hypershift-jira-solve-ci', 'dependabot'}
 
     @classmethod
     def is_bot(cls, login: str) -> bool:
@@ -1513,6 +1513,265 @@ class PRReportGenerator:
             json.dump(output, f, indent=2)
         print(f"Summary data saved to {output_path}")
 
+    @staticmethod
+    def _parse_owners_aliases(path: str = 'OWNERS_ALIASES') -> Dict[str, Set[str]]:
+        """Parse OWNERS_ALIASES YAML file into a dict of group -> set of logins."""
+        import yaml
+        aliases: Dict[str, Set[str]] = {}
+        if not os.path.exists(path):
+            return aliases
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        for group, members in (data or {}).get('aliases', {}).items():
+            aliases[group] = set(members or [])
+        return aliases
+
+    @staticmethod
+    def _get_hs_team(aliases: Dict[str, Set[str]]) -> Set[str]:
+        """Compute the HyperShift team set from OWNERS_ALIASES groups.
+
+        Formula: (core-approvers ∪ core-reviewers ∪ konflux-approvers) - gcp-reviewers
+        """
+        return ((aliases.get('core-approvers', set())
+                 | aliases.get('core-reviewers', set())
+                 | aliases.get('konflux-approvers', set()))
+                - aliases.get('gcp-reviewers', set()))
+
+    def generate_blog_data(self, output_dir: str):
+        """Generate blog_data.json with contributor table, metrics, and pre-rendered markdown.
+
+        Produces all the deterministic data needed for a Material-styled blog post:
+        contributor counts per repo, bugfix counts, GitHub URLs, metrics summary,
+        and pre-rendered markdown fragments (stats cards, tables).
+        """
+        start = self.since_date
+        end = self.end_date
+
+        # Determine HyperShift team from OWNERS_ALIASES
+        aliases = self._parse_owners_aliases()
+        hs_team = self._get_hs_team(aliases)
+        if hs_team:
+            print(f"  HyperShift team ({len(hs_team)} members from OWNERS_ALIASES): "
+                  f"{', '.join(sorted(hs_team))}")
+        else:
+            print("  Warning: could not parse OWNERS_ALIASES, ai-helpers filtering disabled")
+
+        # --- Collect per-author, per-repo PR data ---
+        repo_map = {
+            'openshift/hypershift': 'hypershift',
+            'openshift/release': 'release',
+            'openshift-eng/ai-helpers': 'ai-helpers',
+            'openshift/enhancements': 'enhancements',
+        }
+        # author -> repo -> list of PR dicts
+        author_prs: Dict[str, Dict[str, List[Dict]]] = {}
+        for pr in self.prs:
+            author = pr['author']
+            if self.is_bot(author):
+                continue
+            repo = pr['repo']
+            if author not in author_prs:
+                author_prs[author] = {}
+            if repo not in author_prs[author]:
+                author_prs[author][repo] = []
+            author_prs[author][repo].append(pr)
+
+        # --- Contributor inclusion rules ---
+        hs_authors = {a for a, repos in author_prs.items() if 'openshift/hypershift' in repos}
+        release_authors = {a for a, repos in author_prs.items() if 'openshift/release' in repos}
+        enhancement_authors = {a for a, repos in author_prs.items() if 'openshift/enhancements' in repos}
+        ai_authors = {a for a, repos in author_prs.items() if 'openshift-eng/ai-helpers' in repos}
+
+        # ai-helpers PRs only count if the author is on the HyperShift team (from OWNERS_ALIASES)
+        included = hs_authors | release_authors | enhancement_authors | (ai_authors & hs_team)
+
+        # --- Bugfix detection ---
+        def is_bugfix(pr: Dict) -> bool:
+            return (any('OCPBUGS' in t for t in pr.get('jiraTickets', []))
+                    or 'OCPBUGS' in pr.get('title', ''))
+
+        # --- Build GitHub URL for a count ---
+        def make_url(repo: str, author: str, prs_list: List[Dict]) -> str:
+            if len(prs_list) == 1:
+                return prs_list[0]['url']
+            q = f"is%3Apr+is%3Amerged+author%3A{author}+merged%3A{start}..{end}"
+            if repo == 'openshift/release':
+                q += '+hypershift'
+            return f"https://github.com/{repo}/pulls?q={q}"
+
+        def make_bug_url(author: str, bug_prs: List[Dict]) -> str:
+            if len(bug_prs) == 1:
+                return bug_prs[0]['url']
+            return (f"https://github.com/search?q=org%3Aopenshift+is%3Apr+is%3Amerged+"
+                    f"author%3A{author}+merged%3A{start}..{end}+OCPBUGS&type=pullrequests")
+
+        # --- Build contributor records ---
+        contributors = []
+        for author in sorted(included):
+            repos_data = {}
+            total = 0
+            for full_repo in repo_map:
+                prs_in_repo = author_prs.get(author, {}).get(full_repo, [])
+                # Only include ai-helpers if author is on hs_team
+                if full_repo == 'openshift-eng/ai-helpers' and author not in hs_team:
+                    continue
+                count = len(prs_in_repo)
+                if count > 0:
+                    repos_data[full_repo] = {
+                        'count': count,
+                        'url': make_url(full_repo, author, prs_in_repo),
+                    }
+                    total += count
+
+            bug_prs_list = [pr for repo_prs in author_prs.get(author, {}).values()
+                            for pr in repo_prs if is_bugfix(pr)]
+            bug_count = len(bug_prs_list)
+
+            entry = {
+                'login': author,
+                'repos': repos_data,
+                'bugs': {'count': bug_count, 'url': make_bug_url(author, bug_prs_list)} if bug_count else {'count': 0},
+                'total': total,
+            }
+            # Flag release-only contributors for LLM spot-checking
+            if author in release_authors and author not in (hs_authors | enhancement_authors):
+                entry['release_only'] = True
+                # Include their release PR numbers for easy verification
+                release_prs = author_prs.get(author, {}).get('openshift/release', [])
+                entry['release_pr_numbers'] = [f"openshift/release#{pr['number']}" for pr in release_prs]
+
+            contributors.append(entry)
+
+        contributors.sort(key=lambda c: c['total'], reverse=True)
+
+        # --- Metrics ---
+        merge_times = [pr['readyToMergeHours'] for pr in self.prs
+                       if pr.get('readyToMergeHours') is not None and pr['readyToMergeHours'] > 0]
+        avg_merge = round(sum(merge_times) / len(merge_times), 1) if merge_times else 0
+        bot_prs = len([pr for pr in self.prs if self.is_bot(pr['author'])])
+
+        customer_fixes = 0
+        for pr in self.prs:
+            sfdc_total, _, _ = self._get_pr_sfdc_info(pr)
+            if sfdc_total > 0:
+                customer_fixes += 1
+
+        # Try to read breaking changes / API changes from deep analysis if available
+        breaking_changes = 0
+        api_changes = 0
+        high_impact = 0
+        for path in [os.path.join(output_dir, '.work', 'pr_deep_aggregated.json'),
+                     os.path.join('.work', 'pr_deep_aggregated.json')]:
+            if os.path.exists(path):
+                try:
+                    with open(path) as f:
+                        agg = json.load(f)
+                    summary = agg.get('summary', {})
+                    breaking_changes = summary.get('breaking_changes_count', 0)
+                    api_changes = summary.get('api_changes_count', 0)
+                    high_impact = summary.get('high_impact_count', 0)
+                    break
+                except (json.JSONDecodeError, KeyError):
+                    pass
+
+        by_repo = {}
+        for full_repo in repo_map:
+            by_repo[full_repo] = len([pr for pr in self.prs if pr['repo'] == full_repo])
+
+        reviewer_counts: Dict[str, int] = {}
+        for pr in self.prs:
+            for r in pr.get('reviewers', []):
+                reviewer_counts[r] = reviewer_counts.get(r, 0) + 1
+        top_reviewers = sorted(reviewer_counts.items(), key=lambda x: x[1], reverse=True)[:5]
+
+        stats = {
+            'total_prs': len(self.prs),
+            'contributor_count': len(contributors),
+            'bot_prs': bot_prs,
+            'breaking_changes': breaking_changes,
+            'api_changes': api_changes,
+            'avg_merge_hours': avg_merge,
+            'high_impact': high_impact,
+            'customer_reported_fixes': customer_fixes,
+            'by_repo': by_repo,
+        }
+
+        # --- Pre-render markdown fragments ---
+
+        lg = '{ .lg }'
+        stats_cards = (
+            '<div class="grid cards" markdown>\n\n'
+            f'-   :octicons-git-pull-request-24:{lg} **{stats["total_prs"]}** PRs merged\n'
+            f'-   :octicons-people-24:{lg} **{stats["contributor_count"]}** contributors\n'
+            f'-   :octicons-alert-24:{lg} **{stats["breaking_changes"]}** breaking changes\n'
+            f'-   :octicons-clock-24:{lg} **{stats["avg_merge_hours"]}h** avg merge time\n\n'
+            '</div>'
+        )
+
+        metrics_rows = [
+            ('Total PRs merged', stats['total_prs']),
+            ('Unique contributors', stats['contributor_count']),
+            ('Bot PRs', stats['bot_prs']),
+            ('HyperShift repo PRs', by_repo.get('openshift/hypershift', 0)),
+            ('Release repo PRs', by_repo.get('openshift/release', 0)),
+            ('AI-helpers repo PRs', by_repo.get('openshift-eng/ai-helpers', 0)),
+            ('Enhancement proposals', by_repo.get('openshift/enhancements', 0)),
+            ('Average merge time', f'{avg_merge} hours'),
+            ('High-impact PRs', high_impact),
+            ('Breaking changes', breaking_changes),
+            ('API changes', api_changes),
+            ('Customer-reported fixes', customer_fixes),
+        ]
+        metrics_table = '| Metric | Value |\n|--------|-------|\n'
+        for label, value in metrics_rows:
+            metrics_table += f'| {label} | {value} |\n'
+
+        reviewers_table = '| Reviewer | PRs Reviewed |\n|----------|-------------|\n'
+        for login, count in top_reviewers:
+            reviewers_table += f'| [@{login}](https://github.com/{login}) | {count} |\n'
+
+        contrib_header = ('| Contributor | hypershift | release | ai-helpers | enhancements '
+                          '| :material-bug: bugs | Total |\n'
+                          '|------------|:-:|:-:|:-:|:-:|:-:|:-:|\n')
+        contrib_rows = ''
+        for c in contributors:
+            row_cells = [f'| [@{c["login"]}](https://github.com/{c["login"]})']
+            for full_repo in ['openshift/hypershift', 'openshift/release',
+                              'openshift-eng/ai-helpers', 'openshift/enhancements']:
+                repo_data = c['repos'].get(full_repo)
+                if repo_data:
+                    row_cells.append(f'[{repo_data["count"]}]({repo_data["url"]})')
+                else:
+                    row_cells.append('')
+            if c['bugs']['count'] > 0:
+                row_cells.append(f'[{c["bugs"]["count"]}]({c["bugs"]["url"]})')
+            else:
+                row_cells.append('')
+            row_cells.append(f'**{c["total"]}**')
+            contrib_rows += ' | '.join(row_cells) + ' |\n'
+
+        contributor_table = contrib_header + contrib_rows
+
+        # --- Assemble output ---
+        output = {
+            'period': {'start': start, 'end': end},
+            'stats': stats,
+            'hs_team': sorted(hs_team),
+            'top_reviewers': [{'login': login, 'count': count} for login, count in top_reviewers],
+            'contributors': contributors,
+            'markdown': {
+                'stats_cards': stats_cards,
+                'metrics_table': metrics_table,
+                'top_reviewers_table': reviewers_table,
+                'contributor_table': contributor_table,
+            },
+        }
+
+        blog_data_path = os.path.join(output_dir, 'blog_data.json')
+        with open(blog_data_path, 'w') as f:
+            json.dump(output, f, indent=2)
+        print(f"Blog data saved to {blog_data_path}")
+
     def parse_pr_identifiers(self, pr_ids: List[str]) -> List[Tuple[str, int]]:
         """Parse PR identifiers in owner/repo#number format.
 
@@ -1934,6 +2193,11 @@ Scoring criteria (higher = more important):
         action='store_true',
         help='Resume a previous run: load existing data and re-fetch only repos that failed'
     )
+    parser.add_argument(
+        '--blog-data',
+        action='store_true',
+        help='Generate blog_data.json with contributor table, metrics, and pre-rendered markdown'
+    )
     return parser.parse_args()
 
 
@@ -1950,6 +2214,7 @@ async def main():
     os.makedirs(output_dir, exist_ok=True)
 
     resume = args.resume
+    blog_data = args.blog_data
 
     print(f"Generating PR report for: {since_date} to {end_date}")
     print(f"Using {'async (aiohttp)' if HAS_AIOHTTP else 'sync (requests)'} mode")
@@ -1959,6 +2224,8 @@ async def main():
         print(f"Deep mode: will fetch diffs for {len(deep_prs)} PRs")
     if score_mode:
         print(f"Score mode: will output top {score_limit} PRs by importance")
+    if blog_data:
+        print("Blog data mode: will generate blog_data.json")
     print()
 
     generator = PRReportGenerator(since_date, end_date, output_dir=output_dir)
@@ -1971,6 +2238,10 @@ async def main():
     generator.generate_report(os.path.join(output_dir, 'weekly_pr_report_fast.md'))
     generator.save_raw_data(os.path.join(output_dir, 'hypershift_pr_details_fast.json'))
     generator.save_summary_data(os.path.join(output_dir, 'hypershift_pr_summary.json'))
+
+    # Blog data mode: generate contributor table, metrics, and pre-rendered markdown
+    if blog_data:
+        generator.generate_blog_data(output_dir)
 
     # Score mode: output scored PR list
     if score_mode:

--- a/contrib/repo_metrics/weekly_pr_report.py
+++ b/contrib/repo_metrics/weekly_pr_report.py
@@ -1623,8 +1623,13 @@ class PRReportGenerator:
                     }
                     total += count
 
-            bug_prs_list = [pr for repo_prs in author_prs.get(author, {}).values()
-                            for pr in repo_prs if is_bugfix(pr)]
+            bug_prs_list = [
+                pr
+                for repo_name, repo_prs in author_prs.get(author, {}).items()
+                if not (repo_name == 'openshift-eng/ai-helpers' and author not in hs_team)
+                for pr in repo_prs
+                if is_bugfix(pr)
+            ]
             bug_count = len(bug_prs_list)
 
             entry = {
@@ -1681,6 +1686,8 @@ class PRReportGenerator:
         reviewer_counts: Dict[str, int] = {}
         for pr in self.prs:
             for r in pr.get('reviewers', []):
+                if self.is_bot(r):
+                    continue
                 reviewer_counts[r] = reviewer_counts.get(r, 0) + 1
         top_reviewers = sorted(reviewer_counts.items(), key=lambda x: x[1], reverse=True)[:5]
 

--- a/docs/content/blog/2026-06-progress-report.md
+++ b/docs/content/blog/2026-06-progress-report.md
@@ -193,9 +193,11 @@ In the ai-helpers repository, 36 PRs were merged during this period. [@celebdor]
 
 | Reviewer | PRs Reviewed |
 |----------|-------------|
-| [@coderabbitai](https://github.com/apps/coderabbitai) | 164 |
 | [@bryan-cox](https://github.com/bryan-cox) | 78 |
 | [@jparrill](https://github.com/jparrill) | 41 |
+| [@enxebre](https://github.com/enxebre) | 26 |
+| [@cblecker](https://github.com/cblecker) | 21 |
+| [@csrwng](https://github.com/csrwng) | 19 |
 
 ---
 


### PR DESCRIPTION
## Summary

- Extends the `/pr-report` skill with a `--blog` flag that automates the monthly blog post workflow
- Adds `--blog-data` to `weekly_pr_report.py` to handle all deterministic work (contributor counting, URL generation, table rendering, metrics) so the LLM handles only judgment work (icon selection, admonition placement, sensitive content filtering)
- Uses `OWNERS_ALIASES` to compute HyperShift team membership: `(core-approvers ∪ core-reviewers ∪ konflux-approvers) - gcp-reviewers`, gating ai-helpers PR inclusion on team membership
- Fixes `dependabot` bot detection (login lacks hyphen, not caught by `-bot` pattern)

## Details

**Script changes** (`contrib/repo_metrics/weekly_pr_report.py`):
- `--blog-data` flag produces `blog_data.json` with pre-rendered markdown fragments (stats cards, metrics table, sortable contributor table with linked PR counts)
- `_parse_owners_aliases()` and `_get_hs_team()` static methods for team membership
- Contributor inclusion: `hs_authors ∪ release_authors ∪ enhancement_authors ∪ (ai_authors ∩ hs_team) - bots`
- Release-only contributors flagged with `release_only: true` for LLM spot-checking via `gh pr view --json files`
- `'dependabot'` added to `BOT_LOGINS`

**Skill changes** (`.claude/commands/pr-report.md`):
- `--blog` requires `--progress-report` (validated in Step 0)
- Step 5d-1: Generate blog data (script handles mechanics, LLM spot-checks release-only contributors)
- Step 5d-2: Transform progress report to blog post with content preservation rules (PR links, em dashes, stats) and Material styling
- Step 5d-3: Update `docs/content/blog/index.md` and `docs/mkdocs.yml` nav
- Step 5d-4: Verify with `make docs-aggregate` and `mkdocs serve`

## Test plan

- [x] Ran `--blog-data` against real June 2026 data: 59 contributors (pre-spot-check), 14 release-only flagged, 11 hs_team members confirmed
- [x] Comparison test v1: identified 5 issues (em dash corruption, PR link stripping, wrong title format, stats alteration, excessive admonitions)
- [x] All 5 issues fixed in skill instructions, verified by comparison test v2
- [x] Verified `dependabot` now excluded from contributor table
- [x] Verified cblecker's ai-helpers PRs correctly excluded (GCP team, not hs_team)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a blog-generation mode that turns the PR report into a docs-ready blog post, updates docs navigation, and emits the blog markdown and related artifacts.
  * Added a structured export mode to generate `blog_data.json` for downstream blog generation.
* **Bug Fixes**
  * Improved automated/bot filtering and refined contributor handling for release-only spot-checking.
  * Added validation to stop early with guidance when blog mode is used without the required progress report option.
* **Documentation**
  * Updated the blog “By the Numbers” top reviewers table.
* **Chores**
  * Declared the package dependency required for YAML processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->