### PR TITLE
OCPBUGS-91511: Fix CPO infinite requeue during deletion when OIDC provider is gone

### DIFF
--- a/control-plane-operator/controllers/healthcheck/aws_test.go
+++ b/control-plane-operator/controllers/healthcheck/aws_test.go
@@ -149,11 +149,12 @@ func TestUpdateRunsAWSIdentityCheckDuringDeletion(t *testing.T) {
 		log:                ctrl.Log.WithName("test"),
 	}
 
-	// update() should not return nil silently (the old early-return behavior).
 	// With KAS unavailable and no EC2 client, awsHealthCheckIdentityProvider
 	// sets ValidAWSIdentityProvider to Unknown and returns nil, so update()
 	// itself succeeds but still patches the status.
-	_ = hcu.update(ctx)
+	if err := hcu.update(ctx); err != nil {
+		t.Fatalf("When HCP has a deletionTimestamp, update() should succeed when KAS is unavailable, got: %v", err)
+	}
 
 	updated := &hyperv1.HostedControlPlane{}
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(hcp), updated); err != nil {

--- a/control-plane-operator/controllers/healthcheck/aws_test.go
+++ b/control-plane-operator/controllers/healthcheck/aws_test.go
@@ -4,9 +4,14 @@ import (
 	"testing"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/api"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // TestAWSHealthCheckIdentityProviderConditionLogic tests the condition setting logic
@@ -107,4 +112,62 @@ func TestAWSHealthCheckIdentityProviderConditionLogic(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpdateRunsAWSIdentityCheckDuringDeletion(t *testing.T) {
+	now := metav1.Now()
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-hcp",
+			Namespace:         "test-namespace",
+			Generation:        1,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test-finalizer"},
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.AWSPlatform,
+				AWS:  &hyperv1.AWSPlatformSpec{},
+			},
+		},
+		Status: hyperv1.HostedControlPlaneStatus{
+			Conditions: []metav1.Condition{},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(api.Scheme).
+		WithObjects(hcp).
+		WithStatusSubresource(&hyperv1.HostedControlPlane{}).
+		Build()
+
+	ctx := ctrl.LoggerInto(t.Context(), ctrl.Log.WithName("test"))
+
+	hcu := &HealthCheckUpdater{
+		Client:             fakeClient,
+		HostedControlPlane: client.ObjectKeyFromObject(hcp),
+		log:                ctrl.Log.WithName("test"),
+	}
+
+	// update() should not return nil silently (the old early-return behavior).
+	// With KAS unavailable and no EC2 client, awsHealthCheckIdentityProvider
+	// sets ValidAWSIdentityProvider to Unknown and returns nil, so update()
+	// itself succeeds but still patches the status.
+	_ = hcu.update(ctx)
+
+	updated := &hyperv1.HostedControlPlane{}
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(hcp), updated); err != nil {
+		t.Fatalf("failed to get updated HCP: %v", err)
+	}
+
+	condition := meta.FindStatusCondition(updated.Status.Conditions, string(hyperv1.ValidAWSIdentityProvider))
+	if condition == nil {
+		t.Fatal("When HCP has a deletionTimestamp, it should still evaluate ValidAWSIdentityProvider, but the condition was not set")
+	}
+
+	// KAS is not available, so the check sets Unknown status
+	if condition.Status != metav1.ConditionUnknown {
+		t.Errorf("Expected condition status %v, got %v", metav1.ConditionUnknown, condition.Status)
+	}
+
 }

--- a/control-plane-operator/controllers/healthcheck/healthcheck_controller.go
+++ b/control-plane-operator/controllers/healthcheck/healthcheck_controller.go
@@ -66,18 +66,15 @@ func (hcu *HealthCheckUpdater) update(ctx context.Context) error {
 		return fmt.Errorf("failed to get HostedControlPlane: %w", err)
 	}
 
-	// Return early if deleting
-	if !hostedControlPlane.DeletionTimestamp.IsZero() {
-		return nil
-	}
-
 	originalHostedControlPlane := hostedControlPlane.DeepCopy()
 
 	errs := []error{}
 
-	// Call generic health checks
-
-	// Call platform-specific health checks
+	// NOTE: generic health checks (if added in the future) should be gated
+	// behind hostedControlPlane.DeletionTimestamp.IsZero(). Platform-specific
+	// credential checks below must keep running during deletion so that
+	// shouldCleanupCloudResources() sees an up-to-date ValidAWSIdentityProvider
+	// condition.
 	if hostedControlPlane.Spec.Platform.Type == hyperv1.AWSPlatform {
 		// This is the best effort ping to the identity provider
 		// that enables access from the operator to the cloud provider resources.

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -390,6 +390,8 @@ func (r *HostedControlPlaneReconciler) reconcileDeletion(ctx context.Context, ho
 			switch code {
 			case "UnauthorizedOperation":
 				r.Log.Error(destroyErr, "Skipping AWS default security group deletion because of unauthorized operation.")
+			case "InvalidIdentityToken":
+				r.Log.Error(destroyErr, "Skipping AWS default security group deletion because of invalid identity token (OIDC provider may be missing).")
 			case "DependencyViolation":
 				r.Log.Error(destroyErr, "Skipping AWS default security group deletion because of dependency violation.")
 			default:
@@ -2866,7 +2868,8 @@ func (r *HostedControlPlaneReconciler) destroyAWSDefaultSecurityGroup(ctx contex
 	// Get the security group to delete. If it no longer exists, then there's nothing to do
 	sg, err := supportawsutil.GetSecurityGroup(ctx, r.ec2Client, awsSecurityGroupFilters(hcp.Spec.InfraID))
 	if err != nil {
-		return "", err
+		code := supportawsutil.AWSErrorCode(err)
+		return code, err
 	}
 	if sg == nil {
 		return "", nil
@@ -2910,7 +2913,8 @@ func (r *HostedControlPlaneReconciler) destroyAWSDefaultSecurityGroup(ctx contex
 	// the delete until it's no longer there.
 	sg, err = supportawsutil.GetSecurityGroup(ctx, r.ec2Client, awsSecurityGroupFilters(hcp.Spec.InfraID))
 	if err != nil {
-		return "", err
+		code := supportawsutil.AWSErrorCode(err)
+		return code, err
 	}
 	if sg != nil {
 		return "", fmt.Errorf("security group still exists, waiting on deletion")

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -376,7 +376,7 @@ func (r *HostedControlPlaneReconciler) reconcileDeletion(ctx context.Context, ho
 	if shouldCleanupCloudResources(r.Log, hostedControlPlane) {
 		if code, destroyErr := r.destroyAWSDefaultSecurityGroup(ctx, hostedControlPlane); destroyErr != nil {
 			condition.Message = "failed to delete AWS default security group"
-			if code == "DependencyViolation" {
+			if code == supportawsutil.DependencyViolation {
 				condition.Message = destroyErr.Error()
 			}
 			condition.Reason = hyperv1.AWSErrorReason
@@ -388,11 +388,11 @@ func (r *HostedControlPlaneReconciler) reconcileDeletion(ctx context.Context, ho
 			}
 
 			switch code {
-			case "UnauthorizedOperation":
+			case supportawsutil.UnauthorizedOperation:
 				r.Log.Error(destroyErr, "Skipping AWS default security group deletion because of unauthorized operation.")
-			case "InvalidIdentityToken":
+			case supportawsutil.InvalidIdentityToken:
 				r.Log.Error(destroyErr, "Skipping AWS default security group deletion because of invalid identity token (OIDC provider may be missing).")
-			case "DependencyViolation":
+			case supportawsutil.DependencyViolation:
 				r.Log.Error(destroyErr, "Skipping AWS default security group deletion because of dependency violation.")
 			default:
 				return ctrl.Result{}, fmt.Errorf("failed to delete AWS default security group: %w", destroyErr)

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -4342,6 +4342,17 @@ func TestReconcileDeletion(t *testing.T) {
 			wantCondStatus: metav1.ConditionFalse,
 		},
 		{
+			name: "When DescribeSecurityGroups returns InvalidIdentityToken it should extract the error code and skip gracefully",
+			setupEC2Mock: func(mockCtrl *gomock.Controller) *awsapi.MockEC2API {
+				m := awsapi.NewMockEC2API(mockCtrl)
+				m.EXPECT().DescribeSecurityGroups(gomock.Any(), gomock.Any()).Return(nil,
+					&smithy.GenericAPIError{Code: "InvalidIdentityToken", Message: "No OpenIDConnect provider found in your account"})
+				return m
+			},
+			wantErr:        false,
+			wantCondStatus: metav1.ConditionFalse,
+		},
+		{
 			name: "When destroyAWSDefaultSecurityGroup returns unexpected error, it should propagate the error",
 			setupEC2Mock: func(mockCtrl *gomock.Controller) *awsapi.MockEC2API {
 				m := awsapi.NewMockEC2API(mockCtrl)

--- a/support/awsutil/errorcode.go
+++ b/support/awsutil/errorcode.go
@@ -9,6 +9,7 @@ import (
 const (
 	AuthFailure           = "AuthFailure"
 	DependencyViolation   = "DependencyViolation"
+	InvalidIdentityToken  = "InvalidIdentityToken"
 	UnauthorizedOperation = "UnauthorizedOperation"
 )
 


### PR DESCRIPTION
## What this PR does / why we need it:

When a HostedCluster is being deleted and the OIDC provider has already been removed from AWS, the CPO gets stuck in an infinite requeue loop trying to delete the AWS default security group. The HC finalizer is never removed, permanently leaking the HostedCluster and all its resources on the management cluster.

### When can this occur?

In the normal `hypershift destroy cluster aws` flow, the OIDC provider is only deleted **after** the HCP is fully gone:

1. CLI deletes HC → HC gets DeletionTimestamp
2. Operator deletes NodePools, CAPI cluster (machines need OIDC, so it must exist)
3. Operator deletes HCP → HCP gets DeletionTimestamp
4. CPO runs `reconcileDeletion`, deletes the default security group, removes HCP finalizer
5. HCP is fully deleted; operator cleans up OIDC S3 data, removes its finalizer
6. CLI runs `destroyPlatformSpecifics` → destroys infra and IAM, including the OIDC provider

The bug can only occur if the OIDC provider is deleted by an **external actor** during the small window between step 3 (HCP gets DeletionTimestamp) and step 4 (CPO finishes deleting the security group). In practice, this happens when CI test teardown deletes OIDC resources in parallel with the CPO's deletion sequence — for example, a `control-plane-upgrade` e2e test that cleans up OIDC as part of post-test teardown while the CPO is still reconciling.

### Root cause

The health check controller had a blanket early return on `deletionTimestamp` that skipped all health checks — including `ValidAWSIdentityProvider` validation — during deletion. This left the condition stale at `True`, so `shouldCleanupCloudResources()` kept attempting AWS cleanup that would fail with `InvalidIdentityToken` (OIDC provider gone). Additionally, `destroyAWSDefaultSecurityGroup()` did not extract the AWS error code from `GetSecurityGroup()` failures, returning an empty code string that caused `reconcileDeletion()` to hit its default error path and requeue forever.

### Fix (two commits + review follow-up):

1. **Health check controller**: Remove the blanket early return on `deletionTimestamp`. The AWS identity provider check now continues to run during deletion, allowing `ValidAWSIdentityProvider` to be updated to `False` when the OIDC provider is missing. This lets `shouldCleanupCloudResources()` correctly skip cloud cleanup.

2. **Defense-in-depth**: Extract the AWS error code from `GetSecurityGroup()` failures in `destroyAWSDefaultSecurityGroup()` (was returning empty string). Add `InvalidIdentityToken` to the set of error codes that `reconcileDeletion()` handles gracefully (alongside `UnauthorizedOperation` and `DependencyViolation`), so even if the condition is stale, the deletion path won't get stuck.

3. **Review follow-up**: Use `supportawsutil` constants instead of string literals in the `reconcileDeletion` switch. Assert the `update()` return value in the health check deletion test.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-91511

## Special notes for your reviewer:

The observed instance was a cluster leaked on the `hypershift-ci-2` management cluster since 2026-06-12, causing 100% failure rate on `periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn-conformance` since 2026-06-19. The leaked KAS pods (stuck in `Init:ImagePullBackOff`) were visible to conformance tests from other HostedClusters.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.ai/code) via `/jira:solve OCPBUGS-91511`