### PR TITLE
OCPBUGS-93868: Add missing labels

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -29,6 +29,7 @@ spec:
         component.hypershift.openshift.io/config-hash: 1cdcee0c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
+        app: cloud-controller-manager
         hypershift.openshift.io/control-plane-component: openstack-cloud-controller-manager
         hypershift.openshift.io/hosted-control-plane: hcp-namespace
         infrastructure.openshift.io/cloud-controller-manager: OpenStack

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -29,6 +29,7 @@ spec:
         component.hypershift.openshift.io/config-hash: 1cdcee0c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
+        app: cloud-controller-manager
         hypershift.openshift.io/control-plane-component: openstack-cloud-controller-manager
         hypershift.openshift.io/hosted-control-plane: hcp-namespace
         infrastructure.openshift.io/cloud-controller-manager: OpenStack

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -29,6 +29,7 @@ spec:
         component.hypershift.openshift.io/config-hash: 1cdcee0c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
+        app: cloud-controller-manager
         hypershift.openshift.io/control-plane-component: openstack-cloud-controller-manager
         hypershift.openshift.io/hosted-control-plane: hcp-namespace
         infrastructure.openshift.io/cloud-controller-manager: OpenStack

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -29,6 +29,7 @@ spec:
         component.hypershift.openshift.io/config-hash: 1cdcee0c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
+        app: cloud-controller-manager
         hypershift.openshift.io/control-plane-component: openstack-cloud-controller-manager
         hypershift.openshift.io/hosted-control-plane: hcp-namespace
         infrastructure.openshift.io/cloud-controller-manager: OpenStack

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -29,6 +29,7 @@ spec:
         component.hypershift.openshift.io/config-hash: 1cdcee0c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
+        app: cloud-controller-manager
         hypershift.openshift.io/control-plane-component: openstack-cloud-controller-manager
         hypershift.openshift.io/hosted-control-plane: hcp-namespace
         infrastructure.openshift.io/cloud-controller-manager: OpenStack

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openstack-cloud-controller-manager/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openstack-cloud-controller-manager/deployment.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        app: cloud-controller-manager
         infrastructure.openshift.io/cloud-controller-manager: OpenStack
         k8s-app: openstack-cloud-controller-manager
     spec:


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

EnsureAppLabel (added in 5ddb58a9c, OCPBUGS-60064) requires every pod in the HCP namespace to carry an app label for per-component metrics tracking. The OpenStack CCM deployment appears to have been missed in that fix.

All other platform CCMs (aws-, azure-, gcp-, kubevirt-, powervs-) set app: cloud-controller-manager on their pod template; align OpenStack with the same convention.

Note that this is taken from the stack of patches in #8687 and seems to be the only one needed in 4.22 :fingers_crossed:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes OCPBUGS-93868

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
