### PR TITLE
NO-JIRA: docs: add required pod-security annotation for GCP hosted clusters

### DIFF
--- a/docs/content/how-to/gcp/create-gcp-hosted-cluster.md
+++ b/docs/content/how-to/gcp/create-gcp-hosted-cluster.md
@@ -40,12 +40,22 @@ hypershift create cluster gcp \
   --external-dns-domain=<your-dns-domain> \
   --node-pool-replicas=2 \
   --feature-set=TechPreviewNoUpgrade \
-  --annotations=hypershift.openshift.io/capi-provider-gcp-image=<capg-image>
+  --annotations=hypershift.openshift.io/pod-security-admission-label-override=baseline
 ```
 
-!!! note "CAPG Image Override (GCP-426)"
+!!! note "Pod Security Admission Override Required"
 
-    Until HyperShift's CAPI CRDs serve v1beta2, you must pin the CAPG image via the annotation above. Use the CAPG image from the release payload:
+    GKE clusters enforce pod security policies that block some HyperShift control plane components from starting without the `baseline` override.
+
+!!! warning "CAPG Image Override Required for 4.22.x/4.23.x only ([GCP-841](https://redhat.atlassian.net/browse/GCP-841))"
+
+    The CAPG image in these releases crashes due to a removed `ClusterResourceSet` feature gate. Add the CAPG image annotation:
+
+    ```bash
+    --annotations="hypershift.openshift.io/pod-security-admission-label-override=baseline,hypershift.openshift.io/capi-provider-gcp-image=<capg-image>"
+    ```
+
+    Get the CAPG image from the release payload:
 
     ```bash
     oc adm release info <release-image> --image-for=cluster-api-provider-gcp

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -22747,12 +22747,22 @@ hypershift create cluster gcp \
   --external-dns-domain=<your-dns-domain> \
   --node-pool-replicas=2 \
   --feature-set=TechPreviewNoUpgrade \
-  --annotations=hypershift.openshift.io/capi-provider-gcp-image=<capg-image>
+  --annotations=hypershift.openshift.io/pod-security-admission-label-override=baseline
 ```
 
-!!! note "CAPG Image Override (GCP-426)"
+!!! note "Pod Security Admission Override Required"
 
-    Until HyperShift's CAPI CRDs serve v1beta2, you must pin the CAPG image via the annotation above. Use the CAPG image from the release payload:
+    GKE clusters enforce pod security policies that block some HyperShift control plane components from starting without the `baseline` override.
+
+!!! warning "CAPG Image Override Required for 4.22.x/4.23.x only (GCP-841)"
+
+    The CAPG image in these releases crashes due to a removed `ClusterResourceSet` feature gate. Add the CAPG image annotation:
+
+    ```bash
+    --annotations="hypershift.openshift.io/pod-security-admission-label-override=baseline,hypershift.openshift.io/capi-provider-gcp-image=<capg-image>"
+    ```
+
+    Get the CAPG image from the release payload:
 
     ```bash
     oc adm release info <release-image> --image-for=cluster-api-provider-gcp


### PR DESCRIPTION
## What this PR does / why we need it:

Updates GCP hosted cluster documentation to include the required `pod-security-admission-label-override=baseline` annotation and clarifies version-specific CAPG image override requirements.

GKE clusters enforce pod security policies that require the baseline override annotation for HyperShift control plane components to start.  Additionally, 4.22.x/4.23.x require a CAPG image override due to a removed ClusterResourceSet feature gate ([GCP-841](https://redhat.atlassian.net/browse/GCP-841)). This is not needed for 5.0+.

## Special notes for your reviewer:

- The pod-security annotation is now the default in the example command since it's required for both GKE Autopilot and GKE Standard
- The CAPG image override has been moved to a separate warning callout specific to 4.22.x/4.23.x only
- Documentation now clearly indicates that 5.0+ does not need the CAPG image override

## Checklist:
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [X] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the GCP hosted cluster setup guide with clearer `hypershift create cluster gcp` `--annotations` examples.
  * Added a note that the Pod Security Admission label override (`pod-security-admission-label-override=baseline`) is required for GKE-hosted clusters, and showed it in the command.
  * Replaced older CAPG image override guidance with HyperShift 4.22.x/4.23.x–specific warnings and an updated `--annotations="..., ..."` example, including how to source the CAPG image from the release payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->