### PR TITLE
fix(oauth): use kubeAPIServerDNSName for LoginURL when configured

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
@@ -12,6 +12,8 @@ import (
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/k8sutil"
 
+	pki "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
+
 	osinv1 "github.com/openshift/api/osin/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -72,7 +74,11 @@ func adaptOAuthConfig(cpContext component.WorkloadContext, cfg *osinv1.OsinServe
 	controlPlaneEndpoint := cpContext.HCP.Status.ControlPlaneEndpoint
 	cfg.OAuthConfig.MasterURL = masterUrl
 	cfg.OAuthConfig.MasterPublicURL = masterUrl
-	cfg.OAuthConfig.LoginURL = fmt.Sprintf("https://%s:%d", controlPlaneEndpoint.Host, controlPlaneEndpoint.Port)
+	loginHost := controlPlaneEndpoint.Host
+	if hcp := cpContext.HCP; hcp.Spec.KubeAPIServerDNSName != "" {
+		loginHost = hcp.Spec.KubeAPIServerDNSName
+	}
+	cfg.OAuthConfig.LoginURL = fmt.Sprintf("https://%s:%d", pki.AddBracketsIfIPv6(loginHost), controlPlaneEndpoint.Port)
 	// loginURLOverride can be used to specify an override for the oauth config login url. The need for this arises
 	// when the login a provider uses doesn't conform to the standard login url in hypershift. The only supported use case
 	// for this is IBMCloud Red Hat Openshift

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config_test.go
@@ -1,0 +1,104 @@
+package oauth
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/infra"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	osinv1 "github.com/openshift/api/osin/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestAdaptOAuthConfig_LoginURL(t *testing.T) {
+	const (
+		lbHost    = "10.71.22.118"
+		dnsName   = "api.ocp4.example.com"
+		oauthHost = "oauth.example.com"
+	)
+	var lbPort int32 = 6443
+
+	tests := []struct {
+		name               string
+		kubeAPIServerDNS   string
+		loginURLAnnotation string
+		expectedLoginURL   string
+	}{
+		{
+			name:             "no kubeAPIServerDNSName — uses controlPlaneEndpoint host",
+			kubeAPIServerDNS: "",
+			expectedLoginURL: fmt.Sprintf("https://%s:%d", lbHost, lbPort),
+		},
+		{
+			name:             "kubeAPIServerDNSName set — uses DNS name",
+			kubeAPIServerDNS: dnsName,
+			expectedLoginURL: fmt.Sprintf("https://%s:%d", dnsName, lbPort),
+		},
+		{
+			name:               "kubeAPIServerDNSName set but annotation override present — annotation wins",
+			kubeAPIServerDNS:   dnsName,
+			loginURLAnnotation: "https://iam.custom.ibm.com/login",
+			expectedLoginURL:   "https://iam.custom.ibm.com/login",
+		},
+		{
+			name:               "only annotation override, no DNS name — annotation used",
+			kubeAPIServerDNS:   "",
+			loginURLAnnotation: "https://iam.custom.ibm.com/login",
+			expectedLoginURL:   "https://iam.custom.ibm.com/login",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-ns",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					KubeAPIServerDNSName: tt.kubeAPIServerDNS,
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					ControlPlaneEndpoint: hyperv1.APIEndpoint{
+						Host: lbHost,
+						Port: lbPort,
+					},
+				},
+			}
+			if tt.loginURLAnnotation != "" {
+				hcp.Annotations = map[string]string{
+					hyperv1.OauthLoginURLOverrideAnnotation: tt.loginURLAnnotation,
+				}
+			}
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+				InfraStatus: infra.InfrastructureStatus{
+					OAuthHost: oauthHost,
+					OAuthPort: 443,
+					APIPort:   lbPort,
+				},
+				Client: fake.NewClientBuilder().Build(),
+			}
+
+			cfg := &osinv1.OsinServerConfig{
+				OAuthConfig: osinv1.OAuthConfig{},
+			}
+
+			adaptOAuthConfig(cpContext, cfg)
+
+			g.Expect(cfg.OAuthConfig.LoginURL).To(Equal(tt.expectedLoginURL))
+			g.Expect(cfg.OAuthConfig.MasterURL).To(Equal(fmt.Sprintf("https://%s:%d", oauthHost, 443)))
+			g.Expect(cfg.OAuthConfig.MasterPublicURL).To(Equal(fmt.Sprintf("https://%s:%d", oauthHost, 443)))
+		})
+	}
+}


### PR DESCRIPTION
## Bug

**OCPBUGS-86260**: Hosted Clusters show internal API IP instead of DNS name in login token page

## Problem

When a HostedCluster is configured with `spec.kubeAPIServerDNSName` (e.g., `api.ocp4.example.com`),
the OAuth server login token page shows the raw Load Balancer IP address in the `--server`
parameter instead of the configured DNS name.

**Actual**: `--server=https://10.71.22.118:6443`
**Expected**: `--server=https://api.ocp4.example.com:6443`

## Root Cause

`adaptOAuthConfig` in `v2/oauth/config.go` constructs the `LoginURL` using
`controlPlaneEndpoint.Host` (the LB IP from status) unconditionally, without checking
if `spec.kubeAPIServerDNSName` is set.

The kubeconfig generation path (`v2/kas/kubeconfig.go`) already handles this correctly
via `customExternalURL(hcp.Spec.KubeAPIServerDNSName, ...)` but the OAuth config path
was missed during the v2 refactor.

## Fix

Check `hcp.Spec.KubeAPIServerDNSName` before constructing LoginURL. Precedence:
1. `OauthLoginURLOverrideAnnotation` (highest — IBMCloud ROKS)
2. `Spec.KubeAPIServerDNSName` (when set — **this fix**)
3. `Status.ControlPlaneEndpoint.Host` (default)

Also adds `pki.AddBracketsIfIPv6` wrapping for proper IPv6 address formatting (aligning
with the pattern used elsewhere in the codebase).

## Testing

```
$ go test ./control-plane-operator/controllers/hostedcontrolplane/v2/oauth/ -run TestAdaptOAuthConfig -v -count=1

=== RUN   TestAdaptOAuthConfig_LoginURL
=== RUN   TestAdaptOAuthConfig_LoginURL/no_kubeAPIServerDNSName_—_uses_controlPlaneEndpoint_host
=== RUN   TestAdaptOAuthConfig_LoginURL/kubeAPIServerDNSName_set_—_uses_DNS_name
=== RUN   TestAdaptOAuthConfig_LoginURL/kubeAPIServerDNSName_set_but_annotation_override_present_—_annotation_wins
=== RUN   TestAdaptOAuthConfig_LoginURL/only_annotation_override,_no_DNS_name_—_annotation_used
--- PASS: TestAdaptOAuthConfig_LoginURL (0.03s)
PASS
```

## Files Changed

- `control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go` — fix LoginURL construction
- `control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config_test.go` — new unit tests (4 cases)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth login URL handling so the app now uses the correct host when a custom API server DNS name is set.
  * Added proper IPv6 formatting for login URLs to help prevent connection issues.
  * Kept existing override behavior intact when a login URL override is provided.

* **Tests**
  * Added coverage for login URL selection across override, DNS name, and default host scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->