### PR TITLE
CNTRLPLANE-3616: e2e tests for TLS profile change of konnectivity-server

### DIFF
--- a/test/e2e/v2/tests/control_plane_tls_operator_test.go
+++ b/test/e2e/v2/tests/control_plane_tls_operator_test.go
@@ -46,7 +46,7 @@ type controlPlaneTLSComponent struct {
 	podAppLabel         string // target pod (TLS listener)
 	execPodAppLabel     string // pod to exec into; defaults to podAppLabel
 	execContainerNames  []string
-	connectViaPodIP     bool // when true, probe targetPod.Status.PodIP instead of localhost
+	connectViaPodIP     bool   // when true, probe targetPod.Status.PodIP instead of localhost
 	configMapName       string // PKI operator stores TLS settings in a ConfigMap
 	deploymentName      string // aws-pod-identity-webhook stores TLS settings in deployment command flags
 	deploymentContainer string
@@ -55,11 +55,11 @@ type controlPlaneTLSComponent struct {
 
 var (
 	pkiOperatorTLSComponent = controlPlaneTLSComponent{
-		name:              "control-plane-pki-operator",
-		port:              "8443",
-		podAppLabel:       "control-plane-pki-operator",
+		name:               "control-plane-pki-operator",
+		port:               "8443",
+		podAppLabel:        "control-plane-pki-operator",
 		execContainerNames: []string{"control-plane-pki-operator"},
-		configMapName:     "control-plane-pki-operator-config",
+		configMapName:      "control-plane-pki-operator-config",
 	}
 
 	awsPodIdentityWebhookTLSComponent = controlPlaneTLSComponent{
@@ -72,6 +72,18 @@ var (
 		deploymentName:      "kube-apiserver",
 		deploymentContainer: "aws-pod-identity-webhook",
 		awsOnly:             true,
+	}
+
+	// konnectivity-server runs as a sidecar in the kube-apiserver pod, stores its
+	// minimum TLS version in the container's --tls-min-version flag, and listens on
+	// port 8090. The TLS probe execs into that same container and dials localhost.
+	konnectivityServerTLSComponent = controlPlaneTLSComponent{
+		name:                "konnectivity-server",
+		port:                "8090",
+		podAppLabel:         "kube-apiserver",
+		execContainerNames:  []string{"konnectivity-server"},
+		deploymentName:      "kube-apiserver",
+		deploymentContainer: "konnectivity-server",
 	}
 )
 
@@ -117,6 +129,35 @@ func containerHasTLSMinVersionFlag(container corev1.Container, minTLSVersion str
 	return false
 }
 
+// isPodReady returns true only if the pod has the PodReady condition set to True
+// and every container reports Ready. A pod with no container statuses is treated as
+// not ready to avoid a vacuous pass.
+func isPodReady(pod *corev1.Pod) bool {
+	ready := false
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			ready = true
+			break
+		}
+	}
+	if !ready {
+		return false
+	}
+	if len(pod.Status.ContainerStatuses) == 0 {
+		return false
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if !cs.Ready {
+			return false
+		}
+	}
+	return true
+}
+
+// getFirstRunningPod returns the first running, ready, non-terminating pod with the
+// given app label. Terminating and not-yet-ready pods are skipped: during a rollout
+// (e.g. a TLS profile change) an old pod can still report Running while its containers
+// are being torn down, which makes exec fail with `container not found`.
 func getFirstRunningPod(ctx context.Context, mgmtClient crclient.Client, namespace, appLabel string) (*corev1.Pod, error) {
 	podList := &corev1.PodList{}
 	if err := mgmtClient.List(ctx, podList,
@@ -130,11 +171,19 @@ func getFirstRunningPod(ctx context.Context, mgmtClient crclient.Client, namespa
 	}
 
 	for i := range podList.Items {
-		if podList.Items[i].Status.Phase == corev1.PodRunning {
-			return &podList.Items[i], nil
+		pod := &podList.Items[i]
+		if pod.DeletionTimestamp != nil {
+			continue
 		}
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		if !isPodReady(pod) {
+			continue
+		}
+		return pod, nil
 	}
-	return nil, fmt.Errorf("no running pod found with app=%s in namespace %s", appLabel, namespace)
+	return nil, fmt.Errorf("no running, ready pod found with app=%s in namespace %s", appLabel, namespace)
 }
 
 func resolveTLSProbeContainers(pod *corev1.Pod, candidates []string) []string {
@@ -145,7 +194,10 @@ func resolveTLSProbeContainers(pod *corev1.Pod, candidates []string) []string {
 
 	running := make(map[string]struct{}, len(pod.Status.ContainerStatuses))
 	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Running != nil {
+		// Require Ready, not just Running: a container mid-startup (or being torn
+		// down during a rollout) reports Running before it can serve, and exec into
+		// it races the container lifecycle ("container not found").
+		if cs.State.Running != nil && cs.Ready {
 			running[cs.Name] = struct{}{}
 		}
 	}
@@ -196,27 +248,13 @@ func waitForAppPodRestart(
 		var readyPod *corev1.Pod
 		for i := range podList.Items {
 			pod := &podList.Items[i]
+			if pod.DeletionTimestamp != nil {
+				continue
+			}
 			if pod.Status.Phase != corev1.PodRunning {
 				continue
 			}
-			ready := false
-			for _, cond := range pod.Status.Conditions {
-				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-					ready = true
-					break
-				}
-			}
-			if !ready {
-				continue
-			}
-			allContainersReady := true
-			for _, cs := range pod.Status.ContainerStatuses {
-				if !cs.Ready {
-					allContainersReady = false
-					break
-				}
-			}
-			if !allContainersReady {
+			if !isPodReady(pod) {
 				continue
 			}
 			readyPod = pod
@@ -289,6 +327,26 @@ func expectComponentMinTLSVersion(
 	}
 }
 
+// waitForDeploymentRolloutComplete waits until the named deployment has fully rolled
+// out — the latest generation is observed and all replicas are updated, present (no
+// surge/terminating pods left), and available. TLS probes exec into a component's pod,
+// so probing mid-rollout can hit an old pod whose containers are being torn down
+// ("container not found") or a new pod not yet serving the updated config.
+func waitForDeploymentRolloutComplete(ctx context.Context, mgmtClient crclient.Client, namespace, name string) {
+	Eventually(func(g Gomega) {
+		deployment := &appsv1.Deployment{}
+		g.Expect(mgmtClient.Get(ctx, crclient.ObjectKey{Namespace: namespace, Name: name}, deployment)).
+			To(Succeed(), "failed to get %s deployment", name)
+		g.Expect(deployment.Spec.Replicas).NotTo(BeNil(), "%s deployment should have spec.replicas set", name)
+		desired := *deployment.Spec.Replicas
+		g.Expect(deployment.Status.ObservedGeneration).To(BeNumerically(">=", deployment.Generation),
+			"%s deployment status should observe the latest generation", name)
+		g.Expect(deployment.Status.UpdatedReplicas).To(Equal(desired), "%s should have all replicas updated", name)
+		g.Expect(deployment.Status.Replicas).To(Equal(desired), "%s should have no surge/terminating replicas remaining", name)
+		g.Expect(deployment.Status.AvailableReplicas).To(Equal(desired), "%s should have all replicas available", name)
+	}, 10*time.Minute, 10*time.Second).Should(Succeed(), "%s deployment should complete rollout", name)
+}
+
 func verifyComponentTLSConnectivity(
 	ctx context.Context,
 	tc *internal.TestContext,
@@ -298,6 +356,13 @@ func verifyComponentTLSConnectivity(
 	component controlPlaneTLSComponent,
 	expectations []tlsVersionExpectation,
 ) {
+	// For deployment-backed components, wait for the rollout to fully settle before
+	// probing so the exec targets a pod running the current TLS config rather than a
+	// terminating old pod. Already-settled deployments return immediately.
+	if component.deploymentName != "" {
+		waitForDeploymentRolloutComplete(ctx, mgmtClient, tc.ControlPlaneNamespace, component.deploymentName)
+	}
+
 	for _, expectation := range expectations {
 		expectation := expectation
 		Eventually(func(g Gomega) {
@@ -363,6 +428,40 @@ func hostedClusterHasTLSProfileType(hc *hyperv1.HostedCluster, profileType confi
 		hc.Spec.Configuration.APIServer.TLSSecurityProfile.Type == profileType
 }
 
+// requireModernProfileSet fetches the HostedCluster fresh from the management cluster
+// and calls Fail if it does not currently have the Modern TLS profile. Ordered
+// post-mutation tests use this to assert the precondition established by the earlier
+// "update to Modern" test, and it returns the fetched HostedCluster for callers that
+// need it. It reads fresh (not a cached copy) so it observes the latest profile.
+func requireModernProfileSet(tc *internal.TestContext) *hyperv1.HostedCluster {
+	hostedCluster := &hyperv1.HostedCluster{}
+	Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+		Namespace: tc.ClusterNamespace,
+		Name:      tc.ClusterName,
+	}, hostedCluster)).To(Succeed(), "failed to get HostedCluster")
+	if !hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
+		Fail("HostedCluster does not have Modern TLS profile - previous ordered test should have set it")
+	}
+	return hostedCluster
+}
+
+// requireModernProfileCleared fetches the HostedCluster fresh from the management
+// cluster and calls Fail if it still has the Modern TLS profile. Ordered
+// post-downgrade tests use this to assert the precondition established by the earlier
+// "downgrade" test, and it returns the fetched HostedCluster for callers that need it.
+// It reads fresh (not a cached copy) so it observes the latest profile.
+func requireModernProfileCleared(tc *internal.TestContext) *hyperv1.HostedCluster {
+	hostedCluster := &hyperv1.HostedCluster{}
+	Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+		Namespace: tc.ClusterNamespace,
+		Name:      tc.ClusterName,
+	}, hostedCluster)).To(Succeed(), "failed to get HostedCluster")
+	if hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
+		Fail("HostedCluster still has Modern TLS profile - previous ordered test should have downgraded it")
+	}
+	return hostedCluster
+}
+
 func RegisterControlPlanePKIOperatorTests(getTestCtx internal.TestContextGetter) {
 	VerifyPKIOperatorTLSConfigTest(getTestCtx)
 }
@@ -378,6 +477,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 		var mgmtKubeClient *kubernetes.Clientset
 		var pkiPodUIDBeforeMutation string
 		var kasPodUIDBeforeMutation string
+		var konnectivityPodUIDBeforeMutation string
 
 		BeforeAll(func() {
 			tc = getTestCtx()
@@ -446,6 +546,17 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			}, 1*time.Minute, 5*time.Second).Should(Succeed())
 		})
 
+		It("konnectivity-server should have --tls-min-version set to VersionTLS12 with default/intermediate profile", func() {
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			requireDefaultOrIntermediateTLSProfile(hostedCluster)
+
+			Eventually(func(g Gomega) {
+				expectComponentMinTLSVersion(g, tc.Context, tc.MgmtClient, tc.ControlPlaneNamespace,
+					konnectivityServerTLSComponent, "VersionTLS12")
+			}, 1*time.Minute, 5*time.Second).Should(Succeed())
+		})
+
 		It("control-plane-pki-operator should accept both TLS 1.2 and TLS 1.3 connections with intermediate profile", func() {
 			hostedCluster, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -471,6 +582,18 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 				})
 		})
 
+		It("konnectivity-server should accept both TLS 1.2 and TLS 1.3 connections with intermediate profile", func() {
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			requireDefaultOrIntermediateTLSProfile(hostedCluster)
+
+			verifyComponentTLSConnectivity(tc.Context, tc, tc.MgmtClient, mgmtKubeClient, mgmtRestConfig,
+				konnectivityServerTLSComponent, []tlsVersionExpectation{
+					{opensslFlag: "tls1_2", expectedProtocol: "tlsv1.2"},
+					{opensslFlag: "tls1_3", expectedProtocol: "tlsv1.3"},
+				})
+		})
+
 		It("should update HostedCluster TLS profile to Modern", func() {
 			// Get the HostedCluster from management cluster and update its TLS profile
 			mgmtClient := tc.MgmtClient
@@ -485,6 +608,11 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			Expect(err).NotTo(HaveOccurred(), "failed to get kube-apiserver pod before mutation")
 			kasPodUIDBeforeMutation = string(kasPod.UID)
 			GinkgoWriter.Printf("Captured kube-apiserver pod UID before mutation: %s\n", kasPodUIDBeforeMutation)
+
+			// konnectivity-server is a sidecar in the kube-apiserver pod; track its UID
+			// independently so its connectivity tests wait for the shared pod's restart.
+			konnectivityPodUIDBeforeMutation = string(kasPod.UID)
+			GinkgoWriter.Printf("Captured konnectivity-server (kube-apiserver) pod UID before mutation: %s\n", konnectivityPodUIDBeforeMutation)
 
 			// Update to Modern TLS profile; Eventually retries on conflict after re-get.
 			Eventually(func(g Gomega) {
@@ -516,62 +644,42 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("control-plane-pki-operator should propagate minTLSVersion VersionTLS13 with Modern profile", func() {
-			mgmtClient := tc.MgmtClient
-			hostedCluster := &hyperv1.HostedCluster{}
-			Expect(mgmtClient.Get(tc.Context, crclient.ObjectKey{
-				Namespace: tc.ClusterNamespace,
-				Name:      tc.ClusterName,
-			}, hostedCluster)).To(Succeed(), "failed to get HostedCluster")
-
-			if !hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
-				Fail("HostedCluster does not have Modern TLS profile - previous ordered test should have set it")
-			}
+			requireModernProfileSet(tc)
 
 			Eventually(func(g Gomega) {
-				expectComponentMinTLSVersion(g, tc.Context, mgmtClient, tc.ControlPlaneNamespace,
+				expectComponentMinTLSVersion(g, tc.Context, tc.MgmtClient, tc.ControlPlaneNamespace,
 					pkiOperatorTLSComponent, "VersionTLS13")
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 
 		It("aws-pod-identity-webhook should propagate --tls-min-version VersionTLS13 with Modern profile", func() {
-			mgmtClient := tc.MgmtClient
-			hostedCluster := &hyperv1.HostedCluster{}
-			Expect(mgmtClient.Get(tc.Context, crclient.ObjectKey{
-				Namespace: tc.ClusterNamespace,
-				Name:      tc.ClusterName,
-			}, hostedCluster)).To(Succeed(), "failed to get HostedCluster")
+			hostedCluster := requireModernProfileSet(tc)
 			skipIfComponentNotApplicable(awsPodIdentityWebhookTLSComponent, hostedCluster)
 
-			if !hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
-				Fail("HostedCluster does not have Modern TLS profile - previous ordered test should have set it")
-			}
-
 			Eventually(func(g Gomega) {
-				expectComponentMinTLSVersion(g, tc.Context, mgmtClient, tc.ControlPlaneNamespace,
+				expectComponentMinTLSVersion(g, tc.Context, tc.MgmtClient, tc.ControlPlaneNamespace,
 					awsPodIdentityWebhookTLSComponent, "VersionTLS13")
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 
-		It("control-plane-pki-operator should accept TLS 1.3 but reject TLS 1.2 with Modern profile", func() {
-			// Verify HostedCluster has Modern profile (fetch fresh, not cached)
-			mgmtClient := tc.MgmtClient
-			hostedCluster := &hyperv1.HostedCluster{}
-			err := mgmtClient.Get(tc.Context, crclient.ObjectKey{
-				Namespace: tc.ClusterNamespace,
-				Name:      tc.ClusterName,
-			}, hostedCluster)
-			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+		It("konnectivity-server should propagate --tls-min-version VersionTLS13 with Modern profile", func() {
+			requireModernProfileSet(tc)
 
-			if !hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
-				Fail("HostedCluster does not have Modern TLS profile - previous ordered test should have set it")
-			}
+			Eventually(func(g Gomega) {
+				expectComponentMinTLSVersion(g, tc.Context, tc.MgmtClient, tc.ControlPlaneNamespace,
+					konnectivityServerTLSComponent, "VersionTLS13")
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
+		})
+
+		It("control-plane-pki-operator should accept TLS 1.3 but reject TLS 1.2 with Modern profile", func() {
+			requireModernProfileSet(tc)
 
 			// Wait for PKI operator pod to restart and pick up the new TLS config
-			pkiPodUIDBeforeMutation = waitForAppPodRestart(tc.Context, mgmtClient, tc.ControlPlaneNamespace,
+			pkiPodUIDBeforeMutation = waitForAppPodRestart(tc.Context, tc.MgmtClient, tc.ControlPlaneNamespace,
 				pkiOperatorTLSComponent.podAppLabel, pkiPodUIDBeforeMutation)
 			GinkgoWriter.Printf("New PKI operator pod UID after mutation to Modern profile: %s\n", pkiPodUIDBeforeMutation)
 
-			verifyComponentTLSConnectivity(tc.Context, tc, mgmtClient, mgmtKubeClient, mgmtRestConfig,
+			verifyComponentTLSConnectivity(tc.Context, tc, tc.MgmtClient, mgmtKubeClient, mgmtRestConfig,
 				pkiOperatorTLSComponent, []tlsVersionExpectation{
 					{opensslFlag: "tls1_3", expectedProtocol: "tlsv1.3"},
 					{opensslFlag: "tls1_2", rejectConnection: true},
@@ -579,52 +687,47 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("aws-pod-identity-webhook should accept TLS 1.3 but reject TLS 1.2 with Modern profile", func() {
-			mgmtClient := tc.MgmtClient
-			hostedCluster := &hyperv1.HostedCluster{}
-			err := mgmtClient.Get(tc.Context, crclient.ObjectKey{
-				Namespace: tc.ClusterNamespace,
-				Name:      tc.ClusterName,
-			}, hostedCluster)
-			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+			hostedCluster := requireModernProfileSet(tc)
 			skipIfComponentNotApplicable(awsPodIdentityWebhookTLSComponent, hostedCluster)
-
-			if !hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
-				Fail("HostedCluster does not have Modern TLS profile - previous ordered test should have set it")
-			}
 
 			// Wait for kube-apiserver (webhook sidecar) to restart with the new TLS config.
 			// Both Intermediate and Modern accept TLS 1.3, so probing a stale pod can pass vacuously.
-			kasPodUIDBeforeMutation = waitForAppPodRestart(tc.Context, mgmtClient, tc.ControlPlaneNamespace,
+			kasPodUIDBeforeMutation = waitForAppPodRestart(tc.Context, tc.MgmtClient, tc.ControlPlaneNamespace,
 				awsPodIdentityWebhookTLSComponent.podAppLabel, kasPodUIDBeforeMutation)
 			GinkgoWriter.Printf("New kube-apiserver pod UID after mutation to Modern profile: %s\n", kasPodUIDBeforeMutation)
 
-			verifyComponentTLSConnectivity(tc.Context, tc, mgmtClient, mgmtKubeClient, mgmtRestConfig,
+			verifyComponentTLSConnectivity(tc.Context, tc, tc.MgmtClient, mgmtKubeClient, mgmtRestConfig,
 				awsPodIdentityWebhookTLSComponent, []tlsVersionExpectation{
 					{opensslFlag: "tls1_3", expectedProtocol: "tlsv1.3"},
 					{opensslFlag: "tls1_2", rejectConnection: true},
 				})
 		})
 
+		It("konnectivity-server should accept TLS 1.3 but reject TLS 1.2 with Modern profile", func() {
+			requireModernProfileSet(tc)
+
+			// Wait for the kube-apiserver pod (which hosts konnectivity-server) to restart
+			// with the new TLS config. Both Intermediate and Modern accept TLS 1.3, so
+			// probing a stale pod can pass vacuously.
+			konnectivityPodUIDBeforeMutation = waitForAppPodRestart(tc.Context, tc.MgmtClient, tc.ControlPlaneNamespace,
+				konnectivityServerTLSComponent.podAppLabel, konnectivityPodUIDBeforeMutation)
+			GinkgoWriter.Printf("New konnectivity-server (kube-apiserver) pod UID after mutation to Modern profile: %s\n", konnectivityPodUIDBeforeMutation)
+
+			verifyComponentTLSConnectivity(tc.Context, tc, tc.MgmtClient, mgmtKubeClient, mgmtRestConfig,
+				konnectivityServerTLSComponent, []tlsVersionExpectation{
+					{opensslFlag: "tls1_3", expectedProtocol: "tlsv1.3"},
+					{opensslFlag: "tls1_2", rejectConnection: true},
+				})
+		})
+
 		It("should downgrade HostedCluster TLS profile to default/intermediate", func() {
-			// Get the HostedCluster from management cluster and update its TLS profile
-			mgmtClient := tc.MgmtClient
-
 			// First verify it currently has Modern profile (fetch fresh, not cached)
-			hostedCluster := &hyperv1.HostedCluster{}
-			err := mgmtClient.Get(tc.Context, crclient.ObjectKey{
-				Namespace: tc.ClusterNamespace,
-				Name:      tc.ClusterName,
-			}, hostedCluster)
-			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
-
-			if !hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
-				Fail("HostedCluster does not have Modern TLS profile - previous ordered tests should have set it")
-			}
+			requireModernProfileSet(tc)
 
 			// Remove Modern TLS profile (downgrade to default/Intermediate); Eventually retries on conflict.
 			Eventually(func(g Gomega) {
 				hostedCluster := &hyperv1.HostedCluster{}
-				err := mgmtClient.Get(tc.Context, crclient.ObjectKey{
+				err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
 					Namespace: tc.ClusterNamespace,
 					Name:      tc.ClusterName,
 				}, hostedCluster)
@@ -633,7 +736,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 				// Remove TLS profile to downgrade to default (Intermediate)
 				hostedCluster.Spec.Configuration.APIServer.TLSSecurityProfile = nil
 
-				err = mgmtClient.Update(tc.Context, hostedCluster)
+				err = tc.MgmtClient.Update(tc.Context, hostedCluster)
 				g.Expect(err).NotTo(HaveOccurred(), "failed to remove TLS profile to downgrade to Intermediate")
 			}, 1*time.Minute, 5*time.Second).Should(Succeed(), "failed to downgrade HostedCluster to Intermediate profile")
 
@@ -641,63 +744,42 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("control-plane-pki-operator should propagate minTLSVersion VersionTLS12 after downgrade", func() {
-			mgmtClient := tc.MgmtClient
-			hostedCluster := &hyperv1.HostedCluster{}
-			Expect(mgmtClient.Get(tc.Context, crclient.ObjectKey{
-				Namespace: tc.ClusterNamespace,
-				Name:      tc.ClusterName,
-			}, hostedCluster)).To(Succeed(), "failed to get HostedCluster")
-
-			if hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
-				Fail("HostedCluster still has Modern TLS profile - previous ordered test should have downgraded it")
-			}
+			requireModernProfileCleared(tc)
 
 			Eventually(func(g Gomega) {
-				expectComponentMinTLSVersion(g, tc.Context, mgmtClient, tc.ControlPlaneNamespace,
+				expectComponentMinTLSVersion(g, tc.Context, tc.MgmtClient, tc.ControlPlaneNamespace,
 					pkiOperatorTLSComponent, "VersionTLS12")
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 
 		It("aws-pod-identity-webhook should propagate --tls-min-version VersionTLS12 after downgrade", func() {
-			mgmtClient := tc.MgmtClient
-			hostedCluster := &hyperv1.HostedCluster{}
-			Expect(mgmtClient.Get(tc.Context, crclient.ObjectKey{
-				Namespace: tc.ClusterNamespace,
-				Name:      tc.ClusterName,
-			}, hostedCluster)).To(Succeed(), "failed to get HostedCluster")
+			hostedCluster := requireModernProfileCleared(tc)
 			skipIfComponentNotApplicable(awsPodIdentityWebhookTLSComponent, hostedCluster)
 
-			if hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
-				Fail("HostedCluster still has Modern TLS profile - previous ordered test should have downgraded it")
-			}
-
 			Eventually(func(g Gomega) {
-				expectComponentMinTLSVersion(g, tc.Context, mgmtClient, tc.ControlPlaneNamespace,
+				expectComponentMinTLSVersion(g, tc.Context, tc.MgmtClient, tc.ControlPlaneNamespace,
 					awsPodIdentityWebhookTLSComponent, "VersionTLS12")
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 
-		It("control-plane-pki-operator should accept both TLS 1.2 and TLS 1.3 connections after downgrade to Intermediate profile", func() {
-			// Verify HostedCluster does not have Modern profile (fetch fresh, not cached)
-			mgmtClient := tc.MgmtClient
-			hostedCluster := &hyperv1.HostedCluster{}
-			err := mgmtClient.Get(tc.Context, crclient.ObjectKey{
-				Namespace: tc.ClusterNamespace,
-				Name:      tc.ClusterName,
-			}, hostedCluster)
-			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+		It("konnectivity-server should propagate --tls-min-version VersionTLS12 after downgrade", func() {
+			requireModernProfileCleared(tc)
 
-			// Check that TLS profile is nil (default/Intermediate) or explicitly not Modern
-			if hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
-				Fail("HostedCluster still has Modern TLS profile - previous ordered test should have downgraded it")
-			}
+			Eventually(func(g Gomega) {
+				expectComponentMinTLSVersion(g, tc.Context, tc.MgmtClient, tc.ControlPlaneNamespace,
+					konnectivityServerTLSComponent, "VersionTLS12")
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
+		})
+
+		It("control-plane-pki-operator should accept both TLS 1.2 and TLS 1.3 connections after downgrade to Intermediate profile", func() {
+			requireModernProfileCleared(tc)
 
 			// Wait for PKI operator pod to restart and pick up the downgraded TLS config
-			pkiPodUIDBeforeMutation = waitForAppPodRestart(tc.Context, mgmtClient, tc.ControlPlaneNamespace,
+			pkiPodUIDBeforeMutation = waitForAppPodRestart(tc.Context, tc.MgmtClient, tc.ControlPlaneNamespace,
 				pkiOperatorTLSComponent.podAppLabel, pkiPodUIDBeforeMutation)
 			GinkgoWriter.Printf("New PKI operator pod UID after downgrade to Intermediate profile: %s\n", pkiPodUIDBeforeMutation)
 
-			verifyComponentTLSConnectivity(tc.Context, tc, mgmtClient, mgmtKubeClient, mgmtRestConfig,
+			verifyComponentTLSConnectivity(tc.Context, tc, tc.MgmtClient, mgmtKubeClient, mgmtRestConfig,
 				pkiOperatorTLSComponent, []tlsVersionExpectation{
 					{opensslFlag: "tls1_2", expectedProtocol: "tlsv1.2"},
 					{opensslFlag: "tls1_3", expectedProtocol: "tlsv1.3"},
@@ -705,26 +787,32 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("aws-pod-identity-webhook should accept both TLS 1.2 and TLS 1.3 connections after downgrade to Intermediate profile", func() {
-			mgmtClient := tc.MgmtClient
-			hostedCluster := &hyperv1.HostedCluster{}
-			err := mgmtClient.Get(tc.Context, crclient.ObjectKey{
-				Namespace: tc.ClusterNamespace,
-				Name:      tc.ClusterName,
-			}, hostedCluster)
-			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+			hostedCluster := requireModernProfileCleared(tc)
 			skipIfComponentNotApplicable(awsPodIdentityWebhookTLSComponent, hostedCluster)
 
-			if hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
-				Fail("HostedCluster still has Modern TLS profile - previous ordered test should have downgraded it")
-			}
-
 			// Wait for kube-apiserver (webhook sidecar) to restart with the downgraded TLS config.
-			kasPodUIDBeforeMutation = waitForAppPodRestart(tc.Context, mgmtClient, tc.ControlPlaneNamespace,
+			kasPodUIDBeforeMutation = waitForAppPodRestart(tc.Context, tc.MgmtClient, tc.ControlPlaneNamespace,
 				awsPodIdentityWebhookTLSComponent.podAppLabel, kasPodUIDBeforeMutation)
 			GinkgoWriter.Printf("New kube-apiserver pod UID after downgrade to Intermediate profile: %s\n", kasPodUIDBeforeMutation)
 
-			verifyComponentTLSConnectivity(tc.Context, tc, mgmtClient, mgmtKubeClient, mgmtRestConfig,
+			verifyComponentTLSConnectivity(tc.Context, tc, tc.MgmtClient, mgmtKubeClient, mgmtRestConfig,
 				awsPodIdentityWebhookTLSComponent, []tlsVersionExpectation{
+					{opensslFlag: "tls1_2", expectedProtocol: "tlsv1.2"},
+					{opensslFlag: "tls1_3", expectedProtocol: "tlsv1.3"},
+				})
+		})
+
+		It("konnectivity-server should accept both TLS 1.2 and TLS 1.3 connections after downgrade to Intermediate profile", func() {
+			requireModernProfileCleared(tc)
+
+			// Wait for the kube-apiserver pod (which hosts konnectivity-server) to restart
+			// with the downgraded TLS config.
+			konnectivityPodUIDBeforeMutation = waitForAppPodRestart(tc.Context, tc.MgmtClient, tc.ControlPlaneNamespace,
+				konnectivityServerTLSComponent.podAppLabel, konnectivityPodUIDBeforeMutation)
+			GinkgoWriter.Printf("New konnectivity-server (kube-apiserver) pod UID after downgrade to Intermediate profile: %s\n", konnectivityPodUIDBeforeMutation)
+
+			verifyComponentTLSConnectivity(tc.Context, tc, tc.MgmtClient, mgmtKubeClient, mgmtRestConfig,
+				konnectivityServerTLSComponent, []tlsVersionExpectation{
 					{opensslFlag: "tls1_2", expectedProtocol: "tlsv1.2"},
 					{opensslFlag: "tls1_3", expectedProtocol: "tlsv1.3"},
 				})
@@ -760,7 +848,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 	})
 }
 
-var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneTLS] Control Plane TLS Operator", Label("control-plane-pki-operator", "aws-pod-identity-webhook"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneTLS] Control Plane TLS Operator", Label("control-plane-pki-operator", "aws-pod-identity-webhook", "konnectivity-server"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {

--- a/test/e2e/v2/tests/konnectivity_server_test.go
+++ b/test/e2e/v2/tests/konnectivity_server_test.go
@@ -1,0 +1,558 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// hostedClusterHasTLSProfileType returns true if the HostedCluster has the specified TLS profile type.
+func hostedClusterHasTLSProfileType(hc *hyperv1.HostedCluster, profileType configv1.TLSProfileType) bool {
+	return hc.Spec.Configuration != nil &&
+		hc.Spec.Configuration.APIServer != nil &&
+		hc.Spec.Configuration.APIServer.TLSSecurityProfile != nil &&
+		hc.Spec.Configuration.APIServer.TLSSecurityProfile.Type == profileType
+}
+
+// getTLSMinVersionFromArgs extracts the TLS min version value from container args.
+// It handles both formats: "--tls-min-version=VALUE" and "--tls-min-version" "VALUE"
+func getTLSMinVersionFromArgs(args []string) string {
+	for i, arg := range args {
+		// Check for "--tls-min-version=VALUE" format
+		if strings.HasPrefix(arg, "--tls-min-version=") {
+			return strings.TrimPrefix(arg, "--tls-min-version=")
+		}
+		// Check for "--tls-min-version" "VALUE" format
+		if arg == "--tls-min-version" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// getKubeAPIServerDeployment retrieves the kube-apiserver deployment from the control plane namespace.
+func getKubeAPIServerDeployment(ctx context.Context, client crclient.Client, namespace string) (*appsv1.Deployment, error) {
+	deployment := &appsv1.Deployment{}
+	err := client.Get(ctx, crclient.ObjectKey{
+		Namespace: namespace,
+		Name:      "kube-apiserver",
+	}, deployment)
+	return deployment, err
+}
+
+// waitForKubeAPIServerRollout waits for the kube-apiserver deployment to complete rollout.
+// This ensures all replicas have the latest pod template spec.
+func waitForKubeAPIServerRollout(ctx context.Context, client crclient.Client, namespace string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 15*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		deployment, err := getKubeAPIServerDeployment(ctx, client, namespace)
+		if err != nil {
+			return false, err
+		}
+
+		// Check if rollout is complete
+		// All replicas must be updated, available, and ready
+		if deployment.Status.UpdatedReplicas == *deployment.Spec.Replicas &&
+			deployment.Status.Replicas == *deployment.Spec.Replicas &&
+			deployment.Status.AvailableReplicas == *deployment.Spec.Replicas &&
+			deployment.Status.ObservedGeneration >= deployment.Generation {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+// getReadyKubeAPIServerPod finds and returns a ready kube-apiserver pod.
+// This should be called after waiting for rollout to complete.
+func getReadyKubeAPIServerPod(ctx context.Context, client crclient.Client, namespace string) (*corev1.Pod, error) {
+	kasPodList := &corev1.PodList{}
+	err := client.List(ctx, kasPodList,
+		crclient.InNamespace(namespace),
+		crclient.MatchingLabels{"app": "kube-apiserver"},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(kasPodList.Items) == 0 {
+		return nil, fmt.Errorf("no kube-apiserver pods found")
+	}
+
+	// Find a ready pod
+	for i := range kasPodList.Items {
+		if kasPodList.Items[i].Status.Phase == corev1.PodRunning {
+			for _, cond := range kasPodList.Items[i].Status.Conditions {
+				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+					// Verify all containers are ready
+					// Skip pods with no container statuses to prevent vacuous pass
+					if len(kasPodList.Items[i].Status.ContainerStatuses) == 0 {
+						continue
+					}
+
+					allReady := true
+					for _, cs := range kasPodList.Items[i].Status.ContainerStatuses {
+						if !cs.Ready {
+							allReady = false
+							break
+						}
+					}
+					if allReady {
+						return &kasPodList.Items[i], nil
+					}
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no ready kube-apiserver pod found")
+}
+
+func RegisterKonnectivityServerTests(getTestCtx internal.TestContextGetter) {
+	VerifyKonnectivityServerTLSConfigTest(getTestCtx)
+}
+
+// VerifyKonnectivityServerTLSConfigTest validates that when TLS security profile changes are applied
+// to the HostedCluster, the konnectivity-server container reflects the correct --tls-min-version flag
+// and that the konnectivity-server's HTTPS endpoint enforces those TLS versions correctly.
+func VerifyKonnectivityServerTLSConfigTest(getTestCtx internal.TestContextGetter) {
+	When("konnectivity-server TLS configuration is modified", Ordered, Label("Lifecycle"), func() {
+		var tc *internal.TestContext
+		var originalConfiguration *hyperv1.ClusterConfiguration
+		var mgmtRestConfig *rest.Config
+		var mgmtKubeClient *kubernetes.Clientset
+
+		BeforeAll(func() {
+			tc = getTestCtx()
+
+			// Capture original Configuration from HostedCluster to restore complete state later
+			hostedCluster := tc.GetHostedCluster()
+			if hostedCluster.Spec.Configuration != nil {
+				originalConfiguration = hostedCluster.Spec.Configuration.DeepCopy()
+			}
+
+			// Setup management cluster REST config and kubernetes client for pod exec
+			var err error
+			mgmtRestConfig, err = e2eutil.GetConfig()
+			Expect(err).NotTo(HaveOccurred(), "failed to get management cluster REST config")
+			mgmtKubeClient, err = kubernetes.NewForConfig(mgmtRestConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to create management cluster kubernetes client")
+		})
+
+		It("should have konnectivity-server container with --tls-min-version flag", func() {
+			// Get kube-apiserver deployment to check pod template spec (source of truth)
+			mgmtClient := tc.MgmtClient
+			deployment, err := getKubeAPIServerDeployment(tc.Context, mgmtClient, tc.ControlPlaneNamespace)
+			Expect(err).NotTo(HaveOccurred(), "failed to get kube-apiserver deployment")
+
+			// Find konnectivity-server container in pod template
+			var konnectivityContainer *corev1.Container
+			for i := range deployment.Spec.Template.Spec.Containers {
+				if deployment.Spec.Template.Spec.Containers[i].Name == "konnectivity-server" {
+					konnectivityContainer = &deployment.Spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+
+			Expect(konnectivityContainer).NotTo(BeNil(), "konnectivity-server container should exist in kube-apiserver deployment")
+
+			// Verify --tls-min-version flag exists in container args
+			// It can be either "--tls-min-version=VALUE" or "--tls-min-version" followed by "VALUE"
+			hasTLSMinVersion := false
+			for i, arg := range konnectivityContainer.Args {
+				if strings.HasPrefix(arg, "--tls-min-version=") || arg == "--tls-min-version" {
+					hasTLSMinVersion = true
+					break
+				}
+				// Also check if this is the value following --tls-min-version flag
+				if i > 0 && konnectivityContainer.Args[i-1] == "--tls-min-version" {
+					hasTLSMinVersion = true
+					break
+				}
+			}
+			Expect(hasTLSMinVersion).To(BeTrue(), "konnectivity-server container should have --tls-min-version flag")
+		})
+
+		It("should have --tls-min-version=VersionTLS12 with default/intermediate profile", func() {
+			// Check HostedCluster TLS profile configuration
+			hostedCluster := tc.GetHostedCluster()
+
+			// Only run for nil (default) or explicit Intermediate profile
+			hasProfile := hostedCluster.Spec.Configuration != nil &&
+				hostedCluster.Spec.Configuration.APIServer != nil &&
+				hostedCluster.Spec.Configuration.APIServer.TLSSecurityProfile != nil
+
+			isDefaultOrIntermediate := !hasProfile || hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileIntermediateType)
+
+			if !isDefaultOrIntermediate {
+				Skip("HostedCluster does not have default or Intermediate TLS profile - skipping TLS 1.2 test")
+			}
+
+			// Get kube-apiserver deployment to check pod template spec
+			mgmtClient := tc.MgmtClient
+			deployment, err := getKubeAPIServerDeployment(tc.Context, mgmtClient, tc.ControlPlaneNamespace)
+			Expect(err).NotTo(HaveOccurred(), "failed to get kube-apiserver deployment")
+
+			// Find konnectivity-server container
+			var konnectivityContainer *corev1.Container
+			for i := range deployment.Spec.Template.Spec.Containers {
+				if deployment.Spec.Template.Spec.Containers[i].Name == "konnectivity-server" {
+					konnectivityContainer = &deployment.Spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+
+			Expect(konnectivityContainer).NotTo(BeNil(), "konnectivity-server container should exist")
+
+			// Verify --tls-min-version=VersionTLS12 in args
+			tlsMinVersion := getTLSMinVersionFromArgs(konnectivityContainer.Args)
+			Expect(tlsMinVersion).To(Equal("VersionTLS12"),
+				"konnectivity-server should have --tls-min-version=VersionTLS12 for intermediate profile")
+		})
+
+		It("should accept both TLS 1.2 and TLS 1.3 connections with intermediate profile", func() {
+			// Check HostedCluster TLS profile configuration
+			hostedCluster := tc.GetHostedCluster()
+
+			// Only run for nil (default) or explicit Intermediate profile
+			hasProfile := hostedCluster.Spec.Configuration != nil &&
+				hostedCluster.Spec.Configuration.APIServer != nil &&
+				hostedCluster.Spec.Configuration.APIServer.TLSSecurityProfile != nil
+
+			isDefaultOrIntermediate := !hasProfile || hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileIntermediateType)
+
+			if !isDefaultOrIntermediate {
+				Skip("HostedCluster does not have default or Intermediate TLS profile - skipping TLS 1.2 connectivity test")
+			}
+
+			// Wait for rollout to complete so all pods have the latest config
+			mgmtClient := tc.MgmtClient
+			GinkgoWriter.Printf("Waiting for kube-apiserver rollout to complete\n")
+			err := waitForKubeAPIServerRollout(tc.Context, mgmtClient, tc.ControlPlaneNamespace, 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred(), "kube-apiserver rollout should complete")
+
+			// Get a ready kube-apiserver pod for connectivity testing
+			kasPod, err := getReadyKubeAPIServerPod(tc.Context, mgmtClient, tc.ControlPlaneNamespace)
+			Expect(err).NotTo(HaveOccurred(), "should find a ready kube-apiserver pod")
+
+			// konnectivity-server listens on port 8090 for server connections
+			konnectivityPort := "8090"
+			GinkgoWriter.Printf("Testing TLS connections to konnectivity-server in pod %s on port %s\n", kasPod.Name, konnectivityPort)
+
+			// Test TLS 1.2 connection using openssl s_client from within the kube-apiserver pod
+			tls12Result, err := v2util.RunCommandInPod(tc.Context, mgmtKubeClient, mgmtRestConfig,
+				tc.ControlPlaneNamespace, kasPod.Name, "konnectivity-server",
+				"sh", "-c",
+				fmt.Sprintf("timeout 2 openssl s_client -connect localhost:%s -tls1_2 2>&1 || true", konnectivityPort))
+			Expect(err).NotTo(HaveOccurred(), "failed to exec into kube-apiserver pod for TLS 1.2 test")
+			Expect(strings.ToLower(tls12Result)).To(ContainSubstring("tlsv1.2"),
+				"should confirm TLS 1.2 was used for konnectivity-server port %s", konnectivityPort)
+
+			// Test TLS 1.3 connection using openssl s_client
+			tls13Result, err := v2util.RunCommandInPod(tc.Context, mgmtKubeClient, mgmtRestConfig,
+				tc.ControlPlaneNamespace, kasPod.Name, "konnectivity-server",
+				"sh", "-c",
+				fmt.Sprintf("timeout 2 openssl s_client -connect localhost:%s -tls1_3 2>&1 || true", konnectivityPort))
+			Expect(err).NotTo(HaveOccurred(), "failed to exec into kube-apiserver pod for TLS 1.3 test")
+			Expect(strings.ToLower(tls13Result)).To(ContainSubstring("tlsv1.3"),
+				"should confirm TLS 1.3 was used for konnectivity-server port %s", konnectivityPort)
+		})
+
+		It("should update to --tls-min-version=VersionTLS13 when TLS profile changed to Modern", func() {
+			// Get the HostedCluster from management cluster and update its TLS profile
+			mgmtClient := tc.MgmtClient
+
+			// Update to Modern TLS profile with retry on conflict
+			Eventually(func(g Gomega) {
+				hostedCluster := &hyperv1.HostedCluster{}
+				err := mgmtClient.Get(tc.Context, crclient.ObjectKey{
+					Namespace: tc.ClusterNamespace,
+					Name:      tc.ClusterName,
+				}, hostedCluster)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+
+				// Initialize Configuration if needed
+				if hostedCluster.Spec.Configuration == nil {
+					hostedCluster.Spec.Configuration = &hyperv1.ClusterConfiguration{}
+				}
+				if hostedCluster.Spec.Configuration.APIServer == nil {
+					hostedCluster.Spec.Configuration.APIServer = &configv1.APIServerSpec{}
+				}
+
+				// Update to Modern TLS profile in the HostedCluster CR
+				hostedCluster.Spec.Configuration.APIServer.TLSSecurityProfile = &configv1.TLSSecurityProfile{
+					Type:   configv1.TLSProfileModernType,
+					Modern: &configv1.ModernTLSProfile{},
+				}
+				err = mgmtClient.Update(tc.Context, hostedCluster)
+				g.Expect(apierrors.IsConflict(err)).To(BeFalse(), "conflict on update, retrying")
+				g.Expect(err).NotTo(HaveOccurred(), "failed to update HostedCluster TLS profile to Modern")
+			}, 1*time.Minute, 5*time.Second).Should(Succeed(), "failed to update HostedCluster to Modern profile")
+
+			GinkgoWriter.Printf("Updated HostedCluster to Modern TLS profile, waiting for changes to propagate\n")
+
+			// Wait for deployment to reflect the Modern profile with TLS 1.3
+			Eventually(func(g Gomega) {
+				deployment, err := getKubeAPIServerDeployment(tc.Context, mgmtClient, tc.ControlPlaneNamespace)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to get kube-apiserver deployment")
+
+				// Find konnectivity-server container in pod template
+				var konnectivityContainer *corev1.Container
+				for i := range deployment.Spec.Template.Spec.Containers {
+					if deployment.Spec.Template.Spec.Containers[i].Name == "konnectivity-server" {
+						konnectivityContainer = &deployment.Spec.Template.Spec.Containers[i]
+						break
+					}
+				}
+
+				g.Expect(konnectivityContainer).NotTo(BeNil(), "konnectivity-server container should exist")
+
+				// Verify --tls-min-version=VersionTLS13 in args
+				tlsMinVersion := getTLSMinVersionFromArgs(konnectivityContainer.Args)
+				g.Expect(tlsMinVersion).To(Equal("VersionTLS13"),
+					"konnectivity-server should have --tls-min-version=VersionTLS13 for modern profile")
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+			// Wait for rollout to complete so all pods have the latest config
+			GinkgoWriter.Printf("Waiting for kube-apiserver rollout to complete after Modern profile update\n")
+			err := waitForKubeAPIServerRollout(tc.Context, mgmtClient, tc.ControlPlaneNamespace, 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred(), "kube-apiserver rollout should complete after Modern profile update")
+		})
+
+		It("should accept TLS 1.3 but reject TLS 1.2 with Modern profile", func() {
+			// Verify HostedCluster has Modern profile (fetch fresh, not cached)
+			mgmtClient := tc.MgmtClient
+			hostedCluster := &hyperv1.HostedCluster{}
+			err := mgmtClient.Get(tc.Context, crclient.ObjectKey{
+				Namespace: tc.ClusterNamespace,
+				Name:      tc.ClusterName,
+			}, hostedCluster)
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+
+			if !hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
+				Fail("HostedCluster does not have Modern TLS profile - previous ordered test should have set it")
+			}
+
+			konnectivityPort := "8090"
+
+			// Get a ready kube-apiserver pod for connectivity testing (rollout already completed in previous test)
+			kasPod, err := getReadyKubeAPIServerPod(tc.Context, mgmtClient, tc.ControlPlaneNamespace)
+			Expect(err).NotTo(HaveOccurred(), "should find a ready kube-apiserver pod")
+
+			// Test TLS 1.3 connection should succeed using openssl
+			GinkgoWriter.Printf("Testing TLS 1.3 connection to konnectivity-server in pod %s with Modern profile\n", kasPod.Name)
+			tls13Result, err := v2util.RunCommandInPod(tc.Context, mgmtKubeClient, mgmtRestConfig,
+				tc.ControlPlaneNamespace, kasPod.Name, "konnectivity-server",
+				"sh", "-c",
+				fmt.Sprintf("timeout 2 openssl s_client -connect localhost:%s -tls1_3 2>&1 || true", konnectivityPort))
+			Expect(err).NotTo(HaveOccurred(), "failed to exec into kube-apiserver pod for TLS 1.3 test")
+
+			Expect(strings.ToLower(tls13Result)).To(ContainSubstring("tlsv1.3"),
+				"should confirm TLS 1.3 was used for konnectivity-server with Modern profile")
+
+			// Test TLS 1.2 connection should fail using openssl
+			GinkgoWriter.Printf("Testing TLS 1.2 connection to konnectivity-server in pod %s with Modern profile\n", kasPod.Name)
+			tls12Result, err := v2util.RunCommandInPod(tc.Context, mgmtKubeClient, mgmtRestConfig,
+				tc.ControlPlaneNamespace, kasPod.Name, "konnectivity-server",
+				"sh", "-c",
+				fmt.Sprintf("timeout 2 openssl s_client -connect localhost:%s -tls1_2 2>&1 || true", konnectivityPort))
+			Expect(err).NotTo(HaveOccurred(), "failed to exec into kube-apiserver pod for TLS 1.2 test")
+
+			// TLS 1.2 should be rejected - check that no cipher was negotiated
+			lowerResult := strings.ToLower(tls12Result)
+			Expect(lowerResult).To(ContainSubstring("cipher is (none)"),
+				"TLS 1.2 connection should be rejected with modern profile, got: %s", tls12Result)
+		})
+
+		It("should downgrade to --tls-min-version=VersionTLS12 when Modern TLS profile is removed", func() {
+			// Get the HostedCluster from management cluster and update its TLS profile
+			mgmtClient := tc.MgmtClient
+
+			// First verify it currently has Modern profile (fetch fresh, not cached)
+			hostedCluster := &hyperv1.HostedCluster{}
+			err := mgmtClient.Get(tc.Context, crclient.ObjectKey{
+				Namespace: tc.ClusterNamespace,
+				Name:      tc.ClusterName,
+			}, hostedCluster)
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+
+			if !hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
+				Fail("HostedCluster does not have Modern TLS profile - previous ordered tests should have set it")
+			}
+
+			// Remove Modern TLS profile (downgrade to default/Intermediate) with retry on conflict
+			Eventually(func(g Gomega) {
+				hostedCluster := &hyperv1.HostedCluster{}
+				err := mgmtClient.Get(tc.Context, crclient.ObjectKey{
+					Namespace: tc.ClusterNamespace,
+					Name:      tc.ClusterName,
+				}, hostedCluster)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+
+				// Remove TLS profile to downgrade to default (Intermediate)
+				hostedCluster.Spec.Configuration.APIServer.TLSSecurityProfile = nil
+
+				err = mgmtClient.Update(tc.Context, hostedCluster)
+				g.Expect(apierrors.IsConflict(err)).To(BeFalse(), "conflict on update, retrying")
+				g.Expect(err).NotTo(HaveOccurred(), "failed to remove TLS profile to downgrade to Intermediate")
+			}, 1*time.Minute, 5*time.Second).Should(Succeed(), "failed to downgrade HostedCluster to Intermediate profile")
+
+			GinkgoWriter.Printf("Removed Modern TLS profile from HostedCluster (downgraded to default/Intermediate), waiting for changes to propagate\n")
+
+			// Wait for deployment to reflect the Intermediate profile with TLS 1.2
+			Eventually(func(g Gomega) {
+				deployment, err := getKubeAPIServerDeployment(tc.Context, mgmtClient, tc.ControlPlaneNamespace)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to get kube-apiserver deployment")
+
+				// Find konnectivity-server container in pod template
+				var konnectivityContainer *corev1.Container
+				for i := range deployment.Spec.Template.Spec.Containers {
+					if deployment.Spec.Template.Spec.Containers[i].Name == "konnectivity-server" {
+						konnectivityContainer = &deployment.Spec.Template.Spec.Containers[i]
+						break
+					}
+				}
+
+				g.Expect(konnectivityContainer).NotTo(BeNil(), "konnectivity-server container should exist")
+
+				// Verify --tls-min-version=VersionTLS12 in args
+				tlsMinVersion := getTLSMinVersionFromArgs(konnectivityContainer.Args)
+				g.Expect(tlsMinVersion).To(Equal("VersionTLS12"),
+					"konnectivity-server should have --tls-min-version=VersionTLS12 for intermediate profile")
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+			// Wait for rollout to complete so all pods have the latest config
+			GinkgoWriter.Printf("Waiting for kube-apiserver rollout to complete after downgrade to Intermediate profile\n")
+			err = waitForKubeAPIServerRollout(tc.Context, mgmtClient, tc.ControlPlaneNamespace, 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred(), "kube-apiserver rollout should complete after downgrade to Intermediate profile")
+		})
+
+		It("should accept both TLS 1.2 and TLS 1.3 connections after downgrade to Intermediate profile", func() {
+			// Verify HostedCluster does not have Modern profile (fetch fresh, not cached)
+			mgmtClient := tc.MgmtClient
+			hostedCluster := &hyperv1.HostedCluster{}
+			err := mgmtClient.Get(tc.Context, crclient.ObjectKey{
+				Namespace: tc.ClusterNamespace,
+				Name:      tc.ClusterName,
+			}, hostedCluster)
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+
+			// Check that TLS profile is nil (default/Intermediate) or explicitly not Modern
+			if hostedClusterHasTLSProfileType(hostedCluster, configv1.TLSProfileModernType) {
+				Fail("HostedCluster still has Modern TLS profile - previous ordered test should have downgraded it")
+			}
+
+			// Get a ready kube-apiserver pod for connectivity testing (rollout already completed in previous test)
+			kasPod, err := getReadyKubeAPIServerPod(tc.Context, mgmtClient, tc.ControlPlaneNamespace)
+			Expect(err).NotTo(HaveOccurred(), "should find a ready kube-apiserver pod")
+
+			konnectivityPort := "8090"
+
+			// Test TLS 1.2 connection should succeed using openssl
+			GinkgoWriter.Printf("Testing TLS 1.2 connection to konnectivity-server in pod %s after downgrade to Intermediate profile\n", kasPod.Name)
+			tls12Result, err := v2util.RunCommandInPod(tc.Context, mgmtKubeClient, mgmtRestConfig,
+				tc.ControlPlaneNamespace, kasPod.Name, "konnectivity-server",
+				"sh", "-c",
+				fmt.Sprintf("timeout 2 openssl s_client -connect localhost:%s -tls1_2 2>&1 || true", konnectivityPort))
+			Expect(err).NotTo(HaveOccurred(), "failed to exec into kube-apiserver pod for TLS 1.2 test")
+
+			Expect(strings.ToLower(tls12Result)).To(ContainSubstring("tlsv1.2"),
+				"should confirm TLS 1.2 was accepted for konnectivity-server after downgrade to Intermediate profile")
+
+			// Test TLS 1.3 connection should also succeed using openssl
+			GinkgoWriter.Printf("Testing TLS 1.3 connection to konnectivity-server in pod %s after downgrade to Intermediate profile\n", kasPod.Name)
+			tls13Result, err := v2util.RunCommandInPod(tc.Context, mgmtKubeClient, mgmtRestConfig,
+				tc.ControlPlaneNamespace, kasPod.Name, "konnectivity-server",
+				"sh", "-c",
+				fmt.Sprintf("timeout 2 openssl s_client -connect localhost:%s -tls1_3 2>&1 || true", konnectivityPort))
+			Expect(err).NotTo(HaveOccurred(), "failed to exec into kube-apiserver pod for TLS 1.3 test")
+
+			Expect(strings.ToLower(tls13Result)).To(ContainSubstring("tlsv1.3"),
+				"should confirm TLS 1.3 was accepted for konnectivity-server with Intermediate profile")
+		})
+
+		AfterAll(func() {
+			if tc == nil {
+				return
+			}
+			GinkgoWriter.Printf("Restoring original Configuration\n")
+
+			// Use Eventually with retry on conflict
+			err := wait.PollUntilContextTimeout(tc.Context, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+				hostedCluster := &hyperv1.HostedCluster{}
+				err := tc.MgmtClient.Get(ctx, crclient.ObjectKey{
+					Namespace: tc.ClusterNamespace,
+					Name:      tc.ClusterName,
+				}, hostedCluster)
+				if err != nil {
+					return false, err
+				}
+
+				// Restore the complete original Configuration shape
+				if originalConfiguration == nil {
+					hostedCluster.Spec.Configuration = nil
+				} else {
+					hostedCluster.Spec.Configuration = originalConfiguration.DeepCopy()
+				}
+
+				err = tc.MgmtClient.Update(ctx, hostedCluster)
+				if apierrors.IsConflict(err) {
+					return false, nil // Retry on conflict
+				}
+				if err != nil {
+					return false, err
+				}
+				return true, nil
+			})
+			if err != nil {
+				GinkgoWriter.Printf("Warning: failed to restore original Configuration: %v\n", err)
+			}
+		})
+	})
+}
+
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:KonnectivityServer] Konnectivity Server TLS Configuration", Label("konnectivity-server"), func() {
+	var testCtx *internal.TestContext
+
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+
+		testCtx.ValidateHostedCluster()
+	})
+
+	RegisterKonnectivityServerTests(func() *internal.TestContext { return testCtx })
+})


### PR DESCRIPTION
e2e tests added for konnectivity-server to verify that TLS profile propagation is respected correctly after this new flag addition

test for changes done in https://github.com/openshift/hypershift/pull/8866


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage for TLS settings and connectivity of the `konnectivity-server` sidecar.
  - Verified behavior across default, Modern, and downgraded TLS profiles.
  - Improved TLS probing to validate ready pods and completed deployment rollouts.
  - Added checks to confirm TLS configuration remains synchronized after pod restarts.
  - Updated test descriptions and coverage labels to include `konnectivity-server`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->