### PR TITLE
OCPBUGS-91739: support hierarchical path credential matching for mirrored registries

### DIFF
--- a/support/thirdparty/oc/pkg/cli/image/manifest/dockercredentials/credentials.go
+++ b/support/thirdparty/oc/pkg/cli/image/manifest/dockercredentials/credentials.go
@@ -74,6 +74,15 @@ func BasicFromKeyring(keyring credentialprovider.DockerKeyring, target *url.URL)
 	configs, found := keyring.Lookup(value)
 
 	if !found || len(configs) == 0 {
+		// Walk up the path hierarchy to find credentials registered under a
+		// parent path or hostname-only key. This handles IDMS/ICSP mirrored
+		// registries where the pull-secret has a hostname-only entry (e.g.
+		// "harbor.example.com") but the token endpoint or challenge URL includes
+		// a sub-path (e.g. "harbor.example.com/service/token").
+		if user, pass := lookupByPathHierarchy(keyring, value); user != "" || pass != "" {
+			return user, pass
+		}
+
 		// do a special case check for docker.io to match historical lookups when we respond to a challenge
 		if value == "auth.docker.io/token" {
 			return BasicFromKeyring(keyring, &url.URL{Host: "index.docker.io", Path: "/v1"})
@@ -93,4 +102,28 @@ func BasicFromKeyring(keyring credentialprovider.DockerKeyring, target *url.URL)
 		return "", ""
 	}
 	return configs[0].Username, configs[0].Password
+}
+
+// lookupByPathHierarchy walks up the path components of value to find credentials.
+// For "harbor.example.com/v2/redhat/operator-index", it tries:
+//   - harbor.example.com/v2/redhat/operator-index (already tried by caller)
+//   - harbor.example.com/v2/redhat
+//   - harbor.example.com/v2
+//   - harbor.example.com
+//
+// This supports pull-secrets with hostname-only keys matching images with sub-paths,
+// which is the common case for IDMS/ICSP mirrored registries.
+func lookupByPathHierarchy(keyring credentialprovider.DockerKeyring, value string) (string, string) {
+	for {
+		lastSlash := strings.LastIndex(value, "/")
+		if lastSlash == -1 {
+			break
+		}
+		value = value[:lastSlash]
+		configs, found := keyring.Lookup(value)
+		if found && len(configs) > 0 {
+			return configs[0].Username, configs[0].Password
+		}
+	}
+	return "", ""
 }

--- a/support/thirdparty/oc/pkg/cli/image/manifest/dockercredentials/credentials_test.go
+++ b/support/thirdparty/oc/pkg/cli/image/manifest/dockercredentials/credentials_test.go
@@ -1,0 +1,169 @@
+package dockercredentials
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/openshift/hypershift/support/thirdparty/kubernetes/pkg/credentialprovider"
+)
+
+func TestBasicFromKeyringWithPathHierarchy(t *testing.T) {
+	tests := []struct {
+		name       string
+		pullSecret credentialprovider.DockerConfig
+		lookupURL  *url.URL
+		expectUser string
+		expectPass string
+	}{
+		{
+			name: "FQDN hostname-only key matches sub-path challenge URL",
+			pullSecret: credentialprovider.DockerConfig{
+				"harbor.example.com": {Username: "user1", Password: "pass1"},
+			},
+			lookupURL:  &url.URL{Scheme: "https", Host: "harbor.example.com", Path: "/service/token"},
+			expectUser: "user1",
+			expectPass: "pass1",
+		},
+		{
+			name: "FQDN hostname-only key matches multi-level v2 image path",
+			pullSecret: credentialprovider.DockerConfig{
+				"harbor.example.com": {Username: "user2", Password: "pass2"},
+			},
+			lookupURL:  &url.URL{Scheme: "https", Host: "harbor.example.com", Path: "/v2/redhat/operator-index/manifests/v4.20"},
+			expectUser: "user2",
+			expectPass: "pass2",
+		},
+		{
+			name: "exact path key matches directly without hierarchy walk",
+			pullSecret: credentialprovider.DockerConfig{
+				"harbor.example.com/redhat/operator-index": {Username: "exact", Password: "exact-pass"},
+			},
+			lookupURL:  &url.URL{Scheme: "https", Host: "harbor.example.com", Path: "/redhat/operator-index"},
+			expectUser: "exact",
+			expectPass: "exact-pass",
+		},
+		{
+			name: "intermediate path key found via hierarchy walk",
+			pullSecret: credentialprovider.DockerConfig{
+				"harbor.example.com/redhat": {Username: "mid", Password: "mid-pass"},
+			},
+			lookupURL:  &url.URL{Scheme: "https", Host: "harbor.example.com", Path: "/redhat/operator-index"},
+			expectUser: "mid",
+			expectPass: "mid-pass",
+		},
+		{
+			name: "no match when hostname differs",
+			pullSecret: credentialprovider.DockerConfig{
+				"other-registry.example.com": {Username: "user3", Password: "pass3"},
+			},
+			lookupURL:  &url.URL{Scheme: "https", Host: "harbor.example.com", Path: "/service/token"},
+			expectUser: "",
+			expectPass: "",
+		},
+		{
+			name: "quay.io direct match works without hierarchy walk",
+			pullSecret: credentialprovider.DockerConfig{
+				"quay.io": {Username: "quay-user", Password: "quay-pass"},
+			},
+			lookupURL:  &url.URL{Scheme: "https", Host: "quay.io", Path: ""},
+			expectUser: "quay-user",
+			expectPass: "quay-pass",
+		},
+		{
+			name: "registry with port matches sub-path via hierarchy",
+			pullSecret: credentialprovider.DockerConfig{
+				"registry.example.com:5000": {Username: "port-user", Password: "port-pass"},
+			},
+			lookupURL:  &url.URL{Scheme: "https", Host: "registry.example.com:5000", Path: "/v2/library/nginx/manifests/latest"},
+			expectUser: "port-user",
+			expectPass: "port-pass",
+		},
+		{
+			name: "HTTP with explicit port matches sub-path via hierarchy",
+			pullSecret: credentialprovider.DockerConfig{
+				"registry.example.com:8080": {Username: "http-user", Password: "http-pass"},
+			},
+			lookupURL:  &url.URL{Scheme: "http", Host: "registry.example.com:8080", Path: "/myapp/image"},
+			expectUser: "http-user",
+			expectPass: "http-pass",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keyring := &credentialprovider.BasicDockerKeyring{}
+			keyring.Add(tt.pullSecret)
+
+			user, pass := BasicFromKeyring(keyring, tt.lookupURL)
+
+			if user != tt.expectUser {
+				t.Errorf("expected username %q, got %q", tt.expectUser, user)
+			}
+			if pass != tt.expectPass {
+				t.Errorf("expected password %q, got %q", tt.expectPass, pass)
+			}
+		})
+	}
+}
+
+func TestLookupByPathHierarchy(t *testing.T) {
+	tests := []struct {
+		name       string
+		pullSecret credentialprovider.DockerConfig
+		value      string
+		expectUser string
+		expectPass string
+	}{
+		{
+			name: "walks up to hostname from two-level path",
+			pullSecret: credentialprovider.DockerConfig{
+				"harbor.example.com": {Username: "found", Password: "found-pass"},
+			},
+			value:      "harbor.example.com/redhat/operator-index",
+			expectUser: "found",
+			expectPass: "found-pass",
+		},
+		{
+			name: "finds match at intermediate path level",
+			pullSecret: credentialprovider.DockerConfig{
+				"harbor.example.com/redhat": {Username: "mid", Password: "mid-pass"},
+			},
+			value:      "harbor.example.com/redhat/operator-index",
+			expectUser: "mid",
+			expectPass: "mid-pass",
+		},
+		{
+			name: "no match returns empty",
+			pullSecret: credentialprovider.DockerConfig{
+				"other.example.com": {Username: "nope", Password: "nope"},
+			},
+			value:      "harbor.example.com/redhat/operator-index",
+			expectUser: "",
+			expectPass: "",
+		},
+		{
+			name: "single path component walks to hostname",
+			pullSecret: credentialprovider.DockerConfig{
+				"harbor.example.com": {Username: "host", Password: "host-pass"},
+			},
+			value:      "harbor.example.com/myimage",
+			expectUser: "host",
+			expectPass: "host-pass",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keyring := &credentialprovider.BasicDockerKeyring{}
+			keyring.Add(tt.pullSecret)
+
+			user, pass := lookupByPathHierarchy(keyring, tt.value)
+			if user != tt.expectUser {
+				t.Errorf("expected username %q, got %q", tt.expectUser, user)
+			}
+			if pass != tt.expectPass {
+				t.Errorf("expected password %q, got %q", tt.expectPass, pass)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `lookupByPathHierarchy()` to `BasicFromKeyring()` that walks up path components when the initial keyring lookup finds no match
- Resolves credential resolution for IDMS/ICSP mirrored registries where the pull-secret has a hostname-only key (e.g. `harbor.example.com`) but the auth challenge URL includes sub-paths (e.g. `harbor.example.com/service/token`)
- Same root cause as OCPBUGS-57002 (closed without fix); minimal port of logic from abandoned PR #6731 without its heavy dependency additions

## Problem

HyperShift's catalog image tag-to-digest resolution fails with "unauthorized" on private mirror registries. The Docker distribution auth layer calls `BasicFromKeyring()` with the registry challenge URL, but the existing keyring performs only direct or prefix matching — it does NOT walk up the path hierarchy to find a credential registered under a parent path or hostname-only key.

## Before/After

**Before** (customer scenario: `harbor.blabor.example.com` with IDMS mapping):
```
Pull-secret key: "harbor.blabor.example.com"
Challenge URL value: "harbor.blabor.example.com/service/token"
keyring.Lookup("harbor.blabor.example.com/service/token") → NOT FOUND
Result: 401 Unauthorized
```

**After**:
```
keyring.Lookup("harbor.blabor.example.com/service/token") → NOT FOUND
lookupByPathHierarchy tries: "harbor.blabor.example.com/service" → NOT FOUND
lookupByPathHierarchy tries: "harbor.blabor.example.com" → FOUND
Result: credentials returned, authentication succeeds
```

## Testing

```
$ go test -v ./support/thirdparty/oc/pkg/cli/image/manifest/dockercredentials/
--- PASS: TestBasicFromKeyringWithPathHierarchy (0.00s)
    --- PASS: .../FQDN_hostname-only_key_matches_sub-path_challenge_URL
    --- PASS: .../FQDN_hostname-only_key_matches_multi-level_v2_image_path
    --- PASS: .../exact_path_key_matches_directly_without_hierarchy_walk
    --- PASS: .../intermediate_path_key_found_via_hierarchy_walk
    --- PASS: .../no_match_when_hostname_differs
    --- PASS: .../quay.io_direct_match_works_without_hierarchy_walk
    --- PASS: .../registry_with_port_matches_sub-path_via_hierarchy
    --- PASS: .../HTTP_with_explicit_port_matches_sub-path_via_hierarchy
--- PASS: TestLookupByPathHierarchy (0.00s)
PASS
ok  	.../dockercredentials	1.036s
```

## What This Does NOT Change

- No new dependencies (no go.mod changes)
- No changes to `registryclient/client.go`
- No changes to vendored `keyring.go`
- Existing Docker Hub special-case fallbacks preserved
- Existing port-stripping logic preserved

## Related

- OCPBUGS-57002: Same root cause, closed without fix
- PR #6731: Correct approach, abandoned due to CI failures from `containers/image/v5` + `docker/docker` dep additions
- PR #8468 ([CNTRLPLANE-3314](https://redhat.atlassian.net/browse/CNTRLPLANE-3314)): Open but stalled unified image resolution refactor — no conflict (operates at a higher layer)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker credential resolution when an exact match isn’t found, allowing credentials to be found from parent paths and more specific registry entries.
  * Added coverage for matching registry hosts, ports, and nested path-based credentials, while still returning empty credentials when no match exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->