### PR TITLE
GCP-503: feat(gcp): Implement OrphanDeleter

### DIFF
--- a/control-plane-operator/controllers/healthcheck/gcp.go
+++ b/control-plane-operator/controllers/healthcheck/gcp.go
@@ -1,0 +1,11 @@
+package healthcheck
+
+import (
+	"context"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+func gcpHealthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	return nil
+}

--- a/control-plane-operator/controllers/healthcheck/gcp.go
+++ b/control-plane-operator/controllers/healthcheck/gcp.go
@@ -2,10 +2,89 @@ package healthcheck
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 )
 
 func gcpHealthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	kasAvailable := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.KubeAPIServerAvailable))
+	if kasAvailable == nil || kasAvailable.Status != metav1.ConditionTrue {
+		setGCPConditions(hcp, metav1.ConditionUnknown, hyperv1.StatusUnknownReason,
+			"Cannot validate GCP credentials while KubeAPIServer is not available")
+		return nil
+	}
+
+	if hcp.Spec.Platform.GCP == nil {
+		setGCPConditions(hcp, metav1.ConditionFalse, "MissingGCPConfiguration",
+			"GCP platform configuration is missing from HostedControlPlane spec")
+		return fmt.Errorf("GCP platform configuration is missing from HostedControlPlane spec")
+	}
+
+	computeService, err := initGCPComputeClient(ctx)
+	if err != nil {
+		setGCPConditions(hcp, metav1.ConditionUnknown, hyperv1.StatusUnknownReason,
+			fmt.Sprintf("GCP compute client is not available: %v", err))
+		return nil
+	}
+
+	project := hcp.Spec.Platform.GCP.Project
+	region := hcp.Spec.Platform.GCP.Region
+	if _, err := computeService.Regions.Get(project, region).Context(ctx).Do(); err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && (apiErr.Code == 401 || apiErr.Code == 403) {
+			setGCPConditions(hcp, metav1.ConditionFalse, hyperv1.InvalidIdentityProvider,
+				fmt.Sprintf("GCP credential validation failed: %s", apiErr.Message))
+			return fmt.Errorf("error health checking GCP identity provider: %w", err)
+		}
+
+		setGCPConditions(hcp, metav1.ConditionUnknown, hyperv1.StatusUnknownReason,
+			fmt.Sprintf("GCP API error during credential validation: %v", err))
+		return fmt.Errorf("error health checking GCP identity provider: %w", err)
+	}
+
+	setGCPConditions(hcp, metav1.ConditionTrue, hyperv1.AsExpectedReason, hyperv1.AllIsWellMessage)
 	return nil
+}
+
+func setGCPConditions(hcp *hyperv1.HostedControlPlane, status metav1.ConditionStatus, reason, message string) {
+	meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
+		Type:               string(hyperv1.ValidGCPWorkloadIdentity),
+		ObservedGeneration: hcp.Generation,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+	})
+	meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
+		Type:               string(hyperv1.ValidGCPCredentials),
+		ObservedGeneration: hcp.Generation,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
+func initGCPComputeClient(ctx context.Context) (*compute.Service, error) {
+	credentialsFile := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	if credentialsFile == "" {
+		return nil, fmt.Errorf("GOOGLE_APPLICATION_CREDENTIALS not set")
+	}
+	if _, err := os.Stat(credentialsFile); err != nil {
+		return nil, fmt.Errorf("credentials file not accessible at %s: %w", credentialsFile, err)
+	}
+	httpClient, err := google.DefaultClient(ctx, compute.CloudPlatformScope)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Google Cloud client: %w", err)
+	}
+	return compute.NewService(ctx, option.WithHTTPClient(httpClient))
 }

--- a/control-plane-operator/controllers/healthcheck/gcp.go
+++ b/control-plane-operator/controllers/healthcheck/gcp.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
@@ -41,10 +42,9 @@ func gcpHealthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedCont
 	project := hcp.Spec.Platform.GCP.Project
 	region := hcp.Spec.Platform.GCP.Region
 	if _, err := computeService.Regions.Get(project, region).Context(ctx).Do(); err != nil {
-		var apiErr *googleapi.Error
-		if errors.As(err, &apiErr) && (apiErr.Code == 401 || apiErr.Code == 403) {
+		if isPermanentGCPCredentialError(err) {
 			setGCPConditions(hcp, metav1.ConditionFalse, hyperv1.InvalidIdentityProvider,
-				fmt.Sprintf("GCP credential validation failed: %s", apiErr.Message))
+				fmt.Sprintf("GCP credential validation failed: %v", err))
 			return fmt.Errorf("error health checking GCP identity provider: %w", err)
 		}
 
@@ -72,6 +72,25 @@ func setGCPConditions(hcp *hyperv1.HostedControlPlane, status metav1.ConditionSt
 		Reason:             reason,
 		Message:            message,
 	})
+}
+
+// isPermanentGCPCredentialError returns true if the error indicates a
+// non-transient credential failure (HTTP 401/403 from the API, or a permanent
+// OAuth token exchange failure such as a deleted WIF pool/provider).
+func isPermanentGCPCredentialError(err error) bool {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) && (apiErr.Code == 401 || apiErr.Code == 403) {
+		return true
+	}
+	var retrieveErr *oauth2.RetrieveError
+	if errors.As(err, &retrieveErr) && retrieveErr.Response != nil {
+		code := retrieveErr.Response.StatusCode
+		// 408, 429, 500, 503 are transient per google.AuthenticationError.Temporary()
+		if code == 401 || code == 403 || code == 400 {
+			return true
+		}
+	}
+	return false
 }
 
 func initGCPComputeClient(ctx context.Context) (*compute.Service, error) {

--- a/control-plane-operator/controllers/healthcheck/gcp.go
+++ b/control-plane-operator/controllers/healthcheck/gcp.go
@@ -75,18 +75,36 @@ func setGCPConditions(hcp *hyperv1.HostedControlPlane, status metav1.ConditionSt
 }
 
 // isPermanentGCPCredentialError returns true if the error indicates a
-// non-transient credential failure (HTTP 401/403 from the API, or a permanent
-// OAuth token exchange failure such as a deleted WIF pool/provider).
+// non-transient credential failure: HTTP 401 (always), HTTP 403 from the
+// Compute API only when it is NOT a rate-limit or quota issue, or a permanent
+// OAuth token-exchange failure (e.g. deleted WIF pool/provider).
 func isPermanentGCPCredentialError(err error) bool {
 	var apiErr *googleapi.Error
-	if errors.As(err, &apiErr) && (apiErr.Code == 401 || apiErr.Code == 403) {
-		return true
+	if errors.As(err, &apiErr) {
+		if apiErr.Code == 401 {
+			return true
+		}
+		if apiErr.Code == 403 && !isTransientGCPReason(apiErr) {
+			return true
+		}
 	}
 	var retrieveErr *oauth2.RetrieveError
 	if errors.As(err, &retrieveErr) && retrieveErr.Response != nil {
 		code := retrieveErr.Response.StatusCode
-		// 408, 429, 500, 503 are transient per google.AuthenticationError.Temporary()
-		if code == 401 || code == 403 || code == 400 {
+		if code == 400 || code == 401 || code == 403 {
+			return true
+		}
+	}
+	return false
+}
+
+// isTransientGCPReason returns true if a 403 googleapi.Error carries a reason
+// that indicates a transient quota or rate-limit condition rather than a
+// permanent credential/permission failure.
+func isTransientGCPReason(apiErr *googleapi.Error) bool {
+	for _, item := range apiErr.Errors {
+		switch item.Reason {
+		case "rateLimitExceeded", "userRateLimitExceeded", "dailyLimitExceeded":
 			return true
 		}
 	}

--- a/control-plane-operator/controllers/healthcheck/gcp.go
+++ b/control-plane-operator/controllers/healthcheck/gcp.go
@@ -1,0 +1,152 @@
+package healthcheck
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+// gcpRegionChecker is the function used to check GCP region access.
+// It is a package-level variable to allow injection in tests.
+var gcpRegionChecker = func(ctx context.Context, project, region string) error {
+	computeService, err := initGCPComputeClient(ctx)
+	if err != nil {
+		wrapped := fmt.Errorf("%w: %w", errComputeClientUnavailable, err)
+		ctrl.LoggerFrom(ctx).V(4).Info("GCP compute client not available, skipping credential check", "reason", err.Error())
+		return wrapped
+	}
+	_, err = computeService.Regions.Get(project, region).Context(ctx).Do()
+	return err
+}
+
+// errComputeClientUnavailable is returned by gcpRegionChecker when the GCP
+// compute client cannot be initialized (e.g. missing credentials file).
+var errComputeClientUnavailable = fmt.Errorf("GCP compute client unavailable")
+
+func gcpHealthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	kasAvailable := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.KubeAPIServerAvailable))
+	if kasAvailable == nil || kasAvailable.Status != metav1.ConditionTrue {
+		setGCPConditions(hcp, metav1.ConditionUnknown, hyperv1.StatusUnknownReason,
+			"Cannot validate GCP credentials while KubeAPIServer is not available")
+		return nil
+	}
+
+	if hcp.Spec.Platform.GCP == nil {
+		// Use Unknown rather than False: a missing GCP spec is a configuration
+		// defect, not a credential failure. Setting False would cause
+		// GetCredentialStatus to return CredentialStatusInvalid and trigger
+		// DeleteOrphanedMachines to strip GCPMachine finalizers, potentially
+		// leaking cloud resources. The latch in ComputeGCPCredentialConditions
+		// would then persist that False through teardown.
+		setGCPConditions(hcp, metav1.ConditionUnknown, "MissingGCPConfiguration",
+			"GCP platform configuration is missing from HostedControlPlane spec")
+		return fmt.Errorf("GCP platform configuration is missing from HostedControlPlane spec")
+	}
+
+	project := hcp.Spec.Platform.GCP.Project
+	region := hcp.Spec.Platform.GCP.Region
+	if err := gcpRegionChecker(ctx, project, region); err != nil {
+		if errors.Is(err, errComputeClientUnavailable) {
+			setGCPConditions(hcp, metav1.ConditionUnknown, hyperv1.StatusUnknownReason,
+				"GCP compute client is not available")
+			return nil //nolint:nilerr // missing compute client is not a reconciler error; conditions are set to Unknown
+		}
+		if isWIFTokenError(err) {
+			// WIF token exchange failed: the workload identity configuration is
+			// invalid. Credentials cannot be validated because the token cannot
+			// be obtained; mark ValidGCPCredentials as Unknown.
+			setGCPCondition(hcp, hyperv1.ValidGCPWorkloadIdentity, metav1.ConditionFalse,
+				hyperv1.InvalidIdentityProvider, "GCP Workload Identity Federation token exchange failed")
+			setGCPCondition(hcp, hyperv1.ValidGCPCredentials, metav1.ConditionUnknown,
+				hyperv1.StatusUnknownReason, "Cannot validate GCP credentials: WIF token exchange failed")
+			return fmt.Errorf("error health checking GCP identity provider: %w", err)
+		}
+		if isComputeAuthError(err) {
+			// The WIF token was obtained successfully (WorkloadIdentity is valid)
+			// but the Compute API rejected the resulting credential with HTTP 401.
+			// Only ValidGCPCredentials is False; ValidGCPWorkloadIdentity stays True
+			// because the token exchange itself succeeded.
+			setGCPCondition(hcp, hyperv1.ValidGCPWorkloadIdentity, metav1.ConditionTrue,
+				hyperv1.AsExpectedReason, "GCP Workload Identity Federation token exchange succeeded")
+			setGCPCondition(hcp, hyperv1.ValidGCPCredentials, metav1.ConditionFalse,
+				hyperv1.InvalidIdentityProvider, "GCP credential validation failed: Compute API rejected the credential")
+			return fmt.Errorf("error health checking GCP identity provider: %w", err)
+		}
+
+		setGCPConditions(hcp, metav1.ConditionUnknown, hyperv1.StatusUnknownReason,
+			"GCP API error during credential validation")
+		return fmt.Errorf("error health checking GCP identity provider: %w", err)
+	}
+
+	setGCPConditions(hcp, metav1.ConditionTrue, hyperv1.AsExpectedReason, hyperv1.AllIsWellMessage)
+	return nil
+}
+
+func setGCPCondition(hcp *hyperv1.HostedControlPlane, condType hyperv1.ConditionType, status metav1.ConditionStatus, reason, message string) {
+	meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
+		Type:               string(condType),
+		ObservedGeneration: hcp.Generation,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
+func setGCPConditions(hcp *hyperv1.HostedControlPlane, status metav1.ConditionStatus, reason, message string) {
+	setGCPCondition(hcp, hyperv1.ValidGCPWorkloadIdentity, status, reason, message)
+	setGCPCondition(hcp, hyperv1.ValidGCPCredentials, status, reason, message)
+}
+
+// isWIFTokenError returns true if the error indicates a non-transient WIF
+// token-exchange failure (oauth2.RetrieveError with HTTP 400/401/403).
+// These errors mean the workload identity pool/provider/SA is misconfigured;
+// no Compute API call was made yet.
+func isWIFTokenError(err error) bool {
+	var retrieveErr *oauth2.RetrieveError
+	if errors.As(err, &retrieveErr) && retrieveErr.Response != nil {
+		code := retrieveErr.Response.StatusCode
+		return code == 400 || code == 401 || code == 403
+	}
+	return false
+}
+
+// isComputeAuthError returns true if the Compute API itself rejected the
+// request with HTTP 401 (authentication rejected). This indicates the WIF
+// token was obtained but not accepted by the Compute API.
+//
+// Compute API 403 is NOT treated as an auth error because it means
+// authentication succeeded but authorization failed (missing IAM permission,
+// quota, etc.).
+func isComputeAuthError(err error) bool {
+	var apiErr *googleapi.Error
+	return errors.As(err, &apiErr) && apiErr.Code == 401
+}
+
+func initGCPComputeClient(ctx context.Context) (*compute.Service, error) {
+	credentialsFile := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	if credentialsFile == "" {
+		return nil, fmt.Errorf("GOOGLE_APPLICATION_CREDENTIALS not set")
+	}
+	if _, err := os.Stat(credentialsFile); err != nil {
+		return nil, fmt.Errorf("credentials file not accessible at %s: %w", credentialsFile, err)
+	}
+	httpClient, err := google.DefaultClient(ctx, compute.CloudPlatformScope)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Google Cloud client: %w", err)
+	}
+	return compute.NewService(ctx, option.WithHTTPClient(httpClient))
+}

--- a/control-plane-operator/controllers/healthcheck/gcp_test.go
+++ b/control-plane-operator/controllers/healthcheck/gcp_test.go
@@ -1,0 +1,179 @@
+package healthcheck
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/api"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGCPHealthCheckIdentityProviderConditionLogic(t *testing.T) {
+	testCases := []struct {
+		name            string
+		kasCondition    *metav1.Condition
+		gcpSpec         *hyperv1.GCPPlatformSpec
+		expectedStatus  metav1.ConditionStatus
+		expectedReason  string
+		expectedMessage string
+	}{
+		{
+			name:            "KAS not available - condition missing",
+			kasCondition:    nil,
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  hyperv1.StatusUnknownReason,
+			expectedMessage: "Cannot validate GCP credentials while KubeAPIServer is not available",
+		},
+		{
+			name: "KAS not available - condition False",
+			kasCondition: &metav1.Condition{
+				Type:   string(hyperv1.KubeAPIServerAvailable),
+				Status: metav1.ConditionFalse,
+			},
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  hyperv1.StatusUnknownReason,
+			expectedMessage: "Cannot validate GCP credentials while KubeAPIServer is not available",
+		},
+		{
+			name: "KAS available but GCP spec missing",
+			kasCondition: &metav1.Condition{
+				Type:   string(hyperv1.KubeAPIServerAvailable),
+				Status: metav1.ConditionTrue,
+			},
+			gcpSpec:         nil,
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  "MissingGCPConfiguration",
+			expectedMessage: "GCP platform configuration is missing from HostedControlPlane spec",
+		},
+		{
+			name: "KAS available with GCP spec but no credentials",
+			kasCondition: &metav1.Condition{
+				Type:   string(hyperv1.KubeAPIServerAvailable),
+				Status: metav1.ConditionTrue,
+			},
+			gcpSpec: &hyperv1.GCPPlatformSpec{
+				Project: "test-project",
+				Region:  "us-central1",
+			},
+			expectedStatus: metav1.ConditionUnknown,
+			expectedReason: hyperv1.StatusUnknownReason,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-hcp",
+					Namespace:  "test-namespace",
+					Generation: 1,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.GCPPlatform,
+						GCP:  tc.gcpSpec,
+					},
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{},
+				},
+			}
+
+			if tc.kasCondition != nil {
+				meta.SetStatusCondition(&hcp.Status.Conditions, *tc.kasCondition)
+			}
+
+			// Error is expected for the missing-spec case; ignore return value
+			_ = gcpHealthCheckIdentityProvider(t.Context(), hcp)
+
+			for _, condType := range []string{
+				string(hyperv1.ValidGCPWorkloadIdentity),
+				string(hyperv1.ValidGCPCredentials),
+			} {
+				condition := meta.FindStatusCondition(hcp.Status.Conditions, condType)
+				if condition == nil {
+					t.Fatalf("%s condition was not set", condType)
+				}
+				if condition.Status != tc.expectedStatus {
+					t.Errorf("%s: expected status %v, got %v", condType, tc.expectedStatus, condition.Status)
+				}
+				if condition.Reason != tc.expectedReason {
+					t.Errorf("%s: expected reason %v, got %v", condType, tc.expectedReason, condition.Reason)
+				}
+				if tc.expectedMessage != "" && condition.Message != tc.expectedMessage {
+					t.Errorf("%s: expected message %q, got %q", condType, tc.expectedMessage, condition.Message)
+				}
+				if condition.ObservedGeneration != hcp.Generation {
+					t.Errorf("%s: expected ObservedGeneration %v, got %v", condType, hcp.Generation, condition.ObservedGeneration)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateRunsGCPIdentityCheckDuringDeletion(t *testing.T) {
+	now := metav1.Now()
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-hcp",
+			Namespace:         "test-namespace",
+			Generation:        1,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test-finalizer"},
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.GCPPlatform,
+				GCP: &hyperv1.GCPPlatformSpec{
+					Project: "test-project",
+					Region:  "us-central1",
+				},
+			},
+		},
+		Status: hyperv1.HostedControlPlaneStatus{
+			Conditions: []metav1.Condition{},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(api.Scheme).
+		WithObjects(hcp).
+		WithStatusSubresource(&hyperv1.HostedControlPlane{}).
+		Build()
+
+	ctx := ctrl.LoggerInto(t.Context(), ctrl.Log.WithName("test"))
+
+	hcu := &HealthCheckUpdater{
+		Client:             fakeClient,
+		HostedControlPlane: client.ObjectKeyFromObject(hcp),
+		log:                ctrl.Log.WithName("test"),
+	}
+
+	if err := hcu.update(ctx); err != nil {
+		t.Fatalf("update() should succeed when GCP credentials are not available, got: %v", err)
+	}
+
+	updated := &hyperv1.HostedControlPlane{}
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(hcp), updated); err != nil {
+		t.Fatalf("failed to get updated HCP: %v", err)
+	}
+
+	for _, condType := range []string{
+		string(hyperv1.ValidGCPWorkloadIdentity),
+		string(hyperv1.ValidGCPCredentials),
+	} {
+		condition := meta.FindStatusCondition(updated.Status.Conditions, condType)
+		if condition == nil {
+			t.Fatalf("%s condition was not set during deletion", condType)
+		}
+		if condition.Status != metav1.ConditionUnknown {
+			t.Errorf("%s: expected status %v, got %v", condType, metav1.ConditionUnknown, condition.Status)
+		}
+	}
+}

--- a/control-plane-operator/controllers/healthcheck/gcp_test.go
+++ b/control-plane-operator/controllers/healthcheck/gcp_test.go
@@ -1,6 +1,8 @@
 package healthcheck
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -8,6 +10,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/googleapi"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -185,5 +190,96 @@ func TestUpdateRunsGCPIdentityCheckDuringDeletion(t *testing.T) {
 		if condition.Status != metav1.ConditionUnknown {
 			t.Errorf("%s: expected status %v, got %v", condType, metav1.ConditionUnknown, condition.Status)
 		}
+	}
+}
+
+func TestIsPermanentGCPCredentialError(t *testing.T) {
+	testCases := []struct {
+		name      string
+		err       error
+		permanent bool
+	}{
+		{
+			name:      "401 googleapi error is permanent",
+			err:       &googleapi.Error{Code: 401, Message: "Unauthorized"},
+			permanent: true,
+		},
+		{
+			name:      "403 googleapi error without transient reason is permanent",
+			err:       &googleapi.Error{Code: 403, Message: "Forbidden"},
+			permanent: true,
+		},
+		{
+			name: "403 googleapi error with rateLimitExceeded is transient",
+			err: &googleapi.Error{
+				Code:    403,
+				Message: "Rate Limit Exceeded",
+				Errors:  []googleapi.ErrorItem{{Reason: "rateLimitExceeded", Message: "Rate Limit Exceeded"}},
+			},
+			permanent: false,
+		},
+		{
+			name: "403 googleapi error with userRateLimitExceeded is transient",
+			err: &googleapi.Error{
+				Code:    403,
+				Message: "User Rate Limit Exceeded",
+				Errors:  []googleapi.ErrorItem{{Reason: "userRateLimitExceeded", Message: "User Rate Limit Exceeded"}},
+			},
+			permanent: false,
+		},
+		{
+			name: "403 googleapi error with dailyLimitExceeded is transient",
+			err: &googleapi.Error{
+				Code:    403,
+				Message: "Daily Limit Exceeded",
+				Errors:  []googleapi.ErrorItem{{Reason: "dailyLimitExceeded", Message: "Daily Limit Exceeded"}},
+			},
+			permanent: false,
+		},
+		{
+			name:      "500 googleapi error is not permanent",
+			err:       &googleapi.Error{Code: 500, Message: "Internal Server Error"},
+			permanent: false,
+		},
+		{
+			name: "oauth2 RetrieveError with 401 is permanent",
+			err: &oauth2.RetrieveError{
+				Response: &http.Response{StatusCode: 401},
+			},
+			permanent: true,
+		},
+		{
+			name: "oauth2 RetrieveError with 400 is permanent",
+			err: &oauth2.RetrieveError{
+				Response: &http.Response{StatusCode: 400},
+			},
+			permanent: true,
+		},
+		{
+			name: "oauth2 RetrieveError with 429 is not permanent",
+			err: &oauth2.RetrieveError{
+				Response: &http.Response{StatusCode: 429},
+			},
+			permanent: false,
+		},
+		{
+			name:      "wrapped googleapi 401 error is permanent",
+			err:       fmt.Errorf("compute call failed: %w", &googleapi.Error{Code: 401}),
+			permanent: true,
+		},
+		{
+			name:      "generic error is not permanent",
+			err:       fmt.Errorf("network timeout"),
+			permanent: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isPermanentGCPCredentialError(tc.err)
+			if got != tc.permanent {
+				t.Errorf("isPermanentGCPCredentialError() = %v, want %v", got, tc.permanent)
+			}
+		})
 	}
 }

--- a/control-plane-operator/controllers/healthcheck/gcp_test.go
+++ b/control-plane-operator/controllers/healthcheck/gcp_test.go
@@ -1,0 +1,396 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/api"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/googleapi"
+)
+
+func TestGCPHealthCheckIdentityProviderConditionLogic(t *testing.T) {
+	testCases := []struct {
+		name            string
+		kasCondition    *metav1.Condition
+		gcpSpec         *hyperv1.GCPPlatformSpec
+		expectError     bool
+		expectedStatus  metav1.ConditionStatus
+		expectedReason  string
+		expectedMessage string
+	}{
+		{
+			name:            "When KAS condition is missing, it should set credentials condition to Unknown",
+			kasCondition:    nil,
+			expectError:     false,
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  hyperv1.StatusUnknownReason,
+			expectedMessage: "Cannot validate GCP credentials while KubeAPIServer is not available",
+		},
+		{
+			name: "When KAS condition is False, it should set credentials condition to Unknown",
+			kasCondition: &metav1.Condition{
+				Type:   string(hyperv1.KubeAPIServerAvailable),
+				Status: metav1.ConditionFalse,
+			},
+			expectError:     false,
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  hyperv1.StatusUnknownReason,
+			expectedMessage: "Cannot validate GCP credentials while KubeAPIServer is not available",
+		},
+		{
+			name: "When KAS is available but GCP spec is missing, it should set credentials condition to Unknown",
+			kasCondition: &metav1.Condition{
+				Type:   string(hyperv1.KubeAPIServerAvailable),
+				Status: metav1.ConditionTrue,
+			},
+			gcpSpec:         nil,
+			expectError:     true,
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  "MissingGCPConfiguration",
+			expectedMessage: "GCP platform configuration is missing from HostedControlPlane spec",
+		},
+		{
+			name: "When KAS is available with GCP spec but no credentials, it should set credentials condition to Unknown",
+			kasCondition: &metav1.Condition{
+				Type:   string(hyperv1.KubeAPIServerAvailable),
+				Status: metav1.ConditionTrue,
+			},
+			gcpSpec: &hyperv1.GCPPlatformSpec{
+				Project: "test-project",
+				Region:  "us-central1",
+			},
+			expectError:    false,
+			expectedStatus: metav1.ConditionUnknown,
+			expectedReason: hyperv1.StatusUnknownReason,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-hcp",
+					Namespace:  "test-namespace",
+					Generation: 1,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.GCPPlatform,
+						GCP:  tc.gcpSpec,
+					},
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{},
+				},
+			}
+
+			if tc.kasCondition != nil {
+				meta.SetStatusCondition(&hcp.Status.Conditions, *tc.kasCondition)
+			}
+
+			err := gcpHealthCheckIdentityProvider(t.Context(), hcp)
+			if tc.expectError && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+
+			for _, condType := range []string{
+				string(hyperv1.ValidGCPWorkloadIdentity),
+				string(hyperv1.ValidGCPCredentials),
+			} {
+				condition := meta.FindStatusCondition(hcp.Status.Conditions, condType)
+				if condition == nil {
+					t.Fatalf("%s condition was not set", condType)
+				}
+				if condition.Status != tc.expectedStatus {
+					t.Errorf("%s: expected status %v, got %v", condType, tc.expectedStatus, condition.Status)
+				}
+				if condition.Reason != tc.expectedReason {
+					t.Errorf("%s: expected reason %v, got %v", condType, tc.expectedReason, condition.Reason)
+				}
+				if tc.expectedMessage != "" && condition.Message != tc.expectedMessage {
+					t.Errorf("%s: expected message %q, got %q", condType, tc.expectedMessage, condition.Message)
+				}
+				if condition.ObservedGeneration != hcp.Generation {
+					t.Errorf("%s: expected ObservedGeneration %v, got %v", condType, hcp.Generation, condition.ObservedGeneration)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateRunsGCPIdentityCheckDuringDeletion(t *testing.T) {
+	now := metav1.Now()
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-hcp",
+			Namespace:         "test-namespace",
+			Generation:        1,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test-finalizer"},
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.GCPPlatform,
+				GCP: &hyperv1.GCPPlatformSpec{
+					Project: "test-project",
+					Region:  "us-central1",
+				},
+			},
+		},
+		Status: hyperv1.HostedControlPlaneStatus{
+			Conditions: []metav1.Condition{},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(api.Scheme).
+		WithObjects(hcp).
+		WithStatusSubresource(&hyperv1.HostedControlPlane{}).
+		Build()
+
+	ctx := ctrl.LoggerInto(t.Context(), ctrl.Log.WithName("test"))
+
+	hcu := &HealthCheckUpdater{
+		Client:             fakeClient,
+		HostedControlPlane: client.ObjectKeyFromObject(hcp),
+		log:                ctrl.Log.WithName("test"),
+	}
+
+	if err := hcu.update(ctx); err != nil {
+		t.Fatalf("update() should succeed when GCP credentials are not available, got: %v", err)
+	}
+
+	updated := &hyperv1.HostedControlPlane{}
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(hcp), updated); err != nil {
+		t.Fatalf("failed to get updated HCP: %v", err)
+	}
+
+	for _, condType := range []string{
+		string(hyperv1.ValidGCPWorkloadIdentity),
+		string(hyperv1.ValidGCPCredentials),
+	} {
+		condition := meta.FindStatusCondition(updated.Status.Conditions, condType)
+		if condition == nil {
+			t.Fatalf("%s condition was not set during deletion", condType)
+		}
+		if condition.Status != metav1.ConditionUnknown {
+			t.Errorf("%s: expected status %v, got %v", condType, metav1.ConditionUnknown, condition.Status)
+		}
+	}
+}
+
+func TestGCPHealthCheckConditionDifferentiation(t *testing.T) {
+	kasTrue := &metav1.Condition{
+		Type:   string(hyperv1.KubeAPIServerAvailable),
+		Status: metav1.ConditionTrue,
+	}
+	gcpSpec := &hyperv1.GCPPlatformSpec{Project: "test-project", Region: "us-central1"}
+
+	testCases := []struct {
+		name               string
+		regionErr          error
+		expectedWIFStatus  metav1.ConditionStatus
+		expectedCredStatus metav1.ConditionStatus
+		expectError        bool
+	}{
+		{
+			name:               "When WIF token exchange fails, it should set WIF to False and Credentials to Unknown",
+			regionErr:          &oauth2.RetrieveError{Response: &http.Response{StatusCode: http.StatusUnauthorized}},
+			expectedWIFStatus:  metav1.ConditionFalse,
+			expectedCredStatus: metav1.ConditionUnknown,
+			expectError:        true,
+		},
+		{
+			name:               "When Compute API returns 401, it should set WIF to True and Credentials to False",
+			regionErr:          &googleapi.Error{Code: 401, Message: "Unauthorized"},
+			expectedWIFStatus:  metav1.ConditionTrue,
+			expectedCredStatus: metav1.ConditionFalse,
+			expectError:        true,
+		},
+		{
+			name:               "When Compute API returns transient error, it should set both conditions to Unknown",
+			regionErr:          &googleapi.Error{Code: 500, Message: "Internal Server Error"},
+			expectedWIFStatus:  metav1.ConditionUnknown,
+			expectedCredStatus: metav1.ConditionUnknown,
+			expectError:        true,
+		},
+		{
+			name:               "When Compute API succeeds, it should set both conditions to True",
+			regionErr:          nil,
+			expectedWIFStatus:  metav1.ConditionTrue,
+			expectedCredStatus: metav1.ConditionTrue,
+			expectError:        false,
+		},
+		{
+			name:               "When compute client is unavailable, it should set both conditions to Unknown without returning an error",
+			regionErr:          errComputeClientUnavailable,
+			expectedWIFStatus:  metav1.ConditionUnknown,
+			expectedCredStatus: metav1.ConditionUnknown,
+			expectError:        false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			injectedErr := tc.regionErr
+			old := gcpRegionChecker
+			gcpRegionChecker = func(_ context.Context, _, _ string) error { return injectedErr }
+			defer func() { gcpRegionChecker = old }()
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.GCPPlatform, GCP: gcpSpec},
+				},
+				Status: hyperv1.HostedControlPlaneStatus{Conditions: []metav1.Condition{}},
+			}
+			meta.SetStatusCondition(&hcp.Status.Conditions, *kasTrue)
+
+			err := gcpHealthCheckIdentityProvider(t.Context(), hcp)
+			if tc.expectError && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+
+			wifCond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ValidGCPWorkloadIdentity))
+			if wifCond == nil {
+				t.Fatal("ValidGCPWorkloadIdentity condition was not set")
+			}
+			if wifCond.Status != tc.expectedWIFStatus {
+				t.Errorf("ValidGCPWorkloadIdentity: expected status %v, got %v", tc.expectedWIFStatus, wifCond.Status)
+			}
+
+			credCond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ValidGCPCredentials))
+			if credCond == nil {
+				t.Fatal("ValidGCPCredentials condition was not set")
+			}
+			if credCond.Status != tc.expectedCredStatus {
+				t.Errorf("ValidGCPCredentials: expected status %v, got %v", tc.expectedCredStatus, credCond.Status)
+			}
+		})
+	}
+}
+
+func TestIsWIFTokenError(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "When OAuth2 returns HTTP 401, it should classify the error as a WIF token error",
+			err:  &oauth2.RetrieveError{Response: &http.Response{StatusCode: http.StatusUnauthorized}},
+			want: true,
+		},
+		{
+			name: "When OAuth2 returns HTTP 400, it should classify the error as a WIF token error",
+			err:  &oauth2.RetrieveError{Response: &http.Response{StatusCode: http.StatusBadRequest}},
+			want: true,
+		},
+		{
+			name: "When OAuth2 returns HTTP 403, it should classify the error as a WIF token error",
+			err:  &oauth2.RetrieveError{Response: &http.Response{StatusCode: http.StatusForbidden}},
+			want: true,
+		},
+		{
+			name: "When OAuth2 returns HTTP 429, it should not classify the error as a WIF token error",
+			err:  &oauth2.RetrieveError{Response: &http.Response{StatusCode: http.StatusTooManyRequests}},
+			want: false,
+		},
+		{
+			name: "When a googleapi 401 error occurs, it should not classify the error as a WIF token error",
+			err:  &googleapi.Error{Code: 401, Message: "Unauthorized"},
+			want: false,
+		},
+		{
+			name: "When a generic error occurs, it should not classify the error as a WIF token error",
+			err:  fmt.Errorf("network timeout"),
+			want: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isWIFTokenError(tc.err); got != tc.want {
+				t.Errorf("isWIFTokenError() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsComputeAuthError(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "When a 401 googleapi error occurs, it should classify the error as a compute auth error",
+			err:  &googleapi.Error{Code: 401, Message: "Unauthorized"},
+			want: true,
+		},
+		{
+			name: "When a wrapped googleapi 401 error occurs, it should classify the error as a compute auth error",
+			err:  fmt.Errorf("compute call failed: %w", &googleapi.Error{Code: 401}),
+			want: true,
+		},
+		{
+			name: "When a 403 googleapi error occurs, it should not classify the error as a compute auth error",
+			err:  &googleapi.Error{Code: 403, Message: "Forbidden"},
+			want: false,
+		},
+		{
+			name: "When a 403 googleapi error with rateLimitExceeded occurs, it should not classify the error as a compute auth error",
+			err:  &googleapi.Error{Code: 403, Errors: []googleapi.ErrorItem{{Reason: "rateLimitExceeded"}}},
+			want: false,
+		},
+		{
+			name: "When a 403 googleapi error with quotaExceeded occurs, it should not classify the error as a compute auth error",
+			err:  &googleapi.Error{Code: 403, Errors: []googleapi.ErrorItem{{Reason: "quotaExceeded"}}},
+			want: false,
+		},
+		{
+			name: "When a 403 googleapi error with accessNotConfigured occurs, it should not classify the error as a compute auth error",
+			err:  &googleapi.Error{Code: 403, Errors: []googleapi.ErrorItem{{Reason: "accessNotConfigured"}}},
+			want: false,
+		},
+		{
+			name: "When a 500 googleapi error occurs, it should not classify the error as a compute auth error",
+			err:  &googleapi.Error{Code: 500, Message: "Internal Server Error"},
+			want: false,
+		},
+		{
+			name: "When an OAuth2 error occurs, it should not classify the error as a compute auth error",
+			err:  &oauth2.RetrieveError{Response: &http.Response{StatusCode: http.StatusUnauthorized}},
+			want: false,
+		},
+		{
+			name: "When a generic error occurs, it should not classify the error as a compute auth error",
+			err:  fmt.Errorf("network timeout"),
+			want: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isComputeAuthError(tc.err); got != tc.want {
+				t.Errorf("isComputeAuthError() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/control-plane-operator/controllers/healthcheck/gcp_test.go
+++ b/control-plane-operator/controllers/healthcheck/gcp_test.go
@@ -19,6 +19,7 @@ func TestGCPHealthCheckIdentityProviderConditionLogic(t *testing.T) {
 		name            string
 		kasCondition    *metav1.Condition
 		gcpSpec         *hyperv1.GCPPlatformSpec
+		expectError     bool
 		expectedStatus  metav1.ConditionStatus
 		expectedReason  string
 		expectedMessage string
@@ -26,6 +27,7 @@ func TestGCPHealthCheckIdentityProviderConditionLogic(t *testing.T) {
 		{
 			name:            "KAS not available - condition missing",
 			kasCondition:    nil,
+			expectError:     false,
 			expectedStatus:  metav1.ConditionUnknown,
 			expectedReason:  hyperv1.StatusUnknownReason,
 			expectedMessage: "Cannot validate GCP credentials while KubeAPIServer is not available",
@@ -36,6 +38,7 @@ func TestGCPHealthCheckIdentityProviderConditionLogic(t *testing.T) {
 				Type:   string(hyperv1.KubeAPIServerAvailable),
 				Status: metav1.ConditionFalse,
 			},
+			expectError:     false,
 			expectedStatus:  metav1.ConditionUnknown,
 			expectedReason:  hyperv1.StatusUnknownReason,
 			expectedMessage: "Cannot validate GCP credentials while KubeAPIServer is not available",
@@ -47,6 +50,7 @@ func TestGCPHealthCheckIdentityProviderConditionLogic(t *testing.T) {
 				Status: metav1.ConditionTrue,
 			},
 			gcpSpec:         nil,
+			expectError:     true,
 			expectedStatus:  metav1.ConditionFalse,
 			expectedReason:  "MissingGCPConfiguration",
 			expectedMessage: "GCP platform configuration is missing from HostedControlPlane spec",
@@ -61,6 +65,7 @@ func TestGCPHealthCheckIdentityProviderConditionLogic(t *testing.T) {
 				Project: "test-project",
 				Region:  "us-central1",
 			},
+			expectError:    false,
 			expectedStatus: metav1.ConditionUnknown,
 			expectedReason: hyperv1.StatusUnknownReason,
 		},
@@ -89,8 +94,13 @@ func TestGCPHealthCheckIdentityProviderConditionLogic(t *testing.T) {
 				meta.SetStatusCondition(&hcp.Status.Conditions, *tc.kasCondition)
 			}
 
-			// Error is expected for the missing-spec case; ignore return value
-			_ = gcpHealthCheckIdentityProvider(t.Context(), hcp)
+			err := gcpHealthCheckIdentityProvider(t.Context(), hcp)
+			if tc.expectError && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Fatalf("expected no error but got: %v", err)
+			}
 
 			for _, condType := range []string{
 				string(hyperv1.ValidGCPWorkloadIdentity),

--- a/control-plane-operator/controllers/healthcheck/healthcheck_controller.go
+++ b/control-plane-operator/controllers/healthcheck/healthcheck_controller.go
@@ -81,7 +81,12 @@ func (hcu *HealthCheckUpdater) update(ctx context.Context) error {
 		if err := awsHealthCheckIdentityProvider(ctx, hostedControlPlane); err != nil {
 			errs = append(errs, err)
 		}
+	}
 
+	if hostedControlPlane.Spec.Platform.Type == hyperv1.GCPPlatform {
+		if err := gcpHealthCheckIdentityProvider(ctx, hostedControlPlane); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	// Update the status

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -40,6 +40,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-pki-operator/certificates"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform"
 	platformaws "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/aws"
+	platformgcp "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/gcp"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/proxy"
 	hcmetrics "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/metrics"
 	validations "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/validations"
@@ -445,6 +446,18 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 
 		if updated {
 			// Persist status updates
+			if err := r.Client.Status().Update(ctx, hcluster); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
+			}
+		}
+	}
+
+	// Refresh ValidGCPWorkloadIdentity condition from spec validation.
+	// We set this condition even if the HC is being deleted so that
+	// DeleteOrphanedMachines has a fresh signal. Unlike AWS (which bubbles up
+	// from HCP), this is a pure spec check with no network calls.
+	if hcluster.Spec.Platform.Type == hyperv1.GCPPlatform {
+		if platformgcp.RefreshGCPCredentialConditions(hcluster) {
 			if err := r.Client.Status().Update(ctx, hcluster); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
 			}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -40,7 +40,6 @@ import (
 	"github.com/openshift/hypershift/control-plane-pki-operator/certificates"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform"
 	platformaws "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/aws"
-	platformgcp "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/gcp"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/proxy"
 	hcmetrics "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/metrics"
 	validations "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/validations"
@@ -452,12 +451,36 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	// Refresh ValidGCPWorkloadIdentity condition from spec validation.
-	// We set this condition even if the HC is being deleted so that
-	// DeleteOrphanedMachines has a fresh signal. Unlike AWS (which bubbles up
-	// from HCP), this is a pure spec check with no network calls.
+	// Bubble up ValidGCPWorkloadIdentity and ValidGCPCredentials conditions from the hostedControlPlane.
+	// We set these conditions even if the HC is being deleted so that
+	// DeleteOrphanedMachines has a fresh signal for credential validity.
 	if hcluster.Spec.Platform.Type == hyperv1.GCPPlatform {
-		if platformgcp.RefreshGCPCredentialConditions(hcluster) {
+		updated := false
+		for _, condType := range []hyperv1.ConditionType{
+			hyperv1.ValidGCPWorkloadIdentity,
+			hyperv1.ValidGCPCredentials,
+		} {
+			var cond *metav1.Condition
+			if hcp != nil {
+				cond = meta.FindStatusCondition(hcp.Status.Conditions, string(condType))
+			}
+			if cond == nil {
+				if meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
+					Type:               string(condType),
+					Status:             metav1.ConditionUnknown,
+					Reason:             hyperv1.StatusUnknownReason,
+					ObservedGeneration: hcluster.Generation,
+				}) {
+					updated = true
+				}
+			} else {
+				cond.ObservedGeneration = hcluster.Generation
+				if meta.SetStatusCondition(&hcluster.Status.Conditions, *cond) {
+					updated = true
+				}
+			}
+		}
+		if updated {
 			if err := r.Client.Status().Update(ctx, hcluster); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
 			}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -40,6 +40,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-pki-operator/certificates"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform"
 	platformaws "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/aws"
+	platformgcp "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/gcp"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/proxy"
 	hcmetrics "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/metrics"
 	validations "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/validations"
@@ -445,6 +446,17 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 
 		if updated {
 			// Persist status updates
+			if err := r.Client.Status().Update(ctx, hcluster); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
+			}
+		}
+	}
+
+	// Bubble up ValidGCPWorkloadIdentity and ValidGCPCredentials conditions from the hostedControlPlane.
+	// We set these conditions even if the HC is being deleted so that
+	// DeleteOrphanedMachines has a fresh signal for credential validity.
+	if hcluster.Spec.Platform.Type == hyperv1.GCPPlatform {
+		if changed := platformgcp.ComputeGCPCredentialConditions(hcluster, hcp); changed {
 			if err := r.Client.Status().Update(ctx, hcluster); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
 			}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -305,28 +305,14 @@ func (p GCP) ReconcileCredentials(ctx context.Context, c client.Client, createOr
 	hcluster *hyperv1.HostedCluster,
 	controlPlaneNamespace string,
 ) error {
-	// Validate GCP platform configuration is present
 	if hcluster.Spec.Platform.GCP == nil {
-		setCondition(hcluster, hyperv1.ValidGCPWorkloadIdentity, metav1.ConditionFalse, "MissingGCPConfiguration", "GCP platform configuration is missing")
-		if updateErr := c.Status().Update(ctx, hcluster); updateErr != nil {
-			return fmt.Errorf("GCP platform configuration is missing (failed to update status: %w)", updateErr)
-		}
 		return fmt.Errorf("GCP platform configuration is missing")
 	}
 
-	// Validate Workload Identity Federation configuration (required)
 	if err := validateWorkloadIdentityConfiguration(hcluster); err != nil {
-		setCondition(hcluster, hyperv1.ValidGCPWorkloadIdentity, metav1.ConditionFalse, "InvalidWIFConfiguration", fmt.Sprintf("Workload Identity Federation configuration is invalid: %v", err))
-		if updateErr := c.Status().Update(ctx, hcluster); updateErr != nil {
-			return fmt.Errorf("invalid workload identity configuration: %w (failed to update status: %w)", err, updateErr)
-		}
 		return fmt.Errorf("invalid workload identity configuration: %w", err)
 	}
 
-	// Set successful WIF validation condition
-	setCondition(hcluster, hyperv1.ValidGCPWorkloadIdentity, metav1.ConditionTrue, "ValidWIFConfiguration", "Workload Identity Federation configuration is valid and ready")
-
-	// Create credential secrets following AWS pattern
 	var errs []error
 	syncSecret := func(secret *corev1.Secret, serviceAccountEmail string) error {
 		credentials, err := gcputil.BuildWorkloadIdentityCredentials(hcluster.Spec.Platform.GCP.WorkloadIdentity, serviceAccountEmail)
@@ -343,7 +329,6 @@ func (p GCP) ReconcileCredentials(ctx context.Context, c client.Client, createOr
 		return nil
 	}
 
-	// Create credential secrets for all configured service accounts
 	credentialSecrets := map[hyperv1.GCPServiceAccountEmail]*corev1.Secret{
 		hcluster.Spec.Platform.GCP.WorkloadIdentity.ServiceAccountsEmails.NodePool:        NodePoolManagementCredsSecret(controlPlaneNamespace),
 		hcluster.Spec.Platform.GCP.WorkloadIdentity.ServiceAccountsEmails.ControlPlane:    ControlPlaneOperatorCredsSecret(controlPlaneNamespace),
@@ -360,19 +345,7 @@ func (p GCP) ReconcileCredentials(ctx context.Context, c client.Client, createOr
 	}
 
 	if len(errs) > 0 {
-		setCondition(hcluster, hyperv1.ValidGCPCredentials, metav1.ConditionFalse, "CredentialsError", fmt.Sprintf("Failed to reconcile credentials: %v", errs))
-		if updateErr := c.Status().Update(ctx, hcluster); updateErr != nil {
-			return fmt.Errorf("failed to reconcile GCP credentials: %v (failed to update status: %w)", errs, updateErr)
-		}
 		return fmt.Errorf("failed to reconcile GCP credentials: %v", errs)
-	}
-
-	// Set credentials condition to indicate federation is ready
-	setCondition(hcluster, hyperv1.ValidGCPCredentials, metav1.ConditionTrue, "WIFReady", "GCP Workload Identity Federation is configured and ready")
-
-	// Persist status condition changes to the API server
-	if err := c.Status().Update(ctx, hcluster); err != nil {
-		return fmt.Errorf("failed to update HostedCluster status conditions: %w", err)
 	}
 
 	return nil
@@ -497,40 +470,6 @@ func GetCredentialStatus(hc *hyperv1.HostedCluster) CredentialStatus {
 	return CredentialStatusUnknown
 }
 
-// RefreshGCPCredentialConditions validates GCP workload identity configuration
-// and updates the ValidGCPWorkloadIdentity condition on the HostedCluster.
-// This is a pure spec check with no network calls, safe to call during deletion.
-// Returns true if the condition was updated.
-func RefreshGCPCredentialConditions(hc *hyperv1.HostedCluster) bool {
-	if hc.Spec.Platform.GCP == nil {
-		return meta.SetStatusCondition(&hc.Status.Conditions, metav1.Condition{
-			Type:               string(hyperv1.ValidGCPWorkloadIdentity),
-			Status:             metav1.ConditionFalse,
-			Reason:             "MissingGCPConfiguration",
-			Message:            "GCP platform configuration is missing",
-			ObservedGeneration: hc.Generation,
-		})
-	}
-
-	if err := validateWorkloadIdentityConfiguration(hc); err != nil {
-		return meta.SetStatusCondition(&hc.Status.Conditions, metav1.Condition{
-			Type:               string(hyperv1.ValidGCPWorkloadIdentity),
-			Status:             metav1.ConditionFalse,
-			Reason:             "InvalidWIFConfiguration",
-			Message:            fmt.Sprintf("Workload Identity Federation configuration is invalid: %v", err),
-			ObservedGeneration: hc.Generation,
-		})
-	}
-
-	return meta.SetStatusCondition(&hc.Status.Conditions, metav1.Condition{
-		Type:               string(hyperv1.ValidGCPWorkloadIdentity),
-		Status:             metav1.ConditionTrue,
-		Reason:             "ValidWIFConfiguration",
-		Message:            "Workload Identity Federation configuration is valid and ready",
-		ObservedGeneration: hc.Generation,
-	})
-}
-
 // validateWorkloadIdentityConfiguration validates the Workload Identity Federation configuration.
 // This ensures all required fields are present and properly formatted.
 func validateWorkloadIdentityConfiguration(hcluster *hyperv1.HostedCluster) error {
@@ -606,16 +545,4 @@ func (GCP) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hype
 		logger.Info("removed finalizers of gcpmachine because of invalid GCP credentials", "machine", client.ObjectKeyFromObject(gcpMachine))
 	}
 	return utilerrors.NewAggregate(errs)
-}
-
-// setCondition updates or creates a condition on the HostedCluster.
-// This follows the standard HyperShift pattern for condition management.
-func setCondition(hcluster *hyperv1.HostedCluster, conditionType hyperv1.ConditionType, status metav1.ConditionStatus, reason, message string) {
-	meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
-		Type:               string(conditionType),
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	})
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -33,10 +33,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/utils/ptr"
 
 	capigcp "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/blang/semver"
@@ -304,7 +306,7 @@ func (p GCP) ReconcileCredentials(ctx context.Context, c client.Client, createOr
 	}
 
 	// Validate Workload Identity Federation configuration (required)
-	if err := p.validateWorkloadIdentityConfiguration(hcluster); err != nil {
+	if err := validateWorkloadIdentityConfiguration(hcluster); err != nil {
 		setCondition(hcluster, hyperv1.ValidGCPWorkloadIdentity, metav1.ConditionFalse, "InvalidWIFConfiguration", fmt.Sprintf("Workload Identity Federation configuration is invalid: %v", err))
 		if updateErr := c.Status().Update(ctx, hcluster); updateErr != nil {
 			return fmt.Errorf("invalid workload identity configuration: %w (failed to update status: %w)", err, updateErr)
@@ -477,9 +479,15 @@ func ValidCredentials(hc *hyperv1.HostedCluster) bool {
 	return true
 }
 
+func SetValidGCPWorkloadIdentityAndCalidGCPCredentialsConditions(hc *hyperv1.HostedCluster) {
+	if hc.Spec.Platform.Type != hyperv1.GCPPlatform {
+		return
+	}
+}
+
 // validateWorkloadIdentityConfiguration validates the Workload Identity Federation configuration.
 // This ensures all required fields are present and properly formatted.
-func (p GCP) validateWorkloadIdentityConfiguration(hcluster *hyperv1.HostedCluster) error {
+func validateWorkloadIdentityConfiguration(hcluster *hyperv1.HostedCluster) error {
 	// Note: GCP platform configuration nil check is handled by caller
 	wif := hcluster.Spec.Platform.GCP.WorkloadIdentity
 
@@ -525,6 +533,34 @@ func (p GCP) validateWorkloadIdentityConfiguration(hcluster *hyperv1.HostedClust
 	}
 
 	return nil
+}
+
+func (GCP) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hyperv1.HostedCluster, controlPlaneNamespace string) error {
+	if ValidCredentials(hc) {
+		return nil
+	}
+	gcpMachineList := capigcp.GCPMachineList{}
+	if err := c.List(ctx, &gcpMachineList, client.InNamespace(controlPlaneNamespace)); err != nil {
+		return fmt.Errorf("failed to list GCPMachines in %s: %w", controlPlaneNamespace, err)
+	}
+	logger := ctrl.LoggerFrom(ctx)
+	var errs []error
+	for i := range gcpMachineList.Items {
+		gcpMachine := &gcpMachineList.Items[i]
+		if gcpMachine.DeletionTimestamp.IsZero() ||
+			len(gcpMachine.Finalizers) == 0 {
+			continue
+		}
+
+		gcpMachine.Finalizers = []string{}
+		if err := c.Update(ctx, gcpMachine); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete machine %s/%s: %w", gcpMachine.Namespace, gcpMachine.Name, err))
+			continue
+		}
+		logger.Info("removed finalizers of gcpmachine because of invalid GCP credentials", "machine", client.ObjectKeyFromObject(gcpMachine))
+
+	}
+	return utilerrors.NewAggregate(errs)
 }
 
 // setCondition updates or creates a condition on the HostedCluster.

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -44,6 +44,15 @@ import (
 	"github.com/blang/semver"
 )
 
+// CredentialStatus represents the status of GCP credentials.
+type CredentialStatus int
+
+const (
+	CredentialStatusValid   CredentialStatus = 0
+	CredentialStatusInvalid CredentialStatus = 1
+	CredentialStatusUnknown CredentialStatus = 2
+)
+
 // GCP implements the Platform interface for Google Cloud Platform.
 //
 // This implementation enables HostedCluster reconciliation for GCP platform
@@ -461,28 +470,65 @@ func (p GCP) DeleteCredentials(ctx context.Context, c client.Client, hcluster *h
 	return nil
 }
 
-// ValidCredentials checks if GCP credentials are valid and ready for use.
-// This function validates Workload Identity Federation configuration and status.
-func ValidCredentials(hc *hyperv1.HostedCluster) bool {
-	// Check if GCP Workload Identity Federation is configured and valid
+// GetCredentialStatus returns the GCP credential status (valid/invalid/unknown).
+func GetCredentialStatus(hc *hyperv1.HostedCluster) CredentialStatus {
+	var wifStatus metav1.ConditionStatus
 	validWIF := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPWorkloadIdentity))
-	if validWIF == nil || validWIF.Status != metav1.ConditionTrue {
-		return false
+	if validWIF == nil {
+		wifStatus = metav1.ConditionUnknown
+	} else {
+		wifStatus = validWIF.Status
 	}
 
-	// Check if GCP credentials condition indicates WIF is ready
+	var credsStatus metav1.ConditionStatus
 	validCredentials := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPCredentials))
-	if validCredentials == nil || validCredentials.Status != metav1.ConditionTrue {
-		return false
+	if validCredentials == nil {
+		credsStatus = metav1.ConditionUnknown
+	} else {
+		credsStatus = validCredentials.Status
 	}
 
-	return true
+	if wifStatus == metav1.ConditionFalse || credsStatus == metav1.ConditionFalse {
+		return CredentialStatusInvalid
+	}
+	if wifStatus == metav1.ConditionTrue && credsStatus == metav1.ConditionTrue {
+		return CredentialStatusValid
+	}
+	return CredentialStatusUnknown
 }
 
-func SetValidGCPWorkloadIdentityAndCalidGCPCredentialsConditions(hc *hyperv1.HostedCluster) {
-	if hc.Spec.Platform.Type != hyperv1.GCPPlatform {
-		return
+// RefreshGCPCredentialConditions validates GCP workload identity configuration
+// and updates the ValidGCPWorkloadIdentity condition on the HostedCluster.
+// This is a pure spec check with no network calls, safe to call during deletion.
+// Returns true if the condition was updated.
+func RefreshGCPCredentialConditions(hc *hyperv1.HostedCluster) bool {
+	if hc.Spec.Platform.GCP == nil {
+		return meta.SetStatusCondition(&hc.Status.Conditions, metav1.Condition{
+			Type:               string(hyperv1.ValidGCPWorkloadIdentity),
+			Status:             metav1.ConditionFalse,
+			Reason:             "MissingGCPConfiguration",
+			Message:            "GCP platform configuration is missing",
+			ObservedGeneration: hc.Generation,
+		})
 	}
+
+	if err := validateWorkloadIdentityConfiguration(hc); err != nil {
+		return meta.SetStatusCondition(&hc.Status.Conditions, metav1.Condition{
+			Type:               string(hyperv1.ValidGCPWorkloadIdentity),
+			Status:             metav1.ConditionFalse,
+			Reason:             "InvalidWIFConfiguration",
+			Message:            fmt.Sprintf("Workload Identity Federation configuration is invalid: %v", err),
+			ObservedGeneration: hc.Generation,
+		})
+	}
+
+	return meta.SetStatusCondition(&hc.Status.Conditions, metav1.Condition{
+		Type:               string(hyperv1.ValidGCPWorkloadIdentity),
+		Status:             metav1.ConditionTrue,
+		Reason:             "ValidWIFConfiguration",
+		Message:            "Workload Identity Federation configuration is valid and ready",
+		ObservedGeneration: hc.Generation,
+	})
 }
 
 // validateWorkloadIdentityConfiguration validates the Workload Identity Federation configuration.
@@ -536,7 +582,7 @@ func validateWorkloadIdentityConfiguration(hcluster *hyperv1.HostedCluster) erro
 }
 
 func (GCP) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hyperv1.HostedCluster, controlPlaneNamespace string) error {
-	if ValidCredentials(hc) {
+	if GetCredentialStatus(hc) != CredentialStatusInvalid {
 		return nil
 	}
 	gcpMachineList := capigcp.GCPMachineList{}
@@ -554,11 +600,10 @@ func (GCP) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hype
 
 		gcpMachine.Finalizers = []string{}
 		if err := c.Update(ctx, gcpMachine); err != nil {
-			errs = append(errs, fmt.Errorf("failed to delete machine %s/%s: %w", gcpMachine.Namespace, gcpMachine.Name, err))
+			errs = append(errs, fmt.Errorf("failed to remove finalizers from GCPMachine %s/%s: %w", gcpMachine.Namespace, gcpMachine.Name, err))
 			continue
 		}
 		logger.Info("removed finalizers of gcpmachine because of invalid GCP credentials", "machine", client.ObjectKeyFromObject(gcpMachine))
-
 	}
 	return utilerrors.NewAggregate(errs)
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -34,24 +34,24 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/utils/ptr"
 
 	capigcp "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/blang/semver"
 )
 
-// CredentialStatus represents the status of GCP credentials
+// CredentialStatus represents the status of GCP credentials.
 type CredentialStatus int
 
 const (
-	// CredentialStatusValid indicates that GCP credentials are valid
-	CredentialStatusValid CredentialStatus = 0
-	// CredentialStatusInvalid indicates that GCP credentials are invalid
+	CredentialStatusValid   CredentialStatus = 0
 	CredentialStatusInvalid CredentialStatus = 1
-	// CredentialStatusUnknown indicates that GCP credential status is unknown
 	CredentialStatusUnknown CredentialStatus = 2
 )
 
@@ -316,28 +316,14 @@ func (p GCP) ReconcileCredentials(ctx context.Context, c client.Client, createOr
 	hcluster *hyperv1.HostedCluster,
 	controlPlaneNamespace string,
 ) error {
-	// Validate GCP platform configuration is present
 	if hcluster.Spec.Platform.GCP == nil {
-		setCondition(hcluster, hyperv1.ValidGCPWorkloadIdentity, metav1.ConditionFalse, "MissingGCPConfiguration", "GCP platform configuration is missing")
-		if updateErr := c.Status().Update(ctx, hcluster); updateErr != nil {
-			return fmt.Errorf("GCP platform configuration is missing (failed to update status: %w)", updateErr)
-		}
 		return fmt.Errorf("GCP platform configuration is missing")
 	}
 
-	// Validate Workload Identity Federation configuration (required)
-	if err := p.validateWorkloadIdentityConfiguration(hcluster); err != nil {
-		setCondition(hcluster, hyperv1.ValidGCPWorkloadIdentity, metav1.ConditionFalse, "InvalidWIFConfiguration", fmt.Sprintf("Workload Identity Federation configuration is invalid: %v", err))
-		if updateErr := c.Status().Update(ctx, hcluster); updateErr != nil {
-			return fmt.Errorf("invalid workload identity configuration: %w (failed to update status: %w)", err, updateErr)
-		}
+	if err := validateWorkloadIdentityConfiguration(hcluster); err != nil {
 		return fmt.Errorf("invalid workload identity configuration: %w", err)
 	}
 
-	// Set successful WIF validation condition
-	setCondition(hcluster, hyperv1.ValidGCPWorkloadIdentity, metav1.ConditionTrue, "ValidWIFConfiguration", "Workload Identity Federation configuration is valid and ready")
-
-	// Create credential secrets following AWS pattern
 	var errs []error
 	syncSecret := func(secret *corev1.Secret, serviceAccountEmail string) error {
 		credentials, err := gcputil.BuildWorkloadIdentityCredentials(hcluster.Spec.Platform.GCP.WorkloadIdentity, serviceAccountEmail)
@@ -354,7 +340,6 @@ func (p GCP) ReconcileCredentials(ctx context.Context, c client.Client, createOr
 		return nil
 	}
 
-	// Create credential secrets for all configured service accounts
 	credentialSecrets := map[hyperv1.GCPServiceAccountEmail]*corev1.Secret{
 		hcluster.Spec.Platform.GCP.WorkloadIdentity.ServiceAccountsEmails.NodePool:        NodePoolManagementCredsSecret(controlPlaneNamespace),
 		hcluster.Spec.Platform.GCP.WorkloadIdentity.ServiceAccountsEmails.ControlPlane:    ControlPlaneOperatorCredsSecret(controlPlaneNamespace),
@@ -371,19 +356,7 @@ func (p GCP) ReconcileCredentials(ctx context.Context, c client.Client, createOr
 	}
 
 	if len(errs) > 0 {
-		setCondition(hcluster, hyperv1.ValidGCPCredentials, metav1.ConditionFalse, "CredentialsError", fmt.Sprintf("Failed to reconcile credentials: %v", errs))
-		if updateErr := c.Status().Update(ctx, hcluster); updateErr != nil {
-			return fmt.Errorf("failed to reconcile GCP credentials: %v (failed to update status: %w)", errs, updateErr)
-		}
 		return fmt.Errorf("failed to reconcile GCP credentials: %v", errs)
-	}
-
-	// Set credentials condition to indicate federation is ready
-	setCondition(hcluster, hyperv1.ValidGCPCredentials, metav1.ConditionTrue, "WIFReady", "GCP Workload Identity Federation is configured and ready")
-
-	// Persist status condition changes to the API server
-	if err := c.Status().Update(ctx, hcluster); err != nil {
-		return fmt.Errorf("failed to update HostedCluster status conditions: %w", err)
 	}
 
 	return nil
@@ -481,27 +454,8 @@ func (p GCP) DeleteCredentials(ctx context.Context, c client.Client, hcluster *h
 	return nil
 }
 
-// ValidCredentials checks if GCP credentials are valid and ready for use.
-// This function validates Workload Identity Federation configuration and status.
-func ValidCredentials(hc *hyperv1.HostedCluster) bool {
-	// Check if GCP Workload Identity Federation is configured and valid
-	validWIF := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPWorkloadIdentity))
-	if validWIF == nil || validWIF.Status != metav1.ConditionTrue {
-		return false
-	}
-
-	// Check if GCP credentials condition indicates WIF is ready
-	validCredentials := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPCredentials))
-	if validCredentials == nil || validCredentials.Status != metav1.ConditionTrue {
-		return false
-	}
-
-	return true
-}
-
-// GetCredentialStatus returns the GCP credential status (valid/invalid/unknown)
+// GetCredentialStatus returns the GCP credential status (valid/invalid/unknown).
 func GetCredentialStatus(hc *hyperv1.HostedCluster) CredentialStatus {
-	// Get GCP Workload Identity Federation status
 	var wifStatus metav1.ConditionStatus
 	validWIF := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPWorkloadIdentity))
 	if validWIF == nil {
@@ -510,19 +464,14 @@ func GetCredentialStatus(hc *hyperv1.HostedCluster) CredentialStatus {
 		wifStatus = validWIF.Status
 	}
 
-	// Get GCP credentials status
 	var credsStatus metav1.ConditionStatus
-	validCreds := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPCredentials))
-	if validCreds == nil {
+	validCredentials := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPCredentials))
+	if validCredentials == nil {
 		credsStatus = metav1.ConditionUnknown
 	} else {
-		credsStatus = validCreds.Status
+		credsStatus = validCredentials.Status
 	}
 
-	// Combine the results:
-	// - If either is explicitly False → Invalid
-	// - If both are True → Valid
-	// - Otherwise → Unknown
 	if wifStatus == metav1.ConditionFalse || credsStatus == metav1.ConditionFalse {
 		return CredentialStatusInvalid
 	}
@@ -532,9 +481,56 @@ func GetCredentialStatus(hc *hyperv1.HostedCluster) CredentialStatus {
 	return CredentialStatusUnknown
 }
 
+// ComputeGCPCredentialConditions bubbles up ValidGCPWorkloadIdentity and
+// ValidGCPCredentials from the HostedControlPlane to the HostedCluster.
+// Returns whether any condition changed.
+//
+// Invalid is latched: if the HC already has a False condition and the HCP now
+// reports Unknown (e.g. because KAS is gone during teardown), the existing
+// False is kept so that DeleteOrphanedMachines continues to fire and teardown
+// does not get stuck again.
+func ComputeGCPCredentialConditions(hc *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) bool {
+	var changed bool
+	for _, condType := range []hyperv1.ConditionType{
+		hyperv1.ValidGCPWorkloadIdentity,
+		hyperv1.ValidGCPCredentials,
+	} {
+		var hcpCond *metav1.Condition
+		if hcp != nil {
+			hcpCond = meta.FindStatusCondition(hcp.Status.Conditions, string(condType))
+		}
+
+		var fresh metav1.Condition
+		if hcpCond == nil || hcpCond.Status == metav1.ConditionUnknown {
+			// Latch: keep an existing False on the HC rather than downgrading to
+			// Unknown. This prevents a KAS-unavailable signal during teardown from
+			// clobbering a previously confirmed Invalid state and silently stopping
+			// orphan machine cleanup.
+			existing := meta.FindStatusCondition(hc.Status.Conditions, string(condType))
+			if existing != nil && existing.Status == metav1.ConditionFalse {
+				continue // keep the latched Invalid; nothing to update
+			}
+			fresh = metav1.Condition{
+				Type:               string(condType),
+				Status:             metav1.ConditionUnknown,
+				Reason:             hyperv1.StatusUnknownReason,
+				ObservedGeneration: hc.Generation,
+			}
+		} else {
+			fresh = *hcpCond
+			fresh.ObservedGeneration = hc.Generation
+		}
+
+		if meta.SetStatusCondition(&hc.Status.Conditions, fresh) {
+			changed = true
+		}
+	}
+	return changed
+}
+
 // validateWorkloadIdentityConfiguration validates the Workload Identity Federation configuration.
 // This ensures all required fields are present and properly formatted.
-func (p GCP) validateWorkloadIdentityConfiguration(hcluster *hyperv1.HostedCluster) error {
+func validateWorkloadIdentityConfiguration(hcluster *hyperv1.HostedCluster) error {
 	// Note: GCP platform configuration nil check is handled by caller
 	wif := hcluster.Spec.Platform.GCP.WorkloadIdentity
 
@@ -582,14 +578,29 @@ func (p GCP) validateWorkloadIdentityConfiguration(hcluster *hyperv1.HostedClust
 	return nil
 }
 
-// setCondition updates or creates a condition on the HostedCluster.
-// This follows the standard HyperShift pattern for condition management.
-func setCondition(hcluster *hyperv1.HostedCluster, conditionType hyperv1.ConditionType, status metav1.ConditionStatus, reason, message string) {
-	meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
-		Type:               string(conditionType),
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	})
+func (GCP) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hyperv1.HostedCluster, controlPlaneNamespace string) error {
+	if GetCredentialStatus(hc) != CredentialStatusInvalid {
+		return nil
+	}
+	gcpMachineList := capigcp.GCPMachineList{}
+	if err := c.List(ctx, &gcpMachineList, client.InNamespace(controlPlaneNamespace)); err != nil {
+		return fmt.Errorf("failed to list GCPMachines in %s: %w", controlPlaneNamespace, err)
+	}
+	logger := ctrl.LoggerFrom(ctx)
+	var errs []error
+	for i := range gcpMachineList.Items {
+		gcpMachine := &gcpMachineList.Items[i]
+		if gcpMachine.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if removed := controllerutil.RemoveFinalizer(gcpMachine, capigcp.MachineFinalizer); !removed {
+			continue
+		}
+		if err := c.Update(ctx, gcpMachine); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove finalizer from GCPMachine %s/%s: %w", gcpMachine.Namespace, gcpMachine.Name, err))
+			continue
+		}
+		logger.Info("removed CAPG finalizer from orphaned gcpmachine due to invalid GCP credentials", "machine", client.ObjectKeyFromObject(gcpMachine))
+	}
+	return utilerrors.NewAggregate(errs)
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
@@ -13,102 +13,79 @@ import (
 	capigcp "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 )
 
-// TestValidCredentials tests the ValidCredentials method for various condition states.
-// This tests the logic for checking both ValidGCPWorkloadIdentity and ValidGCPCredentials conditions.
-func TestValidCredentials(t *testing.T) {
+// TestGetCredentialStatus tests the GetCredentialStatus method for various condition states.
+// This tests the tri-state logic for checking both ValidGCPWorkloadIdentity and ValidGCPCredentials conditions.
+func TestGetCredentialStatus(t *testing.T) {
 	tests := []struct {
-		name        string
-		conditions  []metav1.Condition
-		expected    bool
-		description string
+		name       string
+		conditions []metav1.Condition
+		expected   CredentialStatus
 	}{
 		{
-			name: "When both conditions are true, it should return true",
+			name: "both conditions true returns Valid",
 			conditions: []metav1.Condition{
-				{
-					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
-					Status: metav1.ConditionTrue,
-				},
-				{
-					Type:   string(hyperv1.ValidGCPCredentials),
-					Status: metav1.ConditionTrue,
-				},
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
 			},
-			expected:    true,
-			description: "Both conditions are present and true",
+			expected: CredentialStatusValid,
 		},
 		{
-			name: "When ValidGCPWorkloadIdentity is false, it should return false",
+			name: "WIF false returns Invalid",
 			conditions: []metav1.Condition{
-				{
-					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
-					Status: metav1.ConditionFalse,
-				},
-				{
-					Type:   string(hyperv1.ValidGCPCredentials),
-					Status: metav1.ConditionTrue,
-				},
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
 			},
-			expected:    false,
-			description: "ValidGCPWorkloadIdentity is false",
+			expected: CredentialStatusInvalid,
 		},
 		{
-			name: "When ValidGCPCredentials is false, it should return false",
+			name: "credentials false returns Invalid",
 			conditions: []metav1.Condition{
-				{
-					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
-					Status: metav1.ConditionTrue,
-				},
-				{
-					Type:   string(hyperv1.ValidGCPCredentials),
-					Status: metav1.ConditionFalse,
-				},
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
 			},
-			expected:    false,
-			description: "ValidGCPCredentials is false",
+			expected: CredentialStatusInvalid,
 		},
 		{
-			name: "When both conditions are false, it should return false",
+			name: "both conditions false returns Invalid",
 			conditions: []metav1.Condition{
-				{
-					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
-					Status: metav1.ConditionFalse,
-				},
-				{
-					Type:   string(hyperv1.ValidGCPCredentials),
-					Status: metav1.ConditionFalse,
-				},
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
 			},
-			expected:    false,
-			description: "Both conditions are false",
+			expected: CredentialStatusInvalid,
 		},
 		{
-			name: "When ValidGCPWorkloadIdentity is missing, it should return false",
+			name: "WIF missing returns Unknown",
 			conditions: []metav1.Condition{
-				{
-					Type:   string(hyperv1.ValidGCPCredentials),
-					Status: metav1.ConditionTrue,
-				},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
 			},
-			expected:    false,
-			description: "ValidGCPWorkloadIdentity condition is missing",
+			expected: CredentialStatusUnknown,
 		},
 		{
-			name: "When ValidGCPCredentials is missing, it should return false",
+			name: "credentials missing returns Unknown",
 			conditions: []metav1.Condition{
-				{
-					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
-					Status: metav1.ConditionTrue,
-				},
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
 			},
-			expected:    false,
-			description: "ValidGCPCredentials condition is missing",
+			expected: CredentialStatusUnknown,
 		},
 		{
-			name:        "When no conditions exist, it should return false",
-			conditions:  []metav1.Condition{},
-			expected:    false,
-			description: "No conditions present",
+			name:       "no conditions returns Unknown",
+			conditions: []metav1.Condition{},
+			expected:   CredentialStatusUnknown,
+		},
+		{
+			name: "WIF true credentials unknown returns Unknown",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionUnknown},
+			},
+			expected: CredentialStatusUnknown,
+		},
+		{
+			name: "WIF false credentials missing returns Invalid",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
+			},
+			expected: CredentialStatusInvalid,
 		},
 	}
 
@@ -122,8 +99,7 @@ func TestValidCredentials(t *testing.T) {
 				},
 			}
 
-			result := ValidCredentials(hc)
-			g.Expect(result).To(Equal(tt.expected), tt.description)
+			g.Expect(GetCredentialStatus(hc)).To(Equal(tt.expected))
 		})
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
@@ -132,7 +132,6 @@ func TestValidCredentials(t *testing.T) {
 // This expands on the existing TestValidateWorkloadIdentityConfiguration with more comprehensive coverage.
 func TestWorkloadIdentityValidationScenarios(t *testing.T) {
 	g := NewWithT(t)
-	platform := New("test-utilities-image", "test-capg-image", nil)
 
 	tests := []struct {
 		name        string
@@ -213,7 +212,7 @@ func TestWorkloadIdentityValidationScenarios(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := platform.validateWorkloadIdentityConfiguration(tt.hcluster)
+			err := validateWorkloadIdentityConfiguration(tt.hcluster)
 			if tt.expectError {
 				g.Expect(err).ToNot(BeNil())
 				if tt.errorMsg != "" {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
@@ -8,125 +8,11 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	capigcp "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 )
-
-// TestValidCredentials tests the ValidCredentials method for various condition states.
-// This tests the logic for checking both ValidGCPWorkloadIdentity and ValidGCPCredentials conditions.
-func TestValidCredentials(t *testing.T) {
-	tests := []struct {
-		name        string
-		conditions  []metav1.Condition
-		expected    bool
-		description string
-	}{
-		{
-			name: "When both conditions are true, it should return true",
-			conditions: []metav1.Condition{
-				{
-					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
-					Status: metav1.ConditionTrue,
-				},
-				{
-					Type:   string(hyperv1.ValidGCPCredentials),
-					Status: metav1.ConditionTrue,
-				},
-			},
-			expected:    true,
-			description: "Both conditions are present and true",
-		},
-		{
-			name: "When ValidGCPWorkloadIdentity is false, it should return false",
-			conditions: []metav1.Condition{
-				{
-					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
-					Status: metav1.ConditionFalse,
-				},
-				{
-					Type:   string(hyperv1.ValidGCPCredentials),
-					Status: metav1.ConditionTrue,
-				},
-			},
-			expected:    false,
-			description: "ValidGCPWorkloadIdentity is false",
-		},
-		{
-			name: "When ValidGCPCredentials is false, it should return false",
-			conditions: []metav1.Condition{
-				{
-					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
-					Status: metav1.ConditionTrue,
-				},
-				{
-					Type:   string(hyperv1.ValidGCPCredentials),
-					Status: metav1.ConditionFalse,
-				},
-			},
-			expected:    false,
-			description: "ValidGCPCredentials is false",
-		},
-		{
-			name: "When both conditions are false, it should return false",
-			conditions: []metav1.Condition{
-				{
-					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
-					Status: metav1.ConditionFalse,
-				},
-				{
-					Type:   string(hyperv1.ValidGCPCredentials),
-					Status: metav1.ConditionFalse,
-				},
-			},
-			expected:    false,
-			description: "Both conditions are false",
-		},
-		{
-			name: "When ValidGCPWorkloadIdentity is missing, it should return false",
-			conditions: []metav1.Condition{
-				{
-					Type:   string(hyperv1.ValidGCPCredentials),
-					Status: metav1.ConditionTrue,
-				},
-			},
-			expected:    false,
-			description: "ValidGCPWorkloadIdentity condition is missing",
-		},
-		{
-			name: "When ValidGCPCredentials is missing, it should return false",
-			conditions: []metav1.Condition{
-				{
-					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
-					Status: metav1.ConditionTrue,
-				},
-			},
-			expected:    false,
-			description: "ValidGCPCredentials condition is missing",
-		},
-		{
-			name:        "When no conditions exist, it should return false",
-			conditions:  []metav1.Condition{},
-			expected:    false,
-			description: "No conditions present",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-
-			hc := &hyperv1.HostedCluster{
-				Status: hyperv1.HostedClusterStatus{
-					Conditions: tt.conditions,
-				},
-			}
-
-			result := ValidCredentials(hc)
-			g.Expect(result).To(Equal(tt.expected), tt.description)
-		})
-	}
-}
 
 // TestGetCredentialStatus tests the GetCredentialStatus function for various condition states.
 // This tests the tri-state logic (valid/invalid/unknown) for GCP credential conditions.
@@ -267,7 +153,6 @@ func TestGetCredentialStatus(t *testing.T) {
 // This expands on the existing TestValidateWorkloadIdentityConfiguration with more comprehensive coverage.
 func TestWorkloadIdentityValidationScenarios(t *testing.T) {
 	g := NewWithT(t)
-	platform := New("test-utilities-image", "test-capg-image", nil)
 
 	tests := []struct {
 		name        string
@@ -348,7 +233,7 @@ func TestWorkloadIdentityValidationScenarios(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := platform.validateWorkloadIdentityConfiguration(tt.hcluster)
+			err := validateWorkloadIdentityConfiguration(tt.hcluster)
 			if tt.expectError {
 				g.Expect(err).ToNot(BeNil())
 				if tt.errorMsg != "" {
@@ -404,6 +289,141 @@ func TestNetworkConfigAccessSafety(t *testing.T) {
 	g.Expect(gcpCluster.Spec.Region).To(Equal("us-central1"))
 	// Network should not be configured since Name is empty
 	g.Expect(gcpCluster.Spec.Network.Name).To(BeNil())
+}
+
+func TestComputeGCPCredentialConditions(t *testing.T) {
+	tests := []struct {
+		name               string
+		hcConditions       []metav1.Condition
+		hcp                *hyperv1.HostedControlPlane
+		expectedChanged    bool
+		expectedWIFStatus  metav1.ConditionStatus
+		expectedWIFReason  string
+		expectedCredStatus metav1.ConditionStatus
+	}{
+		{
+			name: "When HCP has True conditions, it should bubble them up to HC",
+			hcp: &hyperv1.HostedControlPlane{
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue, Reason: hyperv1.AsExpectedReason},
+						{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue, Reason: hyperv1.AsExpectedReason},
+					},
+				},
+			},
+			expectedChanged:    true,
+			expectedWIFStatus:  metav1.ConditionTrue,
+			expectedWIFReason:  hyperv1.AsExpectedReason,
+			expectedCredStatus: metav1.ConditionTrue,
+		},
+		{
+			name:               "When HCP is nil, it should set conditions to Unknown",
+			hcp:                nil,
+			expectedChanged:    true,
+			expectedWIFStatus:  metav1.ConditionUnknown,
+			expectedWIFReason:  hyperv1.StatusUnknownReason,
+			expectedCredStatus: metav1.ConditionUnknown,
+		},
+		{
+			name: "When HCP has no conditions, it should set conditions to Unknown",
+			hcp: &hyperv1.HostedControlPlane{
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{},
+				},
+			},
+			expectedChanged:    true,
+			expectedWIFStatus:  metav1.ConditionUnknown,
+			expectedWIFReason:  hyperv1.StatusUnknownReason,
+			expectedCredStatus: metav1.ConditionUnknown,
+		},
+		{
+			name: "When HCP has False conditions, it should propagate them to HC",
+			hcp: &hyperv1.HostedControlPlane{
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider},
+						{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider},
+					},
+				},
+			},
+			expectedChanged:    true,
+			expectedWIFStatus:  metav1.ConditionFalse,
+			expectedWIFReason:  hyperv1.InvalidIdentityProvider,
+			expectedCredStatus: metav1.ConditionFalse,
+		},
+		{
+			name: "When HC already has the same conditions, it should not report a change",
+			hcConditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue, Reason: hyperv1.AsExpectedReason, ObservedGeneration: 3},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue, Reason: hyperv1.AsExpectedReason, ObservedGeneration: 3},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue, Reason: hyperv1.AsExpectedReason},
+						{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue, Reason: hyperv1.AsExpectedReason},
+					},
+				},
+			},
+			expectedChanged:    false,
+			expectedWIFStatus:  metav1.ConditionTrue,
+			expectedWIFReason:  hyperv1.AsExpectedReason,
+			expectedCredStatus: metav1.ConditionTrue,
+		},
+		{
+			// Latch: during teardown KAS goes away, HCP sends Unknown. An existing
+			// False on the HC must not be clobbered so DeleteOrphanedMachines keeps firing.
+			name: "When HC has False conditions and HCP sends Unknown, it should latch False and not update",
+			hcConditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider, ObservedGeneration: 3},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider, ObservedGeneration: 3},
+			},
+			hcp:                nil,
+			expectedChanged:    false,
+			expectedWIFStatus:  metav1.ConditionFalse,
+			expectedWIFReason:  hyperv1.InvalidIdentityProvider,
+			expectedCredStatus: metav1.ConditionFalse,
+		},
+		{
+			// Partial latch: WIF is False (latched), Credentials was Unknown — HCP now
+			// sends Unknown for both. WIF stays False; Credentials stays Unknown (no change).
+			name: "When HC has False WIF and Unknown Credentials and HCP sends Unknown, it should latch False WIF only",
+			hcConditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider, ObservedGeneration: 3},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionUnknown, Reason: hyperv1.StatusUnknownReason, ObservedGeneration: 3},
+			},
+			hcp:                nil,
+			expectedChanged:    false,
+			expectedWIFStatus:  metav1.ConditionFalse,
+			expectedWIFReason:  hyperv1.InvalidIdentityProvider,
+			expectedCredStatus: metav1.ConditionUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hc := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 3},
+				Status: hyperv1.HostedClusterStatus{
+					Conditions: tt.hcConditions,
+				},
+			}
+
+			changed := ComputeGCPCredentialConditions(hc, tt.hcp)
+			g.Expect(changed).To(Equal(tt.expectedChanged), "changed flag mismatch")
+
+			wifCond := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPWorkloadIdentity))
+			g.Expect(wifCond).ToNot(BeNil(), "ValidGCPWorkloadIdentity condition must be set")
+			g.Expect(wifCond.Status).To(Equal(tt.expectedWIFStatus), "ValidGCPWorkloadIdentity status mismatch")
+			g.Expect(wifCond.Reason).To(Equal(tt.expectedWIFReason), "ValidGCPWorkloadIdentity reason mismatch")
+
+			credCond := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPCredentials))
+			g.Expect(credCond).ToNot(BeNil(), "ValidGCPCredentials condition must be set")
+			g.Expect(credCond.Status).To(Equal(tt.expectedCredStatus), "ValidGCPCredentials status mismatch")
+		})
+	}
 }
 
 // TestServiceAccountEmailValidation tests that the regex pattern validation for service account emails is working correctly.

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_test.go
@@ -298,8 +298,6 @@ func TestDeleteCredentials(t *testing.T) {
 func TestValidateWorkloadIdentityConfiguration(t *testing.T) {
 	g := NewWithT(t)
 
-	platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
-
 	tests := []struct {
 		name     string
 		mutate   func(*hyperv1.HostedCluster)
@@ -359,7 +357,7 @@ func TestValidateWorkloadIdentityConfiguration(t *testing.T) {
 			if tt.mutate != nil {
 				tt.mutate(hc)
 			}
-			err := platform.validateWorkloadIdentityConfiguration(hc)
+			err := validateWorkloadIdentityConfiguration(hc)
 			if tt.errorMsg != "" {
 				g.Expect(err).ToNot(BeNil())
 				g.Expect(err.Error()).To(ContainSubstring(tt.errorMsg))
@@ -415,4 +413,58 @@ func TestReconcileGCPClusterPreservesServerDefaultedFields(t *testing.T) {
 	g.Expect(gcpCluster.Spec.Network.Name).To(Equal(ptr.To("test-network")))
 	g.Expect(gcpCluster.Spec.Network.Subnets[0].Name).To(Equal("test-subnet"))
 	g.Expect(gcpCluster.Spec.Network.Subnets[0].Region).To(Equal("us-central1"))
+}
+
+func TestDeleteOrphanedMachines(t *testing.T) {
+	g := NewWithT(t)
+
+	platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
+	hc := validHostedCluster()
+
+	// Create a scheme with both HyperShift and CAPG types
+	scheme := runtime.NewScheme()
+	g.Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+	g.Expect(hyperv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(capigcp.AddToScheme(scheme)).To(Succeed())
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(
+			&capigcp.GCPMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-xl-1",
+					Namespace:         "test-control-plane-namespace",
+					DeletionTimestamp: ptr.To(metav1.Now()),
+					Finalizers:        []string{"test", "testz"},
+				},
+			},
+			// GCPMachines without deletionTimestamp should not get their finalizers removed.
+			&capigcp.GCPMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-xl-2",
+					Namespace:  "test-control-plane-namespace",
+					Finalizers: []string{"test", "testz"},
+				},
+			},
+		).
+		WithScheme(scheme).
+		Build()
+
+	err := platform.DeleteOrphanedMachines(
+		t.Context(),
+		fakeClient,
+		hc,
+		"test-control-plane-namespace",
+	)
+	g.Expect(err).To(BeNil())
+
+	gcpMachineList := &capigcp.GCPMachineList{}
+	err = fakeClient.List(t.Context(), gcpMachineList)
+	g.Expect(err).To(BeNil())
+
+	for _, gcpMachine := range gcpMachineList.Items {
+		if !gcpMachine.DeletionTimestamp.IsZero() {
+			g.Expect(gcpMachine.Finalizers).To(BeEmpty())
+		} else {
+			g.Expect(gcpMachine.Finalizers).ToNot(BeEmpty())
+		}
+	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_test.go
@@ -416,18 +416,16 @@ func TestReconcileGCPClusterPreservesServerDefaultedFields(t *testing.T) {
 }
 
 func TestDeleteOrphanedMachines(t *testing.T) {
-	g := NewWithT(t)
+	buildScheme := func(g Gomega) *runtime.Scheme {
+		scheme := runtime.NewScheme()
+		g.Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+		g.Expect(hyperv1.AddToScheme(scheme)).To(Succeed())
+		g.Expect(capigcp.AddToScheme(scheme)).To(Succeed())
+		return scheme
+	}
 
-	platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
-	hc := validHostedCluster()
-
-	// Create a scheme with both HyperShift and CAPG types
-	scheme := runtime.NewScheme()
-	g.Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
-	g.Expect(hyperv1.AddToScheme(scheme)).To(Succeed())
-	g.Expect(capigcp.AddToScheme(scheme)).To(Succeed())
-	fakeClient := fake.NewClientBuilder().
-		WithObjects(
+	gcpMachines := func() []client.Object {
+		return []client.Object{
 			&capigcp.GCPMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-xl-1",
@@ -436,7 +434,6 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					Finalizers:        []string{"test", "testz"},
 				},
 			},
-			// GCPMachines without deletionTimestamp should not get their finalizers removed.
 			&capigcp.GCPMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-xl-2",
@@ -444,27 +441,85 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					Finalizers: []string{"test", "testz"},
 				},
 			},
-		).
-		WithScheme(scheme).
-		Build()
-
-	err := platform.DeleteOrphanedMachines(
-		t.Context(),
-		fakeClient,
-		hc,
-		"test-control-plane-namespace",
-	)
-	g.Expect(err).To(BeNil())
-
-	gcpMachineList := &capigcp.GCPMachineList{}
-	err = fakeClient.List(t.Context(), gcpMachineList)
-	g.Expect(err).To(BeNil())
-
-	for _, gcpMachine := range gcpMachineList.Items {
-		if !gcpMachine.DeletionTimestamp.IsZero() {
-			g.Expect(gcpMachine.Finalizers).To(BeEmpty())
-		} else {
-			g.Expect(gcpMachine.Finalizers).ToNot(BeEmpty())
 		}
 	}
+
+	t.Run("invalid credentials strips finalizers from deleted machines", func(t *testing.T) {
+		g := NewWithT(t)
+		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
+
+		hc := validHostedCluster()
+		hc.Status.Conditions = []metav1.Condition{
+			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
+			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(gcpMachines()...).
+			WithScheme(buildScheme(g)).
+			Build()
+
+		err := platform.DeleteOrphanedMachines(t.Context(), fakeClient, hc, "test-control-plane-namespace")
+		g.Expect(err).To(BeNil())
+
+		gcpMachineList := &capigcp.GCPMachineList{}
+		g.Expect(fakeClient.List(t.Context(), gcpMachineList)).To(Succeed())
+
+		for _, gcpMachine := range gcpMachineList.Items {
+			if !gcpMachine.DeletionTimestamp.IsZero() {
+				g.Expect(gcpMachine.Finalizers).To(BeEmpty())
+			} else {
+				g.Expect(gcpMachine.Finalizers).ToNot(BeEmpty())
+			}
+		}
+	})
+
+	t.Run("valid credentials leaves finalizers unchanged", func(t *testing.T) {
+		g := NewWithT(t)
+		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
+
+		hc := validHostedCluster()
+		hc.Status.Conditions = []metav1.Condition{
+			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
+			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(gcpMachines()...).
+			WithScheme(buildScheme(g)).
+			Build()
+
+		err := platform.DeleteOrphanedMachines(t.Context(), fakeClient, hc, "test-control-plane-namespace")
+		g.Expect(err).To(BeNil())
+
+		gcpMachineList := &capigcp.GCPMachineList{}
+		g.Expect(fakeClient.List(t.Context(), gcpMachineList)).To(Succeed())
+
+		for _, gcpMachine := range gcpMachineList.Items {
+			g.Expect(gcpMachine.Finalizers).To(Equal([]string{"test", "testz"}))
+		}
+	})
+
+	t.Run("unknown credentials leaves finalizers unchanged", func(t *testing.T) {
+		g := NewWithT(t)
+		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
+
+		hc := validHostedCluster()
+		// No conditions set — GetCredentialStatus returns Unknown
+
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(gcpMachines()...).
+			WithScheme(buildScheme(g)).
+			Build()
+
+		err := platform.DeleteOrphanedMachines(t.Context(), fakeClient, hc, "test-control-plane-namespace")
+		g.Expect(err).To(BeNil())
+
+		gcpMachineList := &capigcp.GCPMachineList{}
+		g.Expect(fakeClient.List(t.Context(), gcpMachineList)).To(Succeed())
+
+		for _, gcpMachine := range gcpMachineList.Items {
+			g.Expect(gcpMachine.Finalizers).To(Equal([]string{"test", "testz"}))
+		}
+	})
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_test.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -18,6 +19,7 @@ import (
 	capigcp "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/blang/semver"
@@ -301,8 +303,6 @@ func TestDeleteCredentials(t *testing.T) {
 func TestValidateWorkloadIdentityConfiguration(t *testing.T) {
 	g := NewWithT(t)
 
-	platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
-
 	tests := []struct {
 		name     string
 		mutate   func(*hyperv1.HostedCluster)
@@ -362,7 +362,7 @@ func TestValidateWorkloadIdentityConfiguration(t *testing.T) {
 			if tt.mutate != nil {
 				tt.mutate(hc)
 			}
-			err := platform.validateWorkloadIdentityConfiguration(hc)
+			err := validateWorkloadIdentityConfiguration(hc)
 			if tt.errorMsg != "" {
 				g.Expect(err).ToNot(BeNil())
 				g.Expect(err.Error()).To(ContainSubstring(tt.errorMsg))
@@ -526,4 +526,220 @@ func TestCAPIProviderDeploymentSpecWithTLS(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteOrphanedMachines(t *testing.T) {
+	buildScheme := func(g Gomega) *runtime.Scheme {
+		scheme := runtime.NewScheme()
+		g.Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+		g.Expect(hyperv1.AddToScheme(scheme)).To(Succeed())
+		g.Expect(capigcp.AddToScheme(scheme)).To(Succeed())
+		return scheme
+	}
+
+	gcpMachines := func() []client.Object {
+		return []client.Object{
+			&capigcp.GCPMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-xl-1",
+					Namespace:         "test-control-plane-namespace",
+					DeletionTimestamp: ptr.To(metav1.Now()),
+					Finalizers:        []string{capigcp.MachineFinalizer, "other-controller-finalizer"},
+				},
+			},
+			&capigcp.GCPMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-xl-2",
+					Namespace:  "test-control-plane-namespace",
+					Finalizers: []string{capigcp.MachineFinalizer, "other-controller-finalizer"},
+				},
+			},
+		}
+	}
+
+	t.Run("When credentials are invalid, it should strip the CAPG finalizer from deleting machines", func(t *testing.T) {
+		g := NewWithT(t)
+		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
+
+		hc := validHostedCluster()
+		hc.Status.Conditions = []metav1.Condition{
+			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
+			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(gcpMachines()...).
+			WithScheme(buildScheme(g)).
+			Build()
+
+		err := platform.DeleteOrphanedMachines(t.Context(), fakeClient, hc, "test-control-plane-namespace")
+		g.Expect(err).To(BeNil())
+
+		gcpMachineList := &capigcp.GCPMachineList{}
+		g.Expect(fakeClient.List(t.Context(), gcpMachineList)).To(Succeed())
+
+		for _, gcpMachine := range gcpMachineList.Items {
+			if !gcpMachine.DeletionTimestamp.IsZero() {
+				g.Expect(controllerutil.ContainsFinalizer(&gcpMachine, capigcp.MachineFinalizer)).To(BeFalse(), "CAPG finalizer should be removed")
+				g.Expect(gcpMachine.Finalizers).To(Equal([]string{"other-controller-finalizer"}), "other finalizers should be preserved")
+			} else {
+				g.Expect(gcpMachine.Finalizers).To(Equal([]string{capigcp.MachineFinalizer, "other-controller-finalizer"}))
+			}
+		}
+	})
+
+	t.Run("When credentials are valid, it should leave finalizers unchanged", func(t *testing.T) {
+		g := NewWithT(t)
+		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
+
+		hc := validHostedCluster()
+		hc.Status.Conditions = []metav1.Condition{
+			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
+			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(gcpMachines()...).
+			WithScheme(buildScheme(g)).
+			Build()
+
+		err := platform.DeleteOrphanedMachines(t.Context(), fakeClient, hc, "test-control-plane-namespace")
+		g.Expect(err).To(BeNil())
+
+		gcpMachineList := &capigcp.GCPMachineList{}
+		g.Expect(fakeClient.List(t.Context(), gcpMachineList)).To(Succeed())
+
+		for _, gcpMachine := range gcpMachineList.Items {
+			g.Expect(gcpMachine.Finalizers).To(Equal([]string{capigcp.MachineFinalizer, "other-controller-finalizer"}))
+		}
+	})
+
+	t.Run("When credentials are unknown, it should leave finalizers unchanged", func(t *testing.T) {
+		g := NewWithT(t)
+		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
+
+		hc := validHostedCluster()
+		// No conditions set — GetCredentialStatus returns Unknown
+
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(gcpMachines()...).
+			WithScheme(buildScheme(g)).
+			Build()
+
+		err := platform.DeleteOrphanedMachines(t.Context(), fakeClient, hc, "test-control-plane-namespace")
+		g.Expect(err).To(BeNil())
+
+		gcpMachineList := &capigcp.GCPMachineList{}
+		g.Expect(fakeClient.List(t.Context(), gcpMachineList)).To(Succeed())
+
+		for _, gcpMachine := range gcpMachineList.Items {
+			g.Expect(gcpMachine.Finalizers).To(Equal([]string{capigcp.MachineFinalizer, "other-controller-finalizer"}))
+		}
+	})
+
+	t.Run("When c.List fails, it should return the error", func(t *testing.T) {
+		g := NewWithT(t)
+		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
+
+		hc := validHostedCluster()
+		hc.Status.Conditions = []metav1.Condition{
+			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
+			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+		}
+
+		listErr := fmt.Errorf("list failed")
+		fakeClient := interceptor.NewClient(
+			fake.NewClientBuilder().WithScheme(buildScheme(g)).Build(),
+			interceptor.Funcs{
+				List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+					return listErr
+				},
+			},
+		)
+
+		err := platform.DeleteOrphanedMachines(t.Context(), fakeClient, hc, "test-control-plane-namespace")
+		g.Expect(err).To(MatchError(ContainSubstring("failed to list GCPMachines")), "expected list error to be wrapped")
+	})
+
+	t.Run("When c.Update fails for a machine, it should aggregate errors and continue", func(t *testing.T) {
+		g := NewWithT(t)
+		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
+
+		hc := validHostedCluster()
+		hc.Status.Conditions = []metav1.Condition{
+			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
+			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+		}
+
+		// Two deleted machines; Update fails for both.
+		machines := []client.Object{
+			&capigcp.GCPMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-m-1",
+					Namespace:         "test-control-plane-namespace",
+					DeletionTimestamp: ptr.To(metav1.Now()),
+					Finalizers:        []string{capigcp.MachineFinalizer},
+				},
+			},
+			&capigcp.GCPMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-m-2",
+					Namespace:         "test-control-plane-namespace",
+					DeletionTimestamp: ptr.To(metav1.Now()),
+					Finalizers:        []string{capigcp.MachineFinalizer},
+				},
+			},
+		}
+
+		updateErr := fmt.Errorf("update failed")
+		fakeClient := interceptor.NewClient(
+			fake.NewClientBuilder().WithObjects(machines...).WithScheme(buildScheme(g)).Build(),
+			interceptor.Funcs{
+				Update: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.UpdateOption) error {
+					return updateErr
+				},
+			},
+		)
+
+		err := platform.DeleteOrphanedMachines(t.Context(), fakeClient, hc, "test-control-plane-namespace")
+		g.Expect(err).To(HaveOccurred(), "expected aggregated error")
+		g.Expect(err.Error()).To(ContainSubstring("test-m-1"), "error should mention first machine")
+		g.Expect(err.Error()).To(ContainSubstring("test-m-2"), "error should mention second machine")
+	})
+
+	t.Run("When GCPMachine has no CAPG finalizer, it should skip it without error", func(t *testing.T) {
+		g := NewWithT(t)
+		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
+
+		hc := validHostedCluster()
+		hc.Status.Conditions = []metav1.Condition{
+			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
+			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+		}
+
+		// Deleted machine, but without the CAPG finalizer (already removed by another path).
+		machines := []client.Object{
+			&capigcp.GCPMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-no-finalizer",
+					Namespace:         "test-control-plane-namespace",
+					DeletionTimestamp: ptr.To(metav1.Now()),
+					Finalizers:        []string{"some-other-finalizer"},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(machines...).
+			WithScheme(buildScheme(g)).
+			Build()
+
+		err := platform.DeleteOrphanedMachines(t.Context(), fakeClient, hc, "test-control-plane-namespace")
+		g.Expect(err).To(BeNil(), "machine without CAPG finalizer should be skipped without error")
+
+		// Verify the other finalizer is untouched.
+		gcpMachineList := &capigcp.GCPMachineList{}
+		g.Expect(fakeClient.List(t.Context(), gcpMachineList)).To(Succeed())
+		g.Expect(gcpMachineList.Items[0].Finalizers).To(Equal([]string{"some-other-finalizer"}), "other finalizers must not be modified")
+	})
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -36,13 +36,15 @@ const (
 )
 
 var (
-	_ Platform = aws.AWS{}
-	_ Platform = azure.Azure{}
-	_ Platform = ibmcloud.IBMCloud{}
-	_ Platform = none.None{}
-	_ Platform = agent.Agent{}
-	_ Platform = kubevirt.Kubevirt{}
-	_ Platform = gcp.GCP{}
+	_ Platform      = aws.AWS{}
+	_ Platform      = azure.Azure{}
+	_ Platform      = ibmcloud.IBMCloud{}
+	_ Platform      = none.None{}
+	_ Platform      = agent.Agent{}
+	_ Platform      = kubevirt.Kubevirt{}
+	_ Platform      = gcp.GCP{}
+	_ OrphanDeleter = aws.AWS{}
+	_ OrphanDeleter = gcp.GCP{}
 )
 
 type Platform interface {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -43,7 +43,9 @@ var (
 	_ Platform      = agent.Agent{}
 	_ Platform      = kubevirt.Kubevirt{}
 	_ Platform      = gcp.GCP{}
-	_ OrphanDeleter = &azure.Azure{}
+	_ OrphanDeleter = aws.AWS{}
+	_ OrphanDeleter = azure.Azure{}
+	_ OrphanDeleter = gcp.GCP{}
 )
 
 type Platform interface {


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
Removes finalizers from orphaned GCPMachines when WIF credentials become invalid to prevent cluster teardown getting stuck.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes #[GCP-503](https://redhat.atlassian.net/browse/GCP-503)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GCP health checks for workload identity configuration and credentials after the Kubernetes API becomes available.
  * HostedClusters now reflect GCP credential and workload identity status, including unknown states during deletion.
  * Invalid GCP credentials trigger cleanup of finalizers on terminating machine resources.
* **Bug Fixes**
  * Improved reporting of GCP authentication, configuration, reconciliation, and cleanup errors.
  * Distinguished permanent credential failures from transient GCP API errors.
* **Tests**
  * Added coverage for health checks, credential states, deletion scenarios, and safe finalizer cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->