### PR TITLE
NO-JIRA: add Konflux CI scripts reference and document validate-pr-override-images

### DIFF
--- a/docs/content/contribute/cpo-overrides.md
+++ b/docs/content/contribute/cpo-overrides.md
@@ -210,6 +210,38 @@ To run override tests:
    - Verify platform name spelling
 
 
+## Validating Override Images Contain Claimed PRs
+
+When reviewing a PR that sets CPO override images and claims "includes
+fix from PR #8500 and PR #8512", you can verify the claimed PRs are
+actually present in the image's git history using the
+`/validate-pr-override-images` Claude Code skill.
+
+The PR description must include a structured contract:
+
+```
+branch: 4.20 wants: https://github.com/openshift/hypershift/pull/8593
+branch: 4.21 wants: https://github.com/openshift/hypershift/pull/8593, https://github.com/openshift/hypershift/pull/8565
+```
+
+```
+# In Claude Code, pass the PR number or URL:
+/validate-pr-override-images 8610
+/validate-pr-override-images https://github.com/openshift/hypershift/pull/8610
+```
+
+The skill reads the `vcs-ref` label from each override image via
+`skopeo inspect` to get the commit SHA the image was built from, then
+uses `git merge-base --is-ancestor` to check whether each claimed PR's
+merge commit is an ancestor of that image commit.
+
+Prerequisites: `skopeo`, `gh`, relevant release branches fetched locally
+
+!!! note
+    The `validate-cpo-overrides.yaml`
+    [GitHub Action](../how-to/ci/github-actions.md) runs this same
+    validation automatically on PRs that touch `overrides.yaml`.
+
 ## Security/Production Considerations
 
 - Only use trusted image registries for CPO overrides

--- a/docs/content/contribute/konflux-scripts.md
+++ b/docs/content/contribute/konflux-scripts.md
@@ -8,7 +8,8 @@ in namespace `crt-redhat-acm-tenant`.
 
 ## Predict which pipelines a PR triggers
 
-Before pushing, check which Konflux pipelines your changes would trigger.
+You've changed a Containerfile and some Go code, and want to know which
+Konflux pipelines will fire before you push.
 
 **Tool:** `hack/tools/check-konflux-triggers/`
 
@@ -17,40 +18,67 @@ files against the current branch's changed files. Uses the same `gobwas/glob`
 and `google/cel-go` libraries as Pipelines as Code.
 
 ```bash
-# From the repository root:
+# Check which pipelines would trigger for your current changes:
 (cd hack/tools && go run ./check-konflux-triggers/)
 
-# With a custom base ref (defaults to origin/main):
+# Compare against a different base (e.g., your upstream remote):
 (cd hack/tools && go run ./check-konflux-triggers/ upstream/main)
 ```
 
 ## Build an image from a PR
 
-Use this when you need a container image from an unmerged PR — for example
-to test a fix in a staging cluster, or to rebuild an image whose 5-day PR
-expiry has passed.
+**Scenario 1:** You opened a PR with an OCPBUGS fix and need the built
+image to deploy in a staging cluster for manual validation — but the PR
+hasn't merged yet.
+
+**Scenario 2:** A colleague asks you to test their PR, but it was opened
+a week ago and the 5-day image expiry has already garbage-collected it
+from the registry. You need a fresh build with a longer TTL.
 
 **Skill:** `/konflux-build` — creates a manual Konflux PipelineRun from a
 PR with configurable image expiry (default 30 days).
 
+```
+# In Claude Code:
+/konflux-build 8761
+/konflux-build https://github.com/openshift/hypershift/pull/8761
+```
+
 ## Investigate Enterprise Contract failures
 
-When a PR has failing enterprise contract checks, use this to retrieve
-the detailed violation report, pod logs, and task results from the archived
-PipelineRun.
+Your PR shows a red "enterprise-contract" check on GitHub. The check output
+says something about untrusted tasks or policy violations, but the details
+are sparse. The PipelineRun has already been archived and `oc get` returns
+nothing.
 
 **Skill:** `/konflux-ec-violations` — accesses archived PipelineRuns via
 the KubeArchive REST API, retrieves the EC verify task's JSON report, and
 summarises violations grouped by rule.
 
+```
+# In Claude Code, pass the PR number or URL:
+/konflux-ec-violations 8761
+```
+
+The skill fetches the archived PipelineRun from KubeArchive, finds the
+EC verify task pod, reads the `step-report-json` container logs, and
+presents the violations with rule codes, descriptions, and suggested fixes.
+
 ## Update outdated Tekton tasks
 
-When Enterprise Contract checks report outdated task bundles, use this to
-update the `.tekton/` pipeline files to the latest trusted digests. Also
-checks for migration notes and breaking changes.
+Enterprise Contract checks are failing with `trusted_task.trusted` — your
+`.tekton/` pipeline files reference task bundle digests that are no longer
+in the trusted list.
 
 **Skill:** `/update-konflux-tasks` — parses EC violation logs, identifies
-outdated tasks, fetches migration notes, and applies updates.
+outdated tasks, fetches migration notes from the
+[build-definitions](https://github.com/konflux-ci/build-definitions) repo,
+and applies the digest updates.
+
+```
+# In Claude Code:
+/update-konflux-tasks
+```
 
 ### Standalone scripts
 
@@ -61,20 +89,22 @@ trusted tasks data from the Konflux `data-acceptable-bundles` OCI artifact
 and updates pipeline YAML files to the latest trusted digests.
 
 ```bash
-# Update all .tekton/ pipeline files
+# Update all .tekton/ pipeline files at once:
 hack/tools/scripts/update_trusted_task_bundles.py
 
-# Update specific files
+# Update only the operator push pipeline:
 hack/tools/scripts/update_trusted_task_bundles.py .tekton/hypershift-operator-main-push.yaml
 ```
 
 Prerequisites: `python3`, `oras`
 
 **`hack/tools/scripts/find_task_version_by_digest.sh`** — maps a task
-container image digest to its semantic version tag. Useful when EC reports
-a digest and you need to know which version it corresponds to.
+container image digest to its semantic version tag. Useful when an EC
+violation message gives you a digest like `sha256:a7cc...` and you need
+to know "is this version 0.8 or 0.9?".
 
 ```bash
+# Find which version of clair-scan corresponds to a digest:
 hack/tools/scripts/find_task_version_by_digest.sh clair-scan \
   sha256:a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af
 ```
@@ -83,60 +113,73 @@ Prerequisites: `skopeo`, `jq`
 
 ## Test tag pipeline changes
 
-When modifying the `.tekton/` tag pipeline definition, use this to validate
-the changes against a real tag before merging.
+You're modifying the tag pipeline definition in `.tekton/` (e.g., adding a
+new build step or changing the multi-arch platforms). You need to verify
+the changes actually work before merging — but tag pipelines only trigger
+on `git tag` pushes, so normal PR CI won't exercise them.
 
 **Skill:** `/test-tag-pipeline` — creates a manual PipelineRun from a tag
 commit using your branch's pipeline definition, waits for it to complete,
 and optionally triggers EC validation via a Snapshot.
 
-### Standalone scripts
-
-The skill orchestrates two scripts:
-
-**`hack/tools/scripts/create-manual-tag-pipelinerun.sh`** — creates the
-manual PipelineRun.
-
-```bash
-hack/tools/scripts/create-manual-tag-pipelinerun.sh <tag-name> [branch-spec]
+```
+# In Claude Code, from your branch with tag pipeline changes:
+/test-tag-pipeline v0.1.69
 ```
 
-| Argument | Description |
-|----------|-------------|
-| `tag-name` | The existing tag to rebuild (e.g., `v0.1.69`) |
-| `branch-spec` | Branch with the updated pipeline (default: `main`). Format: `[fork:]branch-name` |
+### Standalone scripts
+
+The skill orchestrates two scripts that can be used independently:
+
+**`hack/tools/scripts/create-manual-tag-pipelinerun.sh`** — creates the
+manual PipelineRun by patching the tag pipeline YAML with your branch's
+commit SHA and submitting it.
 
 ```bash
-# Rebuild v0.1.69 using the pipeline from main
+# Test the tag pipeline from main against tag v0.1.69:
 hack/tools/scripts/create-manual-tag-pipelinerun.sh v0.1.69
 
-# Use a pipeline from a fork branch
+# Test using the pipeline definition from your fork branch:
 hack/tools/scripts/create-manual-tag-pipelinerun.sh v0.1.69 celebdor:fix-tag-pipeline
+
+# Then watch the PipelineRun until it finishes:
+oc get pipelinerun -n crt-redhat-acm-tenant -w -l pipelinesascode.tekton.dev/event-type=push
 ```
 
 Prerequisites: `oc`, `yq`
 
-**`hack/tools/scripts/create-snapshot-from-pipelinerun.sh`** — creates a
-Snapshot from a completed PipelineRun to trigger Enterprise Contract
-validation.
+**`hack/tools/scripts/create-snapshot-from-pipelinerun.sh`** — after the
+build completes, creates an `appstudio.redhat.com/v1alpha1` Snapshot
+resource to trigger Enterprise Contract (EC) validation on the resulting
+image. The Snapshot links the built container image back to its source
+commit and target branch, which is exactly the metadata EC needs to run
+its policy checks.
+
+The script has two modes:
+
+1. **From a live PipelineRun** — extracts `IMAGE_URL`, `IMAGE_DIGEST`,
+   commit SHA, and target branch directly from the PipelineRun's
+   `status.results` and annotations.
+2. **Direct image parameters** — useful when the PipelineRun has already
+   been garbage-collected. You provide the image coordinates and commit
+   metadata explicitly.
 
 ```bash
-# From a PipelineRun name
-hack/tools/scripts/create-snapshot-from-pipelinerun.sh <pipelinerun-name>
-
-# From explicit image details
+# Mode 1: From a completed PipelineRun (extracts image details automatically):
 hack/tools/scripts/create-snapshot-from-pipelinerun.sh \
-  --image-url <url> --image-digest <digest> \
-  [--commit <sha>] [--target-branch <branch>]
+  hypershift-operator-main-manual-v0.1.69-abc12
+
+# Mode 2: Direct parameters (e.g., after PipelineRun was garbage-collected):
+hack/tools/scripts/create-snapshot-from-pipelinerun.sh \
+  --image-url quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-operator-main:v0.1.69 \
+  --image-digest sha256:016e754d... \
+  --pipelinerun hypershift-operator-main-manual-v0.1.69-gb49w \
+  --commit 6e6ecadc61361e4fe359af34dcdee17df06c664e \
+  --target-branch refs/tags/v0.1.69
+
+# Monitor the resulting EC IntegrationTestScenario run:
+oc get snapshot <snapshot-name> -n crt-redhat-acm-tenant -w
+oc get pipelinerun -n crt-redhat-acm-tenant -l appstudio.openshift.io/snapshot=<snapshot-name>
 ```
 
 Prerequisites: `oc`, `jq`
-
-## Validate CPO override images
-
-When reviewing a PR that references CPO override images claiming to include
-fixes from other PRs, use this to verify those claims before approving.
-
-**Skill:** `/validate-pr-override-images` — inspects container image layers
-via `skopeo` and compares commit SHAs to verify the override images actually
-contain the claimed PRs.

--- a/docs/content/contribute/konflux-scripts.md
+++ b/docs/content/contribute/konflux-scripts.md
@@ -1,0 +1,142 @@
+# Konflux CI Tools
+
+Tools for working with Konflux pipelines and builds. Several tasks are
+available both as Claude Code skills (automated) and as standalone scripts
+(manual). The standalone scripts live under `hack/tools/` and require `oc`
+access to the Konflux cluster (`api.stone-prd-rh01.pg1f.p1.openshiftapps.com:6443`)
+in namespace `crt-redhat-acm-tenant`.
+
+## Predict which pipelines a PR triggers
+
+Before pushing, check which Konflux pipelines your changes would trigger.
+
+**Tool:** `hack/tools/check-konflux-triggers/`
+
+Evaluates Pipelines-as-Code CEL expressions from `.tekton/*pull-request*`
+files against the current branch's changed files. Uses the same `gobwas/glob`
+and `google/cel-go` libraries as Pipelines as Code.
+
+```bash
+# From the repository root:
+(cd hack/tools && go run ./check-konflux-triggers/)
+
+# With a custom base ref (defaults to origin/main):
+(cd hack/tools && go run ./check-konflux-triggers/ upstream/main)
+```
+
+## Build an image from a PR
+
+Use this when you need a container image from an unmerged PR — for example
+to test a fix in a staging cluster, or to rebuild an image whose 5-day PR
+expiry has passed.
+
+**Skill:** `/konflux-build` — creates a manual Konflux PipelineRun from a
+PR with configurable image expiry (default 30 days).
+
+## Investigate Enterprise Contract failures
+
+When a PR has failing enterprise contract checks, use this to retrieve
+the detailed violation report, pod logs, and task results from the archived
+PipelineRun.
+
+**Skill:** `/konflux-ec-violations` — accesses archived PipelineRuns via
+the KubeArchive REST API, retrieves the EC verify task's JSON report, and
+summarises violations grouped by rule.
+
+## Update outdated Tekton tasks
+
+When Enterprise Contract checks report outdated task bundles, use this to
+update the `.tekton/` pipeline files to the latest trusted digests. Also
+checks for migration notes and breaking changes.
+
+**Skill:** `/update-konflux-tasks` — parses EC violation logs, identifies
+outdated tasks, fetches migration notes, and applies updates.
+
+### Standalone scripts
+
+The skill uses two scripts that can also be run directly:
+
+**`hack/tools/scripts/update_trusted_task_bundles.py`** — fetches the
+trusted tasks data from the Konflux `data-acceptable-bundles` OCI artifact
+and updates pipeline YAML files to the latest trusted digests.
+
+```bash
+# Update all .tekton/ pipeline files
+hack/tools/scripts/update_trusted_task_bundles.py
+
+# Update specific files
+hack/tools/scripts/update_trusted_task_bundles.py .tekton/hypershift-operator-main-push.yaml
+```
+
+Prerequisites: `python3`, `oras`
+
+**`hack/tools/scripts/find_task_version_by_digest.sh`** — maps a task
+container image digest to its semantic version tag. Useful when EC reports
+a digest and you need to know which version it corresponds to.
+
+```bash
+hack/tools/scripts/find_task_version_by_digest.sh clair-scan \
+  sha256:a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af
+```
+
+Prerequisites: `skopeo`, `jq`
+
+## Test tag pipeline changes
+
+When modifying the `.tekton/` tag pipeline definition, use this to validate
+the changes against a real tag before merging.
+
+**Skill:** `/test-tag-pipeline` — creates a manual PipelineRun from a tag
+commit using your branch's pipeline definition, waits for it to complete,
+and optionally triggers EC validation via a Snapshot.
+
+### Standalone scripts
+
+The skill orchestrates two scripts:
+
+**`hack/tools/scripts/create-manual-tag-pipelinerun.sh`** — creates the
+manual PipelineRun.
+
+```bash
+hack/tools/scripts/create-manual-tag-pipelinerun.sh <tag-name> [branch-spec]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `tag-name` | The existing tag to rebuild (e.g., `v0.1.69`) |
+| `branch-spec` | Branch with the updated pipeline (default: `main`). Format: `[fork:]branch-name` |
+
+```bash
+# Rebuild v0.1.69 using the pipeline from main
+hack/tools/scripts/create-manual-tag-pipelinerun.sh v0.1.69
+
+# Use a pipeline from a fork branch
+hack/tools/scripts/create-manual-tag-pipelinerun.sh v0.1.69 celebdor:fix-tag-pipeline
+```
+
+Prerequisites: `oc`, `yq`
+
+**`hack/tools/scripts/create-snapshot-from-pipelinerun.sh`** — creates a
+Snapshot from a completed PipelineRun to trigger Enterprise Contract
+validation.
+
+```bash
+# From a PipelineRun name
+hack/tools/scripts/create-snapshot-from-pipelinerun.sh <pipelinerun-name>
+
+# From explicit image details
+hack/tools/scripts/create-snapshot-from-pipelinerun.sh \
+  --image-url <url> --image-digest <digest> \
+  [--commit <sha>] [--target-branch <branch>]
+```
+
+Prerequisites: `oc`, `jq`
+
+## Validate CPO override images
+
+When reviewing a PR that references CPO override images claiming to include
+fixes from other PRs, use this to verify those claims before approving.
+
+**Skill:** `/validate-pr-override-images` — inspects container image layers
+via `skopeo` and compares commit SHAs to verify the override images actually
+contain the claimed PRs.

--- a/docs/content/how-to/ci/github-actions.md
+++ b/docs/content/how-to/ci/github-actions.md
@@ -86,7 +86,7 @@ These workflows are triggered by posting a **slash command** as a comment on a p
 | `cpo-container-sync.yaml` | `cpo-container-sync-reusable.yaml` | Validate CPO container image references are in sync |
 | `dependabot-commit-fix.yaml` | `dependabot-commit-fix-reusable.yaml` | Rewrite dependabot commit messages to pass gitlint |
 | `gocacheprog-test.yaml` | `gocacheprog-test-reusable.yaml` | Tests for the `contrib/ci/gocacheprog` build cache tool (path-filtered) |
-| `validate-cpo-overrides.yaml` | — | Validate CPO override images exist and are pullable |
+| `validate-cpo-overrides.yaml` | — | Validate CPO override images contain the PRs claimed in the PR description |
 
 !!! note
     The `sync-community-fork.yaml` workflow runs on push to `main` only (not on PRs) and does not use the reusable pattern. See [Sync Community Fork](sync-community-fork.md) for details.

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -587,6 +587,38 @@ To run override tests:
    - Verify platform name spelling
 
 
+## Validating Override Images Contain Claimed PRs
+
+When reviewing a PR that sets CPO override images and claims "includes
+fix from PR #8500 and PR #8512", you can verify the claimed PRs are
+actually present in the image's git history using the
+`/validate-pr-override-images` Claude Code skill.
+
+The PR description must include a structured contract:
+
+```
+branch: 4.20 wants: https://github.com/openshift/hypershift/pull/8593
+branch: 4.21 wants: https://github.com/openshift/hypershift/pull/8593, https://github.com/openshift/hypershift/pull/8565
+```
+
+```
+# In Claude Code, pass the PR number or URL:
+/validate-pr-override-images 8610
+/validate-pr-override-images https://github.com/openshift/hypershift/pull/8610
+```
+
+The skill reads the `vcs-ref` label from each override image via
+`skopeo inspect` to get the commit SHA the image was built from, then
+uses `git merge-base --is-ancestor` to check whether each claimed PR's
+merge commit is an ancestor of that image commit.
+
+Prerequisites: `skopeo`, `gh`, relevant release branches fetched locally
+
+!!! note
+    The `validate-cpo-overrides.yaml`
+    GitHub Action runs this same
+    validation automatically on PRs that touch `overrides.yaml`.
+
 ## Security/Production Considerations
 
 - Only use trusted image registries for CPO overrides
@@ -1005,6 +1037,197 @@ Use these resources to contribute to HyperShift.
 - Pre-commit hook help
 
 
+
+
+---
+
+## Source: docs/content/contribute/konflux-scripts.md
+
+# Konflux CI Tools
+
+Tools for working with Konflux pipelines and builds. Several tasks are
+available both as Claude Code skills (automated) and as standalone scripts
+(manual). The standalone scripts live under `hack/tools/` and require `oc`
+access to the Konflux cluster (`api.stone-prd-rh01.pg1f.p1.openshiftapps.com:6443`)
+in namespace `crt-redhat-acm-tenant`.
+
+## Predict which pipelines a PR triggers
+
+You've changed a Containerfile and some Go code, and want to know which
+Konflux pipelines will fire before you push.
+
+**Tool:** `hack/tools/check-konflux-triggers/`
+
+Evaluates Pipelines-as-Code CEL expressions from `.tekton/*pull-request*`
+files against the current branch's changed files. Uses the same `gobwas/glob`
+and `google/cel-go` libraries as Pipelines as Code.
+
+```bash
+# Check which pipelines would trigger for your current changes:
+(cd hack/tools && go run ./check-konflux-triggers/)
+
+# Compare against a different base (e.g., your upstream remote):
+(cd hack/tools && go run ./check-konflux-triggers/ upstream/main)
+```
+
+## Build an image from a PR
+
+**Scenario 1:** You opened a PR with an OCPBUGS fix and need the built
+image to deploy in a staging cluster for manual validation — but the PR
+hasn't merged yet.
+
+**Scenario 2:** A colleague asks you to test their PR, but it was opened
+a week ago and the 5-day image expiry has already garbage-collected it
+from the registry. You need a fresh build with a longer TTL.
+
+**Skill:** `/konflux-build` — creates a manual Konflux PipelineRun from a
+PR with configurable image expiry (default 30 days).
+
+```
+# In Claude Code:
+/konflux-build 8761
+/konflux-build https://github.com/openshift/hypershift/pull/8761
+```
+
+## Investigate Enterprise Contract failures
+
+Your PR shows a red "enterprise-contract" check on GitHub. The check output
+says something about untrusted tasks or policy violations, but the details
+are sparse. The PipelineRun has already been archived and `oc get` returns
+nothing.
+
+**Skill:** `/konflux-ec-violations` — accesses archived PipelineRuns via
+the KubeArchive REST API, retrieves the EC verify task's JSON report, and
+summarises violations grouped by rule.
+
+```
+# In Claude Code, pass the PR number or URL:
+/konflux-ec-violations 8761
+```
+
+The skill fetches the archived PipelineRun from KubeArchive, finds the
+EC verify task pod, reads the `step-report-json` container logs, and
+presents the violations with rule codes, descriptions, and suggested fixes.
+
+## Update outdated Tekton tasks
+
+Enterprise Contract checks are failing with `trusted_task.trusted` — your
+`.tekton/` pipeline files reference task bundle digests that are no longer
+in the trusted list.
+
+**Skill:** `/update-konflux-tasks` — parses EC violation logs, identifies
+outdated tasks, fetches migration notes from the
+build-definitions repo,
+and applies the digest updates.
+
+```
+# In Claude Code:
+/update-konflux-tasks
+```
+
+### Standalone scripts
+
+The skill uses two scripts that can also be run directly:
+
+**`hack/tools/scripts/update_trusted_task_bundles.py`** — fetches the
+trusted tasks data from the Konflux `data-acceptable-bundles` OCI artifact
+and updates pipeline YAML files to the latest trusted digests.
+
+```bash
+# Update all .tekton/ pipeline files at once:
+hack/tools/scripts/update_trusted_task_bundles.py
+
+# Update only the operator push pipeline:
+hack/tools/scripts/update_trusted_task_bundles.py .tekton/hypershift-operator-main-push.yaml
+```
+
+Prerequisites: `python3`, `oras`
+
+**`hack/tools/scripts/find_task_version_by_digest.sh`** — maps a task
+container image digest to its semantic version tag. Useful when an EC
+violation message gives you a digest like `sha256:a7cc...` and you need
+to know "is this version 0.8 or 0.9?".
+
+```bash
+# Find which version of clair-scan corresponds to a digest:
+hack/tools/scripts/find_task_version_by_digest.sh clair-scan \
+  sha256:a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af
+```
+
+Prerequisites: `skopeo`, `jq`
+
+## Test tag pipeline changes
+
+You're modifying the tag pipeline definition in `.tekton/` (e.g., adding a
+new build step or changing the multi-arch platforms). You need to verify
+the changes actually work before merging — but tag pipelines only trigger
+on `git tag` pushes, so normal PR CI won't exercise them.
+
+**Skill:** `/test-tag-pipeline` — creates a manual PipelineRun from a tag
+commit using your branch's pipeline definition, waits for it to complete,
+and optionally triggers EC validation via a Snapshot.
+
+```
+# In Claude Code, from your branch with tag pipeline changes:
+/test-tag-pipeline v0.1.69
+```
+
+### Standalone scripts
+
+The skill orchestrates two scripts that can be used independently:
+
+**`hack/tools/scripts/create-manual-tag-pipelinerun.sh`** — creates the
+manual PipelineRun by patching the tag pipeline YAML with your branch's
+commit SHA and submitting it.
+
+```bash
+# Test the tag pipeline from main against tag v0.1.69:
+hack/tools/scripts/create-manual-tag-pipelinerun.sh v0.1.69
+
+# Test using the pipeline definition from your fork branch:
+hack/tools/scripts/create-manual-tag-pipelinerun.sh v0.1.69 celebdor:fix-tag-pipeline
+
+# Then watch the PipelineRun until it finishes:
+oc get pipelinerun -n crt-redhat-acm-tenant -w -l pipelinesascode.tekton.dev/event-type=push
+```
+
+Prerequisites: `oc`, `yq`
+
+**`hack/tools/scripts/create-snapshot-from-pipelinerun.sh`** — after the
+build completes, creates an `appstudio.redhat.com/v1alpha1` Snapshot
+resource to trigger Enterprise Contract (EC) validation on the resulting
+image. The Snapshot links the built container image back to its source
+commit and target branch, which is exactly the metadata EC needs to run
+its policy checks.
+
+The script has two modes:
+
+1. **From a live PipelineRun** — extracts `IMAGE_URL`, `IMAGE_DIGEST`,
+   commit SHA, and target branch directly from the PipelineRun's
+   `status.results` and annotations.
+2. **Direct image parameters** — useful when the PipelineRun has already
+   been garbage-collected. You provide the image coordinates and commit
+   metadata explicitly.
+
+```bash
+# Mode 1: From a completed PipelineRun (extracts image details automatically):
+hack/tools/scripts/create-snapshot-from-pipelinerun.sh \
+  hypershift-operator-main-manual-v0.1.69-abc12
+
+# Mode 2: Direct parameters (e.g., after PipelineRun was garbage-collected):
+hack/tools/scripts/create-snapshot-from-pipelinerun.sh \
+  --image-url quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-operator-main:v0.1.69 \
+  --image-digest sha256:016e754d... \
+  --pipelinerun hypershift-operator-main-manual-v0.1.69-gb49w \
+  --commit 6e6ecadc61361e4fe359af34dcdee17df06c664e \
+  --target-branch refs/tags/v0.1.69
+
+# Monitor the resulting EC IntegrationTestScenario run:
+oc get snapshot <snapshot-name> -n crt-redhat-acm-tenant -w
+oc get pipelinerun -n crt-redhat-acm-tenant -l appstudio.openshift.io/snapshot=<snapshot-name>
+```
+
+Prerequisites: `oc`, `jq`
 
 
 ---
@@ -13933,7 +14156,7 @@ These workflows are triggered by posting a **slash command** as a comment on a p
 | `cpo-container-sync.yaml` | `cpo-container-sync-reusable.yaml` | Validate CPO container image references are in sync |
 | `dependabot-commit-fix.yaml` | `dependabot-commit-fix-reusable.yaml` | Rewrite dependabot commit messages to pass gitlint |
 | `gocacheprog-test.yaml` | `gocacheprog-test-reusable.yaml` | Tests for the `contrib/ci/gocacheprog` build cache tool (path-filtered) |
-| `validate-cpo-overrides.yaml` | — | Validate CPO override images exist and are pullable |
+| `validate-cpo-overrides.yaml` | — | Validate CPO override images contain the PRs claimed in the PR description |
 
 !!! note
     The `sync-community-fork.yaml` workflow runs on push to `main` only (not on PRs) and does not use the reusable pattern. See Sync Community Fork for details.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -413,6 +413,7 @@ nav:
   - 'Develop in Cluster': contribute/develop_in_cluster.md
   - 'Run hypershift-operator locally': contribute/run-hypershift-operator-locally.md
   - 'CPO Overrides': contribute/cpo-overrides.md
+  - 'Konflux CI Scripts': contribute/konflux-scripts.md
   - 'Contribute to docs': contribute/contribute-docs.md
   - 'Retrospective Guidelines': contribute/retrospective-guidelines.md
 - 'Blog':


### PR DESCRIPTION
## Summary

- Adds a new **Konflux CI Scripts** reference page (`docs/content/contribute/konflux-scripts.md`) documenting the existing developer tools for working with Konflux pipelines: trigger prediction, manual builds, EC violation investigation, Tekton task updates, and tag pipeline testing
- Documents the `/validate-pr-override-images` skill in the **CPO Overrides** page where it contextually belongs, with an accurate description (reads `vcs-ref` label via `skopeo inspect` + `git merge-base --is-ancestor`, not layer inspection)
- Fixes the inaccurate description of `validate-cpo-overrides.yaml` in the GitHub Actions docs (it validates image contents, not pullability)

## Test plan

- [ ] Verify `mkdocs serve` renders the new page correctly
- [ ] Verify nav entry appears under "Contribute" section
- [ ] Verify cross-references between pages work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section explaining how to verify that CPO override images include the upstream pull requests claimed in the PR description.
  * Updated the related GitHub Actions workflow documentation to match the new validation behavior.
  * Published a new “Konflux CI Tools” page covering common developer workflows such as CI trigger prediction, manual image builds, EC violation investigation, task bundle updates, tag pipeline testing, and snapshot generation.
  * Updated the contributor docs navigation to include the new Konflux CI Scripts page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->