### PR TITLE
NO-JIRA: fix(e2e-v2): gate ConfigOperatorReconciliationSucceeded on 4.23+

### DIFF
--- a/test/e2e/v2/tests/hosted_cluster_health_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_health_test.go
@@ -62,6 +62,9 @@ func ValidateHostedClusterConditionsTest(getTestCtx internal.TestContextGetter) 
 				delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
 				delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkPolicyRBAC)
 			}
+			if e2eutil.IsLessThan(e2eutil.Version423) {
+				delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
+			}
 
 			Eventually(func(g Gomega) {
 				hc := &hyperv1.HostedCluster{}


### PR DESCRIPTION
## Summary

- The v2 health test unconditionally expects `ConfigOperatorReconciliationSucceeded`, which was introduced in PR #8340 for 4.23+
- The v1 test already gates this with `IsLessThan(Version423)`, but the v2 test was missing the same check
- This causes `e2e-v2-aws` failures on all release-4.22 PRs since the condition doesn't exist on 4.22 clusters

## Test plan

- [ ] Verify `e2e-v2-aws` passes on release-4.22 PRs after this merges
- [ ] Verify `e2e-v2-aws` still passes on main (4.23+ clusters should have the condition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated hosted cluster health checks to align expected conditions with older platform versions, reducing false failures when validating version-specific hosted cluster behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->