### PR TITLE
test: add unit tests for CachedProvider

### DIFF
--- a/support/releaseinfo/cached_provider_test.go
+++ b/support/releaseinfo/cached_provider_test.go
@@ -1,0 +1,59 @@
+package releaseinfo
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+type fakeProvider struct {
+	lookupCount int
+}
+
+func (f *fakeProvider) Lookup(_ context.Context, image string, _ []byte) (*ReleaseImage, error) {
+	f.lookupCount++
+	return &ReleaseImage{ImageStream: nil}, nil
+}
+
+func TestCachedProviderCacheHit(t *testing.T) {
+	g := NewWithT(t)
+	inner := &fakeProvider{}
+	provider := &CachedProvider{
+		Cache: map[string]*ReleaseImage{},
+		Inner: inner,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	image := "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64"
+
+	_, err := provider.Lookup(ctx, image, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(inner.lookupCount).To(Equal(1))
+
+	_, err = provider.Lookup(ctx, image, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(inner.lookupCount).To(Equal(1))
+}
+
+func TestCachedProviderCacheMiss(t *testing.T) {
+	g := NewWithT(t)
+	inner := &fakeProvider{}
+	provider := &CachedProvider{
+		Cache: map[string]*ReleaseImage{},
+		Inner: inner,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for i := 0; i < 3; i++ {
+		image := fmt.Sprintf("quay.io/openshift-release-dev/ocp-release:4.%d.0-x86_64", 17+i)
+		_, err := provider.Lookup(ctx, image, nil)
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+
+	g.Expect(inner.lookupCount).To(Equal(3))
+}


### PR DESCRIPTION
Adds unit tests for CachedProvider cache hit and cache miss behavior in support/releaseinfo. Test PR for review-agent rehearsal — safe to close.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering cached release image lookups.
  * Verified that repeated requests for the same image URL reuse cached results without additional underlying lookups.
  * Verified that different image URLs each trigger a separate underlying lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->