### PR TITLE
OCPBUGS-91650: disable consolidation in karpenter upgrade test

### DIFF
--- a/test/e2e/karpenter_control_plane_upgrade_test.go
+++ b/test/e2e/karpenter_control_plane_upgrade_test.go
@@ -42,6 +42,12 @@ func TestKarpenterUpgradeControlPlane(t *testing.T) {
 		guestClient := e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
 
 		karpenterNodePool := baseNodePool("on-demand", "default")
+		// TODO(maxcao13): We disable consolidation as a hack to prevent flakiness in this blocking test.
+		// Erroneous consolidation can cause the test to fail where the new Node is consolidated due to Empty or
+		// Underutilized before the old node's pods get scheduled to it. The proper fix should come from upstream
+		// Karpenter's disruption ordering/budgeting logic. Ref: https://redhat.atlassian.net/browse/OCPBUGS-91966
+		karpenterNodePool.Spec.Disruption.ConsolidateAfter = karpenterv1.MustParseNillableDuration("Never")
+
 		replicas := 1
 		nodeLabels := map[string]string{
 			karpenterv1.NodePoolLabelKey: karpenterNodePool.Name,


### PR DESCRIPTION
## What this PR does / why we need it:

We disable consolidation as a hack to prevent flakiness in the karpenter_control_plane_upgrade suite and test. Erroenous consolidation can cause the test to fail where the new Node is consolidated by Karpenter due to Empty or Underutilized before the old node's pods get scheduled to it.

We should discuss the actual problem/fix separately in the upstream. Ref: https://redhat.atlassian.net/browse/OCPBUGS-91966. For now this should prevent flaky test failures blocking PRs from merging.

## Which issue(s) this PR fixes:
Fixes https://redhat.atlassian.net/browse/OCPBUGS-91650

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an end-to-end upgrade test to reduce flakiness during control plane upgrade validation.
  * Adjusted the test’s node pool behavior to avoid consolidation-related interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->