### PR TITLE
CNTRLPLANE-3737: Add find-push-pipelinerun script

### DIFF
--- a/hack/tools/scripts/find-push-pipelinerun.sh
+++ b/hack/tools/scripts/find-push-pipelinerun.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly DEFAULT_NAMESPACE="crt-redhat-acm-tenant"
+
+usage() {
+    printf "Find Konflux on-push PipelineRun(s) triggered by a merged PR.\n\n"
+    printf "Usage: %s <PR> [COMPONENT]\n\n" "$(basename "$0")"
+    printf "  PR          One of:\n"
+    printf "                - PR number (e.g., 8761) — repo inferred via gh\n"
+    printf "                - Full URL (e.g., https://github.com/openshift/hypershift/pull/8761)\n"
+    printf "                - owner/repo#number (e.g., openshift/hypershift#8761)\n"
+    printf "  COMPONENT   Optional: filter by component name prefix (e.g., hypershift-release)\n\n"
+    printf "Environment variables:\n"
+    printf "  KONFLUX_NAMESPACE  Konflux namespace (default: %s)\n" "${DEFAULT_NAMESPACE}"
+}
+
+check_prerequisites() {
+    local cmd
+    for cmd in gh oc jq; do
+        if ! command -v "${cmd}" &>/dev/null; then
+            printf "Error: %s is required but not found in PATH\n" "${cmd}" >&2
+            return 1
+        fi
+    done
+}
+
+resolve_pr() {
+    local -r input="$1"
+    local repo pr_number
+
+    if [[ "${input}" =~ ^https://github\.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+        repo="${BASH_REMATCH[1]}"
+        pr_number="${BASH_REMATCH[2]}"
+    elif [[ "${input}" =~ ^([^/]+/[^#]+)#([0-9]+)$ ]]; then
+        repo="${BASH_REMATCH[1]}"
+        pr_number="${BASH_REMATCH[2]}"
+    elif [[ "${input}" =~ ^[0-9]+$ ]]; then
+        pr_number="${input}"
+        repo="$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null)" || {
+            printf "Error: could not determine repo via 'gh repo view'; use owner/repo#%s or a full URL\n" "${pr_number}" >&2
+            return 1
+        }
+    else
+        printf "Error: unrecognized PR reference: %s\n" "${input}" >&2
+        usage >&2
+        return 1
+    fi
+
+    printf '%s\n%s\n' "${repo}" "${pr_number}"
+}
+
+get_merge_sha() {
+    local -r pr_number="$1"
+    local -r repo="$2"
+    local pr_json state sha
+
+    pr_json="$(gh pr view "${pr_number}" --repo "${repo}" --json mergeCommit,state 2>&1)" || {
+        printf "Error: could not fetch PR %s from %s\n" "${pr_number}" "${repo}" >&2
+        return 1
+    }
+
+    state="$(printf '%s' "${pr_json}" | jq -r '.state')"
+    if [[ "${state}" != "MERGED" ]]; then
+        printf "Error: PR %s is not merged (state: %s)\n" "${pr_number}" "${state}" >&2
+        return 1
+    fi
+
+    sha="$(printf '%s' "${pr_json}" | jq -r '.mergeCommit.oid')"
+    printf '%s' "${sha}"
+}
+
+query_pipelineruns() {
+    local -r sha="$1"
+    local -r component="${2:-}"
+    local -r namespace="${KONFLUX_NAMESPACE:-${DEFAULT_NAMESPACE}}"
+    local -r selector="pipelinesascode.tekton.dev/sha=${sha},pipelinesascode.tekton.dev/event-type=push"
+    local output header filtered
+
+    output="$(oc get pipelineruns -n "${namespace}" -l "${selector}" \
+        -o custom-columns="\
+NAME:.metadata.name,\
+STATUS:.status.conditions[0].reason,\
+CREATED:.metadata.creationTimestamp" \
+        --sort-by=.metadata.creationTimestamp 2>&1)" || {
+        printf "Error: failed to query PipelineRuns (are you logged in to the Konflux cluster?)\n" >&2
+        return 1
+    }
+
+    if [[ -n "${component}" ]]; then
+        header="$(printf '%s\n' "${output}" | head -1)"
+        filtered="$(printf '%s\n' "${output}" | tail -n +2 | grep "^${component}" || true)"
+        if [[ -z "${filtered}" ]]; then
+            printf "No push PipelineRuns found for component '%s' at commit %s\n" "${component}" "${sha}" >&2
+            return 1
+        fi
+        printf '%s\n%s\n' "${header}" "${filtered}"
+    else
+        if [[ "$(printf '%s\n' "${output}" | wc -l)" -le 1 ]]; then
+            printf "No push PipelineRuns found for commit %s\n" "${sha}" >&2
+            return 1
+        fi
+        printf '%s\n' "${output}"
+    fi
+}
+
+main() {
+    if [[ $# -lt 1 || "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+        usage
+        return 0
+    fi
+
+    local -r component="${2:-}"
+    local resolved repo pr_number sha
+
+    check_prerequisites
+
+    resolved="$(resolve_pr "$1")"
+    repo="$(printf '%s\n' "${resolved}" | sed -n '1p')"
+    pr_number="$(printf '%s\n' "${resolved}" | sed -n '2p')"
+
+    sha="$(get_merge_sha "${pr_number}" "${repo}")"
+    printf "PR https://github.com/%s/pull/%s merged at commit %s\n\n" "${repo}" "${pr_number}" "${sha}" >&2
+
+    query_pipelineruns "${sha}" "${component}"
+}
+
+main "$@"

--- a/hack/tools/scripts/find-push-pipelinerun.sh
+++ b/hack/tools/scripts/find-push-pipelinerun.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 readonly DEFAULT_NAMESPACE="crt-redhat-acm-tenant"
 readonly DEFAULT_KA_HOST="https://kubearchive-api-server-product-kubearchive.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
+readonly LOG_URL_ANNOTATION="pipelinesascode.tekton.dev/log-url"
 
 usage() {
     printf "Find Konflux on-push PipelineRun(s) triggered by a merged PR.\n\n"
@@ -72,23 +73,39 @@ get_merge_sha() {
     printf '%s' "${sha}"
 }
 
+format_pipelineruns() {
+    local items
+    items="$(jq -r '
+        [.items[] | {
+            name: .metadata.name,
+            status: (.status.conditions[0].reason // "<none>"),
+            created: .metadata.creationTimestamp,
+            url: (.metadata.annotations["'"${LOG_URL_ANNOTATION}"'"] // "")
+        }]
+        | sort_by(.created)
+        | .[]
+        | [.name, .status, .created, .url]
+        | @tsv')"
+
+    if [[ -z "${items}" ]]; then
+        return 1
+    fi
+
+    printf "%-50s %-20s %-25s %s\n" "NAME" "STATUS" "CREATED" "URL"
+    while IFS=$'\t' read -r name status created url; do
+        printf "%-50s %-20s %-25s %s\n" "${name}" "${status}" "${created}" "${url}"
+    done <<< "${items}"
+}
+
 query_pipelineruns_live() {
     local -r sha="$1"
     local -r namespace="$2"
     local -r selector="pipelinesascode.tekton.dev/sha=${sha},pipelinesascode.tekton.dev/event-type=push"
     local output
 
-    output="$(oc get pipelineruns -n "${namespace}" -l "${selector}" \
-        -o custom-columns="\
-NAME:.metadata.name,\
-STATUS:.status.conditions[0].reason,\
-CREATED:.metadata.creationTimestamp" \
-        --sort-by=.metadata.creationTimestamp 2>&1)" || return 1
+    output="$(oc get pipelineruns -n "${namespace}" -l "${selector}" -o json 2>&1)" || return 1
 
-    if [[ "$(printf '%s\n' "${output}" | wc -l)" -le 1 ]]; then
-        return 1
-    fi
-    printf '%s\n' "${output}"
+    printf '%s' "${output}" | format_pipelineruns
 }
 
 query_pipelineruns_archived() {
@@ -96,7 +113,7 @@ query_pipelineruns_archived() {
     local -r namespace="$2"
     local -r ka_host="${KUBEARCHIVE_HOST:-${DEFAULT_KA_HOST}}"
     local -r selector="pipelinesascode.tekton.dev/sha=${sha},pipelinesascode.tekton.dev/event-type=push"
-    local token response items
+    local token response
 
     token="$(oc whoami -t 2>/dev/null)" || {
         printf "Error: could not get auth token via 'oc whoami -t'\n" >&2
@@ -109,21 +126,7 @@ query_pipelineruns_archived() {
         return 1
     }
 
-    items="$(printf '%s' "${response}" | jq -r '
-        .items
-        | sort_by(.metadata.creationTimestamp)
-        | .[]
-        | [.metadata.name, (.status.conditions[0].reason // "<none>"), .metadata.creationTimestamp]
-        | @tsv')"
-
-    if [[ -z "${items}" ]]; then
-        return 1
-    fi
-
-    printf "%-50s %-20s %s\n" "NAME" "STATUS" "CREATED"
-    while IFS=$'\t' read -r name status created; do
-        printf "%-50s %-20s %s\n" "${name}" "${status}" "${created}"
-    done <<< "${items}"
+    printf '%s' "${response}" | format_pipelineruns
 }
 
 filter_by_component() {

--- a/hack/tools/scripts/find-push-pipelinerun.sh
+++ b/hack/tools/scripts/find-push-pipelinerun.sh
@@ -189,4 +189,6 @@ main() {
     query_pipelineruns "${sha}" "${component}"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/hack/tools/scripts/find-push-pipelinerun.sh
+++ b/hack/tools/scripts/find-push-pipelinerun.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
-readonly DEFAULT_NAMESPACE="crt-redhat-acm-tenant"
-readonly DEFAULT_KA_HOST="https://kubearchive-api-server-product-kubearchive.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
-readonly LOG_URL_ANNOTATION="pipelinesascode.tekton.dev/log-url"
+# Guard readonly to allow re-sourcing (e.g. in tests)
+_set_default() { declare -g -r "$1"="$2" 2>/dev/null || true; }
+_set_default DEFAULT_NAMESPACE "crt-redhat-acm-tenant"
+_set_default DEFAULT_KA_HOST "https://kubearchive-api-server-product-kubearchive.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
+_set_default LOG_URL_ANNOTATION "pipelinesascode.tekton.dev/log-url"
+_set_default WATCH_INTERVAL 15
 
 usage() {
     printf "Find Konflux on-push PipelineRun(s) triggered by a merged PR.\n\n"
-    printf "Usage: %s <PR> [COMPONENT]\n\n" "$(basename "$0")"
+    printf "Usage: %s [OPTIONS] <PR> [COMPONENT]\n\n" "$(basename "$0")"
     printf "  PR          One of:\n"
     printf "                - PR number (e.g., 8761) — repo inferred via gh\n"
     printf "                - Full URL (e.g., https://github.com/openshift/hypershift/pull/8761)\n"
     printf "                - owner/repo#number (e.g., openshift/hypershift#8761)\n"
     printf "  COMPONENT   Optional: filter by component name prefix (e.g., hypershift-release)\n\n"
+    printf "Options:\n"
+    printf "  -w, --watch   Poll until all PipelineRuns complete\n\n"
     printf "Environment variables:\n"
     printf "  KONFLUX_NAMESPACE  Konflux namespace (default: %s)\n" "${DEFAULT_NAMESPACE}"
     printf "  KUBEARCHIVE_HOST   KubeArchive API host (default: %s)\n" "${DEFAULT_KA_HOST}"
@@ -58,7 +62,7 @@ get_merge_sha() {
     local -r repo="$2"
     local pr_json state sha
 
-    pr_json="$(gh pr view "${pr_number}" --repo "${repo}" --json mergeCommit,state 2>&1)" || {
+    pr_json="$(gh pr view "${pr_number}" --repo "${repo}" --json mergeCommit,state)" || {
         printf "Error: could not fetch PR %s from %s\n" "${pr_number}" "${repo}" >&2
         return 1
     }
@@ -74,8 +78,10 @@ get_merge_sha() {
 }
 
 format_pipelineruns() {
-    local items
-    items="$(jq -r '
+    local input formatted images
+    input="$(cat)"
+
+    formatted="$(printf '%s' "${input}" | jq -r '
         [.items[] | {
             name: .metadata.name,
             status: (.status.conditions[0].reason // "<none>"),
@@ -83,18 +89,44 @@ format_pipelineruns() {
             url: (.metadata.annotations["'"${LOG_URL_ANNOTATION}"'"] // "")
         }]
         | sort_by(.created)
-        | .[]
-        | [.name, .status, .created, .url]
-        | @tsv')"
+        | if length == 0 then empty else . end
+        | (["NAME","STATUS","CREATED","URL"],
+           (.[] | [.name, .status, .created, .url]))
+        | @tsv
+    ')" || return 1
 
-    if [[ -z "${items}" ]]; then
+    if [[ -z "${formatted}" ]]; then
         return 1
     fi
 
-    printf "%-50s %-20s %-25s %s\n" "NAME" "STATUS" "CREATED" "URL"
-    while IFS=$'\t' read -r name status created url; do
-        printf "%-50s %-20s %-25s %s\n" "${name}" "${status}" "${created}" "${url}"
-    done <<< "${items}"
+    images="$(printf '%s' "${input}" | jq -r '
+        [.items[] | {
+            name: .metadata.name,
+            image: (
+                [.status.results[]? | select(.name == "IMAGE_URL") | .value][0]
+                + (
+                    [.status.results[]? | select(.name == "IMAGE_DIGEST") | .value][0]
+                    // empty
+                    | "@" + .
+                )
+            ) // ""
+        }]
+        | .[] | select(.image != "") | [.name, .image] | @tsv
+    ')"
+
+    printf '%s\n' "${formatted}" | column -t -s $'\t'
+
+    if [[ -n "${images}" ]]; then
+        printf '\n'
+        while IFS=$'\t' read -r name image; do
+            printf "  %s IMAGE: %s\n" "${name}" "${image}"
+        done <<< "${images}"
+    fi
+}
+
+has_pending() {
+    local -r formatted="$1"
+    printf '%s\n' "${formatted}" | tail -n +2 | awk '{print $2}' | grep -qvE '^(Completed|Failed|Succeeded|Error)$'
 }
 
 query_pipelineruns_live() {
@@ -103,7 +135,7 @@ query_pipelineruns_live() {
     local -r selector="pipelinesascode.tekton.dev/sha=${sha},pipelinesascode.tekton.dev/event-type=push"
     local output
 
-    output="$(oc get pipelineruns -n "${namespace}" -l "${selector}" -o json 2>&1)" || return 1
+    output="$(oc get pipelineruns -n "${namespace}" -l "${selector}" -o json 2>/dev/null)" || return 1
 
     printf '%s' "${output}" | format_pipelineruns
 }
@@ -169,24 +201,47 @@ query_pipelineruns() {
 }
 
 main() {
-    if [[ $# -lt 1 || "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    set -euo pipefail
+
+    local watch=false
+    local positional=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -w|--watch) watch=true; shift ;;
+            -h|--help) usage; return 0 ;;
+            *) positional+=("$1"); shift ;;
+        esac
+    done
+
+    if [[ ${#positional[@]} -lt 1 ]]; then
         usage
         return 0
     fi
 
-    local -r component="${2:-}"
-    local resolved repo pr_number sha
+    local -r pr_ref="${positional[0]}"
+    local -r component="${positional[1]:-}"
+    local resolved repo pr_number sha output
 
     check_prerequisites
 
-    resolved="$(resolve_pr "$1")"
+    resolved="$(resolve_pr "${pr_ref}")"
     repo="$(printf '%s\n' "${resolved}" | sed -n '1p')"
     pr_number="$(printf '%s\n' "${resolved}" | sed -n '2p')"
 
     sha="$(get_merge_sha "${pr_number}" "${repo}")"
     printf "PR https://github.com/%s/pull/%s merged at commit %s\n\n" "${repo}" "${pr_number}" "${sha}" >&2
 
-    query_pipelineruns "${sha}" "${component}"
+    output="$(query_pipelineruns "${sha}" "${component}")"
+    printf '%s\n' "${output}"
+
+    if [[ "${watch}" == true ]]; then
+        while has_pending "${output}"; do
+            sleep "${WATCH_INTERVAL}"
+            printf "\n--- refreshing (%ss) ---\n\n" "${WATCH_INTERVAL}" >&2
+            output="$(query_pipelineruns "${sha}" "${component}")"
+            printf '%s\n' "${output}"
+        done
+    fi
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/hack/tools/scripts/find-push-pipelinerun.sh
+++ b/hack/tools/scripts/find-push-pipelinerun.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 readonly DEFAULT_NAMESPACE="crt-redhat-acm-tenant"
+readonly DEFAULT_KA_HOST="https://kubearchive-api-server-product-kubearchive.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
 
 usage() {
     printf "Find Konflux on-push PipelineRun(s) triggered by a merged PR.\n\n"
@@ -13,11 +14,12 @@ usage() {
     printf "  COMPONENT   Optional: filter by component name prefix (e.g., hypershift-release)\n\n"
     printf "Environment variables:\n"
     printf "  KONFLUX_NAMESPACE  Konflux namespace (default: %s)\n" "${DEFAULT_NAMESPACE}"
+    printf "  KUBEARCHIVE_HOST   KubeArchive API host (default: %s)\n" "${DEFAULT_KA_HOST}"
 }
 
 check_prerequisites() {
     local cmd
-    for cmd in gh oc jq; do
+    for cmd in gh oc jq curl; do
         if ! command -v "${cmd}" &>/dev/null; then
             printf "Error: %s is required but not found in PATH\n" "${cmd}" >&2
             return 1
@@ -70,36 +72,95 @@ get_merge_sha() {
     printf '%s' "${sha}"
 }
 
-query_pipelineruns() {
+query_pipelineruns_live() {
     local -r sha="$1"
-    local -r component="${2:-}"
-    local -r namespace="${KONFLUX_NAMESPACE:-${DEFAULT_NAMESPACE}}"
+    local -r namespace="$2"
     local -r selector="pipelinesascode.tekton.dev/sha=${sha},pipelinesascode.tekton.dev/event-type=push"
-    local output header filtered
+    local output
 
     output="$(oc get pipelineruns -n "${namespace}" -l "${selector}" \
         -o custom-columns="\
 NAME:.metadata.name,\
 STATUS:.status.conditions[0].reason,\
 CREATED:.metadata.creationTimestamp" \
-        --sort-by=.metadata.creationTimestamp 2>&1)" || {
-        printf "Error: failed to query PipelineRuns (are you logged in to the Konflux cluster?)\n" >&2
+        --sort-by=.metadata.creationTimestamp 2>&1)" || return 1
+
+    if [[ "$(printf '%s\n' "${output}" | wc -l)" -le 1 ]]; then
+        return 1
+    fi
+    printf '%s\n' "${output}"
+}
+
+query_pipelineruns_archived() {
+    local -r sha="$1"
+    local -r namespace="$2"
+    local -r ka_host="${KUBEARCHIVE_HOST:-${DEFAULT_KA_HOST}}"
+    local -r selector="pipelinesascode.tekton.dev/sha=${sha},pipelinesascode.tekton.dev/event-type=push"
+    local token response items
+
+    token="$(oc whoami -t 2>/dev/null)" || {
+        printf "Error: could not get auth token via 'oc whoami -t'\n" >&2
         return 1
     }
 
-    if [[ -n "${component}" ]]; then
-        header="$(printf '%s\n' "${output}" | head -1)"
-        filtered="$(printf '%s\n' "${output}" | tail -n +2 | grep "^${component}" || true)"
-        if [[ -z "${filtered}" ]]; then
-            printf "No push PipelineRuns found for component '%s' at commit %s\n" "${component}" "${sha}" >&2
-            return 1
-        fi
-        printf '%s\n%s\n' "${header}" "${filtered}"
+    response="$(curl -sf -H "Authorization: Bearer ${token}" \
+        "${ka_host}/apis/tekton.dev/v1/namespaces/${namespace}/pipelineruns?labelSelector=${selector}")" || {
+        printf "Error: KubeArchive query failed (is %s reachable?)\n" "${ka_host}" >&2
+        return 1
+    }
+
+    items="$(printf '%s' "${response}" | jq -r '
+        .items
+        | sort_by(.metadata.creationTimestamp)
+        | .[]
+        | [.metadata.name, (.status.conditions[0].reason // "<none>"), .metadata.creationTimestamp]
+        | @tsv')"
+
+    if [[ -z "${items}" ]]; then
+        return 1
+    fi
+
+    printf "%-50s %-20s %s\n" "NAME" "STATUS" "CREATED"
+    while IFS=$'\t' read -r name status created; do
+        printf "%-50s %-20s %s\n" "${name}" "${status}" "${created}"
+    done <<< "${items}"
+}
+
+filter_by_component() {
+    local -r component="$1"
+    local -r sha="$2"
+    local output header filtered
+
+    output="$(cat)"
+    header="$(printf '%s\n' "${output}" | head -1)"
+    filtered="$(printf '%s\n' "${output}" | tail -n +2 | grep "^${component}" || true)"
+    if [[ -z "${filtered}" ]]; then
+        printf "No push PipelineRuns found for component '%s' at commit %s\n" "${component}" "${sha}" >&2
+        return 1
+    fi
+    printf '%s\n%s\n' "${header}" "${filtered}"
+}
+
+query_pipelineruns() {
+    local -r sha="$1"
+    local -r component="${2:-}"
+    local -r namespace="${KONFLUX_NAMESPACE:-${DEFAULT_NAMESPACE}}"
+    local output
+
+    if output="$(query_pipelineruns_live "${sha}" "${namespace}" 2>/dev/null)"; then
+        :
     else
-        if [[ "$(printf '%s\n' "${output}" | wc -l)" -le 1 ]]; then
+        printf "No live PipelineRuns found, querying KubeArchive...\n" >&2
+        output="$(query_pipelineruns_archived "${sha}" "${namespace}")" || {
             printf "No push PipelineRuns found for commit %s\n" "${sha}" >&2
             return 1
-        fi
+        }
+        printf "(source: KubeArchive)\n\n" >&2
+    fi
+
+    if [[ -n "${component}" ]]; then
+        printf '%s\n' "${output}" | filter_by_component "${component}" "${sha}"
+    else
         printf '%s\n' "${output}"
     fi
 }

--- a/hack/tools/scripts/find-push-pipelinerun.sh
+++ b/hack/tools/scripts/find-push-pipelinerun.sh
@@ -78,7 +78,7 @@ get_merge_sha() {
 }
 
 format_pipelineruns() {
-    local input formatted images
+    local input formatted
     input="$(cat)"
 
     formatted="$(printf '%s' "${input}" | jq -r '
@@ -86,12 +86,19 @@ format_pipelineruns() {
             name: .metadata.name,
             status: (.status.conditions[0].reason // "<none>"),
             created: .metadata.creationTimestamp,
-            url: (.metadata.annotations["'"${LOG_URL_ANNOTATION}"'"] // "")
+            url: (.metadata.annotations["'"${LOG_URL_ANNOTATION}"'"] // ""),
+            image: (
+                ([.status.results[]? | select(.name == "IMAGE_URL") | .value][0] // "") as $url
+                | ([.status.results[]? | select(.name == "IMAGE_DIGEST") | .value][0] // null) as $digest
+                | if $url != "" and $digest then $url + "@" + $digest
+                  elif $url != "" then $url
+                  else "" end
+            )
         }]
         | sort_by(.created)
         | if length == 0 then empty else . end
-        | (["NAME","STATUS","CREATED","URL"],
-           (.[] | [.name, .status, .created, .url]))
+        | (["NAME","STATUS","CREATED","URL","IMAGE"],
+           (.[] | [.name, .status, .created, .url, .image]))
         | @tsv
     ')" || return 1
 
@@ -99,29 +106,7 @@ format_pipelineruns() {
         return 1
     fi
 
-    images="$(printf '%s' "${input}" | jq -r '
-        [.items[] | {
-            name: .metadata.name,
-            image: (
-                [.status.results[]? | select(.name == "IMAGE_URL") | .value][0]
-                + (
-                    [.status.results[]? | select(.name == "IMAGE_DIGEST") | .value][0]
-                    // empty
-                    | "@" + .
-                )
-            ) // ""
-        }]
-        | .[] | select(.image != "") | [.name, .image] | @tsv
-    ')"
-
     printf '%s\n' "${formatted}" | column -t -s $'\t'
-
-    if [[ -n "${images}" ]]; then
-        printf '\n'
-        while IFS=$'\t' read -r name image; do
-            printf "  %s IMAGE: %s\n" "${name}" "${image}"
-        done <<< "${images}"
-    fi
 }
 
 has_pending() {
@@ -152,8 +137,9 @@ query_pipelineruns_archived() {
         return 1
     }
 
-    response="$(curl -sf -H "Authorization: Bearer ${token}" \
-        "${ka_host}/apis/tekton.dev/v1/namespaces/${namespace}/pipelineruns?labelSelector=${selector}")" || {
+    response="$(curl -sf --connect-timeout 5 --max-time 30 -G -H "Authorization: Bearer ${token}" \
+        --data-urlencode "labelSelector=${selector}" \
+        "${ka_host}/apis/tekton.dev/v1/namespaces/${namespace}/pipelineruns")" || {
         printf "Error: KubeArchive query failed (is %s reachable?)\n" "${ka_host}" >&2
         return 1
     }
@@ -168,7 +154,7 @@ filter_by_component() {
 
     output="$(cat)"
     header="$(printf '%s\n' "${output}" | head -1)"
-    filtered="$(printf '%s\n' "${output}" | tail -n +2 | grep "^${component}" || true)"
+    filtered="$(printf '%s\n' "${output}" | tail -n +2 | awk -v prefix="${component}" 'index($0, prefix) == 1' || true)"
     if [[ -z "${filtered}" ]]; then
         printf "No push PipelineRuns found for component '%s' at commit %s\n" "${component}" "${sha}" >&2
         return 1
@@ -215,7 +201,7 @@ main() {
 
     if [[ ${#positional[@]} -lt 1 ]]; then
         usage
-        return 0
+        return 1
     fi
 
     local -r pr_ref="${positional[0]}"

--- a/hack/tools/scripts/find-push-pipelinerun_test.bats
+++ b/hack/tools/scripts/find-push-pipelinerun_test.bats
@@ -58,15 +58,29 @@ setup() {
     [[ "$output" == *"https://example.com/run/abc"* ]]
 }
 
+@test "format_pipelineruns: shows IMAGE for completed runs with results" {
+    local json='{"items":[{"metadata":{"name":"my-plr","creationTimestamp":"2026-06-26T13:00:00Z","annotations":{}},"status":{"conditions":[{"reason":"Completed"}],"results":[{"name":"IMAGE_URL","value":"quay.io/org/img:tag"},{"name":"IMAGE_DIGEST","value":"sha256:abc123"}]}}]}'
+
+    output="$(printf '%s' "${json}" | format_pipelineruns)"
+    [[ "$output" == *"IMAGE: quay.io/org/img:tag@sha256:abc123"* ]]
+}
+
+@test "format_pipelineruns: no IMAGE line when no results" {
+    local json='{"items":[{"metadata":{"name":"my-plr","creationTimestamp":"2026-06-26T13:00:00Z","annotations":{}},"status":{"conditions":[{"reason":"Running"}]}}]}'
+
+    output="$(printf '%s' "${json}" | format_pipelineruns)"
+    [[ "$output" != *"IMAGE:"* ]]
+}
+
 @test "format_pipelineruns: sorts by creation timestamp" {
     local json='{"items":[{"metadata":{"name":"second","creationTimestamp":"2026-06-26T14:00:00Z","annotations":{}},"status":{"conditions":[{"reason":"Running"}]}},{"metadata":{"name":"first","creationTimestamp":"2026-06-26T13:00:00Z","annotations":{}},"status":{"conditions":[{"reason":"Completed"}]}}]}'
 
     output="$(printf '%s' "${json}" | format_pipelineruns)"
-    local first_line second_line
-    first_line="$(sed -n '2p' <<< "$output")"
-    second_line="$(sed -n '3p' <<< "$output")"
-    [[ "$first_line" == *"first"* ]]
-    [[ "$second_line" == *"second"* ]]
+    local first_data second_data
+    first_data="$(grep -n "first\|second" <<< "$output" | head -1)"
+    second_data="$(grep -n "first\|second" <<< "$output" | tail -1)"
+    [[ "$first_data" == *"first"* ]]
+    [[ "$second_data" == *"second"* ]]
 }
 
 @test "format_pipelineruns: returns 1 on empty items" {
@@ -86,6 +100,26 @@ setup() {
 
     output="$(printf '%s' "${json}" | format_pipelineruns)"
     [[ "$output" == *"<none>"* ]]
+}
+
+# --- has_pending ---
+
+@test "has_pending: returns 0 when runs are still in progress" {
+    local table
+    table="$(printf '%-50s %-20s %-25s %s\n' "NAME" "STATUS" "CREATED" "URL"
+             printf '%-50s %-20s %-25s %s\n' "plr-a" "Running" "2026-06-26T13:00:00Z" ""
+             printf '%-50s %-20s %-25s %s\n' "plr-b" "Completed" "2026-06-26T13:00:00Z" "")"
+    run has_pending "${table}"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "has_pending: returns 1 when all runs are terminal" {
+    local table
+    table="$(printf '%-50s %-20s %-25s %s\n' "NAME" "STATUS" "CREATED" "URL"
+             printf '%-50s %-20s %-25s %s\n' "plr-a" "Failed" "2026-06-26T13:00:00Z" ""
+             printf '%-50s %-20s %-25s %s\n' "plr-b" "Completed" "2026-06-26T13:00:00Z" "")"
+    run has_pending "${table}"
+    [[ "$status" -ne 0 ]]
 }
 
 # --- filter_by_component ---

--- a/hack/tools/scripts/find-push-pipelinerun_test.bats
+++ b/hack/tools/scripts/find-push-pipelinerun_test.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    source "${SCRIPT_DIR}/find-push-pipelinerun.sh"
+}
+
+# --- resolve_pr ---
+
+@test "resolve_pr: parses full GitHub URL" {
+    run resolve_pr "https://github.com/openshift/hypershift/pull/8761"
+    [[ "$status" -eq 0 ]]
+    [[ "$(sed -n '1p' <<< "$output")" == "openshift/hypershift" ]]
+    [[ "$(sed -n '2p' <<< "$output")" == "8761" ]]
+}
+
+@test "resolve_pr: parses GitHub URL with trailing slash" {
+    run resolve_pr "https://github.com/openshift/hypershift/pull/8761/"
+    [[ "$status" -eq 0 ]]
+    [[ "$(sed -n '1p' <<< "$output")" == "openshift/hypershift" ]]
+    [[ "$(sed -n '2p' <<< "$output")" == "8761" ]]
+}
+
+@test "resolve_pr: parses owner/repo#number" {
+    run resolve_pr "openshift/hypershift#8761"
+    [[ "$status" -eq 0 ]]
+    [[ "$(sed -n '1p' <<< "$output")" == "openshift/hypershift" ]]
+    [[ "$(sed -n '2p' <<< "$output")" == "8761" ]]
+}
+
+@test "resolve_pr: parses owner/repo#number with org containing hyphens" {
+    run resolve_pr "my-org/my-repo#42"
+    [[ "$status" -eq 0 ]]
+    [[ "$(sed -n '1p' <<< "$output")" == "my-org/my-repo" ]]
+    [[ "$(sed -n '2p' <<< "$output")" == "42" ]]
+}
+
+@test "resolve_pr: rejects non-numeric non-URL input" {
+    run resolve_pr "not-a-pr"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"unrecognized PR reference"* ]]
+}
+
+@test "resolve_pr: rejects empty input" {
+    run resolve_pr ""
+    [[ "$status" -ne 0 ]]
+}
+
+# --- format_pipelineruns ---
+
+@test "format_pipelineruns: formats JSON items into table" {
+    local json='{"items":[{"metadata":{"name":"my-pipeline-on-push-abc12","creationTimestamp":"2026-06-26T13:47:51Z","annotations":{"pipelinesascode.tekton.dev/log-url":"https://example.com/run/abc"}},"status":{"conditions":[{"reason":"Completed"}]}}]}'
+
+    output="$(printf '%s' "${json}" | format_pipelineruns)"
+    [[ "$output" == *"NAME"* ]]
+    [[ "$output" == *"my-pipeline-on-push-abc12"* ]]
+    [[ "$output" == *"Completed"* ]]
+    [[ "$output" == *"https://example.com/run/abc"* ]]
+}
+
+@test "format_pipelineruns: sorts by creation timestamp" {
+    local json='{"items":[{"metadata":{"name":"second","creationTimestamp":"2026-06-26T14:00:00Z","annotations":{}},"status":{"conditions":[{"reason":"Running"}]}},{"metadata":{"name":"first","creationTimestamp":"2026-06-26T13:00:00Z","annotations":{}},"status":{"conditions":[{"reason":"Completed"}]}}]}'
+
+    output="$(printf '%s' "${json}" | format_pipelineruns)"
+    local first_line second_line
+    first_line="$(sed -n '2p' <<< "$output")"
+    second_line="$(sed -n '3p' <<< "$output")"
+    [[ "$first_line" == *"first"* ]]
+    [[ "$second_line" == *"second"* ]]
+}
+
+@test "format_pipelineruns: returns 1 on empty items" {
+    run format_pipelineruns <<< '{"items":[]}'
+    [[ "$status" -ne 0 ]]
+}
+
+@test "format_pipelineruns: handles missing log-url annotation" {
+    local json='{"items":[{"metadata":{"name":"no-url","creationTimestamp":"2026-06-26T13:00:00Z","annotations":{}},"status":{"conditions":[{"reason":"Completed"}]}}]}'
+
+    output="$(printf '%s' "${json}" | format_pipelineruns)"
+    [[ "$output" == *"no-url"* ]]
+}
+
+@test "format_pipelineruns: handles missing status conditions" {
+    local json='{"items":[{"metadata":{"name":"no-status","creationTimestamp":"2026-06-26T13:00:00Z","annotations":{}},"status":{}}]}'
+
+    output="$(printf '%s' "${json}" | format_pipelineruns)"
+    [[ "$output" == *"<none>"* ]]
+}
+
+# --- filter_by_component ---
+
+@test "filter_by_component: filters matching rows" {
+    local table
+    table="$(printf '%-50s %-20s %-25s %s\n' "NAME" "STATUS" "CREATED" "URL"
+             printf '%-50s %-20s %-25s %s\n' "hypershift-cli-on-push-abc" "Failed" "2026-06-26T13:47:51Z" "https://example.com/1"
+             printf '%-50s %-20s %-25s %s\n' "hypershift-release-on-push-def" "Completed" "2026-06-26T13:47:51Z" "https://example.com/2")"
+
+    output="$(printf '%s\n' "${table}" | filter_by_component hypershift-release abc123)"
+    [[ "$output" == *"hypershift-release"* ]]
+    [[ "$output" != *"hypershift-cli"* ]]
+}
+
+@test "filter_by_component: returns 1 when no match" {
+    local table
+    table="$(printf '%-50s %-20s %-25s %s\n' "NAME" "STATUS" "CREATED" "URL"
+             printf '%-50s %-20s %-25s %s\n' "hypershift-cli-on-push-abc" "Failed" "2026-06-26T13:47:51Z" "")"
+
+    run filter_by_component nonexistent abc123 <<< "${table}"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"No push PipelineRuns found for component"* ]]
+}
+
+@test "filter_by_component: preserves header" {
+    local table
+    table="$(printf '%-50s %-20s %-25s %s\n' "NAME" "STATUS" "CREATED" "URL"
+             printf '%-50s %-20s %-25s %s\n' "hypershift-release-on-push-def" "Completed" "2026-06-26T13:47:51Z" "")"
+
+    output="$(printf '%s\n' "${table}" | filter_by_component hypershift-release abc123)"
+    [[ "$(sed -n '1p' <<< "$output")" == *"NAME"* ]]
+}

--- a/hack/tools/scripts/find-push-pipelinerun_test.bats
+++ b/hack/tools/scripts/find-push-pipelinerun_test.bats
@@ -58,18 +58,33 @@ setup() {
     [[ "$output" == *"https://example.com/run/abc"* ]]
 }
 
-@test "format_pipelineruns: shows IMAGE for completed runs with results" {
+@test "format_pipelineruns: shows image column for completed runs with results" {
     local json='{"items":[{"metadata":{"name":"my-plr","creationTimestamp":"2026-06-26T13:00:00Z","annotations":{}},"status":{"conditions":[{"reason":"Completed"}],"results":[{"name":"IMAGE_URL","value":"quay.io/org/img:tag"},{"name":"IMAGE_DIGEST","value":"sha256:abc123"}]}}]}'
 
     output="$(printf '%s' "${json}" | format_pipelineruns)"
-    [[ "$output" == *"IMAGE: quay.io/org/img:tag@sha256:abc123"* ]]
+    [[ "$output" == *"IMAGE"* ]]
+    [[ "$output" == *"quay.io/org/img:tag@sha256:abc123"* ]]
 }
 
-@test "format_pipelineruns: no IMAGE line when no results" {
+@test "format_pipelineruns: shows image URL when no digest present" {
+    local json='{"items":[{"metadata":{"name":"my-plr","creationTimestamp":"2026-06-26T13:00:00Z","annotations":{}},"status":{"conditions":[{"reason":"Completed"}],"results":[{"name":"IMAGE_URL","value":"quay.io/org/img:tag"}]}}]}'
+
+    output="$(printf '%s' "${json}" | format_pipelineruns)"
+    [[ "$output" == *"quay.io/org/img:tag"* ]]
+}
+
+@test "format_pipelineruns: image column empty when only digest present" {
+    local json='{"items":[{"metadata":{"name":"my-plr","creationTimestamp":"2026-06-26T13:00:00Z","annotations":{}},"status":{"conditions":[{"reason":"Completed"}],"results":[{"name":"IMAGE_DIGEST","value":"sha256:abc123"}]}}]}'
+
+    output="$(printf '%s' "${json}" | format_pipelineruns)"
+    [[ "$output" != *"sha256"* ]]
+}
+
+@test "format_pipelineruns: image column empty when no results" {
     local json='{"items":[{"metadata":{"name":"my-plr","creationTimestamp":"2026-06-26T13:00:00Z","annotations":{}},"status":{"conditions":[{"reason":"Running"}]}}]}'
 
     output="$(printf '%s' "${json}" | format_pipelineruns)"
-    [[ "$output" != *"IMAGE:"* ]]
+    [[ "$output" != *"quay.io"* ]]
 }
 
 @test "format_pipelineruns: sorts by creation timestamp" {


### PR DESCRIPTION
## Summary

- Add `hack/tools/scripts/find-push-pipelinerun.sh` to find Konflux on-push PipelineRun(s) triggered by a merged GitHub PR
- Accepts a bare PR number (repo inferred via `gh`), full GitHub URL, or `owner/repo#number` format
- Queries live PipelineRuns via `oc get`, falls back to KubeArchive REST API for archived runs
- Displays PipelineRun name, status, creation timestamp, and Konflux UI URL (from `pipelinesascode.tekton.dev/log-url` annotation)
- Optional component name filter
- Includes bats unit tests for input parsing, JSON formatting, and component filtering

## Example

```
$ find-push-pipelinerun.sh 8761
PR https://github.com/openshift/hypershift/pull/8761 merged at commit aeadb45792...

No live PipelineRuns found, querying KubeArchive...
(source: KubeArchive)

NAME                                               STATUS               CREATED                   URL
hypershift-cli-mce-27-on-push-7j48x                Failed               2026-06-26T13:47:51Z      https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/...
hypershift-release-mce-27-on-push-jvq72            Completed            2026-06-26T13:47:51Z      https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/...
```

## Test plan

- [x] `shellcheck` passes clean
- [x] `bats` unit tests pass (14/14)
- [x] Manual test: bare PR number, `owner/repo#number`, full URL
- [x] Manual test: component filter
- [x] Manual test: KubeArchive fallback (archived PipelineRuns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line utility to locate Tekton push `PipelineRun` records for a merged pull request, resolving PR references from common GitHub URL formats.
  * Outputs results in a readable table (including image and log details) and supports optional component-name filtering.
  * Added live “watch” mode to refresh results until all matching pipeline runs reach a terminal state.
* **Bug Fixes**
  * Improved robustness when optional `PipelineRun` fields (e.g., conditions or log annotations) are missing.
* **Tests**
  * Added automated tests covering PR parsing, result formatting (sorting and missing fields), pending-state detection, and component filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->