### PR TITLE
CNTRLPLANE-3616: setting min-tls-version for the konnectivity-server container

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -229,6 +229,7 @@ spec:
         - 30s
         - --server-count
         - "3"
+        - --tls-min-version=VersionTLS12
         - --cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/proxy-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/GCP/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/GCP/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -233,6 +233,7 @@ spec:
         - 30s
         - --server-count
         - "3"
+        - --tls-min-version=VersionTLS12
         - --cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/proxy-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -223,6 +223,7 @@ spec:
         - 30s
         - --server-count
         - "3"
+        - --tls-min-version=VersionTLS12
         - --cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/proxy-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -223,6 +223,7 @@ spec:
         - 30s
         - --server-count
         - "3"
+        - --tls-min-version=VersionTLS12
         - --cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/proxy-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -223,6 +223,7 @@ spec:
         - 30s
         - --server-count
         - "3"
+        - --tls-min-version=VersionTLS12
         - --cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/proxy-server

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment.go
@@ -71,10 +71,16 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			strconv.Itoa(int(serverCount)),
 		)
 
+		minTLSVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile())
+		if len(minTLSVersion) != 0 {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", minTLSVersion))
+		}
+
 		cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile())
 		if len(cipherSuites) != 0 {
 			c.Args = append(c.Args, fmt.Sprintf("--cipher-suites=%s", strings.Join(cipherSuites, ",")))
 		}
+
 	})
 
 	payloadVersion := cpContext.UserReleaseImageProvider.Version()

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment_test.go
@@ -1,6 +1,7 @@
 package kas
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -8,9 +9,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/testutil"
 
 	configv1 "github.com/openshift/api/config/v1"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -286,6 +290,140 @@ func TestApplyAWSPodIdentityWebhookContainer(t *testing.T) {
 			podSpec := &corev1.PodSpec{}
 			applyAWSPodIdentityWebhookContainer(podSpec, tc.hcp)
 			tc.validatePod(g, podSpec)
+		})
+	}
+}
+
+func TestKonnectivityServerTLSMinVersion(t *testing.T) {
+	testCases := []struct {
+		name           string
+		hcp            *hyperv1.HostedControlPlane
+		expectedMinTLS string
+	}{
+		{
+			name:           "When TLS security profile is nil it should use default Intermediate profile for konnectivity-server",
+			expectedMinTLS: "VersionTLS12",
+			hcp:            &hyperv1.HostedControlPlane{},
+		},
+		{
+			name:           "When TLS security profile is Old it should set TLS 1.0 for konnectivity-server",
+			expectedMinTLS: "VersionTLS10",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: &configv1.TLSSecurityProfile{
+								Type: configv1.TLSProfileOldType,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "When TLS security profile is Intermediate it should set TLS 1.2 for konnectivity-server",
+			expectedMinTLS: "VersionTLS12",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: &configv1.TLSSecurityProfile{
+								Type: configv1.TLSProfileIntermediateType,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "When TLS security profile is Modern it should set TLS 1.3 for konnectivity-server",
+			expectedMinTLS: "VersionTLS13",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: &configv1.TLSSecurityProfile{
+								Type: configv1.TLSProfileModernType,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "When TLS security profile is Custom with TLS 1.2 it should set TLS 1.2 for konnectivity-server",
+			expectedMinTLS: "VersionTLS12",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: &configv1.TLSSecurityProfile{
+								Type: configv1.TLSProfileCustomType,
+								Custom: &configv1.CustomTLSProfile{
+									TLSProfileSpec: configv1.TLSProfileSpec{
+										MinTLSVersion: configv1.VersionTLS12,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "When TLS security profile is Custom with TLS 1.3 it should set TLS 1.3 for konnectivity-server",
+			expectedMinTLS: "VersionTLS13",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: &configv1.TLSSecurityProfile{
+								Type: configv1.TLSProfileCustomType,
+								Custom: &configv1.CustomTLSProfile{
+									TLSProfileSpec: configv1.TLSProfileSpec{
+										MinTLSVersion: configv1.VersionTLS13,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			cpContext := component.WorkloadContext{
+				HCP:                      tc.hcp,
+				UserReleaseImageProvider: testutil.FakeImageProvider(),
+			}
+
+			deployment := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "konnectivity-server",
+									Image: "konnectivity-server:latest",
+									Args:  []string{},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := adaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			container := findContainerByNameInPod(&deployment.Spec.Template.Spec, "konnectivity-server")
+			g.Expect(container).NotTo(BeNil())
+			expected := fmt.Sprintf("--tls-min-version=%s", tc.expectedMinTLS)
+			g.Expect(container.Args).To(ContainElement(expected))
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:

This PR uses the `HostedCluster` object to determine appropriate values for the `--min-tls-version` flag on the `konnectivity-server` container (`kube-apiserver` sidecar). Expected cipher suites were already provided for the same container.

```
apiserver-network-proxy$ ./bin/proxy-server --help 2>&1 | grep tls
      --tls-min-version string               Minimum TLS version for server connections. Accepted values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. Empty defaults to VersionTLS12.
apiserver-network-proxy$
```

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Control plane deployments can now automatically set a minimum TLS version for the konnectivity server based on the configured TLS security profile.
* **Bug Fixes**
  * TLS-related konnectivity server arguments are now generated more completely; existing cipher suite behavior is unchanged.
* **Tests**
  * Added unit coverage to verify the correct `konnectivity-server` TLS minimum version flag is applied across supported TLS security profile variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->