### PR TITLE
feat(e2e): dump Azure LB status during test artifact collection

### DIFF
--- a/test/e2e/util/dump/azure.go
+++ b/test/e2e/util/dump/azure.go
@@ -1,0 +1,103 @@
+package dump
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	cmdutil "github.com/openshift/hypershift/cmd/util"
+	"github.com/openshift/hypershift/support/azureutil"
+
+	"github.com/go-logr/logr"
+)
+
+// DumpAzureLBStatus dumps the state of all Azure Load Balancers in the hosted
+// cluster's resource group to azure-lb-status.json in the artifact directory.
+// This is useful for diagnosing networking issues where traffic is not reaching
+// the hosted cluster (e.g. konnectivity or ingress failures caused by Azure LB
+// misconfiguration or missing backend pool members).
+func DumpAzureLBStatus(ctx context.Context, hc *hyperv1.HostedCluster, azureCredentialsFile string, artifactDir string) error {
+	if hc.Spec.Platform.Azure == nil {
+		return fmt.Errorf("hosted cluster %s/%s does not have Azure platform configuration", hc.Namespace, hc.Name)
+	}
+
+	subscriptionID := hc.Spec.Platform.Azure.SubscriptionID
+	resourceGroupName := hc.Spec.Platform.Azure.ResourceGroupName
+	cloudName := hc.Spec.Platform.Azure.Cloud
+
+	if subscriptionID == "" || resourceGroupName == "" {
+		return fmt.Errorf("hosted cluster %s/%s is missing Azure subscriptionID or resourceGroupName", hc.Namespace, hc.Name)
+	}
+
+	azureCreds, err := setupCredentials(azureCredentialsFile)
+	if err != nil {
+		return fmt.Errorf("failed to set up Azure credentials: %w", err)
+	}
+
+	cloudConfig, err := azureutil.GetAzureCloudConfiguration(cloudName)
+	if err != nil {
+		return fmt.Errorf("failed to get Azure cloud configuration for %q: %w", cloudName, err)
+	}
+
+	clientOpts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: cloudConfig,
+		},
+	}
+
+	lbClient, err := armnetwork.NewLoadBalancersClient(subscriptionID, azureCreds, clientOpts)
+	if err != nil {
+		return fmt.Errorf("failed to create Azure LoadBalancers client: %w", err)
+	}
+
+	var loadBalancers []*armnetwork.LoadBalancer
+	pager := lbClient.NewListPager(resourceGroupName, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list load balancers in resource group %s: %w", resourceGroupName, err)
+		}
+		loadBalancers = append(loadBalancers, page.Value...)
+	}
+
+	output := map[string]interface{}{
+		"subscriptionID":    subscriptionID,
+		"resourceGroupName": resourceGroupName,
+		"cloud":             cloudName,
+		"hostedCluster":     fmt.Sprintf("%s/%s", hc.Namespace, hc.Name),
+		"infraID":           hc.Spec.InfraID,
+		"loadBalancerCount": len(loadBalancers),
+		"loadBalancers":     loadBalancers,
+	}
+
+	data, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal load balancer status: %w", err)
+	}
+
+	outputPath := filepath.Join(artifactDir, "azure-lb-status.json")
+	if err := os.WriteFile(outputPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", outputPath, err)
+	}
+
+	return nil
+}
+
+// setupCredentials reads Azure credentials from the given file and returns
+// a TokenCredential suitable for ARM client creation. This follows the same
+// pattern as cmd/util.SetupAzureCredentials but without requiring a logger.
+func setupCredentials(credentialsFile string) (azcore.TokenCredential, error) {
+	_, creds, err := cmdutil.SetupAzureCredentials(logr.Discard(), nil, credentialsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup Azure credentials from %s: %w", credentialsFile, err)
+	}
+	return creds, nil
+}
+

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -412,6 +412,17 @@ func newClusterDumper(hc *hyperv1.HostedCluster, opts *PlatformAgnosticOptions, 
 				t.Logf("Failed to dump machine journals; this is nonfatal: %v", err)
 			}
 			return utilerrors.NewAggregate(dumpErrors)
+		case hyperv1.AzurePlatform:
+			var dumpErrors []error
+			err := dump.DumpAzureLBStatus(ctx, hc, opts.AzurePlatform.CredentialsFile, artifactDir)
+			if err != nil {
+				t.Logf("Failed saving Azure LB status; this is nonfatal: %v", err)
+			}
+			err = dump.DumpHostedCluster(ctx, t, hc, dumpGuestCluster, artifactDir)
+			if err != nil {
+				dumpErrors = append(dumpErrors, fmt.Errorf("failed to dump hosted cluster: %w", err))
+			}
+			return utilerrors.NewAggregate(dumpErrors)
 		default:
 			err := dump.DumpHostedCluster(ctx, t, hc, dumpGuestCluster, artifactDir)
 			if err != nil {


### PR DESCRIPTION
## Summary

- Add Azure Load Balancer state dumping to e2e test artifact collection for Azure platform tests
- Captures full LB config (frontend IPs, backend pools, rules, health probes) as `azure-lb-status.json`

## Context

Investigation of a `TestUpgradeControlPlane` failure on AKS revealed that the ingress canary route was unreachable for the entire cluster lifetime. The konnectivity agent TCP-connected to the Azure LB but connections were closed within 2-3ms. The router pod was healthy but never received any connections.

We could not determine whether the Azure LB was forwarding traffic because we had **no Azure-level diagnostics** in the e2e artifact dump. The dump already collects AWS console logs (`DumpMachineConsoleLogs`) but had nothing Azure-specific.

## Changes

### New file: `test/e2e/util/dump/azure.go`
- `DumpAzureLBStatus()` lists all load balancers in the HC's resource group
- Uses the already-vendored `armnetwork/v5` SDK
- Authenticates via `cmd/util.SetupAzureCredentials` (same pattern as existing Azure infra code)
- Writes full LB state as formatted JSON to `azure-lb-status.json`
- Includes frontend IPs, backend address pools, load balancing rules, and health probes

### Modified: `test/e2e/util/fixture.go`
- Added `case hyperv1.AzurePlatform:` to the platform switch in `newClusterDumper()`
- Calls `DumpAzureLBStatus()` before `DumpHostedCluster()`, matching the AWS pattern
- LB dump failures are logged as nonfatal

## Test plan

- [ ] Verify `go build ./test/e2e/...` compiles cleanly
- [ ] Verify `go vet ./test/e2e/util/dump/` passes
- [ ] Run an Azure e2e test and verify `azure-lb-status.json` appears in artifacts
- [ ] Verify the JSON contains LB frontend IPs, backend pools, rules, and probes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Azure load balancer status reporting to end-to-end test artifacts.
  * Azure cluster dumps now include load balancer details alongside existing hosted cluster information.

* **Bug Fixes**
  * Improved Azure artifact collection so load balancer status is captured even if part of the dump process fails.
  * Error reporting now preserves more context when Azure status collection encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->