### PR TITLE
NO-JIRA: Add missing verify targets to GitHub Actions workflow

### DIFF
--- a/.github/workflows/verify-reusable.yaml
+++ b/.github/workflows/verify-reusable.yaml
@@ -14,11 +14,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
+      - run: |
+          if [ -n "${{ github.base_ref }}" ]; then
+            git fetch origin "${{ github.base_ref }}:${{ github.base_ref }}"
+          fi
       - run: make generate update
       - run: make staticcheck
       - run: make fmt
       - run: make vet
+      - run: make verify-api-deps
+      - run: make verify-crd-schema
+      - run: make verify-docs-nav
       - run: |
           git update-index --refresh
           git diff-index --cached --quiet --ignore-submodules HEAD --

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The following guidelines will help ensure a smooth contribution process for both
 
 3. **Review before submitting**: Look at your changes from a reviewer's perspective and explain anything that might not be immediately clear in your PR description.
 
-4. **Use proper commit format**: 
+4. **Use proper commit format**:
     1. Write commit subjects in [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) (e.g., "Fix bug" not "Fixed bug")
     2. Follow [conventional commit format](https://www.conventionalcommits.org/) and include "Why" and "How" in commit messages
 
@@ -33,6 +33,10 @@ The following guidelines will help ensure a smooth contribution process for both
 ### CI
 
 This project uses [Prow](https://docs.ci.openshift.org/) and [GitHub Actions](https://github.com/openshift/hypershift/actions) for CI. Lightweight checks (linting, unit tests, verification) run automatically on pushes and pull requests. E2E tests that consume real cloud infrastructure only run after a reviewer grants `/lgtm`, to avoid unnecessary resource usage on work-in-progress PRs.
+
+**Adding CI targets:** When you add a new `make` target to `verify-parallel` or any other CI-facing Makefile target, you must also add it to the corresponding GitHub Actions workflow (e.g., `.github/workflows/verify-reusable.yaml` for verify targets, or as a new "reusable" target). GitHub Actions provide fast feedback on PRs; Prow runs heavier e2e tests. Targets that only exist in the Makefile without a matching GH Actions step will not run in CI.
+
+See hack/github-actions-runner/README.md for details.
 
 Useful Prow commands:
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -106,12 +106,12 @@ nav:
       - 'CI Pipeline Configuration': how-to/ci/v2-testing/ci-pipeline.md
       - 'Debugging CI Failures': how-to/ci/v2-testing/debugging.md
       - 'Migrating from V1': how-to/ci/v2-testing/migration.md
+  - 'Cluster Capabilities': how-to/cluster-capabilities.md
   - 'Common':
     - how-to/common/exposing-services-from-hcp.md
     - 'Global Pull Secret': how-to/common/global-pull-secret.md
     - 'HCP Networking Requirements': how-to/common/hcp-networking-requirements.md
     - how-to/common/multi-arch-on-hcp.md
-  - 'Cluster Capabilities': how-to/cluster-capabilities.md
   - how-to/metrics-sets.md
   - 'Configure OCP components':
     - how-to/configure-ocp-components/index.md


### PR DESCRIPTION
## Summary

- Add `verify-api-deps`, `verify-crd-schema`, and `verify-docs-nav` to the `verify-reusable.yaml` GitHub Actions workflow so they run on PRs instead of only in Prow
- Enable full git history fetch (`fetch-depth: 0`) needed by `verify-crd-schema` for CRD schema comparison against the base branch
- Fix `docs/mkdocs.yml` nav ordering (`Cluster Capabilities` before `Common`) caught by `verify-docs-nav`
- Add guidance in `CONTRIBUTING.md` that new Makefile CI targets must have a matching GitHub Actions workflow step

## Test plan

- [x] `make verify-docs-nav` passes locally after the mkdocs.yml fix
- [ ] GH Actions verify workflow runs the three new steps on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contributor guide with clearer PR submission and CI expectations.
  * Adjusted the documentation navigation order for easier browsing.

* **Chores**
  * Expanded automated verification to use full repository history and run additional checks during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->