### PR TITLE
ROSAENG-14082: --dump-guest-cluster option can now optionally be supplied with policies

### DIFF
--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -70,9 +71,15 @@ import (
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
+// DumpGuestClusterPolicy controls guest-cluster dump behavior.
+// Policies which can be parsed as a bool are not supported.
+type DumpGuestClusterPolicy string
+
 const (
-	hypershiftNamespace = "hypershift"
-	kubevirtNamespace   = "openshift-cnv"
+	hypershiftNamespace                               = "hypershift"
+	kubevirtNamespace                                 = "openshift-cnv"
+	DirectKubeApiServiceAccess DumpGuestClusterPolicy = "direct-kube-api-service-access"
+	FailOnError                DumpGuestClusterPolicy = "fail-on-error"
 )
 
 var (
@@ -115,6 +122,11 @@ var (
 		&prometheusoperatorv1.ServiceMonitor{},
 		&prometheusoperatorv1.PodMonitor{},
 	}
+
+	allowedDumpGuestClusterPolicies = map[DumpGuestClusterPolicy]struct{}{
+		DirectKubeApiServiceAccess: {},
+		FailOnError:                {},
+	}
 )
 
 type DumpOptions struct {
@@ -129,8 +141,8 @@ type DumpOptions struct {
 	// are located, when using the agent platform.
 	AgentNamespace string
 
-	DumpGuestCluster                   bool
-	DumpGuestClusterThroughKubeService bool
+	IsDumpingGuestCluster    bool
+	DumpGuestClusterPolicies map[DumpGuestClusterPolicy]struct{}
 
 	ImpersonateAs string
 
@@ -140,6 +152,10 @@ type DumpOptions struct {
 type DumpCallback func(ctx context.Context, opts *DumpOptions) error
 
 func NewDumpCommand(dumpCallback DumpCallback) *cobra.Command {
+	const defaultDumpGuestClusterPolicy = "default-policy" // Not a real policy, placeholder to allow --dump-guest-cluster to be specified without a value
+	var dumpGuestClusterFlag string
+	var dumpGuestClusterThroughKubeService bool
+
 	cmd := &cobra.Command{
 		Use:          "cluster",
 		Short:        "Dumps hostedcluster diagnostic info",
@@ -147,12 +163,13 @@ func NewDumpCommand(dumpCallback DumpCallback) *cobra.Command {
 	}
 
 	opts := &DumpOptions{
-		Namespace:      "clusters",
-		Name:           "example",
-		ArtifactDir:    "",
-		ArchiveDump:    true,
-		AgentNamespace: "",
-		Log:            log.Log,
+		Namespace:                "clusters",
+		Name:                     "example",
+		ArtifactDir:              "",
+		ArchiveDump:              true,
+		AgentNamespace:           "",
+		DumpGuestClusterPolicies: map[DumpGuestClusterPolicy]struct{}{},
+		Log:                      log.Log,
 	}
 
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace of the hostedcluster to dump")
@@ -161,14 +178,42 @@ func NewDumpCommand(dumpCallback DumpCallback) *cobra.Command {
 	cmd.Flags().StringVar(&opts.ArtifactDir, "artifact-dir", opts.ArtifactDir, "Destination directory for dump files")
 	cmd.Flags().BoolVar(&opts.ArchiveDump, "archive-dump", opts.ArchiveDump, "Create a tar archive of the artifact directory")
 	cmd.Flags().StringVar(&opts.AgentNamespace, "agent-namespace", opts.AgentNamespace, "For agent platform, the namespace where the agents are located")
-	cmd.Flags().BoolVar(&opts.DumpGuestCluster, "dump-guest-cluster", opts.DumpGuestCluster, "Dump data plane content as well")
-	cmd.Flags().BoolVar(&opts.DumpGuestClusterThroughKubeService, "dump-guest-cluster-through-kube-service", opts.DumpGuestClusterThroughKubeService,
-		"Dump data plane content through the kube-apiserver service (to be used within MC clusters for which debug handlers are disabled)")
+	cmd.Flags().StringVar(&dumpGuestClusterFlag, "dump-guest-cluster", "", "Dump data plane content as well. "+
+		"Optionally takes an argument, a comma separated list of policies, here are the possible values: "+
+		"'"+string(DirectKubeApiServiceAccess)+"' tells the hypershift CLI to directly access the kube API service of the hosted cluster without port-forwarding it; "+
+		"this is only possible if the hypershift CLI is run from within a cluster; this is suitable if this (management) cluster has its debug handlers disabled. "+
+		"'"+string(FailOnError)+"' makes the hypershift CLI exit in error if the dump fails instead of just logging a warning.")
+	// Deprecated, replaced by --dump-guest-cluster direct-kube-api-service-access
+	cmd.Flags().BoolVar(&dumpGuestClusterThroughKubeService, "dump-guest-cluster-through-kube-service", false, "")
 
 	_ = cmd.MarkFlagRequired("artifact-dir")
+	cmd.Flags().Lookup("dump-guest-cluster").NoOptDefVal = defaultDumpGuestClusterPolicy // allow to set --dump-guest-cluster without a value
 	cmd.MarkFlagsMutuallyExclusive("dump-guest-cluster", "dump-guest-cluster-through-kube-service")
+	_ = cmd.Flags().MarkDeprecated("dump-guest-cluster-through-kube-service", "use --dump-guest-cluster=direct-kube-api-service-access instead")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		isDumpingGuestCluster, err := strconv.ParseBool(dumpGuestClusterFlag)
+		if err == nil {
+			// Backward compatibility: when --dump-guest-cluster used to be a boolean flag
+			opts.IsDumpingGuestCluster = isDumpingGuestCluster
+		} else if len(dumpGuestClusterFlag) > 0 {
+			opts.IsDumpingGuestCluster = true
+
+			if dumpGuestClusterFlag != defaultDumpGuestClusterPolicy {
+				for _, policy := range strings.Split(dumpGuestClusterFlag, ",") {
+					if _, ok := allowedDumpGuestClusterPolicies[DumpGuestClusterPolicy(policy)]; !ok {
+						return fmt.Errorf("unsupported --dump-guest-cluster policy: %v", policy)
+					}
+					opts.DumpGuestClusterPolicies[DumpGuestClusterPolicy(policy)] = struct{}{}
+				}
+			}
+		}
+
+		if dumpGuestClusterThroughKubeService {
+			opts.IsDumpingGuestCluster = true
+			opts.DumpGuestClusterPolicies[DirectKubeApiServiceAccess] = struct{}{}
+		}
+
 		return dumpCallback(cmd.Context(), opts)
 	}
 	return cmd
@@ -224,7 +269,7 @@ func dumpGuestCluster(ctx context.Context, opts *DumpOptions) error {
 	var localPort int
 	var forwarderStop chan struct{}
 
-	if opts.DumpGuestClusterThroughKubeService {
+	if _, ok := opts.DumpGuestClusterPolicies[DirectKubeApiServiceAccess]; ok {
 		localPort = -1 // Indicates connection via kube-apiserver service instead of port-forward
 	} else {
 		localPort = rand.IntN(45000-32767) + 32767
@@ -504,8 +549,11 @@ func DumpCluster(ctx context.Context, opts *DumpOptions) error {
 
 	gatherNetworkLogs(ocCommand, controlPlaneNamespace, opts.ArtifactDir, ctx, c, opts.Log)
 
-	if opts.DumpGuestCluster || opts.DumpGuestClusterThroughKubeService {
+	if opts.IsDumpingGuestCluster {
 		if err = dumpGuestCluster(ctx, opts); err != nil {
+			if _, ok := opts.DumpGuestClusterPolicies[FailOnError]; ok {
+				return fmt.Errorf("failed to dump guest cluster: %w", err)
+			}
 			opts.Log.Error(err, "Failed to dump guest cluster")
 		}
 	}

--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -137,7 +137,9 @@ type DumpOptions struct {
 	Log logr.Logger
 }
 
-func NewDumpCommand() *cobra.Command {
+type DumpCallback func(ctx context.Context, opts *DumpOptions) error
+
+func NewDumpCommand(dumpCallback DumpCallback) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "cluster",
 		Short:        "Dumps hostedcluster diagnostic info",
@@ -167,15 +169,15 @@ func NewDumpCommand() *cobra.Command {
 	cmd.MarkFlagsMutuallyExclusive("dump-guest-cluster", "dump-guest-cluster-through-kube-service")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		return dumpClusterWithRetry(cmd.Context(), opts)
+		return dumpCallback(cmd.Context(), opts)
 	}
 	return cmd
 }
 
-// dumpClusterWithRetry retries DumpCluster on a fixed 5-second interval until
+// DumpClusterWithRetry retries DumpCluster on a fixed 5-second interval until
 // it succeeds or the context is canceled. Every error is treated as retryable —
 // the caller controls the deadline via the context.
-func dumpClusterWithRetry(ctx context.Context, opts *DumpOptions) error {
+func DumpClusterWithRetry(ctx context.Context, opts *DumpOptions) error {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 

--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -137,7 +137,9 @@ type DumpOptions struct {
 	Log logr.Logger
 }
 
-func NewDumpCommand() *cobra.Command {
+type DumpCallback func(ctx context.Context, opts *DumpOptions) error
+
+func NewDumpCommand(dumpCallback DumpCallback) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "cluster",
 		Short:        "Dumps hostedcluster diagnostic info",
@@ -167,7 +169,7 @@ func NewDumpCommand() *cobra.Command {
 	cmd.MarkFlagsMutuallyExclusive("dump-guest-cluster", "dump-guest-cluster-through-kube-service")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if err := DumpCluster(cmd.Context(), opts); err != nil {
+		if err := dumpCallback(cmd.Context(), opts); err != nil {
 			opts.Log.Error(err, "Error")
 			return err
 		}

--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -70,9 +71,15 @@ import (
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
+// DumpGuestClusterPolicy controls guest-cluster dump behavior.
+// Policies which can be parsed as a bool are not supported.
+type DumpGuestClusterPolicy string
+
 const (
-	hypershiftNamespace = "hypershift"
-	kubevirtNamespace   = "openshift-cnv"
+	hypershiftNamespace                               = "hypershift"
+	kubevirtNamespace                                 = "openshift-cnv"
+	DirectKubeApiServiceAccess DumpGuestClusterPolicy = "direct-kube-api-service-access"
+	FailOnError                DumpGuestClusterPolicy = "fail-on-error"
 )
 
 var (
@@ -115,6 +122,11 @@ var (
 		&prometheusoperatorv1.ServiceMonitor{},
 		&prometheusoperatorv1.PodMonitor{},
 	}
+
+	allowedDumpGuestClusterPolicies = map[DumpGuestClusterPolicy]struct{}{
+		DirectKubeApiServiceAccess: {},
+		FailOnError:                {},
+	}
 )
 
 type DumpOptions struct {
@@ -129,8 +141,8 @@ type DumpOptions struct {
 	// are located, when using the agent platform.
 	AgentNamespace string
 
-	DumpGuestCluster                   bool
-	DumpGuestClusterThroughKubeService bool
+	IsDumpingGuestCluster    bool
+	DumpGuestClusterPolicies map[DumpGuestClusterPolicy]struct{}
 
 	ImpersonateAs string
 
@@ -140,6 +152,10 @@ type DumpOptions struct {
 type DumpCallback func(ctx context.Context, opts *DumpOptions) error
 
 func NewDumpCommand(dumpCallback DumpCallback) *cobra.Command {
+	const defaultDumpGuestClusterPolicy = "default-policy" // Not a real policy, placeholder to allow --dump-guest-cluster to be specified without a value
+	var dumpGuestClusterFlag string
+	var dumpGuestClusterThroughKubeService bool
+
 	cmd := &cobra.Command{
 		Use:          "cluster",
 		Short:        "Dumps hostedcluster diagnostic info",
@@ -147,12 +163,13 @@ func NewDumpCommand(dumpCallback DumpCallback) *cobra.Command {
 	}
 
 	opts := &DumpOptions{
-		Namespace:      "clusters",
-		Name:           "example",
-		ArtifactDir:    "",
-		ArchiveDump:    true,
-		AgentNamespace: "",
-		Log:            log.Log,
+		Namespace:                "clusters",
+		Name:                     "example",
+		ArtifactDir:              "",
+		ArchiveDump:              true,
+		AgentNamespace:           "",
+		DumpGuestClusterPolicies: map[DumpGuestClusterPolicy]struct{}{},
+		Log:                      log.Log,
 	}
 
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace of the hostedcluster to dump")
@@ -161,14 +178,42 @@ func NewDumpCommand(dumpCallback DumpCallback) *cobra.Command {
 	cmd.Flags().StringVar(&opts.ArtifactDir, "artifact-dir", opts.ArtifactDir, "Destination directory for dump files")
 	cmd.Flags().BoolVar(&opts.ArchiveDump, "archive-dump", opts.ArchiveDump, "Create a tar archive of the artifact directory")
 	cmd.Flags().StringVar(&opts.AgentNamespace, "agent-namespace", opts.AgentNamespace, "For agent platform, the namespace where the agents are located")
-	cmd.Flags().BoolVar(&opts.DumpGuestCluster, "dump-guest-cluster", opts.DumpGuestCluster, "Dump data plane content as well")
-	cmd.Flags().BoolVar(&opts.DumpGuestClusterThroughKubeService, "dump-guest-cluster-through-kube-service", opts.DumpGuestClusterThroughKubeService,
-		"Dump data plane content through the kube-apiserver service (to be used within MC clusters for which debug handlers are disabled)")
+	cmd.Flags().StringVar(&dumpGuestClusterFlag, "dump-guest-cluster", "", "Dump data plane content as well. "+
+		"Optionally takes an argument, a comma separated list of policies, here are the possible values: "+
+		"'"+string(DirectKubeApiServiceAccess)+"' tells the hypershift CLI to directly access the kube API service of the hosted cluster without port-forwarding it; "+
+		"this is only possible if the hypershift CLI is run from within a cluster; this is suitable if this (management) cluster has its debug handlers disabled. "+
+		"'"+string(FailOnError)+"' makes the hypershift CLI exit in error if the dump fails instead of just logging a warning.")
+	// Deprecated, replaced by --dump-guest-cluster direct-kube-api-service-access
+	cmd.Flags().BoolVar(&dumpGuestClusterThroughKubeService, "dump-guest-cluster-through-kube-service", false, "")
 
 	_ = cmd.MarkFlagRequired("artifact-dir")
+	cmd.Flags().Lookup("dump-guest-cluster").NoOptDefVal = defaultDumpGuestClusterPolicy // allow to set --dump-guest-cluster without a value
 	cmd.MarkFlagsMutuallyExclusive("dump-guest-cluster", "dump-guest-cluster-through-kube-service")
+	_ = cmd.Flags().MarkDeprecated("dump-guest-cluster-through-kube-service", "use --dump-guest-cluster=direct-kube-api-service-access instead")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		isDumpingGuestCluster, err := strconv.ParseBool(dumpGuestClusterFlag)
+		if err == nil {
+			// Backward compatibility: when --dump-guest-cluster used to be a boolean flag
+			opts.IsDumpingGuestCluster = isDumpingGuestCluster
+		} else if len(dumpGuestClusterFlag) > 0 {
+			opts.IsDumpingGuestCluster = true
+
+			if dumpGuestClusterFlag != defaultDumpGuestClusterPolicy {
+				for _, policy := range strings.Split(dumpGuestClusterFlag, ",") {
+					if _, ok := allowedDumpGuestClusterPolicies[DumpGuestClusterPolicy(policy)]; !ok {
+						return fmt.Errorf("unsupported --dump-guest-cluster policy: %v", policy)
+					}
+					opts.DumpGuestClusterPolicies[DumpGuestClusterPolicy(policy)] = struct{}{}
+				}
+			}
+		}
+
+		if dumpGuestClusterThroughKubeService {
+			opts.IsDumpingGuestCluster = true
+			opts.DumpGuestClusterPolicies[DirectKubeApiServiceAccess] = struct{}{}
+		}
+
 		if err := dumpCallback(cmd.Context(), opts); err != nil {
 			opts.Log.Error(err, "Error")
 			return err
@@ -201,7 +246,7 @@ func dumpGuestCluster(ctx context.Context, opts *DumpOptions) error {
 	var localPort int
 	var forwarderStop chan struct{}
 
-	if opts.DumpGuestClusterThroughKubeService {
+	if _, ok := opts.DumpGuestClusterPolicies[DirectKubeApiServiceAccess]; ok {
 		localPort = -1 // Indicates connection via kube-apiserver service instead of port-forward
 	} else {
 		localPort = rand.IntN(45000-32767) + 32767
@@ -481,8 +526,11 @@ func DumpCluster(ctx context.Context, opts *DumpOptions) error {
 
 	gatherNetworkLogs(ocCommand, controlPlaneNamespace, opts.ArtifactDir, ctx, c, opts.Log)
 
-	if opts.DumpGuestCluster || opts.DumpGuestClusterThroughKubeService {
+	if opts.IsDumpingGuestCluster {
 		if err = dumpGuestCluster(ctx, opts); err != nil {
+			if _, ok := opts.DumpGuestClusterPolicies[FailOnError]; ok {
+				return fmt.Errorf("failed to dump guest cluster: %w", err)
+			}
 			opts.Log.Error(err, "Failed to dump guest cluster")
 		}
 	}

--- a/cmd/cluster/core/dump_test.go
+++ b/cmd/cluster/core/dump_test.go
@@ -31,7 +31,7 @@ func TestDumpClusterWithRetry(t *testing.T) {
 			Log:         logr.Discard(),
 		}
 
-		err := dumpClusterWithRetry(ctx, opts)
+		err := DumpClusterWithRetry(ctx, opts)
 		if err == nil {
 			t.Fatal("expected an error when context is canceled, got nil")
 		}

--- a/cmd/cluster/core/dump_test.go
+++ b/cmd/cluster/core/dump_test.go
@@ -96,3 +96,113 @@ func TestIsResourceRegistered(t *testing.T) {
 		})
 	}
 }
+
+func TestNewDumpCommand(t *testing.T) {
+	t.Run("When using the --dump-guest-cluster flag", func(t *testing.T) {
+		tests := []struct {
+			name               string
+			args               []string
+			isExpectingAnError bool
+			isExpectingADump   bool
+			expectedPolicies   []DumpGuestClusterPolicy
+		}{
+			{
+				name:               "When the flag is not set, it should not dump the guest cluster",
+				args:               []string{"--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   false,
+				expectedPolicies:   []DumpGuestClusterPolicy{},
+			},
+			{
+				name:               "When the flag is set with no policy specified, it should dump the guest cluster with no policy",
+				args:               []string{"--dump-guest-cluster", "--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   true,
+				expectedPolicies:   []DumpGuestClusterPolicy{},
+			},
+			{
+				name:               "When the flag is set with true as a value, it should dump the guest cluster with no policy",
+				args:               []string{"--dump-guest-cluster=true", "--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   true,
+				expectedPolicies:   []DumpGuestClusterPolicy{},
+			},
+			{
+				name:               "When the flag is set with false as a value, it should not dump the guest cluster",
+				args:               []string{"--dump-guest-cluster=false", "--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   false,
+				expectedPolicies:   []DumpGuestClusterPolicy{},
+			},
+			{
+				name:               "When the deprecated --dump-guest-cluster-through-kube-service flag is set instead, it should dump the guest cluster with the direct-kube-api-service-access policy",
+				args:               []string{"--dump-guest-cluster-through-kube-service", "--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   true,
+				expectedPolicies:   []DumpGuestClusterPolicy{DirectKubeApiServiceAccess},
+			},
+			{
+				name:               "When the flag is set to direct-kube-api-service-access policy, it should dump the guest cluster with this policy only",
+				args:               []string{"--dump-guest-cluster=direct-kube-api-service-access", "--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   true,
+				expectedPolicies:   []DumpGuestClusterPolicy{DirectKubeApiServiceAccess},
+			},
+			{
+				name:               "When the flag is set with all policies, it should dump the guest cluster with these policies",
+				args:               []string{"--dump-guest-cluster=direct-kube-api-service-access,fail-on-error", "--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   true,
+				expectedPolicies:   []DumpGuestClusterPolicy{DirectKubeApiServiceAccess, FailOnError},
+			},
+			{
+				name:               "When the flag is set with an invalid policy, it should return an error",
+				args:               []string{"--dump-guest-cluster=direct-kube-api-service-access,invalid-policy", "--artifact-dir", "test"},
+				isExpectingAnError: true,
+				isExpectingADump:   false,
+				expectedPolicies:   []DumpGuestClusterPolicy{},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				var capturedOpts *DumpOptions
+				cmd := NewDumpCommand(func(ctx context.Context, opts *DumpOptions) error {
+					capturedOpts = opts
+					return nil
+				})
+				cmd.SetArgs(test.args)
+				err := cmd.Execute()
+
+				if test.isExpectingAnError {
+					if err == nil {
+						t.Fatal("expected an error but got none")
+					}
+					return
+				}
+
+				if err != nil {
+					t.Fatalf("did not expect an error but got: %v", err)
+				}
+
+				if capturedOpts == nil {
+					t.Fatal("expected dump callback to be called but it wasn't")
+				}
+
+				if capturedOpts.IsDumpingGuestCluster != test.isExpectingADump {
+					t.Fatalf("expected IsDumpingGuestCluster to be %v but got %v", test.isExpectingADump, capturedOpts.IsDumpingGuestCluster)
+				}
+
+				if len(capturedOpts.DumpGuestClusterPolicies) != len(test.expectedPolicies) {
+					t.Fatalf("expected DumpGuestClusterPolicies to have length %d but got %d", len(test.expectedPolicies), len(capturedOpts.DumpGuestClusterPolicies))
+				}
+
+				for _, policy := range test.expectedPolicies {
+					if _, exists := capturedOpts.DumpGuestClusterPolicies[policy]; !exists {
+						t.Fatalf("expected DumpGuestClusterPolicies to contain policy %s but it did not", policy)
+					}
+				}
+			})
+		}
+	})
+}

--- a/cmd/cluster/core/dump_test.go
+++ b/cmd/cluster/core/dump_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -67,4 +68,114 @@ func TestIsResourceRegistered(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewDumpCommand(t *testing.T) {
+	t.Run("When using the --dump-guest-cluster flag", func(t *testing.T) {
+		tests := []struct {
+			name               string
+			args               []string
+			isExpectingAnError bool
+			isExpectingADump   bool
+			expectedPolicies   []DumpGuestClusterPolicy
+		}{
+			{
+				name:               "When the flag is not set, it should not dump the guest cluster",
+				args:               []string{"--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   false,
+				expectedPolicies:   []DumpGuestClusterPolicy{},
+			},
+			{
+				name:               "When the flag is set with no policy specified, it should dump the guest cluster with no policy",
+				args:               []string{"--dump-guest-cluster", "--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   true,
+				expectedPolicies:   []DumpGuestClusterPolicy{},
+			},
+			{
+				name:               "When the flag is set with true as a value, it should dump the guest cluster with no policy",
+				args:               []string{"--dump-guest-cluster=true", "--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   true,
+				expectedPolicies:   []DumpGuestClusterPolicy{},
+			},
+			{
+				name:               "When the flag is set with false as a value, it should not dump the guest cluster",
+				args:               []string{"--dump-guest-cluster=false", "--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   false,
+				expectedPolicies:   []DumpGuestClusterPolicy{},
+			},
+			{
+				name:               "When the deprecated --dump-guest-cluster-through-kube-service flag is set instead, it should dump the guest cluster with the direct-kube-api-service-access policy",
+				args:               []string{"--dump-guest-cluster-through-kube-service", "--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   true,
+				expectedPolicies:   []DumpGuestClusterPolicy{DirectKubeApiServiceAccess},
+			},
+			{
+				name:               "When the flag is set to direct-kube-api-service-access policy, it should dump the guest cluster with this policy only",
+				args:               []string{"--dump-guest-cluster=direct-kube-api-service-access", "--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   true,
+				expectedPolicies:   []DumpGuestClusterPolicy{DirectKubeApiServiceAccess},
+			},
+			{
+				name:               "When the flag is set with all policies, it should dump the guest cluster with these policies",
+				args:               []string{"--dump-guest-cluster=direct-kube-api-service-access,fail-on-error", "--artifact-dir", "test"},
+				isExpectingAnError: false,
+				isExpectingADump:   true,
+				expectedPolicies:   []DumpGuestClusterPolicy{DirectKubeApiServiceAccess, FailOnError},
+			},
+			{
+				name:               "When the flag is set with an invalid policy, it should return an error",
+				args:               []string{"--dump-guest-cluster=direct-kube-api-service-access,invalid-policy", "--artifact-dir", "test"},
+				isExpectingAnError: true,
+				isExpectingADump:   false,
+				expectedPolicies:   []DumpGuestClusterPolicy{},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				var capturedOpts *DumpOptions
+				cmd := NewDumpCommand(func(ctx context.Context, opts *DumpOptions) error {
+					capturedOpts = opts
+					return nil
+				})
+				cmd.SetArgs(test.args)
+				err := cmd.Execute()
+
+				if test.isExpectingAnError {
+					if err == nil {
+						t.Fatal("expected an error but got none")
+					}
+					return
+				}
+
+				if err != nil {
+					t.Fatalf("did not expect an error but got: %v", err)
+				}
+
+				if capturedOpts == nil {
+					t.Fatal("expected dump callback to be called but it wasn't")
+				}
+
+				if capturedOpts.IsDumpingGuestCluster != test.isExpectingADump {
+					t.Fatalf("expected IsDumpingGuestCluster to be %v but got %v", test.isExpectingADump, capturedOpts.IsDumpingGuestCluster)
+				}
+
+				if len(capturedOpts.DumpGuestClusterPolicies) != len(test.expectedPolicies) {
+					t.Fatalf("expected DumpGuestClusterPolicies to have length %d but got %d", len(test.expectedPolicies), len(capturedOpts.DumpGuestClusterPolicies))
+				}
+
+				for _, policy := range test.expectedPolicies {
+					if _, exists := capturedOpts.DumpGuestClusterPolicies[policy]; !exists {
+						t.Fatalf("expected DumpGuestClusterPolicies to contain policy %s but it did not", policy)
+					}
+				}
+			})
+		}
+	})
 }

--- a/cmd/dump/dump.go
+++ b/cmd/dump/dump.go
@@ -13,7 +13,7 @@ func NewCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cmd.AddCommand(core.NewDumpCommand())
+	cmd.AddCommand(core.NewDumpCommand(core.DumpCluster))
 
 	return cmd
 }

--- a/cmd/dump/dump.go
+++ b/cmd/dump/dump.go
@@ -13,7 +13,7 @@ func NewCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cmd.AddCommand(core.NewDumpCommand())
+	cmd.AddCommand(core.NewDumpCommand(core.DumpClusterWithRetry))
 
 	return cmd
 }

--- a/test/e2e/util/dump/dump.go
+++ b/test/e2e/util/dump/dump.go
@@ -24,7 +24,7 @@ import (
 // DumpHostedCluster dumps the contents of the hosted cluster to the given artifact
 // directory, and returns an error if any aspect of that operation fails. The loop
 // detector is configured to return an error when any warnings are detected.
-func DumpHostedCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedCluster, dumpGuestCluster bool, artifactDir string) error {
+func DumpHostedCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedCluster, isDumpingGuestCluster bool, dumpGuestClusterPolicies map[core.DumpGuestClusterPolicy]struct{}, artifactDir string) error {
 	dumpLogFile := filepath.Join(artifactDir, "dump.log")
 	dumpLog, err := os.Create(dumpLogFile)
 	if err != nil {
@@ -44,12 +44,13 @@ func DumpHostedCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedClus
 		}
 	}
 	err = core.DumpCluster(ctx, &core.DumpOptions{
-		Namespace:        hc.Namespace,
-		Name:             hc.Name,
-		ArtifactDir:      artifactDir,
-		LogCheckers:      []core.LogChecker{findKubeObjectUpdateLoops},
-		DumpGuestCluster: dumpGuestCluster,
-		Log:              zapr.NewLogger(dumpLogger),
+		Namespace:                hc.Namespace,
+		Name:                     hc.Name,
+		ArtifactDir:              artifactDir,
+		LogCheckers:              []core.LogChecker{findKubeObjectUpdateLoops},
+		IsDumpingGuestCluster:    isDumpingGuestCluster,
+		DumpGuestClusterPolicies: dumpGuestClusterPolicies,
+		Log:                      zapr.NewLogger(dumpLogger),
 	})
 	if err != nil {
 		allErrors = append(allErrors, fmt.Errorf("failed to dump cluster: %w", err))

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -402,12 +402,14 @@ func clusterTag(infraID string) string {
 // a cluster based on the cluster's platform. The output directory will be named
 // according to the test name. So, the returned dump function should be called
 // at most once per unique test name.
-func newClusterDumper(hc *hyperv1.HostedCluster, opts *PlatformAgnosticOptions, artifactDir string) func(ctx context.Context, t *testing.T, dumpGuestCluster bool) error {
-	return func(ctx context.Context, t *testing.T, dumpGuestCluster bool) error {
+func newClusterDumper(hc *hyperv1.HostedCluster, opts *PlatformAgnosticOptions, artifactDir string) func(ctx context.Context, t *testing.T, isDumpingGuestCluster bool) error {
+	return func(ctx context.Context, t *testing.T, isDumpingGuestCluster bool) error {
 		if len(artifactDir) == 0 {
 			t.Logf("Skipping cluster dump because no artifact directory was provided")
 			return nil
 		}
+
+		noDumpGuestClusterPolicies := make(map[core.DumpGuestClusterPolicy]struct{})
 
 		switch hc.Spec.Platform.Type {
 		case hyperv1.AWSPlatform:
@@ -416,7 +418,7 @@ func newClusterDumper(hc *hyperv1.HostedCluster, opts *PlatformAgnosticOptions, 
 			if err != nil {
 				t.Logf("Failed saving machine console logs; this is nonfatal: %v", err)
 			}
-			err = dump.DumpHostedCluster(ctx, t, hc, dumpGuestCluster, artifactDir)
+			err = dump.DumpHostedCluster(ctx, t, hc, isDumpingGuestCluster, noDumpGuestClusterPolicies, artifactDir)
 			if err != nil {
 				dumpErrors = append(dumpErrors, fmt.Errorf("failed to dump hosted cluster: %w", err))
 			}
@@ -426,7 +428,7 @@ func newClusterDumper(hc *hyperv1.HostedCluster, opts *PlatformAgnosticOptions, 
 			}
 			return utilerrors.NewAggregate(dumpErrors)
 		default:
-			err := dump.DumpHostedCluster(ctx, t, hc, dumpGuestCluster, artifactDir)
+			err := dump.DumpHostedCluster(ctx, t, hc, isDumpingGuestCluster, noDumpGuestClusterPolicies, artifactDir)
 			if err != nil {
 				return fmt.Errorf("failed to dump hosted cluster: %w", err)
 			}


### PR DESCRIPTION
## What this PR does / why we need it:

`--dump-guest-cluster-through-kube-service` is deprecated in favor of `--dump-guest-cluster=direct-kube-api-service-access`.

There is also a `fail-on-error` policy which can be supplied to `--dump-guest-cluster` to get the command end up in error in case of a problem instead of just logging it.

## Which issue(s) this PR fixes:

The stolostron docker image used by `osdctl` implements a trial and error approach due to this change:
https://github.com/stolostron/must-gather/commit/ac40038ca4ea139ccc3cc9888ae80a32331899ed

This approach makes sense but is only working if the `hypershift dump cluster` command is exiting an error when there is a problem.
In order to not add a new option, the semantic of `--dump-guest-cluster` has been twisted a bit to support policies which will tell how the dump must be performed.
The first call of the dump command in stolostron will have to be changed from:
```
if ! "${hypershift_cmd[@]}" --dump-guest-cluster; then
```
To:
```
if ! "${hypershift_cmd[@]}" --dump-guest-cluster=fail-on-error; then
```

Fixes [ROSAENG-14082](https://redhat.atlassian.net/browse/ROSAENG-14082)

## Special notes for your reviewer:

## Checklist:
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added policy-based controls for guest-cluster dumps via `--dump-guest-cluster` (comma-separated), including selectable kubeconfig connectivity mode and fail-on-error behavior.
  * Legacy boolean-style values for `--dump-guest-cluster` are still accepted; mutually exclusive guest-dump flags are enforced.
* **Bug Fixes**
  * Guest dump failures now only fail the overall dump when the fail-on-error policy is selected; otherwise they’re logged and the dump continues.
* **Deprecations**
  * `--dump-guest-cluster-through-kube-service` remains supported but maps to the direct Kubernetes API service access policy.
* **Tests**
  * Added unit tests for parsing, validation, and error handling of guest-dump policy inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->