### PR TITLE
OCPCLOUD-3261: feat(cloud providers): inject centralized TLS configuration

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -72,6 +72,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 89075f9f58de25b192aa9c8eea594e77ed65c46d3b9519828bc0db4a133d8168
+    hypershift.openshift.io/desired-state-hash: 2606a7171611056a202c9ccfafab026f27887c9b031db72814bd5881bfdb1152
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: aws-cloud-controller-manager
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -72,6 +72,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: c2852262e32547f9731417e139957c60da76f24b6fb18273b0c8afa58a48a13c
+    hypershift.openshift.io/desired-state-hash: 07d7d6d26b68b736911e9c9263b1e7928efe763c415d021dde5105d5082905f4
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: aws-cloud-controller-manager
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -72,6 +72,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 89075f9f58de25b192aa9c8eea594e77ed65c46d3b9519828bc0db4a133d8168
+    hypershift.openshift.io/desired-state-hash: 2606a7171611056a202c9ccfafab026f27887c9b031db72814bd5881bfdb1152
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: aws-cloud-controller-manager
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 1168ce43d310abd35750261e14bc9a21b165c9b4e4011641e4e67019bca6f4a5
+    hypershift.openshift.io/desired-state-hash: 243533360a625e36f34bedc44fb437e92ae305a3dda75e0f5d859415d6d83bf0
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: aws-cloud-controller-manager
@@ -74,6 +74,7 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS13
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -72,6 +72,7 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS13
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -72,6 +72,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 1168ce43d310abd35750261e14bc9a21b165c9b4e4011641e4e67019bca6f4a5
+    hypershift.openshift.io/desired-state-hash: e8cd2c7426b899184616f0aa2755e1bab40cfaa28acdc4ea877c184896f58566
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: aws-cloud-controller-manager
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -72,6 +72,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 1168ce43d310abd35750261e14bc9a21b165c9b4e4011641e4e67019bca6f4a5
+    hypershift.openshift.io/desired-state-hash: e8cd2c7426b899184616f0aa2755e1bab40cfaa28acdc4ea877c184896f58566
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: aws-cloud-controller-manager
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: d101942d7403ad1b699d056798aea2aa6a60e4775abdbbe8abf2eccc7c386f27
+    hypershift.openshift.io/desired-state-hash: 0f7a20ce338d58ddcfd2167e46ae5fd7911b3d79110aede81514d792b41c8055
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: azure-cloud-controller-manager
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: d50237ac13b64fb551fdd3819c66515e8f29f3f2af5c4da3ba643df9c5d41880
+    hypershift.openshift.io/desired-state-hash: 05145338d25da24cb2b8ac3f4ac4ccb198f79e351e124f8fd886bc7252eb3e33
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: azure-cloud-controller-manager
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: c21a522e99eab8d330752941bf6a3290827f1f06a61782c940b6224c2a7779ff
+    hypershift.openshift.io/desired-state-hash: 2235c4c40339c8f311147dd8ff1da77740430885a94e5c77c8476070dbf2525f
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: azure-cloud-controller-manager
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 2aeda730e82ffe06c98bee4839ffb00877a0dbe26c779a577ff4957bb836b2c2
+    hypershift.openshift.io/desired-state-hash: 8a21c2f77541fb3e8e03240960cc53b21aeaa6b16c96d7e4c204fcca3fd15284
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: azure-cloud-controller-manager
@@ -76,6 +76,7 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS13
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -74,6 +74,7 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS13
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 2aeda730e82ffe06c98bee4839ffb00877a0dbe26c779a577ff4957bb836b2c2
+    hypershift.openshift.io/desired-state-hash: 3243daaf9e11c7626dcac597241a6df08ff2e4e77957a2df92eb1c8618f7790b
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: azure-cloud-controller-manager
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 2aeda730e82ffe06c98bee4839ffb00877a0dbe26c779a577ff4957bb836b2c2
+    hypershift.openshift.io/desired-state-hash: 3243daaf9e11c7626dcac597241a6df08ff2e4e77957a2df92eb1c8618f7790b
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: azure-cloud-controller-manager
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -73,6 +73,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: e0960ca8d8ad44d83ddd92ca33580c1c883288b1ddebd0e8214b2a3afcfda409
+    hypershift.openshift.io/desired-state-hash: 98c9bb8ea2ccb1c4e721957c03f384ddbaa243814041d865ebc48b18148ae978
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: gcp-cloud-controller-manager
@@ -75,6 +75,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -73,6 +73,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: d569d2e2cb5e624eb765979ff93b90696afc955c8e4d725ad490de43793a0eb0
+    hypershift.openshift.io/desired-state-hash: 054d33f676f1ae41f9458e099f76dac5cb11bfa5b334a55b23178b7210953e0e
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: gcp-cloud-controller-manager
@@ -75,6 +75,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -73,6 +73,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: e0960ca8d8ad44d83ddd92ca33580c1c883288b1ddebd0e8214b2a3afcfda409
+    hypershift.openshift.io/desired-state-hash: 98c9bb8ea2ccb1c4e721957c03f384ddbaa243814041d865ebc48b18148ae978
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: gcp-cloud-controller-manager
@@ -75,6 +75,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 1d3aeab5f87901acaf738b92736e051a0bfc5e8afc05ffe36fba5a0aad60da77
+    hypershift.openshift.io/desired-state-hash: 56bbab7fed989d94d98ab1607d90e37cb65319f7c6526e2e7126e01f1edd3f24
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: gcp-cloud-controller-manager
@@ -75,6 +75,7 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS13
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -73,6 +73,7 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS13
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -73,6 +73,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 1d3aeab5f87901acaf738b92736e051a0bfc5e8afc05ffe36fba5a0aad60da77
+    hypershift.openshift.io/desired-state-hash: 961d7646f48fe4d7eb8a46c98ccb033fc2b647deec41bbab7c599f0b2c7decb4
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: gcp-cloud-controller-manager
@@ -75,6 +75,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -73,6 +73,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 1d3aeab5f87901acaf738b92736e051a0bfc5e8afc05ffe36fba5a0aad60da77
+    hypershift.openshift.io/desired-state-hash: 961d7646f48fe4d7eb8a46c98ccb033fc2b647deec41bbab7c599f0b2c7decb4
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: gcp-cloud-controller-manager
@@ -75,6 +75,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -85,6 +85,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 7b5b7401322ad29da2a1c4ec4a75892611eca3ee8f48218c76362bc7fc337523
+    hypershift.openshift.io/desired-state-hash: cc4da44dc8f7985ecc63820b4fccfa80ead5549587782c2496e0707b3c44d0d0
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kubevirt-cloud-controller-manager
@@ -87,6 +87,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -85,6 +85,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 7233401aa521c65326489a5dbad8615c81284a407e90603c91bef82ed65cd68c
+    hypershift.openshift.io/desired-state-hash: bba97ede61aedf6a1f089e9c27c8a71ea799bf3ae3fa0891c54442b7b64ce2e6
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kubevirt-cloud-controller-manager
@@ -87,6 +87,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -85,6 +85,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 7b5b7401322ad29da2a1c4ec4a75892611eca3ee8f48218c76362bc7fc337523
+    hypershift.openshift.io/desired-state-hash: cc4da44dc8f7985ecc63820b4fccfa80ead5549587782c2496e0707b3c44d0d0
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kubevirt-cloud-controller-manager
@@ -87,6 +87,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 7b5b7401322ad29da2a1c4ec4a75892611eca3ee8f48218c76362bc7fc337523
+    hypershift.openshift.io/desired-state-hash: fa9d53842d3e010153f3d10b7c290d1bfb64b622be24d1a1053740626dcf397d
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kubevirt-cloud-controller-manager
@@ -87,6 +87,7 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS13
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -85,6 +85,7 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS13
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -85,6 +85,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 7b5b7401322ad29da2a1c4ec4a75892611eca3ee8f48218c76362bc7fc337523
+    hypershift.openshift.io/desired-state-hash: cc4da44dc8f7985ecc63820b4fccfa80ead5549587782c2496e0707b3c44d0d0
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kubevirt-cloud-controller-manager
@@ -87,6 +87,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -85,6 +85,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 7b5b7401322ad29da2a1c4ec4a75892611eca3ee8f48218c76362bc7fc337523
+    hypershift.openshift.io/desired-state-hash: cc4da44dc8f7985ecc63820b4fccfa80ead5549587782c2496e0707b3c44d0d0
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kubevirt-cloud-controller-manager
@@ -87,6 +87,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: fd7854c32bc31069506e427704707cb4f218bb648d0171b51d54dd0103b59638
+    hypershift.openshift.io/desired-state-hash: 21c4dc5b883bb487a9b5be4f42358b9f9e6ae21c0588049e3226b8d54f004513
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openstack-cloud-controller-manager
@@ -78,6 +78,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: a50fb17cb2ccfc7e32b4195001132c8abec873f98698499f7bb7cdae9eb2da57
+    hypershift.openshift.io/desired-state-hash: 31d4833dfe910174cdf08abfac22875ff37113095d5440fff8d41091a10aacdf
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openstack-cloud-controller-manager
@@ -78,6 +78,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: fd7854c32bc31069506e427704707cb4f218bb648d0171b51d54dd0103b59638
+    hypershift.openshift.io/desired-state-hash: 21c4dc5b883bb487a9b5be4f42358b9f9e6ae21c0588049e3226b8d54f004513
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openstack-cloud-controller-manager
@@ -78,6 +78,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: fd7854c32bc31069506e427704707cb4f218bb648d0171b51d54dd0103b59638
+    hypershift.openshift.io/desired-state-hash: 2ebed326a98fcba522dc4b6734d322559b454842270b9a52f2f06121323478e0
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openstack-cloud-controller-manager
@@ -78,6 +78,7 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS13
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -76,6 +76,7 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS13
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: fd7854c32bc31069506e427704707cb4f218bb648d0171b51d54dd0103b59638
+    hypershift.openshift.io/desired-state-hash: 21c4dc5b883bb487a9b5be4f42358b9f9e6ae21c0588049e3226b8d54f004513
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openstack-cloud-controller-manager
@@ -78,6 +78,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: fd7854c32bc31069506e427704707cb4f218bb648d0171b51d54dd0103b59638
+    hypershift.openshift.io/desired-state-hash: 21c4dc5b883bb487a9b5be4f42358b9f9e6ae21c0588049e3226b8d54f004513
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openstack-cloud-controller-manager
@@ -78,6 +78,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -61,7 +61,6 @@ spec:
       - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
-        - --use-service-account-credentials=true
         - --configure-cloud-routes=false
         - --cloud-provider=ibm
         - --cloud-config=/etc/ibm/ccm-config
@@ -71,7 +70,6 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --use-service-account-credentials=false
         - --tls-min-version=VersionTLS12
         - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -58,8 +58,7 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /bin/ibm-cloud-controller-manager
+      - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
         - --use-service-account-credentials=true
@@ -71,9 +70,12 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --use-service-account-credentials=false
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
+        - /bin/ibm-cloud-controller-manager
         env:
         - name: POD_IP_ADDRESS
           valueFrom:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 9a12d6c2ea7e4c191e61786b4a1190a8f7ef404a8f76916d1b22d94306e046f2
+    hypershift.openshift.io/desired-state-hash: 01f976afcc5357164bfea66ffb12a3852dd62aadc3f599b85e0c12a6479d9031
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: powervs-cloud-controller-manager
@@ -60,8 +60,7 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /bin/ibm-cloud-controller-manager
+      - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
         - --use-service-account-credentials=true
@@ -73,9 +72,12 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --use-service-account-credentials=false
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
+        - /bin/ibm-cloud-controller-manager
         env:
         - name: POD_IP_ADDRESS
           valueFrom:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -63,7 +63,6 @@ spec:
       - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
-        - --use-service-account-credentials=true
         - --configure-cloud-routes=false
         - --cloud-provider=ibm
         - --cloud-config=/etc/ibm/ccm-config
@@ -73,7 +72,6 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --use-service-account-credentials=false
         - --tls-min-version=VersionTLS12
         - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -61,7 +61,6 @@ spec:
       - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
-        - --use-service-account-credentials=true
         - --configure-cloud-routes=false
         - --cloud-provider=ibm
         - --cloud-config=/etc/ibm/ccm-config
@@ -71,7 +70,6 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --use-service-account-credentials=false
         - --tls-min-version=VersionTLS12
         - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -58,8 +58,7 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /bin/ibm-cloud-controller-manager
+      - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
         - --use-service-account-credentials=true
@@ -71,9 +70,12 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --use-service-account-credentials=false
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
+        - /bin/ibm-cloud-controller-manager
         env:
         - name: POD_IP_ADDRESS
           valueFrom:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 46838ae410c8a597979b15bb09eff38ab841897b13d9defe8ac26a38aa49f0d0
+    hypershift.openshift.io/desired-state-hash: 30bb6204669147e204cca77df5632c62c173418315ae94c7ad16cc65fc889e37
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: powervs-cloud-controller-manager
@@ -60,8 +60,7 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /bin/ibm-cloud-controller-manager
+      - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
         - --use-service-account-credentials=true
@@ -73,9 +72,12 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --use-service-account-credentials=false
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
+        - /bin/ibm-cloud-controller-manager
         env:
         - name: POD_IP_ADDRESS
           valueFrom:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -63,7 +63,6 @@ spec:
       - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
-        - --use-service-account-credentials=true
         - --configure-cloud-routes=false
         - --cloud-provider=ibm
         - --cloud-config=/etc/ibm/ccm-config
@@ -73,7 +72,6 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --use-service-account-credentials=false
         - --tls-min-version=VersionTLS12
         - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -61,7 +61,6 @@ spec:
       - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
-        - --use-service-account-credentials=true
         - --configure-cloud-routes=false
         - --cloud-provider=ibm
         - --cloud-config=/etc/ibm/ccm-config
@@ -71,7 +70,6 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --use-service-account-credentials=false
         - --tls-min-version=VersionTLS12
         - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -58,8 +58,7 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /bin/ibm-cloud-controller-manager
+      - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
         - --use-service-account-credentials=true
@@ -71,9 +70,12 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --use-service-account-credentials=false
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
+        - /bin/ibm-cloud-controller-manager
         env:
         - name: POD_IP_ADDRESS
           valueFrom:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 9a12d6c2ea7e4c191e61786b4a1190a8f7ef404a8f76916d1b22d94306e046f2
+    hypershift.openshift.io/desired-state-hash: 01f976afcc5357164bfea66ffb12a3852dd62aadc3f599b85e0c12a6479d9031
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: powervs-cloud-controller-manager
@@ -60,8 +60,7 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /bin/ibm-cloud-controller-manager
+      - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
         - --use-service-account-credentials=true
@@ -73,9 +72,12 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --use-service-account-credentials=false
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
+        - /bin/ibm-cloud-controller-manager
         env:
         - name: POD_IP_ADDRESS
           valueFrom:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -63,7 +63,6 @@ spec:
       - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
-        - --use-service-account-credentials=true
         - --configure-cloud-routes=false
         - --cloud-provider=ibm
         - --cloud-config=/etc/ibm/ccm-config
@@ -73,7 +72,6 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --use-service-account-credentials=false
         - --tls-min-version=VersionTLS12
         - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 9a12d6c2ea7e4c191e61786b4a1190a8f7ef404a8f76916d1b22d94306e046f2
+    hypershift.openshift.io/desired-state-hash: 39d7ff361855d4b715d62b51da3a994df4bc733c76e49e7fbfeb0a3a538fb6e4
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: powervs-cloud-controller-manager
@@ -60,8 +60,7 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /bin/ibm-cloud-controller-manager
+      - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
         - --use-service-account-credentials=true
@@ -73,9 +72,11 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --use-service-account-credentials=false
+        - --tls-min-version=VersionTLS13
+        command:
+        - /bin/ibm-cloud-controller-manager
         env:
         - name: POD_IP_ADDRESS
           valueFrom:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -63,7 +63,6 @@ spec:
       - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
-        - --use-service-account-credentials=true
         - --configure-cloud-routes=false
         - --cloud-provider=ibm
         - --cloud-config=/etc/ibm/ccm-config
@@ -73,7 +72,6 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --use-service-account-credentials=false
         - --tls-min-version=VersionTLS13
         command:
         - /bin/ibm-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -61,7 +61,6 @@ spec:
       - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
-        - --use-service-account-credentials=true
         - --configure-cloud-routes=false
         - --cloud-provider=ibm
         - --cloud-config=/etc/ibm/ccm-config
@@ -71,7 +70,6 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --use-service-account-credentials=false
         - --tls-min-version=VersionTLS13
         command:
         - /bin/ibm-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/ModernTLS/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -58,8 +58,7 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /bin/ibm-cloud-controller-manager
+      - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
         - --use-service-account-credentials=true
@@ -71,9 +70,11 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --use-service-account-credentials=false
+        - --tls-min-version=VersionTLS13
+        command:
+        - /bin/ibm-cloud-controller-manager
         env:
         - name: POD_IP_ADDRESS
           valueFrom:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -61,7 +61,6 @@ spec:
       - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
-        - --use-service-account-credentials=true
         - --configure-cloud-routes=false
         - --cloud-provider=ibm
         - --cloud-config=/etc/ibm/ccm-config
@@ -71,7 +70,6 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --use-service-account-credentials=false
         - --tls-min-version=VersionTLS12
         - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -58,8 +58,7 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /bin/ibm-cloud-controller-manager
+      - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
         - --use-service-account-credentials=true
@@ -71,9 +70,12 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --use-service-account-credentials=false
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
+        - /bin/ibm-cloud-controller-manager
         env:
         - name: POD_IP_ADDRESS
           valueFrom:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 9a12d6c2ea7e4c191e61786b4a1190a8f7ef404a8f76916d1b22d94306e046f2
+    hypershift.openshift.io/desired-state-hash: 01f976afcc5357164bfea66ffb12a3852dd62aadc3f599b85e0c12a6479d9031
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: powervs-cloud-controller-manager
@@ -60,8 +60,7 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /bin/ibm-cloud-controller-manager
+      - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
         - --use-service-account-credentials=true
@@ -73,9 +72,12 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --use-service-account-credentials=false
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
+        - /bin/ibm-cloud-controller-manager
         env:
         - name: POD_IP_ADDRESS
           valueFrom:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -63,7 +63,6 @@ spec:
       - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
-        - --use-service-account-credentials=true
         - --configure-cloud-routes=false
         - --cloud-provider=ibm
         - --cloud-config=/etc/ibm/ccm-config
@@ -73,7 +72,6 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --use-service-account-credentials=false
         - --tls-min-version=VersionTLS12
         - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -61,7 +61,6 @@ spec:
       - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
-        - --use-service-account-credentials=true
         - --configure-cloud-routes=false
         - --cloud-provider=ibm
         - --cloud-config=/etc/ibm/ccm-config
@@ -71,7 +70,6 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --use-service-account-credentials=false
         - --tls-min-version=VersionTLS12
         - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -58,8 +58,7 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /bin/ibm-cloud-controller-manager
+      - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
         - --use-service-account-credentials=true
@@ -71,9 +70,12 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --use-service-account-credentials=false
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
+        - /bin/ibm-cloud-controller-manager
         env:
         - name: POD_IP_ADDRESS
           valueFrom:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 9a12d6c2ea7e4c191e61786b4a1190a8f7ef404a8f76916d1b22d94306e046f2
+    hypershift.openshift.io/desired-state-hash: 01f976afcc5357164bfea66ffb12a3852dd62aadc3f599b85e0c12a6479d9031
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: powervs-cloud-controller-manager
@@ -60,8 +60,7 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /bin/ibm-cloud-controller-manager
+      - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
         - --use-service-account-credentials=true
@@ -73,9 +72,12 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --use-service-account-credentials=false
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
+        - /bin/ibm-cloud-controller-manager
         env:
         - name: POD_IP_ADDRESS
           valueFrom:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -63,7 +63,6 @@ spec:
       - args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
-        - --use-service-account-credentials=true
         - --configure-cloud-routes=false
         - --cloud-provider=ibm
         - --cloud-config=/etc/ibm/ccm-config
@@ -73,7 +72,6 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --use-service-account-credentials=false
         - --tls-min-version=VersionTLS12
         - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/powervs-cloud-controller-manager/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/powervs-cloud-controller-manager/deployment.yaml
@@ -19,7 +19,6 @@ spec:
         args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
-        - --use-service-account-credentials=true
         - --configure-cloud-routes=false
         - --cloud-provider=ibm
         - --cloud-config=/etc/ibm/ccm-config
@@ -29,7 +28,6 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --use-service-account-credentials=false
         env:
         - name: POD_IP_ADDRESS
           valueFrom:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/powervs-cloud-controller-manager/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/powervs-cloud-controller-manager/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
       - command:
         - /bin/ibm-cloud-controller-manager
+        args:
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)
         - --use-service-account-credentials=true
@@ -27,7 +28,6 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --use-service-account-credentials=false
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
@@ -25,6 +25,9 @@ func (capi *CAPIManagerOptions) adaptDeployment(cpContext component.WorkloadCont
 		if version.GE(config.Version419) {
 			c.Args = append(c.Args, "--feature-gates=MachineSetPreflightChecks=false")
 		}
+		if version.Major >= 5 || (version.Major == 4 && version.Minor >= 23) {
+			c.Args = append(c.Args, config.TLSArgs(cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile())...)
+		}
 
 		if len(capi.imageOverride) > 0 {
 			c.Image = capi.imageOverride

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
@@ -25,6 +25,9 @@ func (capi *CAPIManagerOptions) adaptDeployment(cpContext component.WorkloadCont
 		if version.GE(config.Version419) {
 			c.Args = append(c.Args, "--feature-gates=MachineSetPreflightChecks=false")
 		}
+		if version.Major >= 5 || (version.Major == 4 && version.Minor >= 23) {
+			c.Args = config.AppendTLSArgs(c.Args, cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile())
+		}
 
 		if len(capi.imageOverride) > 0 {
 			c.Image = capi.imageOverride

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/testutil"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -23,6 +25,7 @@ func TestAdaptDeployment(t *testing.T) {
 		imageOverride    string
 		version          string
 		hcpAnnotations   map[string]string
+		tlsProfile       *configv1.TLSSecurityProfile
 		expectedArgs     []string
 		unexpectedArgs   []string
 		expectedImage    string
@@ -64,6 +67,28 @@ func TestAdaptDeployment(t *testing.T) {
 			expectedImage:    "cluster-capi-controllers",
 			expectedAnnotKey: k8sutil.HostedClusterAnnotation,
 		},
+		{
+			name:           "When version is 4.22.0, it should not add TLS args",
+			version:        "4.22.0",
+			tlsProfile:     &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType},
+			expectedArgs:   []string{"--feature-gates=MachineSetPreflightChecks=false"},
+			unexpectedArgs: []string{"--tls-min-version=VersionTLS12"},
+			expectedImage:  "cluster-capi-controllers",
+		},
+		{
+			name:          "When version is 4.23.0, it should add TLS args",
+			version:       "4.23.0",
+			tlsProfile:    &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType},
+			expectedArgs:  []string{"--feature-gates=MachineSetPreflightChecks=false", "--tls-min-version=VersionTLS12"},
+			expectedImage: "cluster-capi-controllers",
+		},
+		{
+			name:          "When version is 5.0.0, it should add TLS args",
+			version:       "5.0.0",
+			tlsProfile:    &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType},
+			expectedArgs:  []string{"--feature-gates=MachineSetPreflightChecks=false", "--tls-min-version=VersionTLS12"},
+			expectedImage: "cluster-capi-controllers",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -76,6 +101,13 @@ func TestAdaptDeployment(t *testing.T) {
 					Name:        "test-hcp",
 					Namespace:   "test-namespace",
 					Annotations: tc.hcpAnnotations,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: tc.tlsProfile,
+						},
+					},
 				},
 			}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/deployment.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
@@ -16,6 +17,12 @@ const (
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	podspec.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		proxy.SetEnvVars(&c.Env)
+	})
+
+	hcp := cpContext.HCP
+
+	podspec.UpdateContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
 	})
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/deployment.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
@@ -16,6 +17,12 @@ const (
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	podspec.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		proxy.SetEnvVars(&c.Env)
+	})
+
+	hcp := cpContext.HCP
+
+	podspec.UpdateContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		c.Args = config.AppendTLSArgs(c.Args, hcp.Spec.Configuration.GetTLSSecurityProfile())
 	})
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/deployment_test.go
@@ -10,6 +10,9 @@ import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
+	configv1 "github.com/openshift/api/config/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -121,6 +124,119 @@ func TestAdaptDeployment(t *testing.T) {
 			g.Expect(container).ToNot(BeNil(), "cloud-controller-manager container should exist")
 
 			tc.validate(g, container)
+		})
+	}
+}
+
+func buildHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.AWSPlatform,
+			},
+		},
+	}
+
+	if tlsProfile != nil {
+		hcp.Spec.Configuration = &hyperv1.ClusterConfiguration{
+			APIServer: &configv1.APIServerSpec{
+				TLSSecurityProfile: tlsProfile,
+			},
+		}
+	}
+
+	return hcp
+}
+
+func buildDeployment(args []string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "cloud-controller-manager",
+							Args: append([]string{}, args...),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestAdaptDeploymentTLS(t *testing.T) {
+	t.Parallel()
+
+	baseArgs := []string{
+		"--cloud-provider=aws",
+		"--use-service-account-credentials=false",
+	}
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name         string
+		tlsProfile   *configv1.TLSSecurityProfile
+		expectedArgs []string
+	}{
+		{
+			name:       "When TLS profile is nil it should append intermediate defaults",
+			tlsProfile: nil,
+			expectedArgs: append(baseArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			),
+		},
+		{
+			name: "When using Modern TLS profile it should append only min-version",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedArgs: append(baseArgs, "--tls-min-version=VersionTLS13"),
+		},
+		{
+			name:       "When using Custom TLS profile it should append custom TLS args",
+			tlsProfile: customTLSProfile,
+			expectedArgs: append(baseArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			hcp := buildHostedControlPlane(tc.tlsProfile)
+			deployment := buildDeployment(baseArgs)
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+			}
+			err := adaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			container := podspec.FindContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers)
+			g.Expect(container).ToNot(BeNil(), "cloud-controller-manager container should exist")
+			g.Expect(container.Args).To(Equal(tc.expectedArgs))
 		})
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/deployment.go
@@ -17,10 +17,14 @@ const (
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
+
 	podspec.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args,
 			fmt.Sprintf("--cluster-name=%s", cpContext.HCP.Spec.InfraID),
 		)
+		c.Args = config.AppendTLSArgs(c.Args, hcp.Spec.Configuration.GetTLSSecurityProfile())
+
 		if azureutil.IsAroHCPByHCP(cpContext.HCP) {
 			c.VolumeMounts = append(c.VolumeMounts,
 				azureutil.CreateVolumeMountForAzureSecretStoreProviderClass(config.ManagedAzureCloudProviderSecretStoreVolumeName),

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/deployment.go
@@ -17,10 +17,14 @@ const (
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
+
 	podspec.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args,
 			fmt.Sprintf("--cluster-name=%s", cpContext.HCP.Spec.InfraID),
 		)
+		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+
 		if azureutil.IsAroHCPByHCP(cpContext.HCP) {
 			c.VolumeMounts = append(c.VolumeMounts,
 				azureutil.CreateVolumeMountForAzureSecretStoreProviderClass(config.ManagedAzureCloudProviderSecretStoreVolumeName),

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/deployment_test.go
@@ -1,0 +1,136 @@
+package azure
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func buildHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			InfraID: "test-infra-id",
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.AzurePlatform,
+			},
+		},
+	}
+
+	if tlsProfile != nil {
+		hcp.Spec.Configuration = &hyperv1.ClusterConfiguration{
+			APIServer: &configv1.APIServerSpec{
+				TLSSecurityProfile: tlsProfile,
+			},
+		}
+	}
+
+	return hcp
+}
+
+func buildDeployment(args []string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "cloud-controller-manager",
+							Args: append([]string{}, args...),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestAdaptDeployment(t *testing.T) {
+	t.Parallel()
+
+	baseArgs := []string{
+		"--cloud-config=/etc/cloud/cloud.conf",
+		"--cloud-provider=azure",
+	}
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name         string
+		tlsProfile   *configv1.TLSSecurityProfile
+		expectedArgs []string
+	}{
+		{
+			name:       "When TLS profile is nil it should append intermediate defaults",
+			tlsProfile: nil,
+			expectedArgs: append(baseArgs,
+				"--cluster-name=test-infra-id",
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			),
+		},
+		{
+			name: "When using Modern TLS profile it should append only min-version",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedArgs: append(baseArgs,
+				"--cluster-name=test-infra-id",
+				"--tls-min-version=VersionTLS13",
+			),
+		},
+		{
+			name:       "When using Custom TLS profile it should append custom TLS args",
+			tlsProfile: customTLSProfile,
+			expectedArgs: append(baseArgs,
+				"--cluster-name=test-infra-id",
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			hcp := buildHostedControlPlane(tc.tlsProfile)
+			deployment := buildDeployment(baseArgs)
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+			}
+			err := adaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			container := podspec.FindContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers)
+			g.Expect(container).ToNot(BeNil(), "cloud-controller-manager container should exist")
+			g.Expect(container.Args).To(Equal(tc.expectedArgs))
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/component.go
@@ -2,7 +2,12 @@ package gcp
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -35,6 +40,7 @@ func NewComponent() component.ControlPlaneComponent {
 	// The deployment.yaml mounts that pre-created secret.
 	return component.NewDeploymentComponent(ComponentName, &gcpOptions{}).
 		WithPredicate(predicate).
+		WithAdaptFunction(adaptDeployment).
 		WithManifestAdapter(
 			"config.yaml",
 			component.WithAdaptFunction(adaptConfig),
@@ -49,4 +55,14 @@ func NewComponent() component.ControlPlaneComponent {
 
 func predicate(cpContext component.WorkloadContext) (bool, error) {
 	return cpContext.HCP.Spec.Platform.Type == hyperv1.GCPPlatform, nil
+}
+
+func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
+
+	podspec.UpdateContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		c.Args = config.AppendTLSArgs(c.Args, hcp.Spec.Configuration.GetTLSSecurityProfile())
+	})
+
+	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/component.go
@@ -2,7 +2,12 @@ package gcp
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -35,6 +40,7 @@ func NewComponent() component.ControlPlaneComponent {
 	// The deployment.yaml mounts that pre-created secret.
 	return component.NewDeploymentComponent(ComponentName, &gcpOptions{}).
 		WithPredicate(predicate).
+		WithAdaptFunction(adaptDeployment).
 		WithManifestAdapter(
 			"config.yaml",
 			component.WithAdaptFunction(adaptConfig),
@@ -49,4 +55,14 @@ func NewComponent() component.ControlPlaneComponent {
 
 func predicate(cpContext component.WorkloadContext) (bool, error) {
 	return cpContext.HCP.Spec.Platform.Type == hyperv1.GCPPlatform, nil
+}
+
+func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
+
+	podspec.UpdateContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+	})
+
+	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/deployment_test.go
@@ -1,0 +1,130 @@
+package gcp
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func buildHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.GCPPlatform,
+			},
+		},
+	}
+
+	if tlsProfile != nil {
+		hcp.Spec.Configuration = &hyperv1.ClusterConfiguration{
+			APIServer: &configv1.APIServerSpec{
+				TLSSecurityProfile: tlsProfile,
+			},
+		}
+	}
+
+	return hcp
+}
+
+func buildDeployment(args []string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "cloud-controller-manager",
+							Args: append([]string{}, args...),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestAdaptDeployment(t *testing.T) {
+	t.Parallel()
+
+	baseArgs := []string{
+		"--cloud-provider=gce",
+		"--use-service-account-credentials=true",
+	}
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name         string
+		tlsProfile   *configv1.TLSSecurityProfile
+		expectedArgs []string
+	}{
+		{
+			name:       "When TLS profile is nil it should append intermediate defaults",
+			tlsProfile: nil,
+			expectedArgs: append(baseArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			),
+		},
+		{
+			name: "When using Modern TLS profile it should append only min-version",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedArgs: append(baseArgs, "--tls-min-version=VersionTLS13"),
+		},
+		{
+			name:       "When using Custom TLS profile it should append custom TLS args",
+			tlsProfile: customTLSProfile,
+			expectedArgs: append(baseArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			hcp := buildHostedControlPlane(tc.tlsProfile)
+			deployment := buildDeployment(baseArgs)
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+			}
+			err := adaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			container := podspec.FindContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers)
+			g.Expect(container).ToNot(BeNil(), "cloud-controller-manager container should exist")
+			g.Expect(container.Args).To(Equal(tc.expectedArgs))
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/deployment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
@@ -37,6 +38,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		c.Args = append(c.Args,
 			fmt.Sprintf("--cluster-name=%s", clusterName),
 		)
+		c.Args = config.AppendTLSArgs(c.Args, hcp.Spec.Configuration.GetTLSSecurityProfile())
 
 		if isExternalInfra {
 			c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/deployment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
@@ -37,6 +38,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		c.Args = append(c.Args,
 			fmt.Sprintf("--cluster-name=%s", clusterName),
 		)
+		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
 
 		if isExternalInfra {
 			c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/deployment_test.go
@@ -1,0 +1,138 @@
+package kubevirt
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func buildHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"cluster.x-k8s.io/cluster-name": "test-cluster",
+			},
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.KubevirtPlatform,
+			},
+		},
+	}
+
+	if tlsProfile != nil {
+		hcp.Spec.Configuration = &hyperv1.ClusterConfiguration{
+			APIServer: &configv1.APIServerSpec{
+				TLSSecurityProfile: tlsProfile,
+			},
+		}
+	}
+
+	return hcp
+}
+
+func buildDeployment(args []string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "cloud-controller-manager",
+							Args: append([]string{}, args...),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestAdaptDeployment(t *testing.T) {
+	t.Parallel()
+
+	baseArgs := []string{
+		"--cloud-provider=kubevirt",
+		"--use-service-account-credentials=true",
+	}
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name         string
+		tlsProfile   *configv1.TLSSecurityProfile
+		expectedArgs []string
+	}{
+		{
+			name:       "When TLS profile is nil it should append intermediate defaults",
+			tlsProfile: nil,
+			expectedArgs: append(baseArgs,
+				"--cluster-name=test-cluster",
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			),
+		},
+		{
+			name: "When using Modern TLS profile it should append only min-version",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedArgs: append(baseArgs,
+				"--cluster-name=test-cluster",
+				"--tls-min-version=VersionTLS13",
+			),
+		},
+		{
+			name:       "When using Custom TLS profile it should append custom TLS args",
+			tlsProfile: customTLSProfile,
+			expectedArgs: append(baseArgs,
+				"--cluster-name=test-cluster",
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			hcp := buildHostedControlPlane(tc.tlsProfile)
+			deployment := buildDeployment(baseArgs)
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+			}
+			err := adaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			container := podspec.FindContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers)
+			g.Expect(container).ToNot(BeNil(), "cloud-controller-manager container should exist")
+			g.Expect(container.Args).To(Equal(tc.expectedArgs))
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
@@ -20,6 +21,7 @@ const (
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
 	credentialsSecret, err := getCredentialsSecret(cpContext)
 	if err != nil {
 		return err
@@ -35,6 +37,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			Name:  "OCP_INFRASTRUCTURE_NAME",
 			Value: cpContext.HCP.Spec.InfraID,
 		})
+		c.Args = config.AppendTLSArgs(c.Args, hcp.Spec.Configuration.GetTLSSecurityProfile())
 
 		if hasCACert {
 			c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
@@ -20,6 +21,7 @@ const (
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
 	credentialsSecret, err := getCredentialsSecret(cpContext)
 	if err != nil {
 		return err
@@ -35,6 +37,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			Name:  "OCP_INFRASTRUCTURE_NAME",
 			Value: cpContext.HCP.Spec.InfraID,
 		})
+		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
 
 		if hasCACert {
 			c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment_test.go
@@ -1,0 +1,166 @@
+package openstack
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func buildHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			InfraID: "test-infra-id",
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.OpenStackPlatform,
+				OpenStack: &hyperv1.OpenStackPlatformSpec{
+					IdentityRef: hyperv1.OpenStackIdentityReference{
+						Name: "test-cloud-credentials",
+					},
+				},
+			},
+		},
+	}
+
+	if tlsProfile != nil {
+		hcp.Spec.Configuration = &hyperv1.ClusterConfiguration{
+			APIServer: &configv1.APIServerSpec{
+				TLSSecurityProfile: tlsProfile,
+			},
+		}
+	}
+
+	return hcp
+}
+
+func buildDeployment(args []string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "cloud-controller-manager",
+							Args: append([]string{}, args...),
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: secretOCCMVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "old-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestAdaptDeployment(t *testing.T) {
+	t.Parallel()
+
+	baseArgs := []string{
+		"--cloud-provider=openstack",
+		"--use-service-account-credentials=true",
+	}
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name         string
+		tlsProfile   *configv1.TLSSecurityProfile
+		expectedArgs []string
+	}{
+		{
+			name:       "When TLS profile is nil it should append intermediate defaults",
+			tlsProfile: nil,
+			expectedArgs: append(baseArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			),
+		},
+		{
+			name: "When using Modern TLS profile it should append only min-version",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedArgs: append(baseArgs,
+				"--tls-min-version=VersionTLS13",
+			),
+		},
+		{
+			name:       "When using Custom TLS profile it should append custom TLS args",
+			tlsProfile: customTLSProfile,
+			expectedArgs: append(baseArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			hcp := buildHostedControlPlane(tc.tlsProfile)
+			deployment := buildDeployment(baseArgs)
+
+			// Create credentials secret
+			credentialsSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cloud-credentials",
+					Namespace: "test-namespace",
+				},
+				Data: map[string][]byte{
+					"clouds.yaml": []byte("test-data"),
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithObjects(credentialsSecret).
+				Build()
+
+			cpContext := component.WorkloadContext{
+				HCP:    hcp,
+				Client: fakeClient,
+			}
+			err := adaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			container := podspec.FindContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers)
+			g.Expect(container).ToNot(BeNil(), "cloud-controller-manager container should exist")
+			g.Expect(container.Args).To(Equal(tc.expectedArgs))
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment.go
@@ -3,6 +3,7 @@ package powervs
 import (
 	"fmt"
 
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
@@ -19,6 +20,10 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	if hcp.Spec.Platform.PowerVS == nil {
 		return fmt.Errorf(".spec.platform.powervs is not defined")
 	}
+
+	podspec.UpdateContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		c.Args = config.AppendTLSArgs(c.Args, hcp.Spec.Configuration.GetTLSSecurityProfile())
+	})
 
 	podspec.UpdateVolume(cloudCredsVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 		v.Secret.SecretName = hcp.Spec.Platform.PowerVS.KubeCloudControllerCreds.Name

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment.go
@@ -3,6 +3,7 @@ package powervs
 import (
 	"fmt"
 
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
@@ -19,6 +20,10 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	if hcp.Spec.Platform.PowerVS == nil {
 		return fmt.Errorf(".spec.platform.powervs is not defined")
 	}
+
+	podspec.UpdateContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+	})
 
 	podspec.UpdateVolume(cloudCredsVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 		v.Secret.SecretName = hcp.Spec.Platform.PowerVS.KubeCloudControllerCreds.Name

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment_test.go
@@ -10,6 +10,8 @@ import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -247,4 +249,132 @@ func TestCloudCredsVolumeNameConstant(t *testing.T) {
 
 		g.Expect(cloudCredsVolumeName).To(Equal("cloud-creds"))
 	})
+}
+
+func buildHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.PowerVSPlatform,
+				PowerVS: &hyperv1.PowerVSPlatformSpec{
+					KubeCloudControllerCreds: corev1.LocalObjectReference{
+						Name: "test-creds",
+					},
+				},
+			},
+		},
+	}
+
+	if tlsProfile != nil {
+		hcp.Spec.Configuration = &hyperv1.ClusterConfiguration{
+			APIServer: &configv1.APIServerSpec{
+				TLSSecurityProfile: tlsProfile,
+			},
+		}
+	}
+
+	return hcp
+}
+
+func buildDeployment(args []string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "cloud-controller-manager",
+							Args: append([]string{}, args...),
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: cloudCredsVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "original-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestAdaptDeploymentTLSArgs(t *testing.T) {
+	t.Parallel()
+
+	baseArgs := []string{
+		"--cloud-provider=ibm",
+		"--use-service-account-credentials=true",
+	}
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name         string
+		tlsProfile   *configv1.TLSSecurityProfile
+		expectedArgs []string
+	}{
+		{
+			name:       "When TLS profile is nil it should append intermediate defaults",
+			tlsProfile: nil,
+			expectedArgs: append(baseArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			),
+		},
+		{
+			name: "When using Modern TLS profile it should append only min-version",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedArgs: append(baseArgs, "--tls-min-version=VersionTLS13"),
+		},
+		{
+			name:       "When using Custom TLS profile it should append custom TLS args",
+			tlsProfile: customTLSProfile,
+			expectedArgs: append(baseArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			hcp := buildHostedControlPlane(tc.tlsProfile)
+			deployment := buildDeployment(baseArgs)
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+			}
+			err := adaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			container := podspec.FindContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers)
+			g.Expect(container).ToNot(BeNil(), "cloud-controller-manager container should exist")
+			g.Expect(container.Args).To(Equal(tc.expectedArgs))
+		})
+	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/deployment.go
@@ -2,7 +2,6 @@ package kcm
 
 import (
 	"fmt"
-	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -55,12 +54,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			c.Args = append(c.Args, "--node-monitor-grace-period=50s")
 		}
 
-		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
-		}
-		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
-		}
+		c.Args = config.AppendTLSArgs(c.Args, hcp.Spec.Configuration.GetTLSSecurityProfile())
 		if util.StringListContains(hcp.Annotations[hyperv1.DisableProfilingAnnotation], ComponentName) {
 			c.Args = append(c.Args, "--profiling=false")
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/deployment.go
@@ -2,7 +2,6 @@ package kcm
 
 import (
 	"fmt"
-	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -55,12 +54,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			c.Args = append(c.Args, "--node-monitor-grace-period=50s")
 		}
 
-		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
-		}
-		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
-		}
+		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
 		if util.StringListContains(hcp.Annotations[hyperv1.DisableProfilingAnnotation], ComponentName) {
 			c.Args = append(c.Args, "--profiling=false")
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/deployment.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"fmt"
-	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
@@ -21,12 +20,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	}
 	configuration := cpContext.HCP.Spec.Configuration
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		if tlsMinVersion := config.MinTLSVersion(configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
-		}
-		if cipherSuites := config.CipherSuites(configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
-		}
+		c.Args = config.AppendTLSArgs(c.Args, configuration.GetTLSSecurityProfile())
 		if util.StringListContains(cpContext.HCP.Annotations[hyperv1.DisableProfilingAnnotation], ComponentName) {
 			c.Args = append(c.Args, "--profiling=false")
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/deployment.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"fmt"
-	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
@@ -21,12 +20,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	}
 	configuration := cpContext.HCP.Spec.Configuration
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		if tlsMinVersion := config.MinTLSVersion(configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
-		}
-		if cipherSuites := config.CipherSuites(configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
-		}
+		c.Args = append(c.Args, config.TLSArgs(configuration.GetTLSSecurityProfile())...)
 		if util.StringListContains(cpContext.HCP.Annotations[hyperv1.DisableProfilingAnnotation], ComponentName) {
 			c.Args = append(c.Args, "--profiling=false")
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/machine_approver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/machine_approver/deployment.go
@@ -2,7 +2,6 @@ package machineapprover
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -17,13 +16,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	configuration := hcp.Spec.Configuration
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args, fmt.Sprintf("--machine-namespace=%s", hcp.Namespace))
-
-		if tlsMinVersion := config.MinTLSVersion(configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
-		}
-		if cipherSuites := config.CipherSuites(configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
-		}
+		c.Args = config.AppendTLSArgs(c.Args, configuration.GetTLSSecurityProfile())
 	})
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/machine_approver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/machine_approver/deployment.go
@@ -2,7 +2,6 @@ package machineapprover
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -17,13 +16,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	configuration := hcp.Spec.Configuration
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args, fmt.Sprintf("--machine-namespace=%s", hcp.Namespace))
-
-		if tlsMinVersion := config.MinTLSVersion(configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
-		}
-		if cipherSuites := config.CipherSuites(configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
-		}
+		c.Args = append(c.Args, config.TLSArgs(configuration.GetTLSSecurityProfile())...)
 	})
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
@@ -51,12 +51,8 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		c.Args = append(c.Args,
 			fmt.Sprintf("--api-audiences=%s", cpContext.HCP.Spec.IssuerURL),
 			fmt.Sprintf("--etcd-servers=%s", etcdURL),
-			fmt.Sprintf("--tls-min-version=%s", config.MinTLSVersion(configuration.GetTLSSecurityProfile())),
 		)
-
-		if cipherSuites := config.CipherSuites(configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
-		}
+		c.Args = config.AppendTLSArgs(c.Args, configuration.GetTLSSecurityProfile())
 
 		if cpContext.HCP.Spec.AuditWebhook != nil && len(cpContext.HCP.Spec.AuditWebhook.Name) > 0 {
 			c.Args = append(c.Args, fmt.Sprintf("--audit-webhook-config-file=%s", path.Join("/etc/kubernetes/auditwebhook", hyperv1.AuditWebhookKubeconfigKey)))

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
@@ -51,12 +51,8 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		c.Args = append(c.Args,
 			fmt.Sprintf("--api-audiences=%s", cpContext.HCP.Spec.IssuerURL),
 			fmt.Sprintf("--etcd-servers=%s", etcdURL),
-			fmt.Sprintf("--tls-min-version=%s", config.MinTLSVersion(configuration.GetTLSSecurityProfile())),
 		)
-
-		if cipherSuites := config.CipherSuites(configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
-		}
+		c.Args = append(c.Args, config.TLSArgs(configuration.GetTLSSecurityProfile())...)
 
 		if cpContext.HCP.Spec.AuditWebhook != nil && len(cpContext.HCP.Spec.AuditWebhook.Name) > 0 {
 			c.Args = append(c.Args, fmt.Sprintf("--audit-webhook-config-file=%s", path.Join("/etc/kubernetes/auditwebhook", hyperv1.AuditWebhookKubeconfigKey)))

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/clusterapi"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
@@ -24,6 +25,8 @@ import (
 
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/blang/semver"
 )
 
 const (
@@ -36,7 +39,15 @@ const (
 	capiProviderAgentRBACLabelValue = "true"
 )
 
-type Agent struct{}
+type Agent struct {
+	payloadVersion *semver.Version
+}
+
+func New(payloadVersion *semver.Version) *Agent {
+	return &Agent{
+		payloadVersion: payloadVersion,
+	}
+}
 
 func (p Agent) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
 	hcluster *hyperv1.HostedCluster,
@@ -68,7 +79,7 @@ func (p Agent) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, create
 	return agentCluster, nil
 }
 
-func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := imageCAPAgent
 	if envImage := os.Getenv(images.AgentCAPIProviderEnvVar); len(envImage) > 0 {
 		providerImage = envImage
@@ -76,6 +87,18 @@ func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIAgentProviderImage]; ok {
 		providerImage = override
 	}
+
+	args := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--health-probe-bind-address=:8081",
+		"--metrics-bind-address=127.0.0.1:8080",
+		"--leader-elect",
+		"--agent-namespace", hcluster.Spec.Platform.Agent.AgentNamespace,
+	}
+	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
+		args = append(args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+	}
+
 	deploymentSpec := &appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
 		Template: corev1.PodTemplateSpec{
@@ -96,13 +119,7 @@ func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 							},
 						},
 						Command: []string{"/manager"},
-						Args: []string{
-							"--namespace", "$(MY_NAMESPACE)",
-							"--health-probe-bind-address=:8081",
-							"--metrics-bind-address=127.0.0.1:8080",
-							"--leader-elect",
-							"--agent-namespace", hcluster.Spec.Platform.Agent.AgentNamespace,
-						},
+						Args:    args,
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/clusterapi"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
@@ -24,6 +25,8 @@ import (
 
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/blang/semver"
 )
 
 const (
@@ -36,7 +39,15 @@ const (
 	capiProviderAgentRBACLabelValue = "true"
 )
 
-type Agent struct{}
+type Agent struct {
+	payloadVersion *semver.Version
+}
+
+func New(payloadVersion *semver.Version) *Agent {
+	return &Agent{
+		payloadVersion: payloadVersion,
+	}
+}
 
 func (p Agent) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
 	hcluster *hyperv1.HostedCluster,
@@ -68,7 +79,7 @@ func (p Agent) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, create
 	return agentCluster, nil
 }
 
-func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := imageCAPAgent
 	if envImage := os.Getenv(images.AgentCAPIProviderEnvVar); len(envImage) > 0 {
 		providerImage = envImage
@@ -76,6 +87,18 @@ func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIAgentProviderImage]; ok {
 		providerImage = override
 	}
+
+	args := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--health-probe-bind-address=:8081",
+		"--metrics-bind-address=127.0.0.1:8080",
+		"--leader-elect",
+		"--agent-namespace", hcluster.Spec.Platform.Agent.AgentNamespace,
+	}
+	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
+		args = config.AppendTLSArgs(args, hcp.Spec.Configuration.GetTLSSecurityProfile())
+	}
+
 	deploymentSpec := &appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
 		Template: corev1.PodTemplateSpec{
@@ -96,13 +119,7 @@ func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 							},
 						},
 						Command: []string{"/manager"},
-						Args: []string{
-							"--namespace", "$(MY_NAMESPACE)",
-							"--health-probe-bind-address=:8081",
-							"--metrics-bind-address=127.0.0.1:8080",
-							"--leader-elect",
-							"--agent-namespace", hcluster.Spec.Platform.Agent.AgentNamespace,
-						},
+						Args:    args,
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
@@ -10,21 +10,25 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	hyperapi "github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
 
+	configv1 "github.com/openshift/api/config/v1"
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/blang/semver"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -358,11 +362,169 @@ func TestReconcileCAPIInfraCR(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			client := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).Build()
-			goInfraCR, err := Agent{}.ReconcileCAPIInfraCR(t.Context(), client, controllerutil.CreateOrUpdate, test.hostedCluster, test.controlPlaneNamespace, test.APIEndpoint)
+			goInfraCR, err := New(nil).ReconcileCAPIInfraCR(t.Context(), client, controllerutil.CreateOrUpdate, test.hostedCluster, test.controlPlaneNamespace, test.APIEndpoint)
 			g.Expect(err).To(Not(HaveOccurred()))
 			if diff := cmp.Diff(goInfraCR, test.expectedObject); diff != "" {
 				t.Errorf("got and expected differ: %s", diff)
 			}
+		})
+	}
+}
+
+func buildHostedCluster(agentNamespace string, annotations map[string]string) *hyperv1.HostedCluster {
+	hc := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+		},
+		Spec: hyperv1.HostedClusterSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.AgentPlatform,
+				Agent: &hyperv1.AgentPlatformSpec{
+					AgentNamespace: agentNamespace,
+				},
+			},
+		},
+	}
+	if annotations != nil {
+		hc.Annotations = annotations
+	}
+	return hc
+}
+
+func buildHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	return &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Configuration: &hyperv1.ClusterConfiguration{
+				APIServer: &configv1.APIServerSpec{
+					TLSSecurityProfile: tlsProfile,
+				},
+			},
+		},
+	}
+}
+
+func TestCAPIProviderDeploymentSpec(t *testing.T) {
+	defaultAgentNamespace := "agent-ns"
+
+	defaultArgs := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--health-probe-bind-address=:8081",
+		"--metrics-bind-address=127.0.0.1:8080",
+		"--leader-elect",
+	}
+
+	defaultArgsWithAgentNs := append(defaultArgs,
+		"--agent-namespace", defaultAgentNamespace,
+	)
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		hcluster       *hyperv1.HostedCluster
+		hcp            *hyperv1.HostedControlPlane
+		payloadVersion *semver.Version
+		envVars        map[string]string
+		expectedImage  string
+		expectedArgs   []string
+	}{
+		{
+			name:           "When default image is used with no overrides",
+			hcluster:       buildHostedCluster(defaultAgentNamespace, nil),
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedImage:  imageCAPAgent,
+			expectedArgs:   defaultArgsWithAgentNs,
+		},
+		{
+			name:     "When image is overridden by environment variable",
+			hcluster: buildHostedCluster(defaultAgentNamespace, nil),
+			envVars: map[string]string{
+				images.AgentCAPIProviderEnvVar: "custom-env-image:v1.0",
+			},
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedImage:  "custom-env-image:v1.0",
+			expectedArgs:   defaultArgsWithAgentNs,
+		},
+		{
+			name: "When image is overridden by annotation it should take precedence over env var",
+			hcluster: buildHostedCluster(defaultAgentNamespace, map[string]string{
+				hyperv1.ClusterAPIAgentProviderImage: "annotation-image:v2.0",
+			}),
+			envVars: map[string]string{
+				images.AgentCAPIProviderEnvVar: "custom-env-image:v1.0",
+			},
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedImage:  "annotation-image:v2.0",
+			expectedArgs:   defaultArgsWithAgentNs,
+		},
+		{
+			name:     "When version is 4.22 and HCP has TLS profile it should not append TLS args",
+			hcluster: buildHostedCluster(defaultAgentNamespace, nil),
+			hcp: buildHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.22.0")),
+			expectedImage:  imageCAPAgent,
+			expectedArgs:   defaultArgsWithAgentNs,
+		},
+		{
+			name:     "When version is 4.23 and HCP has Modern TLS profile it should append min-version only",
+			hcluster: buildHostedCluster(defaultAgentNamespace, nil),
+			hcp: buildHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedImage:  imageCAPAgent,
+			expectedArgs: append(defaultArgsWithAgentNs,
+				"--tls-min-version=VersionTLS13",
+			),
+		},
+		{
+			name:           "When version is 5.0 and HCP has custom TLS profile it should append custom TLS args",
+			hcluster:       buildHostedCluster("custom-agent-namespace", nil),
+			hcp:            buildHostedControlPlane(customTLSProfile),
+			payloadVersion: ptr.To(semver.MustParse("5.0.0")),
+			expectedImage:  imageCAPAgent,
+			expectedArgs: append(defaultArgs,
+				"--agent-namespace", "custom-agent-namespace",
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			for key, value := range tc.envVars {
+				t.Setenv(key, value)
+			}
+
+			platform := New(tc.payloadVersion)
+			spec, err := platform.CAPIProviderDeploymentSpec(tc.hcluster, tc.hcp)
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(spec).ToNot(BeNil())
+			g.Expect(spec.Template.Spec.Containers).To(HaveLen(1))
+			g.Expect(spec.Template.Spec.Containers[0].Image).To(Equal(tc.expectedImage))
+			g.Expect(spec.Template.Spec.Containers[0].Args).To(Equal(tc.expectedArgs))
 		})
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
@@ -10,21 +10,25 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	hyperapi "github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
 
+	configv1 "github.com/openshift/api/config/v1"
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/blang/semver"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -322,11 +326,169 @@ func TestReconcileCAPIInfraCR(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			client := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).Build()
-			goInfraCR, err := Agent{}.ReconcileCAPIInfraCR(t.Context(), client, controllerutil.CreateOrUpdate, test.hostedCluster, test.controlPlaneNamespace, test.APIEndpoint)
+			goInfraCR, err := New(nil).ReconcileCAPIInfraCR(t.Context(), client, controllerutil.CreateOrUpdate, test.hostedCluster, test.controlPlaneNamespace, test.APIEndpoint)
 			g.Expect(err).To(Not(HaveOccurred()))
 			if diff := cmp.Diff(goInfraCR, test.expectedObject); diff != "" {
 				t.Errorf("got and expected differ: %s", diff)
 			}
+		})
+	}
+}
+
+func buildHostedCluster(agentNamespace string, annotations map[string]string) *hyperv1.HostedCluster {
+	hc := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+		},
+		Spec: hyperv1.HostedClusterSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.AgentPlatform,
+				Agent: &hyperv1.AgentPlatformSpec{
+					AgentNamespace: agentNamespace,
+				},
+			},
+		},
+	}
+	if annotations != nil {
+		hc.Annotations = annotations
+	}
+	return hc
+}
+
+func buildHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	return &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Configuration: &hyperv1.ClusterConfiguration{
+				APIServer: &configv1.APIServerSpec{
+					TLSSecurityProfile: tlsProfile,
+				},
+			},
+		},
+	}
+}
+
+func TestCAPIProviderDeploymentSpec(t *testing.T) {
+	defaultAgentNamespace := "agent-ns"
+
+	defaultArgs := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--health-probe-bind-address=:8081",
+		"--metrics-bind-address=127.0.0.1:8080",
+		"--leader-elect",
+	}
+
+	defaultArgsWithAgentNs := append(defaultArgs,
+		"--agent-namespace", defaultAgentNamespace,
+	)
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		hcluster       *hyperv1.HostedCluster
+		hcp            *hyperv1.HostedControlPlane
+		payloadVersion *semver.Version
+		envVars        map[string]string
+		expectedImage  string
+		expectedArgs   []string
+	}{
+		{
+			name:           "When default image is used with no overrides",
+			hcluster:       buildHostedCluster(defaultAgentNamespace, nil),
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedImage:  imageCAPAgent,
+			expectedArgs:   defaultArgsWithAgentNs,
+		},
+		{
+			name:     "When image is overridden by environment variable",
+			hcluster: buildHostedCluster(defaultAgentNamespace, nil),
+			envVars: map[string]string{
+				images.AgentCAPIProviderEnvVar: "custom-env-image:v1.0",
+			},
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedImage:  "custom-env-image:v1.0",
+			expectedArgs:   defaultArgsWithAgentNs,
+		},
+		{
+			name: "When image is overridden by annotation it should take precedence over env var",
+			hcluster: buildHostedCluster(defaultAgentNamespace, map[string]string{
+				hyperv1.ClusterAPIAgentProviderImage: "annotation-image:v2.0",
+			}),
+			envVars: map[string]string{
+				images.AgentCAPIProviderEnvVar: "custom-env-image:v1.0",
+			},
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedImage:  "annotation-image:v2.0",
+			expectedArgs:   defaultArgsWithAgentNs,
+		},
+		{
+			name:     "When version is 4.22 and HCP has TLS profile it should not append TLS args",
+			hcluster: buildHostedCluster(defaultAgentNamespace, nil),
+			hcp: buildHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.22.0")),
+			expectedImage:  imageCAPAgent,
+			expectedArgs:   defaultArgsWithAgentNs,
+		},
+		{
+			name:     "When version is 4.23 and HCP has Modern TLS profile it should append min-version only",
+			hcluster: buildHostedCluster(defaultAgentNamespace, nil),
+			hcp: buildHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedImage:  imageCAPAgent,
+			expectedArgs: append(defaultArgsWithAgentNs,
+				"--tls-min-version=VersionTLS13",
+			),
+		},
+		{
+			name:           "When version is 5.0 and HCP has custom TLS profile it should append custom TLS args",
+			hcluster:       buildHostedCluster("custom-agent-namespace", nil),
+			hcp:            buildHostedControlPlane(customTLSProfile),
+			payloadVersion: ptr.To(semver.MustParse("5.0.0")),
+			expectedImage:  imageCAPAgent,
+			expectedArgs: append(defaultArgs,
+				"--agent-namespace", "custom-agent-namespace",
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			for key, value := range tc.envVars {
+				t.Setenv(key, value)
+			}
+
+			platform := New(tc.payloadVersion)
+			spec, err := platform.CAPIProviderDeploymentSpec(tc.hcluster, tc.hcp)
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(spec).ToNot(BeNil())
+			g.Expect(spec.Template.Spec.Containers).To(HaveLen(1))
+			g.Expect(spec.Template.Spec.Containers[0].Image).To(Equal(tc.expectedImage))
+			g.Expect(spec.Template.Spec.Containers[0].Args).To(Equal(tc.expectedArgs))
 		})
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
 
@@ -100,7 +101,7 @@ func (p AWS) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOr
 	return awsCluster, nil
 }
 
-func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := p.capiProviderImage
 	if envImage := os.Getenv(images.AWSCAPIProviderEnvVar); len(envImage) > 0 {
 		// Only override CAPA image with env var if payload version < 4.12
@@ -117,6 +118,16 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hype
 	}
 	if p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor > 15)) {
 		featureGates = append(featureGates, "ROSA=false")
+	}
+
+	args := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--v=4",
+		"--leader-elect=true",
+		fmt.Sprintf("--feature-gates=%s", strings.Join(featureGates, ",")),
+	}
+	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
+		args = append(args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
 	}
 
 	defaultMode := int32(0640)
@@ -211,11 +222,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hype
 								Value: "true",
 							},
 						},
-						Args: []string{"--namespace", "$(MY_NAMESPACE)",
-							"--v=4",
-							"--leader-elect=true",
-							fmt.Sprintf("--feature-gates=%s", strings.Join(featureGates, ",")),
-						},
+						Args: args,
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "healthz",

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
 
@@ -100,7 +101,7 @@ func (p AWS) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOr
 	return awsCluster, nil
 }
 
-func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := p.capiProviderImage
 	if envImage := os.Getenv(images.AWSCAPIProviderEnvVar); len(envImage) > 0 {
 		// Only override CAPA image with env var if payload version < 4.12
@@ -117,6 +118,16 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hype
 	}
 	if p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor > 15)) {
 		featureGates = append(featureGates, "ROSA=false")
+	}
+
+	args := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--v=4",
+		"--leader-elect=true",
+		fmt.Sprintf("--feature-gates=%s", strings.Join(featureGates, ",")),
+	}
+	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
+		args = config.AppendTLSArgs(args, hcp.Spec.Configuration.GetTLSSecurityProfile())
 	}
 
 	defaultMode := int32(0640)
@@ -211,11 +222,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hype
 								Value: "true",
 							},
 						},
-						Args: []string{"--namespace", "$(MY_NAMESPACE)",
-							"--v=4",
-							"--leader-elect=true",
-							fmt.Sprintf("--feature-gates=%s", strings.Join(featureGates, ",")),
-						},
+						Args: args,
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "healthz",

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws_test.go
@@ -5,11 +5,16 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
+	configv1 "github.com/openshift/api/config/v1"
+
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 
+	"github.com/blang/semver"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -245,6 +250,136 @@ region = us-east-1
 			}
 			if creds != tt.want {
 				t.Errorf("expected creds:\n%s, but got:\n%s", tt.want, creds)
+			}
+		})
+	}
+}
+
+func buildAWSHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	return &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Configuration: &hyperv1.ClusterConfiguration{
+				APIServer: &configv1.APIServerSpec{
+					TLSSecurityProfile: tlsProfile,
+				},
+			},
+		},
+	}
+}
+
+func TestCAPIProviderDeploymentSpec(t *testing.T) {
+	defaultArgs := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--v=4",
+		"--leader-elect=true",
+		"--feature-gates=EKS=false,ROSA=false",
+	}
+
+	defaultImage := "test-capi-image"
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		hcp            *hyperv1.HostedControlPlane
+		payloadVersion *semver.Version
+		expectedImage  string
+		expectedArgs   []string
+	}{
+		{
+			name:           "When HostedControlPlane is nil it should not append TLS args",
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedImage:  defaultImage,
+			expectedArgs:   defaultArgs,
+		},
+		{
+			name: "When version is 4.22 and HCP has TLS profile it should not append TLS args",
+			hcp: buildAWSHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.22.0")),
+			expectedImage:  defaultImage,
+			expectedArgs:   defaultArgs,
+		},
+		{
+			name: "When version is 4.23 and HCP has Modern TLS profile it should append min-version only",
+			hcp: buildAWSHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedImage:  defaultImage,
+			expectedArgs: append(defaultArgs,
+				"--tls-min-version=VersionTLS13",
+			),
+		},
+		{
+			name:           "When version is 5.0 and HCP has custom TLS profile it should append custom TLS args",
+			hcp:            buildAWSHostedControlPlane(customTLSProfile),
+			payloadVersion: ptr.To(semver.MustParse("5.0.0")),
+			expectedImage:  defaultImage,
+			expectedArgs: append(defaultArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			platform := AWS{
+				capiProviderImage: tc.expectedImage,
+				payloadVersion:    tc.payloadVersion,
+			}
+			spec, err := platform.CAPIProviderDeploymentSpec(&hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+					},
+				},
+			}, tc.hcp)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if spec == nil {
+				t.Fatal("expected deployment spec, got nil")
+			}
+			if len(spec.Template.Spec.Containers) == 0 {
+				t.Fatal("expected at least 1 container, got 0")
+			}
+
+			var managerContainer *corev1.Container
+			for i := range spec.Template.Spec.Containers {
+				if spec.Template.Spec.Containers[i].Name == "manager" {
+					managerContainer = &spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+			if managerContainer == nil {
+				t.Fatal("manager container not found")
+			}
+
+			if managerContainer.Image != tc.expectedImage {
+				t.Errorf("expected image %s, got %s", tc.expectedImage, managerContainer.Image)
+			}
+
+			if diff := cmp.Diff(managerContainer.Args, tc.expectedArgs); diff != "" {
+				t.Errorf("args differ (-got +want):\n%s", diff)
 			}
 		})
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -93,7 +93,7 @@ func (a Azure) ReconcileCAPIInfraCR(
 	return azureCluster, nil
 }
 
-func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	image := a.capiProviderImage
 	if envImage := os.Getenv(images.AzureCAPIProviderEnvVar); len(envImage) > 0 {
 		image = envImage
@@ -101,6 +101,17 @@ func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIAzureProviderImage]; ok {
 		image = override
 	}
+
+	args := []string{
+		"--namespace=$(MY_NAMESPACE)",
+		"--leader-elect=true",
+		"--feature-gates=MachinePool=false,ASOAPI=false",
+		"--disable-controllers-or-webhooks=DisableASOSecretController",
+	}
+	if hcp != nil && a.payloadVersion != nil && (a.payloadVersion.Major >= 5 || (a.payloadVersion.Major == 4 && a.payloadVersion.Minor >= 23)) {
+		args = append(args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+	}
+
 	defaultMode := int32(0640)
 	deploymentSpec := &appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
@@ -112,12 +123,7 @@ func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 						Name:            "manager",
 						Image:           image,
 						ImagePullPolicy: corev1.PullIfNotPresent,
-						Args: []string{
-							"--namespace=$(MY_NAMESPACE)",
-							"--leader-elect=true",
-							"--feature-gates=MachinePool=false,ASOAPI=false",
-							"--disable-controllers-or-webhooks=DisableASOSecretController",
-						},
+						Args:            args,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -93,7 +93,7 @@ func (a Azure) ReconcileCAPIInfraCR(
 	return azureCluster, nil
 }
 
-func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	image := a.capiProviderImage
 	if envImage := os.Getenv(images.AzureCAPIProviderEnvVar); len(envImage) > 0 {
 		image = envImage
@@ -101,6 +101,17 @@ func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIAzureProviderImage]; ok {
 		image = override
 	}
+
+	args := []string{
+		"--namespace=$(MY_NAMESPACE)",
+		"--leader-elect=true",
+		"--feature-gates=MachinePool=false,ASOAPI=false",
+		"--disable-controllers-or-webhooks=DisableASOSecretController",
+	}
+	if hcp != nil && a.payloadVersion != nil && (a.payloadVersion.Major >= 5 || (a.payloadVersion.Major == 4 && a.payloadVersion.Minor >= 23)) {
+		args = config.AppendTLSArgs(args, hcp.Spec.Configuration.GetTLSSecurityProfile())
+	}
+
 	defaultMode := int32(0640)
 	deploymentSpec := &appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
@@ -112,12 +123,7 @@ func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 						Name:            "manager",
 						Image:           image,
 						ImagePullPolicy: corev1.PullIfNotPresent,
-						Args: []string{
-							"--namespace=$(MY_NAMESPACE)",
-							"--leader-elect=true",
-							"--feature-gates=MachinePool=false,ASOAPI=false",
-							"--disable-controllers-or-webhooks=DisableASOSecretController",
-						},
+						Args:            args,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
@@ -14,8 +14,11 @@ import (
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/config"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -24,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/blang/semver"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestReconcileAzureClusterIdentity(t *testing.T) {
@@ -720,6 +724,136 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 				for _, machine := range azureMachineList.Items {
 					g.Expect(machine.Finalizers).To(Equal(tc.azureMachines[0].Finalizers), "finalizers should not be modified")
 				}
+			}
+		})
+	}
+}
+
+func buildAzureHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	return &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Configuration: &hyperv1.ClusterConfiguration{
+				APIServer: &configv1.APIServerSpec{
+					TLSSecurityProfile: tlsProfile,
+				},
+			},
+		},
+	}
+}
+
+func TestCAPIProviderDeploymentSpec(t *testing.T) {
+	defaultArgs := []string{
+		"--namespace=$(MY_NAMESPACE)",
+		"--leader-elect=true",
+		"--feature-gates=MachinePool=false,ASOAPI=false",
+		"--disable-controllers-or-webhooks=DisableASOSecretController",
+	}
+
+	defaultImage := "test-capi-image"
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		hcp            *hyperv1.HostedControlPlane
+		payloadVersion *semver.Version
+		expectedImage  string
+		expectedArgs   []string
+	}{
+		{
+			name:           "When HostedControlPlane is nil it should not append TLS args",
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedImage:  defaultImage,
+			expectedArgs:   defaultArgs,
+		},
+		{
+			name: "When version is 4.22 and HCP has TLS profile it should not append TLS args",
+			hcp: buildAzureHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.22.0")),
+			expectedImage:  defaultImage,
+			expectedArgs:   defaultArgs,
+		},
+		{
+			name: "When version is 4.23 and HCP has Modern TLS profile it should append min-version only",
+			hcp: buildAzureHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedImage:  defaultImage,
+			expectedArgs: append(defaultArgs,
+				"--tls-min-version=VersionTLS13",
+			),
+		},
+		{
+			name:           "When version is 5.0 and HCP has custom TLS profile it should append custom TLS args",
+			hcp:            buildAzureHostedControlPlane(customTLSProfile),
+			payloadVersion: ptr.To(semver.MustParse("5.0.0")),
+			expectedImage:  defaultImage,
+			expectedArgs: append(defaultArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			platform := Azure{
+				capiProviderImage: tc.expectedImage,
+				payloadVersion:    tc.payloadVersion,
+			}
+			spec, err := platform.CAPIProviderDeploymentSpec(&hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+					},
+				},
+			}, tc.hcp)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if spec == nil {
+				t.Fatal("expected deployment spec, got nil")
+			}
+			if len(spec.Template.Spec.Containers) == 0 {
+				t.Fatal("expected at least 1 container, got 0")
+			}
+
+			var managerContainer *corev1.Container
+			for i := range spec.Template.Spec.Containers {
+				if spec.Template.Spec.Containers[i].Name == "manager" {
+					managerContainer = &spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+			if managerContainer == nil {
+				t.Fatal("manager container not found")
+			}
+
+			if managerContainer.Image != tc.expectedImage {
+				t.Errorf("expected image %s, got %s", tc.expectedImage, managerContainer.Image)
+			}
+
+			if diff := cmp.Diff(managerContainer.Args, tc.expectedArgs); diff != "" {
+				t.Errorf("args differ (-got +want):\n%s", diff)
 			}
 		})
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/gcputil"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/k8sutil"
@@ -177,7 +178,7 @@ func (p GCP) reconcileGCPCluster(gcpCluster *capigcp.GCPCluster, hcluster *hyper
 // CAPIProviderDeploymentSpec implements CAPG controller deployment specification.
 // This method creates a deployment spec for the CAPG (Cluster API Provider GCP)
 // controller with proper image handling, feature gates, and WIF preparation.
-func (p GCP) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p GCP) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	// Validate GCP platform configuration is present
 	if hcluster.Spec.Platform.GCP == nil {
 		return nil, fmt.Errorf("GCP platform configuration is missing")
@@ -207,6 +208,9 @@ func (p GCP) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hype
 		"--leader-elect=true",
 		fmt.Sprintf("--feature-gates=%s", strings.Join(featureGates, ",")),
 		"--v=2",
+	}
+	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
+		args = append(args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
 	}
 
 	containers := []corev1.Container{

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/gcputil"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/k8sutil"
@@ -177,7 +178,7 @@ func (p GCP) reconcileGCPCluster(gcpCluster *capigcp.GCPCluster, hcluster *hyper
 // CAPIProviderDeploymentSpec implements CAPG controller deployment specification.
 // This method creates a deployment spec for the CAPG (Cluster API Provider GCP)
 // controller with proper image handling, feature gates, and WIF preparation.
-func (p GCP) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p GCP) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	// Validate GCP platform configuration is present
 	if hcluster.Spec.Platform.GCP == nil {
 		return nil, fmt.Errorf("GCP platform configuration is missing")
@@ -207,6 +208,9 @@ func (p GCP) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hype
 		"--leader-elect=true",
 		fmt.Sprintf("--feature-gates=%s", strings.Join(featureGates, ",")),
 		"--v=2",
+	}
+	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
+		args = config.AppendTLSArgs(args, hcp.Spec.Configuration.GetTLSSecurityProfile())
 	}
 
 	containers := []corev1.Container{

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_test.go
@@ -8,6 +8,8 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -19,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/blang/semver"
+	"github.com/google/go-cmp/cmp"
 )
 
 const (
@@ -415,4 +418,112 @@ func TestReconcileGCPClusterPreservesServerDefaultedFields(t *testing.T) {
 	g.Expect(gcpCluster.Spec.Network.Name).To(Equal(ptr.To("test-network")))
 	g.Expect(gcpCluster.Spec.Network.Subnets[0].Name).To(Equal("test-subnet"))
 	g.Expect(gcpCluster.Spec.Network.Subnets[0].Region).To(Equal("us-central1"))
+}
+
+func buildGCPHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	return &hyperv1.HostedControlPlane{
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Configuration: &hyperv1.ClusterConfiguration{
+				APIServer: &configv1.APIServerSpec{
+					TLSSecurityProfile: tlsProfile,
+				},
+			},
+		},
+	}
+}
+
+func TestCAPIProviderDeploymentSpecWithTLS(t *testing.T) {
+	defaultArgs := []string{
+		"--namespace=$(MY_NAMESPACE)",
+		"--leader-elect=true",
+		"--feature-gates=MachinePool=false",
+		"--v=2",
+	}
+
+	defaultUtilitiesImage := "test-utilities-image"
+	defaultCapgImage := "test-capg-image"
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		hcp            *hyperv1.HostedControlPlane
+		payloadVersion *semver.Version
+		expectedArgs   []string
+	}{
+		{
+			name:           "When HostedControlPlane is nil it should not append TLS args",
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedArgs:   defaultArgs,
+		},
+		{
+			name: "When version is 4.22 and HCP has TLS profile it should not append TLS args",
+			hcp: buildGCPHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.22.0")),
+			expectedArgs:   defaultArgs,
+		},
+		{
+			name: "When version is 4.23 and HCP has Modern TLS profile it should append min-version only",
+			hcp: buildGCPHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedArgs: append(defaultArgs,
+				"--tls-min-version=VersionTLS13",
+			),
+		},
+		{
+			name:           "When version is 5.0 and HCP has custom TLS profile it should append custom TLS args",
+			hcp:            buildGCPHostedControlPlane(customTLSProfile),
+			payloadVersion: ptr.To(semver.MustParse("5.0.0")),
+			expectedArgs: append(defaultArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			platform := New(defaultUtilitiesImage, defaultCapgImage, tc.payloadVersion)
+			spec, err := platform.CAPIProviderDeploymentSpec(
+				&hyperv1.HostedCluster{
+					Spec: hyperv1.HostedClusterSpec{
+						Platform: hyperv1.PlatformSpec{
+							Type: hyperv1.GCPPlatform,
+							GCP:  &hyperv1.GCPPlatformSpec{},
+						},
+					},
+				},
+				tc.hcp,
+			)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if spec == nil {
+				t.Fatal("expected deployment spec, got nil")
+			}
+			if len(spec.Template.Spec.Containers) == 0 {
+				t.Fatal("expected at least 1 container, got 0")
+			}
+
+			if diff := cmp.Diff(spec.Template.Spec.Containers[0].Args, tc.expectedArgs); diff != "" {
+				t.Errorf("args differ (-got +want):\n%s", diff)
+			}
+		})
+	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
 
@@ -21,6 +22,7 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/blang/semver"
 	cdicore "kubevirt.io/containerized-data-importer-api/pkg/apis/core"
 )
 
@@ -28,7 +30,15 @@ const (
 	hostedClusterAnnotation = "hypershift.openshift.io/cluster"
 )
 
-type Kubevirt struct{}
+type Kubevirt struct {
+	payloadVersion *semver.Version
+}
+
+func New(payloadVersion *semver.Version) *Kubevirt {
+	return &Kubevirt{
+		payloadVersion: payloadVersion,
+	}
+}
 
 func (p Kubevirt) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
 	hcluster *hyperv1.HostedCluster,
@@ -68,7 +78,7 @@ func reconcileKubevirtCluster(kubevirtCluster *capikubevirt.KubevirtCluster, hcl
 	kubevirtCluster.Status.Ready = true
 }
 
-func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := ""
 	if envImage := os.Getenv(images.KubevirtCAPIProviderEnvVar); len(envImage) > 0 {
 		providerImage = envImage
@@ -79,6 +89,16 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ 
 	if providerImage == "" {
 		return nil, fmt.Errorf("kubevirt CAPI provider image not specified by environment variable %s or annotation %s", images.KubevirtCAPIProviderEnvVar, hyperv1.ClusterAPIKubeVirtProviderImage)
 	}
+
+	args := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--v=4",
+		"--leader-elect=true",
+	}
+	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
+		args = append(args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+	}
+
 	defaultMode := int32(0640)
 	return &appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
@@ -131,11 +151,7 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ 
 							},
 						},
 						Command: []string{"/manager"},
-						Args: []string{
-							"--namespace", "$(MY_NAMESPACE)",
-							"--v=4",
-							"--leader-elect=true",
-						},
+						Args:    args,
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "healthz",

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
 
@@ -21,6 +22,7 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/blang/semver"
 	cdicore "kubevirt.io/containerized-data-importer-api/pkg/apis/core"
 )
 
@@ -28,7 +30,15 @@ const (
 	hostedClusterAnnotation = "hypershift.openshift.io/cluster"
 )
 
-type Kubevirt struct{}
+type Kubevirt struct {
+	payloadVersion *semver.Version
+}
+
+func New(payloadVersion *semver.Version) *Kubevirt {
+	return &Kubevirt{
+		payloadVersion: payloadVersion,
+	}
+}
 
 func (p Kubevirt) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
 	hcluster *hyperv1.HostedCluster,
@@ -68,7 +78,7 @@ func reconcileKubevirtCluster(kubevirtCluster *capikubevirt.KubevirtCluster, hcl
 	kubevirtCluster.Status.Ready = true
 }
 
-func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := ""
 	if envImage := os.Getenv(images.KubevirtCAPIProviderEnvVar); len(envImage) > 0 {
 		providerImage = envImage
@@ -79,6 +89,16 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ 
 	if providerImage == "" {
 		return nil, fmt.Errorf("kubevirt CAPI provider image not specified by environment variable %s or annotation %s", images.KubevirtCAPIProviderEnvVar, hyperv1.ClusterAPIKubeVirtProviderImage)
 	}
+
+	args := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--v=4",
+		"--leader-elect=true",
+	}
+	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
+		args = config.AppendTLSArgs(args, hcp.Spec.Configuration.GetTLSSecurityProfile())
+	}
+
 	defaultMode := int32(0640)
 	return &appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
@@ -131,11 +151,7 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ 
 							},
 						},
 						Command: []string{"/manager"},
-						Args: []string{
-							"--namespace", "$(MY_NAMESPACE)",
-							"--v=4",
-							"--leader-elect=true",
-						},
+						Args:    args,
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "healthz",

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt_test.go
@@ -7,8 +7,12 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
+	configv1 "github.com/openshift/api/config/v1"
+
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -16,11 +20,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/blang/semver"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestReconcileCAPIInfraCR(t *testing.T) {
-	kubevirt := Kubevirt{}
+	kubevirt := New(nil)
 	fakeClient := fake.NewClientBuilder().Build()
 	testNamespace := "testNamespace"
 	hcluster := &hyperv1.HostedCluster{
@@ -95,7 +100,7 @@ func TestReconcileCAPIInfraCR(t *testing.T) {
 }
 
 func TestReconcileCredentials(t *testing.T) {
-	kubevirt := Kubevirt{}
+	kubevirt := New(nil)
 	fakeClient := fake.NewClientBuilder().Build()
 	fnCallsCount := 0
 	createOrUpdateFN := func(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
@@ -113,7 +118,7 @@ func TestReconcileCredentials(t *testing.T) {
 }
 
 func TestReconcileSecretEncryption(t *testing.T) {
-	kubevirt := Kubevirt{}
+	kubevirt := New(nil)
 	fakeClient := fake.NewClientBuilder().Build()
 	fnCallsCount := 0
 	createOrUpdateFN := func(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
@@ -127,5 +132,123 @@ func TestReconcileSecretEncryption(t *testing.T) {
 	}
 	if fnCallsCount > 0 {
 		t.Fatalf("create or update func should not be called")
+	}
+}
+
+func buildKubeVirtHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	return &hyperv1.HostedControlPlane{
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Configuration: &hyperv1.ClusterConfiguration{
+				APIServer: &configv1.APIServerSpec{
+					TLSSecurityProfile: tlsProfile,
+				},
+			},
+		},
+	}
+}
+
+func TestCAPIProviderDeploymentSpec(t *testing.T) {
+	defaultArgs := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--v=4",
+		"--leader-elect=true",
+	}
+
+	defaultImage := "test-capi-image"
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		hcp            *hyperv1.HostedControlPlane
+		payloadVersion *semver.Version
+		expectedArgs   []string
+	}{
+		{
+			name:           "When HostedControlPlane is nil it should not append TLS args",
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedArgs:   defaultArgs,
+		},
+		{
+			name: "When version is 4.22 and HCP has TLS profile it should not append TLS args",
+			hcp: buildKubeVirtHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.22.0")),
+			expectedArgs:   defaultArgs,
+		},
+		{
+			name: "When version is 4.23 and HCP has Modern TLS profile it should append min-version only",
+			hcp: buildKubeVirtHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedArgs: append(defaultArgs,
+				"--tls-min-version=VersionTLS13",
+			),
+		},
+		{
+			name:           "When version is 5.0 and HCP has custom TLS profile it should append custom TLS args",
+			hcp:            buildKubeVirtHostedControlPlane(customTLSProfile),
+			payloadVersion: ptr.To(semver.MustParse("5.0.0")),
+			expectedArgs: append(defaultArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			platform := New(tc.payloadVersion)
+			spec, err := platform.CAPIProviderDeploymentSpec(&hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						hyperv1.ClusterAPIKubeVirtProviderImage: defaultImage,
+					},
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+					},
+				},
+			}, tc.hcp)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if spec == nil {
+				t.Fatal("expected deployment spec, got nil")
+			}
+			if len(spec.Template.Spec.Containers) == 0 {
+				t.Fatal("expected at least 1 container, got 0")
+			}
+
+			var managerContainer *corev1.Container
+			for i := range spec.Template.Spec.Containers {
+				if spec.Template.Spec.Containers[i].Name == "manager" {
+					managerContainer = &spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+			if managerContainer == nil {
+				t.Fatal("manager container not found")
+			}
+
+			if diff := cmp.Diff(managerContainer.Args, tc.expectedArgs); diff != "" {
+				t.Errorf("args differ (-got +want):\n%s", diff)
+			}
+		})
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
@@ -7,6 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/openstackutil"
 	"github.com/openshift/hypershift/support/upsert"
@@ -174,7 +175,7 @@ func reconcileOpenStackClusterSpec(hcluster *hyperv1.HostedCluster, openStackClu
 	return nil
 }
 
-func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	capoImage := a.capiProviderImage
 	if envImage := os.Getenv(images.OpenStackCAPIProviderEnvVar); len(envImage) > 0 {
 		capoImage = envImage
@@ -189,6 +190,25 @@ func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _
 	if override, ok := hcluster.Annotations[hyperv1.OpenStackResourceControllerImage]; ok {
 		orcImage = override
 	}
+
+	capoArgs := []string{
+		"--namespace=$(MY_NAMESPACE)",
+		"--leader-elect",
+		"--v=2",
+		// HyperShift runs CAPO in a namespace-scoped deployment and manages CRDs
+		// itself. CAPO v0.14 introduced a crdmigrator controller that requires
+		// cluster-scoped RBAC (list openstackclusteridentities, patch
+		// customresourcedefinitions) that we do not and cannot grant. Skipping
+		// all phases causes crdmigrator.SetupWithManager to return early without
+		// registering the controller, eliminating the spurious RBAC errors.
+		"--skip-crd-migration-phases=StorageVersionMigration",
+		"--skip-crd-migration-phases=CleanupManagedFields",
+	}
+
+	if hcp != nil && a.payloadVersion != nil && (a.payloadVersion.Major >= 5 || (a.payloadVersion.Major == 4 && a.payloadVersion.Minor >= 23)) {
+		capoArgs = append(capoArgs, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+	}
+
 	allowPrivilegeEscalation := false
 	defaultMode := int32(0640)
 	deploymentSpec := appsv1.DeploymentSpec{
@@ -221,19 +241,7 @@ func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _
 					Image:           capoImage,
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         []string{"/manager"},
-					Args: []string{
-						"--namespace=$(MY_NAMESPACE)",
-						"--leader-elect",
-						"--v=2",
-						// HyperShift runs CAPO in a namespace-scoped deployment and manages CRDs
-						// itself. CAPO v0.14 introduced a crdmigrator controller that requires
-						// cluster-scoped RBAC (list openstackclusteridentities, patch
-						// customresourcedefinitions) that we do not and cannot grant. Skipping
-						// all phases causes crdmigrator.SetupWithManager to return early without
-						// registering the controller, eliminating the spurious RBAC errors.
-						"--skip-crd-migration-phases=StorageVersionMigration",
-						"--skip-crd-migration-phases=CleanupManagedFields",
-					},
+					Args:            capoArgs,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
@@ -7,6 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/openstackutil"
 	"github.com/openshift/hypershift/support/upsert"
@@ -174,7 +175,7 @@ func reconcileOpenStackClusterSpec(hcluster *hyperv1.HostedCluster, openStackClu
 	return nil
 }
 
-func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	capoImage := a.capiProviderImage
 	if envImage := os.Getenv(images.OpenStackCAPIProviderEnvVar); len(envImage) > 0 {
 		capoImage = envImage
@@ -189,6 +190,25 @@ func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _
 	if override, ok := hcluster.Annotations[hyperv1.OpenStackResourceControllerImage]; ok {
 		orcImage = override
 	}
+
+	capoArgs := []string{
+		"--namespace=$(MY_NAMESPACE)",
+		"--leader-elect",
+		"--v=2",
+		// HyperShift runs CAPO in a namespace-scoped deployment and manages CRDs
+		// itself. CAPO v0.14 introduced a crdmigrator controller that requires
+		// cluster-scoped RBAC (list openstackclusteridentities, patch
+		// customresourcedefinitions) that we do not and cannot grant. Skipping
+		// all phases causes crdmigrator.SetupWithManager to return early without
+		// registering the controller, eliminating the spurious RBAC errors.
+		"--skip-crd-migration-phases=StorageVersionMigration",
+		"--skip-crd-migration-phases=CleanupManagedFields",
+	}
+
+	if hcp != nil && a.payloadVersion != nil && (a.payloadVersion.Major >= 5 || (a.payloadVersion.Major == 4 && a.payloadVersion.Minor >= 23)) {
+		capoArgs = config.AppendTLSArgs(capoArgs, hcp.Spec.Configuration.GetTLSSecurityProfile())
+	}
+
 	allowPrivilegeEscalation := false
 	defaultMode := int32(0640)
 	deploymentSpec := appsv1.DeploymentSpec{
@@ -221,19 +241,7 @@ func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _
 					Image:           capoImage,
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         []string{"/manager"},
-					Args: []string{
-						"--namespace=$(MY_NAMESPACE)",
-						"--leader-elect",
-						"--v=2",
-						// HyperShift runs CAPO in a namespace-scoped deployment and manages CRDs
-						// itself. CAPO v0.14 introduced a crdmigrator controller that requires
-						// cluster-scoped RBAC (list openstackclusteridentities, patch
-						// customresourcedefinitions) that we do not and cannot grant. Skipping
-						// all phases causes crdmigrator.SetupWithManager to return early without
-						// registering the controller, eliminating the spurious RBAC errors.
-						"--skip-crd-migration-phases=StorageVersionMigration",
-						"--skip-crd-migration-phases=CleanupManagedFields",
-					},
+					Args:            capoArgs,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack_test.go
@@ -7,6 +7,8 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/api/util/ipnet"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -243,7 +245,105 @@ func TestReconcileOpenStackCluster(t *testing.T) {
 	}
 }
 
+func buildDeploymentSpec(managerArgs []string, additionalContainers ...corev1.Container) *appsv1.DeploymentSpec {
+	return &appsv1.DeploymentSpec{
+		Replicas: ptr.To[int32](1),
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				TerminationGracePeriodSeconds: ptr.To[int64](10),
+				Volumes: []corev1.Volume{
+					{
+						Name: "capi-webhooks-tls",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								DefaultMode: ptr.To[int32](0640),
+								SecretName:  "capi-webhooks-tls",
+							},
+						},
+					},
+					{
+						Name: "svc-kubeconfig",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								DefaultMode: ptr.To[int32](0640),
+								SecretName:  "service-network-admin-kubeconfig",
+							},
+						},
+					},
+				},
+				Containers: append([]corev1.Container{
+					{
+						Name:            "manager",
+						Image:           "capi-provider-image",
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Command:         []string{"/manager"},
+						Args:            managerArgs,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("10Mi"),
+							},
+						},
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "healthz",
+								ContainerPort: 9440,
+								Protocol:      corev1.ProtocolTCP,
+							},
+						},
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/healthz",
+									Port: intstr.FromString("healthz"),
+								},
+							},
+						},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/readyz",
+									Port: intstr.FromString("healthz"),
+								},
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "capi-webhooks-tls",
+								ReadOnly:  true,
+								MountPath: "/tmp/k8s-webhook-server/serving-certs",
+							},
+							{
+								Name:      "svc-kubeconfig",
+								MountPath: "/etc/kubernetes",
+							},
+						},
+						Env: []corev1.EnvVar{
+							{
+								Name: "MY_NAMESPACE",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.namespace",
+									},
+								},
+							},
+						},
+					},
+				}, additionalContainers...),
+			},
+		},
+	}
+}
+
 func TestCAPIProviderDeploymentSpec(t *testing.T) {
+	defaultArgs := []string{
+		"--namespace=$(MY_NAMESPACE)",
+		"--leader-elect",
+		"--v=2",
+		"--skip-crd-migration-phases=StorageVersionMigration",
+		"--skip-crd-migration-phases=CleanupManagedFields",
+	}
+
 	testCases := []struct {
 		name           string
 		hcluster       *hyperv1.HostedCluster
@@ -268,99 +368,9 @@ func TestCAPIProviderDeploymentSpec(t *testing.T) {
 				},
 			},
 			payloadVersion: ptr.To(semver.MustParse("4.18.0")),
-			expectedSpec: &appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](1),
-				Template: corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						TerminationGracePeriodSeconds: ptr.To[int64](10),
-						Volumes: []corev1.Volume{
-							{
-								Name: "capi-webhooks-tls",
-								VolumeSource: corev1.VolumeSource{
-									Secret: &corev1.SecretVolumeSource{
-										DefaultMode: ptr.To[int32](0640),
-										SecretName:  "capi-webhooks-tls",
-									},
-								},
-							},
-							{
-								Name: "svc-kubeconfig",
-								VolumeSource: corev1.VolumeSource{
-									Secret: &corev1.SecretVolumeSource{
-										DefaultMode: ptr.To[int32](0640),
-										SecretName:  "service-network-admin-kubeconfig",
-									},
-								},
-							},
-						},
-						Containers: []corev1.Container{{
-							Name:            "manager",
-							Image:           "capi-provider-image",
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Command:         []string{"/manager"},
-							Args: []string{
-								"--namespace=$(MY_NAMESPACE)",
-								"--leader-elect",
-								"--v=2",
-								"--skip-crd-migration-phases=StorageVersionMigration",
-								"--skip-crd-migration-phases=CleanupManagedFields",
-							},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("10m"),
-									corev1.ResourceMemory: resource.MustParse("10Mi"),
-								},
-							},
-							Ports: []corev1.ContainerPort{
-								{
-									Name:          "healthz",
-									ContainerPort: 9440,
-									Protocol:      corev1.ProtocolTCP,
-								},
-							},
-							LivenessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/healthz",
-										Port: intstr.FromString("healthz"),
-									},
-								},
-							},
-							ReadinessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/readyz",
-										Port: intstr.FromString("healthz"),
-									},
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "capi-webhooks-tls",
-									ReadOnly:  true,
-									MountPath: "/tmp/k8s-webhook-server/serving-certs",
-								},
-								{
-									Name:      "svc-kubeconfig",
-									MountPath: "/etc/kubernetes",
-								},
-							},
-							Env: []corev1.EnvVar{
-								{
-									Name: "MY_NAMESPACE",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
-									},
-								},
-							},
-						}},
-					},
-				},
-			},
-			expectedErr: false,
-			envVars:     map[string]string{},
+			expectedSpec:   buildDeploymentSpec(defaultArgs),
+			expectedErr:    false,
+			envVars:        map[string]string{},
 		},
 		{
 			name: "deployment spec on 4.19.0 (with ORC)",
@@ -378,159 +388,66 @@ func TestCAPIProviderDeploymentSpec(t *testing.T) {
 				},
 			},
 			payloadVersion: ptr.To(semver.MustParse("4.19.0")),
-			expectedSpec: &appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](1),
-				Template: corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						TerminationGracePeriodSeconds: ptr.To[int64](10),
-						Volumes: []corev1.Volume{
-							{
-								Name: "capi-webhooks-tls",
-								VolumeSource: corev1.VolumeSource{
-									Secret: &corev1.SecretVolumeSource{
-										DefaultMode: ptr.To[int32](0640),
-										SecretName:  "capi-webhooks-tls",
-									},
-								},
-							},
-							{
-								Name: "svc-kubeconfig",
-								VolumeSource: corev1.VolumeSource{
-									Secret: &corev1.SecretVolumeSource{
-										DefaultMode: ptr.To[int32](0640),
-										SecretName:  "service-network-admin-kubeconfig",
-									},
-								},
-							},
+			expectedSpec: buildDeploymentSpec(defaultArgs, corev1.Container{
+				Name:            "orc-manager",
+				Image:           "orc-image",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Command:         []string{"/manager"},
+				Args: []string{
+					"--namespace=$(MY_NAMESPACE)",
+					"--leader-elect",
+					"--health-probe-bind-address=:8081",
+					"--zap-log-level=4",
+				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: ptr.To(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{
+							"ALL",
 						},
-						Containers: []corev1.Container{
-							{
-								Name:            "manager",
-								Image:           "capi-provider-image",
-								ImagePullPolicy: corev1.PullIfNotPresent,
-								Command:         []string{"/manager"},
-								Args: []string{
-									"--namespace=$(MY_NAMESPACE)",
-									"--leader-elect",
-									"--v=2",
-									"--skip-crd-migration-phases=StorageVersionMigration",
-									"--skip-crd-migration-phases=CleanupManagedFields",
-								},
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("10m"),
-										corev1.ResourceMemory: resource.MustParse("10Mi"),
-									},
-								},
-								Ports: []corev1.ContainerPort{
-									{
-										Name:          "healthz",
-										ContainerPort: 9440,
-										Protocol:      corev1.ProtocolTCP,
-									},
-								},
-								LivenessProbe: &corev1.Probe{
-									ProbeHandler: corev1.ProbeHandler{
-										HTTPGet: &corev1.HTTPGetAction{
-											Path: "/healthz",
-											Port: intstr.FromString("healthz"),
-										},
-									},
-								},
-								ReadinessProbe: &corev1.Probe{
-									ProbeHandler: corev1.ProbeHandler{
-										HTTPGet: &corev1.HTTPGetAction{
-											Path: "/readyz",
-											Port: intstr.FromString("healthz"),
-										},
-									},
-								},
-								VolumeMounts: []corev1.VolumeMount{
-									{
-										Name:      "capi-webhooks-tls",
-										ReadOnly:  true,
-										MountPath: "/tmp/k8s-webhook-server/serving-certs",
-									},
-									{
-										Name:      "svc-kubeconfig",
-										MountPath: "/etc/kubernetes",
-									},
-								},
-								Env: []corev1.EnvVar{
-									{
-										Name: "MY_NAMESPACE",
-										ValueFrom: &corev1.EnvVarSource{
-											FieldRef: &corev1.ObjectFieldSelector{
-												FieldPath: "metadata.namespace",
-											},
-										},
-									},
-								},
-							},
-							{
-								Name:            "orc-manager",
-								Image:           "orc-image",
-								ImagePullPolicy: corev1.PullIfNotPresent,
-								Command:         []string{"/manager"},
-								Args: []string{
-									"--namespace=$(MY_NAMESPACE)",
-									"--leader-elect",
-									"--health-probe-bind-address=:8081",
-									"--zap-log-level=4",
-								},
-								SecurityContext: &corev1.SecurityContext{
-									AllowPrivilegeEscalation: ptr.To(false),
-									Capabilities: &corev1.Capabilities{
-										Drop: []corev1.Capability{
-											"ALL",
-										},
-									},
-								},
-								LivenessProbe: &corev1.Probe{
-									ProbeHandler: corev1.ProbeHandler{
-										HTTPGet: &corev1.HTTPGetAction{
-											Path: "/healthz",
-											Port: intstr.FromInt(8081),
-										},
-									},
-									InitialDelaySeconds: 15,
-									PeriodSeconds:       20,
-								},
-								ReadinessProbe: &corev1.Probe{
-									ProbeHandler: corev1.ProbeHandler{
-										HTTPGet: &corev1.HTTPGetAction{
-											Path: "/readyz",
-											Port: intstr.FromInt(8081),
-										},
-									},
-									InitialDelaySeconds: 5,
-									PeriodSeconds:       10,
-								},
-								Resources: corev1.ResourceRequirements{
-									Limits: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("500m"),
-										corev1.ResourceMemory: resource.MustParse("128Mi"),
-									},
-									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("10m"),
-										corev1.ResourceMemory: resource.MustParse("64Mi"),
-									},
-								},
-								Env: []corev1.EnvVar{
-									{
-										Name: "MY_NAMESPACE",
-										ValueFrom: &corev1.EnvVarSource{
-											FieldRef: &corev1.ObjectFieldSelector{
-												FieldPath: "metadata.namespace",
-											},
-										},
-									},
-								},
+					},
+				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/healthz",
+							Port: intstr.FromInt(8081),
+						},
+					},
+					InitialDelaySeconds: 15,
+					PeriodSeconds:       20,
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/readyz",
+							Port: intstr.FromInt(8081),
+						},
+					},
+					InitialDelaySeconds: 5,
+					PeriodSeconds:       10,
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
+					},
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name: "MY_NAMESPACE",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.namespace",
 							},
 						},
 					},
 				},
-			},
+			}),
 			expectedErr: false,
 			envVars:     map[string]string{},
 		},
@@ -560,6 +477,126 @@ func TestCAPIProviderDeploymentSpec(t *testing.T) {
 				if diff := cmp.Diff(tc.expectedSpec, result); diff != "" {
 					t.Errorf("reconciled CAPO Provider DeploymentSpec differs from expected spec: %s", diff)
 				}
+			}
+		})
+	}
+}
+
+func buildOpenStackHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	return &hyperv1.HostedControlPlane{
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Configuration: &hyperv1.ClusterConfiguration{
+				APIServer: &configv1.APIServerSpec{
+					TLSSecurityProfile: tlsProfile,
+				},
+			},
+		},
+	}
+}
+
+func TestCAPIProviderDeploymentSpecWithTLS(t *testing.T) {
+	defaultArgs := []string{
+		"--namespace=$(MY_NAMESPACE)",
+		"--leader-elect",
+		"--v=2",
+		"--skip-crd-migration-phases=StorageVersionMigration",
+		"--skip-crd-migration-phases=CleanupManagedFields",
+	}
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		hcp            *hyperv1.HostedControlPlane
+		payloadVersion *semver.Version
+		expectedArgs   []string
+	}{
+		{
+			name:           "When HostedControlPlane is nil it should not append TLS args",
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedArgs:   defaultArgs,
+		},
+		{
+			name: "When version is 4.22 and HCP has TLS profile it should not append TLS args",
+			hcp: buildOpenStackHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.22.0")),
+			expectedArgs:   defaultArgs,
+		},
+		{
+			name: "When version is 4.23 and HCP has Modern TLS profile it should append min-version only",
+			hcp: buildOpenStackHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedArgs: append(defaultArgs,
+				"--tls-min-version=VersionTLS13",
+			),
+		},
+		{
+			name:           "When version is 5.0 and HCP has custom TLS profile it should append custom TLS args",
+			hcp:            buildOpenStackHostedControlPlane(customTLSProfile),
+			payloadVersion: ptr.To(semver.MustParse("5.0.0")),
+			expectedArgs: append(defaultArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			platform := OpenStack{
+				capiProviderImage: "test-capi-image",
+				orcImage:          "test-orc-image",
+				payloadVersion:    tc.payloadVersion,
+			}
+			spec, err := platform.CAPIProviderDeploymentSpec(&hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						OpenStack: &hyperv1.OpenStackPlatformSpec{},
+					},
+				},
+			}, tc.hcp)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if spec == nil {
+				t.Fatal("expected deployment spec, got nil")
+			}
+			if len(spec.Template.Spec.Containers) == 0 {
+				t.Fatal("expected at least 1 container, got 0")
+			}
+
+			var managerContainer *corev1.Container
+			for i := range spec.Template.Spec.Containers {
+				if spec.Template.Spec.Containers[i].Name == "manager" {
+					managerContainer = &spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+			if managerContainer == nil {
+				t.Fatal("manager container not found")
+			}
+
+			if diff := cmp.Diff(managerContainer.Args, tc.expectedArgs); diff != "" {
+				t.Errorf("args differ (-got +want):\n%s", diff)
 			}
 		})
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -117,9 +117,21 @@ func GetPlatform(ctx context.Context, hcluster *hyperv1.HostedCluster, releasePr
 	case hyperv1.NonePlatform:
 		platform = &none.None{}
 	case hyperv1.AgentPlatform:
-		platform = &agent.Agent{}
+		if pullSecretBytes != nil {
+			payloadVersion, err = imgUtil.GetPayloadVersion(ctx, releaseProvider, hcluster, pullSecretBytes)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch payload version: %w", err)
+			}
+		}
+		platform = agent.New(payloadVersion)
 	case hyperv1.KubevirtPlatform:
-		platform = &kubevirt.Kubevirt{}
+		if pullSecretBytes != nil {
+			payloadVersion, err = imgUtil.GetPayloadVersion(ctx, releaseProvider, hcluster, pullSecretBytes)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch payload version: %w", err)
+			}
+		}
+		platform = kubevirt.New(payloadVersion)
 	case hyperv1.AzurePlatform:
 		if pullSecretBytes != nil {
 			capiImageProvider, err = imgUtil.GetPayloadImage(ctx, releaseProvider, hcluster, AzureCAPIProvider, pullSecretBytes)
@@ -139,8 +151,12 @@ func GetPlatform(ctx context.Context, hcluster *hyperv1.HostedCluster, releasePr
 			if err != nil {
 				return nil, fmt.Errorf("failed to retrieve capi image: %w", err)
 			}
+			payloadVersion, err = imgUtil.GetPayloadVersion(ctx, releaseProvider, hcluster, pullSecretBytes)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch payload version: %w", err)
+			}
 		}
-		platform = powervs.New(capiImageProvider)
+		platform = powervs.New(capiImageProvider, payloadVersion)
 	case hyperv1.OpenStackPlatform:
 		if pullSecretBytes != nil {
 			capiImageProvider, err = imgUtil.GetPayloadImage(ctx, releaseProvider, hcluster, OpenStackCAPIProvider, pullSecretBytes)

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
 
@@ -20,16 +21,20 @@ import (
 	capiibmv1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/blang/semver"
 )
 
-func New(capiProviderImage string) *PowerVS {
+func New(capiProviderImage string, payloadVersion *semver.Version) *PowerVS {
 	return &PowerVS{
 		capiProviderImage: capiProviderImage,
+		payloadVersion:    payloadVersion,
 	}
 }
 
 type PowerVS struct {
 	capiProviderImage string
+	payloadVersion    *semver.Version
 }
 
 func (p PowerVS) DeleteCredentials(ctx context.Context, c client.Client, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error {
@@ -75,7 +80,7 @@ func (p PowerVS) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, crea
 	return ibmCluster, nil
 }
 
-func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	defaultMode := int32(416)
 
 	providerImage := p.capiProviderImage
@@ -84,6 +89,15 @@ func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *
 	}
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIPowerVSProviderImage]; ok {
 		providerImage = override
+	}
+
+	args := []string{"--namespace", "$(MY_NAMESPACE)",
+		"--v=4",
+		"--leader-elect=true",
+		"--provider-id-fmt=v2",
+	}
+	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
+		args = append(args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
 	}
 
 	deploymentSpec := &appsv1.DeploymentSpec{
@@ -146,11 +160,7 @@ func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *
 							},
 						},
 						Command: []string{"/bin/cluster-api-provider-ibmcloud-controller-manager"},
-						Args: []string{"--namespace", "$(MY_NAMESPACE)",
-							"--v=4",
-							"--leader-elect=true",
-							"--provider-id-fmt=v2",
-						},
+						Args:    args,
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "healthz",

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
 
@@ -20,16 +21,20 @@ import (
 	capiibmv1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/blang/semver"
 )
 
-func New(capiProviderImage string) *PowerVS {
+func New(capiProviderImage string, payloadVersion *semver.Version) *PowerVS {
 	return &PowerVS{
 		capiProviderImage: capiProviderImage,
+		payloadVersion:    payloadVersion,
 	}
 }
 
 type PowerVS struct {
 	capiProviderImage string
+	payloadVersion    *semver.Version
 }
 
 func (p PowerVS) DeleteCredentials(ctx context.Context, c client.Client, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error {
@@ -75,7 +80,7 @@ func (p PowerVS) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, crea
 	return ibmCluster, nil
 }
 
-func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	defaultMode := int32(416)
 
 	providerImage := p.capiProviderImage
@@ -84,6 +89,15 @@ func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *
 	}
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIPowerVSProviderImage]; ok {
 		providerImage = override
+	}
+
+	args := []string{"--namespace", "$(MY_NAMESPACE)",
+		"--v=4",
+		"--leader-elect=true",
+		"--provider-id-fmt=v2",
+	}
+	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
+		args = config.AppendTLSArgs(args, hcp.Spec.Configuration.GetTLSSecurityProfile())
 	}
 
 	deploymentSpec := &appsv1.DeploymentSpec{
@@ -146,11 +160,7 @@ func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *
 							},
 						},
 						Command: []string{"/bin/cluster-api-provider-ibmcloud-controller-manager"},
-						Args: []string{"--namespace", "$(MY_NAMESPACE)",
-							"--v=4",
-							"--leader-elect=true",
-							"--provider-id-fmt=v2",
-						},
+						Args:    args,
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "healthz",

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs_test.go
@@ -1,0 +1,129 @@
+package powervs
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/blang/semver"
+	"github.com/google/go-cmp/cmp"
+)
+
+func buildPowerVSHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {
+	return &hyperv1.HostedControlPlane{
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Configuration: &hyperv1.ClusterConfiguration{
+				APIServer: &configv1.APIServerSpec{
+					TLSSecurityProfile: tlsProfile,
+				},
+			},
+		},
+	}
+}
+
+func TestCAPIProviderDeploymentSpec(t *testing.T) {
+	defaultArgs := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--v=4",
+		"--leader-elect=true",
+		"--provider-id-fmt=v2",
+	}
+
+	customTLSProfile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		hcp            *hyperv1.HostedControlPlane
+		payloadVersion *semver.Version
+		expectedArgs   []string
+	}{
+		{
+			name:           "When HostedControlPlane is nil it should not append TLS args",
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedArgs:   defaultArgs,
+		},
+		{
+			name: "When version is 4.22 and HCP has TLS profile it should not append TLS args",
+			hcp: buildPowerVSHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.22.0")),
+			expectedArgs:   defaultArgs,
+		},
+		{
+			name: "When version is 4.23 and HCP has Modern TLS profile it should append min-version only",
+			hcp: buildPowerVSHostedControlPlane(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			payloadVersion: ptr.To(semver.MustParse("4.23.0")),
+			expectedArgs: append(defaultArgs,
+				"--tls-min-version=VersionTLS13",
+			),
+		},
+		{
+			name:           "When version is 5.0 and HCP has custom TLS profile it should append custom TLS args",
+			hcp:            buildPowerVSHostedControlPlane(customTLSProfile),
+			payloadVersion: ptr.To(semver.MustParse("5.0.0")),
+			expectedArgs: append(defaultArgs,
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			platform := New("", tc.payloadVersion)
+			hcluster := &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type:    hyperv1.PowerVSPlatform,
+						PowerVS: &hyperv1.PowerVSPlatformSpec{},
+					},
+				},
+			}
+			spec, err := platform.CAPIProviderDeploymentSpec(hcluster, tc.hcp)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if spec == nil {
+				t.Fatal("expected deployment spec, got nil")
+			}
+			if len(spec.Template.Spec.Containers) == 0 {
+				t.Fatal("expected at least 1 container, got 0")
+			}
+
+			var managerContainer *corev1.Container
+			for i := range spec.Template.Spec.Containers {
+				if spec.Template.Spec.Containers[i].Name == "manager" {
+					managerContainer = &spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+			if managerContainer == nil {
+				t.Fatal("manager container not found")
+			}
+
+			if diff := cmp.Diff(managerContainer.Args, tc.expectedArgs); diff != "" {
+				t.Errorf("args differ (-got +want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/support/config/cipher.go
+++ b/support/config/cipher.go
@@ -3,6 +3,8 @@ package config
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
+	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/crypto"
@@ -123,4 +125,14 @@ func SetCipherSuitesUsingAPIServer(apiServerConfig *configv1.APIServer) (func(*t
 	return func(tlsConfig *tls.Config) {
 		tlsConfig.CipherSuites = suites
 	}, nil
+}
+
+func AppendTLSArgs(args []string, profile *configv1.TLSSecurityProfile) []string {
+	if tlsMinVersion := MinTLSVersion(profile); tlsMinVersion != "" {
+		args = append(args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+	}
+	if cipherSuites := CipherSuites(profile); len(cipherSuites) != 0 {
+		args = append(args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+	}
+	return args
 }

--- a/support/config/cipher_test.go
+++ b/support/config/cipher_test.go
@@ -254,3 +254,98 @@ func TestSupportedEtcdCipherSuites(t *testing.T) {
 		})
 	}
 }
+
+func TestAppendTLSArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputArgs    []string
+		profile      *configv1.TLSSecurityProfile
+		expectedArgs []string
+	}{
+		{
+			name:      "When profile is nil it should append intermediate defaults",
+			inputArgs: []string{"--namespace=test"},
+			profile:   nil,
+			expectedArgs: []string{
+				"--namespace=test",
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			},
+		},
+		{
+			name:      "When using Modern profile it should append only min-version",
+			inputArgs: []string{"--namespace=test"},
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedArgs: []string{
+				"--namespace=test",
+				"--tls-min-version=VersionTLS13",
+			},
+		},
+		{
+			name:      "When using Intermediate profile it should append min-version and cipher-suites",
+			inputArgs: []string{"--namespace=test"},
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectedArgs: []string{
+				"--namespace=test",
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			},
+		},
+		{
+			name:      "When using Custom profile with specific ciphers it should append custom TLS args",
+			inputArgs: []string{"--namespace=test"},
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"ECDHE-RSA-AES128-GCM-SHA256",
+						},
+					},
+				},
+			},
+			expectedArgs: []string{
+				"--namespace=test",
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			},
+		},
+		{
+			name:      "When input args is empty it should work correctly",
+			inputArgs: []string{},
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedArgs: []string{
+				"--tls-min-version=VersionTLS13",
+			},
+		},
+		{
+			name:      "When using Old profile it should append min-version and cipher-suites",
+			inputArgs: []string{},
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			expectedArgs: []string{
+				"--tls-min-version=VersionTLS10",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result := AppendTLSArgs(test.inputArgs, test.profile)
+
+			g.Expect(result).To(Equal(test.expectedArgs))
+		})
+	}
+}

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// TLSArgs returns TLS-related command-line arguments for a given TLS security profile.
+// It returns a slice of strings containing --tls-min-version and --tls-cipher-suites flags
+// based on the provided profile. The caller is responsible for appending these to their
+// argument list using the spread operator (...).
+func TLSArgs(profile *configv1.TLSSecurityProfile) []string {
+	var tlsArgs []string
+	if tlsMinVersion := MinTLSVersion(profile); tlsMinVersion != "" {
+		tlsArgs = append(tlsArgs, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+	}
+	if cipherSuites := CipherSuites(profile); len(cipherSuites) != 0 {
+		tlsArgs = append(tlsArgs, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+	}
+	return tlsArgs
+}

--- a/support/config/deployment_test.go
+++ b/support/config/deployment_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestTLSArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		profile      *configv1.TLSSecurityProfile
+		expectedArgs []string
+	}{
+		{
+			name:    "When profile is nil it should return intermediate defaults",
+			profile: nil,
+			expectedArgs: []string{
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			},
+		},
+		{
+			name: "When using Modern profile it should return only min-version",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedArgs: []string{
+				"--tls-min-version=VersionTLS13",
+			},
+		},
+		{
+			name: "When using Intermediate profile it should return min-version and cipher-suites",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectedArgs: []string{
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			},
+		},
+		{
+			name: "When using Custom profile with specific ciphers it should return custom TLS args",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"ECDHE-RSA-AES128-GCM-SHA256",
+						},
+					},
+				},
+			},
+			expectedArgs: []string{
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			},
+		},
+		{
+			name: "When using Old profile it should return min-version and cipher-suites",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			expectedArgs: []string{
+				"--tls-min-version=VersionTLS10",
+				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result := TLSArgs(test.profile)
+
+			g.Expect(result).To(Equal(test.expectedArgs))
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

- have all cloud-controller-manager providers honor the centralized TLS configuration
- have all capi-provider deployments honor the centralized TLS configuration

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud provider controllers now automatically apply TLS security profile settings.
  * When configured, deployments set the minimum TLS version and cipher suites (comma-delimited) for both the cloud controller manager and the platform manager components.
  * Supported across AWS, Azure, GCP, KubeVirt, OpenStack, and PowerVS.
* **Chores**
  * Improved CLI argument construction to apply TLS flags consistently across providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->