### PR TITLE
OCPBUGS-95615: fix(kubevirt): use only first MachineInternalIP per family in EndpointSlice endpoints

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
@@ -129,10 +129,20 @@ func (r *reconciler) reconcileKubevirtPassthroughService(ctx context.Context, _ 
 				log.Info("Skipping link-local address for EndpointSlice", "address", machineAddress.Address, "machine", machine.Name)
 				continue
 			}
+			// Use only the first address per family. CAPK PR #366 exposes all VMI
+			// interface IPs (for dual-stack CSR approval), including ovn-k8s-mp0
+			// management port IPs that are not routable from the management cluster.
+			// This assumes CAPK reports the pod-network IP first; if CAPK changes
+			// address ordering, this logic must be revisited.
+			// See: OCPBUGS-95615, kubernetes-sigs/cluster-api-provider-kubevirt#366
 			if parsedAddr.Is4() {
-				ipv4MachineAddresses = append(ipv4MachineAddresses, machineAddress.Address)
+				if len(ipv4MachineAddresses) == 0 {
+					ipv4MachineAddresses = append(ipv4MachineAddresses, machineAddress.Address)
+				}
 			} else {
-				ipv6MachineAddresses = append(ipv6MachineAddresses, machineAddress.Address)
+				if len(ipv6MachineAddresses) == 0 {
+					ipv6MachineAddresses = append(ipv6MachineAddresses, machineAddress.Address)
+				}
 			}
 		}
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine_test.go
@@ -422,6 +422,45 @@ func TestReconcileDefaultIngressEndpoints(t *testing.T) {
 		},
 	}
 
+	machinesWithExtraInternalIPs := []capiv1.Machine{
+		{
+			TypeMeta:   machineTypeMeta,
+			ObjectMeta: worker1Meta,
+			Spec: capiv1.MachineSpec{
+				InfrastructureRef: corev1.ObjectReference{
+					Name: vmWorker1Meta.Name,
+				},
+			},
+			Status: capiv1.MachineStatus{
+				Phase: string(capiv1.MachinePhaseRunning),
+				Addresses: []capiv1.MachineAddress{
+					{Type: capiv1.MachineInternalIP, Address: "192.168.1.3"},
+					{Type: capiv1.MachineInternalIP, Address: "10.8.20.2"},
+					{Type: capiv1.MachineInternalIP, Address: "2001:db8:a0b:12f0::3"},
+					{Type: capiv1.MachineInternalIP, Address: "fd00:10:8::3"},
+				},
+			},
+		},
+		{
+			TypeMeta:   machineTypeMeta,
+			ObjectMeta: worker2Meta,
+			Spec: capiv1.MachineSpec{
+				InfrastructureRef: corev1.ObjectReference{
+					Name: vmWorker2Meta.Name,
+				},
+			},
+			Status: capiv1.MachineStatus{
+				Phase: string(capiv1.MachinePhaseRunning),
+				Addresses: []capiv1.MachineAddress{
+					{Type: capiv1.MachineInternalIP, Address: "192.168.1.4"},
+					{Type: capiv1.MachineInternalIP, Address: "10.8.0.2"},
+					{Type: capiv1.MachineInternalIP, Address: "2001:db8:a0b:12f0::4"},
+					{Type: capiv1.MachineInternalIP, Address: "fd00:10:8::4"},
+				},
+			},
+		},
+	}
+
 	testCases := []struct {
 		name                          string
 		machines                      []capiv1.Machine
@@ -492,6 +531,24 @@ func TestReconcileDefaultIngressEndpoints(t *testing.T) {
 				kccmEndpointSliceIPv4(machinesWithLinkLocalAddresses[1], pairOfVirtualMachines[1]),
 				kccmEndpointSliceIPv6(machinesWithLinkLocalAddresses[0], pairOfVirtualMachines[0]),
 				kccmEndpointSliceIPv6(machinesWithLinkLocalAddresses[1], pairOfVirtualMachines[1]),
+			},
+			hcp: kubevirtHCP,
+		},
+		{
+			name:             "When machines have multiple same-family InternalIPs it should use only the first per family",
+			machines:         machinesWithExtraInternalIPs,
+			virtualMachines:  pairOfVirtualMachines,
+			services:         []corev1.Service{defaultIngressService, kccmService},
+			expectedServices: []corev1.Service{defaultIngressService, kccmService},
+			expectedIngressEndpointSlices: []discoveryv1.EndpointSlice{
+				defaultIngressEndpointSliceIPv4(machinesWithExtraInternalIPs[0], pairOfVirtualMachines[0]),
+				defaultIngressEndpointSliceIPv4(machinesWithExtraInternalIPs[1], pairOfVirtualMachines[1]),
+				defaultIngressEndpointSliceIPv6(machinesWithExtraInternalIPs[0], pairOfVirtualMachines[0]),
+				defaultIngressEndpointSliceIPv6(machinesWithExtraInternalIPs[1], pairOfVirtualMachines[1]),
+				kccmEndpointSliceIPv4(machinesWithExtraInternalIPs[0], pairOfVirtualMachines[0]),
+				kccmEndpointSliceIPv4(machinesWithExtraInternalIPs[1], pairOfVirtualMachines[1]),
+				kccmEndpointSliceIPv6(machinesWithExtraInternalIPs[0], pairOfVirtualMachines[0]),
+				kccmEndpointSliceIPv6(machinesWithExtraInternalIPs[1], pairOfVirtualMachines[1]),
 			},
 			hcp: kubevirtHCP,
 		},


### PR DESCRIPTION
## What this PR does / why we need it:

Since CAPK PR [kubernetes-sigs/cluster-api-provider-kubevirt#366](https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/pull/366) began exposing all VMI interface IPs for dual-stack CSR approval, `Machine.Status.Addresses` includes `ovn-k8s-mp0` management port IPs from the guest cluster's OVN overlay alongside the VM's routable pod network IP.

The HCCO machine controller was putting **all** `MachineInternalIP` addresses into `EndpointSlice.Endpoint.Addresses`, causing MetalLB/kube-proxy to round-robin traffic to non-routable `ovn-k8s-mp0` IPs and producing ~50% connection timeouts on LoadBalancer services exposed via MetalLB.

The existing link-local filter ([OCPBUGS-83711](https://redhat.atlassian.net/browse/OCPBUGS-83711), PR #8264) does not catch these IPs because they are regular RFC1918 addresses (e.g. `10.8.x.2`), not link-local.

This PR uses only the **first** `MachineInternalIP` per IP family, which is the VM's primary pod network IP on the management cluster. This matches the convention already used in e2e tests (`firstMachineAddress` in `nodepool_kv_advanced_multinet_test.go`).

## Which issue(s) this PR fixes:

Related to [OCPBUGS-83711](https://redhat.atlassian.net/browse/OCPBUGS-83711) (link-local filter) and [OCPBUGS-84269](https://redhat.atlassian.net/browse/OCPBUGS-84269) / PR #8230 (CIDR conflict false positive) — same root cause (CAPK PR #366), different symptom.

Customer cases: 04485238, 04485252

## Checklist:

- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed internal IP selection for endpoint generation when machines report multiple IPv4/IPv6 addresses, so only the first IPv4 and the first IPv6 per machine are used.
  * Prevents additional same-family addresses from being included in KubeVirt-related endpoint-slice generation.
  * Added test coverage to verify endpoint slices ignore extra InternalIP entries beyond the first per IP family.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->