### PR TITLE
[release-4.21] OCPBUGS-93927: fix(cpo): deduplicate VPC endpoint subnets by AZ to prevent DuplicateSubnetsInSameZone

### DIFF
--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -658,7 +658,8 @@ func controlPlaneOperatorPolicy(hostedZone string, sharedVPC bool) policyBinding
 						"ec2:RevokeSecurityGroupIngress",
 						"ec2:RevokeSecurityGroupEgress",
 						"ec2:DescribeSecurityGroups",
-						"ec2:DescribeVpcs"
+						"ec2:DescribeVpcs",
+						"ec2:DescribeSubnets"
 					],
 					"Resource": "*"
 				}
@@ -684,7 +685,8 @@ func controlPlaneOperatorPolicy(hostedZone string, sharedVPC bool) policyBinding
 						"ec2:RevokeSecurityGroupIngress",
 						"ec2:RevokeSecurityGroupEgress",
 						"ec2:DescribeSecurityGroups",
-						"ec2:DescribeVpcs"
+						"ec2:DescribeVpcs",
+						"ec2:DescribeSubnets"
 					],
 					"Resource": "*"
 				},
@@ -758,7 +760,8 @@ func sharedVPCEndpointRole(controlPlaneRoleARN string) sharedVPCPolicyBinding {
 						"ec2:RevokeSecurityGroupIngress",
 						"ec2:RevokeSecurityGroupEgress",
 						"ec2:DescribeSecurityGroups",
-						"ec2:DescribeVpcs"
+						"ec2:DescribeVpcs",
+						"ec2:DescribeSubnets"
 					],
 					"Resource": "*"
 				}

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -194,6 +195,9 @@ type AWSEndpointServiceReconciler struct {
 	client.Client
 	upsert.CreateOrUpdateProvider
 	awsClientBuilder clientBuilder
+
+	subnetAZMu    sync.RWMutex
+	subnetAZCache map[string]string
 }
 
 type clientBuilder struct {
@@ -513,6 +517,93 @@ func diffIDs(desired []string, existing []*string) (added, removed []*string) {
 	return
 }
 
+// deduplicateSubnetsByAZ ensures at most one subnet per AZ is passed to
+// CreateVpcEndpoint/ModifyVpcEndpoint, since AWS rejects requests with
+// multiple subnets in the same AZ.
+func (r *AWSEndpointServiceReconciler) deduplicateSubnetsByAZ(ctx context.Context, ec2Client ec2iface.EC2API, subnetIDs []string) ([]string, error) {
+	if len(subnetIDs) <= 1 {
+		return subnetIDs, nil
+	}
+
+	// Read-only path: all subnets already cached, no AWS call needed.
+	r.subnetAZMu.RLock()
+	allCached := r.subnetAZCache != nil
+	if allCached {
+		for _, id := range subnetIDs {
+			if _, ok := r.subnetAZCache[id]; !ok {
+				allCached = false
+				break
+			}
+		}
+	}
+	if allCached {
+		azForSubnet := make(map[string]string, len(subnetIDs))
+		for _, id := range subnetIDs {
+			azForSubnet[id] = r.subnetAZCache[id]
+		}
+		r.subnetAZMu.RUnlock()
+		return pickOneSubnetPerAZ(subnetIDs, azForSubnet), nil
+	}
+	r.subnetAZMu.RUnlock()
+
+	// Write path: new subnets found, call DescribeSubnets to populate cache.
+	r.subnetAZMu.Lock()
+	if r.subnetAZCache == nil {
+		r.subnetAZCache = make(map[string]string)
+	}
+
+	// Re-check which subnets are uncached — between the RUnlock and Lock above,
+	// another reconcile may have already fetched them.
+	var uncached []string
+	for _, id := range subnetIDs {
+		if _, ok := r.subnetAZCache[id]; !ok {
+			uncached = append(uncached, id)
+		}
+	}
+
+	if len(uncached) > 0 {
+		output, err := ec2Client.DescribeSubnetsWithContext(ctx, &ec2.DescribeSubnetsInput{
+			SubnetIds: aws.StringSlice(uncached),
+		})
+		if err != nil {
+			r.subnetAZMu.Unlock()
+			return nil, fmt.Errorf("failed to describe subnets for AZ deduplication: %w", err)
+		}
+		for _, subnet := range output.Subnets {
+			r.subnetAZCache[aws.StringValue(subnet.SubnetId)] = aws.StringValue(subnet.AvailabilityZone)
+		}
+	}
+
+	azForSubnet := make(map[string]string, len(subnetIDs))
+	for _, id := range subnetIDs {
+		azForSubnet[id] = r.subnetAZCache[id]
+	}
+	r.subnetAZMu.Unlock()
+
+	return pickOneSubnetPerAZ(subnetIDs, azForSubnet), nil
+}
+
+func pickOneSubnetPerAZ(subnetIDs []string, azForSubnet map[string]string) []string {
+	sorted := make([]string, len(subnetIDs))
+	copy(sorted, subnetIDs)
+	sort.Strings(sorted)
+
+	azToSubnet := make(map[string]string)
+	for _, id := range sorted {
+		az := azForSubnet[id]
+		if _, exists := azToSubnet[az]; !exists {
+			azToSubnet[az] = id
+		}
+	}
+
+	deduped := make([]string, 0, len(azToSubnet))
+	for _, id := range azToSubnet {
+		deduped = append(deduped, id)
+	}
+	sort.Strings(deduped)
+	return deduped
+}
+
 func (r *AWSEndpointServiceReconciler) reconcileAWSEndpointService(ctx context.Context, awsEndpointService *hyperv1.AWSEndpointService, hcp *hyperv1.HostedControlPlane, ec2Client ec2iface.EC2API, route53Client route53iface.Route53API) error {
 	log, err := logr.FromContext(ctx)
 	if err != nil {
@@ -526,6 +617,13 @@ func (r *AWSEndpointServiceReconciler) reconcileAWSEndpointService(ctx context.C
 
 	if err := r.reconcileAWSEndpointSecurityGroup(ctx, ec2Client, awsEndpointService, hcp); err != nil {
 		return err
+	}
+
+	deduped, err := r.deduplicateSubnetsByAZ(ctx, ec2Client, awsEndpointService.Spec.SubnetIDs)
+	if err != nil {
+		log.Error(err, "failed to deduplicate subnets by AZ, proceeding with original list")
+	} else {
+		awsEndpointService.Spec.SubnetIDs = deduped
 	}
 
 	endpointID := awsEndpointService.Status.EndpointID

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
@@ -1,6 +1,7 @@
 package awsprivatelink
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -10,7 +11,9 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -203,6 +206,133 @@ func TestDiffPermissions(t *testing.T) {
 			g := NewGomegaWithT(t)
 			result := diffPermissions(test.actual, test.required)
 			g.Expect(result).To(Equal(test.expected))
+		})
+	}
+}
+
+type mockEC2Client struct {
+	ec2iface.EC2API
+	describeSubnetsOutput *ec2.DescribeSubnetsOutput
+	describeSubnetsErr    error
+}
+
+func (m *mockEC2Client) DescribeSubnetsWithContext(_ context.Context, _ *ec2.DescribeSubnetsInput, _ ...request.Option) (*ec2.DescribeSubnetsOutput, error) {
+	return m.describeSubnetsOutput, m.describeSubnetsErr
+}
+
+func TestDeduplicateSubnetsByAZ(t *testing.T) {
+	tests := []struct {
+		name      string
+		subnetIDs []string
+		cachedAZs map[string]string
+		mock      *mockEC2Client
+		want      []string
+		wantErr   bool
+	}{
+		{
+			name:      "When the subnet list is empty it should return empty",
+			subnetIDs: []string{},
+			want:      []string{},
+		},
+		{
+			name:      "When there is a single subnet it should return it unchanged",
+			subnetIDs: []string{"subnet-1"},
+			want:      []string{"subnet-1"},
+		},
+		{
+			name:      "When subnets are in different AZs it should keep all",
+			subnetIDs: []string{"subnet-1", "subnet-2"},
+			mock: &mockEC2Client{
+				describeSubnetsOutput: &ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{
+						{SubnetId: aws.String("subnet-1"), AvailabilityZone: aws.String("us-east-1a")},
+						{SubnetId: aws.String("subnet-2"), AvailabilityZone: aws.String("us-east-1b")},
+					},
+				},
+			},
+			want: []string{"subnet-1", "subnet-2"},
+		},
+		{
+			name:      "When subnets are in the same AZ it should pick the lexicographically first",
+			subnetIDs: []string{"subnet-b", "subnet-a"},
+			mock: &mockEC2Client{
+				describeSubnetsOutput: &ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{
+						{SubnetId: aws.String("subnet-b"), AvailabilityZone: aws.String("us-east-1a")},
+						{SubnetId: aws.String("subnet-a"), AvailabilityZone: aws.String("us-east-1a")},
+					},
+				},
+			},
+			want: []string{"subnet-a"},
+		},
+		{
+			name:      "When subnets span mixed AZs it should deduplicate only the shared AZ",
+			subnetIDs: []string{"subnet-1", "subnet-2", "subnet-3"},
+			mock: &mockEC2Client{
+				describeSubnetsOutput: &ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{
+						{SubnetId: aws.String("subnet-1"), AvailabilityZone: aws.String("us-east-1a")},
+						{SubnetId: aws.String("subnet-2"), AvailabilityZone: aws.String("us-east-1a")},
+						{SubnetId: aws.String("subnet-3"), AvailabilityZone: aws.String("us-east-1b")},
+					},
+				},
+			},
+			want: []string{"subnet-1", "subnet-3"},
+		},
+		{
+			name:      "When all subnets are cached it should not call AWS",
+			subnetIDs: []string{"subnet-1", "subnet-2"},
+			cachedAZs: map[string]string{
+				"subnet-1": "us-east-1a",
+				"subnet-2": "us-east-1b",
+			},
+			want: []string{"subnet-1", "subnet-2"},
+		},
+		{
+			name:      "When some subnets are cached it should only fetch uncached ones",
+			subnetIDs: []string{"subnet-1", "subnet-2"},
+			cachedAZs: map[string]string{
+				"subnet-1": "us-east-1a",
+			},
+			mock: &mockEC2Client{
+				describeSubnetsOutput: &ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{
+						{SubnetId: aws.String("subnet-2"), AvailabilityZone: aws.String("us-east-1b")},
+					},
+				},
+			},
+			want: []string{"subnet-1", "subnet-2"},
+		},
+		{
+			name:      "When the DescribeSubnets API fails it should return an error",
+			subnetIDs: []string{"subnet-1", "subnet-2"},
+			mock: &mockEC2Client{
+				describeSubnetsErr: fmt.Errorf("access denied"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			r := &AWSEndpointServiceReconciler{
+				subnetAZCache: tt.cachedAZs,
+			}
+			var ec2Client ec2iface.EC2API
+			if tt.mock != nil {
+				ec2Client = tt.mock
+			} else {
+				ec2Client = &mockEC2Client{}
+			}
+
+			got, err := r.deduplicateSubnetsByAZ(context.Background(), ec2Client, tt.subnetIDs)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Backport of #8651 to `release-4.21`.

When multiple NodePools reference subnets in the same AWS availability zone, the CPO's VPC endpoint reconciler now deduplicates them before calling `CreateVpcEndpoint` or `ModifyVpcEndpoint`, preventing the AWS `DuplicateSubnetsInSameZone` error.

- Adds an in-memory AZ cache (`sync.RWMutex` + map) to the `AWSEndpointServiceReconciler` to avoid repeated `DescribeSubnets` calls
- Lexicographic subnet selection ensures deterministic deduplication across concurrent reconciles
- Graceful degradation: if `DescribeSubnets` fails (e.g. missing IAM permission), the original subnet list passes through unchanged
- Adds `ec2:DescribeSubnets` to the control-plane-operator and shared-vpc-endpoint IAM policies

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-93927

## Special notes for your reviewer:

Adapted from the 4.22 backport (#8724) for AWS SDK v1 (`aws-sdk-go`) used on release-4.21. The logic is identical; only the AWS API call patterns differ (`DescribeSubnetsWithContext`, `aws.StringValue`, `ec2iface.EC2API`).

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)