### PR TITLE
NO-JIRA: chore: update github actions runner image to go 1.26.4

### DIFF
--- a/Dockerfile.github-actions-runner
+++ b/Dockerfile.github-actions-runner
@@ -19,7 +19,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
-ARG GO_VERSION=1.25.7
+ARG GO_VERSION=1.26.4
 RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz
 
 RUN OCP_ARCH=$([ "$TARGETARCH" = "amd64" ] && echo "x86_64" || echo "aarch64") && \


### PR DESCRIPTION
this is necessary to enable linting support for an PR upgrading hypershift images to golang 1.26.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

bumps the go minor version of the github actions image to make use of 1.26.4

this is a necessary prerequisite to upgrading the project go version to 1.26.4, as golangci lint built in the actions image must be built using a greater or equal golang version.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes #8823 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions runner image to use a newer Go toolchain by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->