### PR TITLE
OCPBUGS-94238: Add missing CLI IAM role policy entry

### DIFF
--- a/cmd/infra/aws/create_cli_role.go
+++ b/cmd/infra/aws/create_cli_role.go
@@ -118,6 +118,7 @@ const (
 					"iam:DeleteOpenIDConnectProvider",
 					"iam:GetRolePolicy",
 					"iam:ListAttachedRolePolicies",
+					"iam:ListRolePolicies",
 					"iam:DetachRolePolicy"
 				],
 				"Resource": "*"


### PR DESCRIPTION
Before this commit, clusters created via the CLI with `--sts-creds` couldn't be fully deleted due to a missing `iam:ListRolePolicies` policy entry, preventing IAM role cleanup.

This commit corrects the policy so all IAM resources created by the CLI flow can be deleted.

There's currently no e2e coverage for the STS flow at all, which should be addressed in a followup.

Fixes OCPBUGS-94238


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded AWS CLI role permissions to support additional IAM role policy listing during setup and management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->