### PR TITLE
feat(ignition): improve observability for ignition server and proxy

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ignition-server-proxy/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ignition-server-proxy/deployment.yaml
@@ -24,11 +24,16 @@ spec:
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
           cat <<EOF > /tmp/haproxy.conf
+          global
+            log stdout local0
+
           defaults
             mode http
+            log global
+            option httplog
             timeout connect 5s
-            timeout client 30s
-            timeout server 30s
+            timeout client 300s
+            timeout server 300s
 
           frontend ignition-server
             bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
@@ -60,6 +65,8 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /tmp
+          name: tmp-dir
       volumes:
       - name: serving-cert
         secret:
@@ -69,3 +76,5 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - emptyDir: {}
+        name: tmp-dir

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -267,8 +268,13 @@ func run(ctx context.Context, opts Options) error {
 		}
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("Content-Length", strconv.Itoa(len(value.Payload)))
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(value.Payload)
+		n, err = w.Write(value.Payload)
+		if err != nil {
+			log.Printf("Failed to write ignition payload: wrote %d/%d bytes: %v", n, len(value.Payload), err)
+		}
+		log.Printf("Served ignition payload: %d bytes", len(value.Payload))
 
 		eventRecorder.Event(tokenSecret, corev1.EventTypeNormal, "GetPayload", "")
 		getRequestsPerNodePool.WithLabelValues(r.Header.Get("NodePool")).Inc()

--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -227,7 +227,7 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	token := string(tokenSecret.Data[TokenSecretTokenKey])
 	if value, ok := r.PayloadStore.Get(token); ok {
-		log.Info("Payload found in cache")
+		log.Info("Payload found in cache", "payloadSize", len(value.Payload))
 
 		if tokenNeedRotation(timeLived) {
 			log.Info("Rotating token ID")
@@ -278,7 +278,7 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return nil, fmt.Errorf("error getting ignition payload: %w", err)
 		}
 		duration := time.Since(start).Round(time.Second).Seconds()
-		log.Info("got ignition payload", "duration", duration)
+		log.Info("got ignition payload", "duration", duration, "payloadSize", len(payload))
 		PayloadGenerationSeconds.Observe(duration)
 		return payload, err
 	}()


### PR DESCRIPTION
## Summary

- Add logging and increase timeouts in the ignition-server-proxy haproxy config
- Log write errors, set Content-Length, and log payload size in the ignition server HTTP handler
- Add payload size to structured log messages in the token secret reconciler

## Context

Investigation of a `TestCreateClusterRequestServingIsolation` failure on AWS revealed that when an ignition fetch fails mid-stream (`unexpected EOF` after HTTP 200), we have near-zero observability into the failure:

1. The **ignition-server-proxy** haproxy had **no logging** — pod logs were completely empty
2. The **ignition-server** silently discarded `w.Write()` errors — no signal that the payload didn't reach the client
3. No `Content-Length` header was set, so the client couldn't distinguish truncation from a complete response
4. Payload size was never logged, making it impossible to correlate what was generated vs what was transferred

## Changes

### ignition-server-proxy haproxy config
- Added `global` section with `log stdout local0` for access logging
- Added `log global` and `option httplog` in `defaults` for per-request logging
- Increased `timeout client` and `timeout server` from `30s` to `300s` (the router uses `86400s` for comparison)

### ignition-server HTTP handler (`start.go`)
- Set `Content-Length` header before writing — eliminates chunked encoding ambiguity and lets clients detect truncation
- Capture and log `w.Write()` errors with bytes written vs total payload size
- Log payload size on every successful serve

### Token secret reconciler (`tokensecret_controller.go`)
- Added `payloadSize` field to "Payload found in cache" log message
- Added `payloadSize` field to "got ignition payload" log message

## Test plan

- [ ] Verify ignition-server and ignition-server-proxy compile cleanly
- [ ] Verify ignition-server-proxy unit tests pass
- [ ] Verify ignition-server-proxy pod logs show haproxy access logs in a running cluster
- [ ] Verify ignition payload size appears in ignition-server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved response handling for ignition payload delivery, including correct content length reporting and clearer logging of the size served.
* **Bug Fixes**
  * Increased proxy timeout settings to better handle slower requests.
  * Updated proxy logging to provide more detailed request information.
  * Added support for temporary file storage needed by the proxy at runtime.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->