### PR TITLE
OCPBUGS-94178: Remove --skip-crd-migration-phases flags from CAPI deployment

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-api/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-api/deployment.yaml
@@ -28,8 +28,6 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-retry-period=26s
         - --leader-elect-renew-deadline=107s
-        - --skip-crd-migration-phases=StorageVersionMigration
-        - --skip-crd-migration-phases=CleanupManagedFields
         env:
         - name: MY_NAMESPACE
           valueFrom:

--- a/hypershift-operator/controllers/hostedcluster/testdata/cluster-api/zz_fixture_TestReconcileComponents.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/cluster-api/zz_fixture_TestReconcileComponents.yaml
@@ -68,8 +68,6 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-retry-period=26s
         - --leader-elect-renew-deadline=107s
-        - --skip-crd-migration-phases=StorageVersionMigration
-        - --skip-crd-migration-phases=CleanupManagedFields
         env:
         - name: MY_NAMESPACE
           valueFrom:


### PR DESCRIPTION
## Summary
- Removes `--skip-crd-migration-phases=StorageVersionMigration` and `--skip-crd-migration-phases=CleanupManagedFields` flags from the core CAPI deployment template
- These flags were introduced in PR #8687 but are not supported by older CAPI images shipped with earlier OCP releases, causing the CAPI controller to fail to start
- The OpenStack-specific CAPO deployment retains the flags since CAPO v0.14 supports them
- The flags should be re-added later conditionally based on CAPI version support

## Test plan
- [x] `make test` passes
- [x] `make verify` passes
- [ ] Verify CAPI controller starts successfully on older OCP clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the cluster API controller startup settings so it no longer skips CRD migration-related phases. This helps ensure migration and cleanup steps run as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->