### PR TITLE
OCPBUGS-123149: feat(ignition-server, ignition-server-proxy): inject centralized TLS configuration

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+kind: ConfigMap
+metadata:
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -8,15 +8,15 @@ data:
       timeout server 30s
 
     frontend ignition-server
-      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
       default_backend ignition_servers
 
     backend ignition_servers
-      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
 kind: ConfigMap
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 0e6844cd629f2aafb4bb4f76832422933ebabf1ee339b0e57b29e1735ec3b791
+    hypershift.openshift.io/desired-state-hash: bad9f3f8ecab6ebbf72b0d19bb0c7b313b4e84138ceb20f02929d821b0e08527
   name: ignition-server-proxy-config
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
+kind: ConfigMap
+metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: 0e6844cd629f2aafb4bb4f76832422933ebabf1ee339b0e57b29e1735ec3b791
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
@@ -20,5 +20,8 @@ status:
     type: RolloutComplete
   resources:
   - group: ""
+    kind: ConfigMap
+    name: ignition-server-proxy-config
+  - group: ""
     kind: Service
     name: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -85,21 +85,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -124,6 +110,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -145,6 +134,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 20e5f6e1e5b5db60f7ba7d8cce50caf9998c4769be560d2a75df536ce17ddc75
+    hypershift.openshift.io/desired-state-hash: aa2504e70335653815da6bacf8787512cbe375c54508292c0a7f1d8b7b785334
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: 208be704
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -87,21 +87,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -126,6 +112,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -147,6 +136,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: aa2504e70335653815da6bacf8787512cbe375c54508292c0a7f1d8b7b785334
+    hypershift.openshift.io/desired-state-hash: cb62d90b55c528ca5ff2447b93f7235f3f2cee7c3b7ec3889f9dc06e7fc327e3
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: 208be704
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: cb62d90b55c528ca5ff2447b93f7235f3f2cee7c3b7ec3889f9dc06e7fc327e3
+    hypershift.openshift.io/desired-state-hash: 9c0d04f42908aae3760cfe4017402ca7b4bf0840cc543c22a705d44544d5fc2a
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -102,6 +102,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_BIND_SERVICE
@@ -118,6 +119,8 @@ spec:
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
+      securityContext:
+        runAsNonRoot: true
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+kind: ConfigMap
+metadata:
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -8,15 +8,15 @@ data:
       timeout server 30s
 
     frontend ignition-server
-      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
       default_backend ignition_servers
 
     backend ignition_servers
-      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
 kind: ConfigMap
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 0e6844cd629f2aafb4bb4f76832422933ebabf1ee339b0e57b29e1735ec3b791
+    hypershift.openshift.io/desired-state-hash: bad9f3f8ecab6ebbf72b0d19bb0c7b313b4e84138ceb20f02929d821b0e08527
   name: ignition-server-proxy-config
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
+kind: ConfigMap
+metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: 0e6844cd629f2aafb4bb4f76832422933ebabf1ee339b0e57b29e1735ec3b791
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
@@ -20,5 +20,8 @@ status:
     type: RolloutComplete
   resources:
   - group: ""
+    kind: ConfigMap
+    name: ignition-server-proxy-config
+  - group: ""
     kind: Service
     name: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -85,21 +85,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -128,6 +114,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -149,6 +138,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 2ce2debd9664394337c02e3a2e4799b315ad7124778f450aa4115504785ef933
+    hypershift.openshift.io/desired-state-hash: 2e211ba633d56cb7f188e59a7415f63ca841aff1fcd235476c7660a2dda99678
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: 208be704
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 2e211ba633d56cb7f188e59a7415f63ca841aff1fcd235476c7660a2dda99678
+    hypershift.openshift.io/desired-state-hash: f65dbff5386ac182a0659a0b63f1eeb0c28733e8c6a642e19446c2b3f9dac9b0
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -122,6 +122,8 @@ spec:
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
+      securityContext:
+        runAsNonRoot: true
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 3941c65ae7f9d75604d2749f756adcd973fe0a9e4ae0c744e50d2225025194cd
+    hypershift.openshift.io/desired-state-hash: 2ce2debd9664394337c02e3a2e4799b315ad7124778f450aa4115504785ef933
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: 208be704
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -87,21 +87,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -130,6 +116,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -151,6 +140,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+kind: ConfigMap
+metadata:
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -8,15 +8,15 @@ data:
       timeout server 30s
 
     frontend ignition-server
-      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
       default_backend ignition_servers
 
     backend ignition_servers
-      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
 kind: ConfigMap
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 0e6844cd629f2aafb4bb4f76832422933ebabf1ee339b0e57b29e1735ec3b791
+    hypershift.openshift.io/desired-state-hash: bad9f3f8ecab6ebbf72b0d19bb0c7b313b4e84138ceb20f02929d821b0e08527
   name: ignition-server-proxy-config
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
+kind: ConfigMap
+metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: 0e6844cd629f2aafb4bb4f76832422933ebabf1ee339b0e57b29e1735ec3b791
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
@@ -20,5 +20,8 @@ status:
     type: RolloutComplete
   resources:
   - group: ""
+    kind: ConfigMap
+    name: ignition-server-proxy-config
+  - group: ""
     kind: Service
     name: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -85,21 +85,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -124,6 +110,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -145,6 +134,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 20e5f6e1e5b5db60f7ba7d8cce50caf9998c4769be560d2a75df536ce17ddc75
+    hypershift.openshift.io/desired-state-hash: aa2504e70335653815da6bacf8787512cbe375c54508292c0a7f1d8b7b785334
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: 208be704
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -87,21 +87,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -126,6 +112,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -147,6 +136,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: aa2504e70335653815da6bacf8787512cbe375c54508292c0a7f1d8b7b785334
+    hypershift.openshift.io/desired-state-hash: cb62d90b55c528ca5ff2447b93f7235f3f2cee7c3b7ec3889f9dc06e7fc327e3
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: 208be704
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: cb62d90b55c528ca5ff2447b93f7235f3f2cee7c3b7ec3889f9dc06e7fc327e3
+    hypershift.openshift.io/desired-state-hash: 9c0d04f42908aae3760cfe4017402ca7b4bf0840cc543c22a705d44544d5fc2a
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -102,6 +102,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_BIND_SERVICE
@@ -118,6 +119,8 @@ spec:
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
+      securityContext:
+        runAsNonRoot: true
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
+kind: ConfigMap
+metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: 0e6844cd629f2aafb4bb4f76832422933ebabf1ee339b0e57b29e1735ec3b791
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -8,15 +8,15 @@ data:
       timeout server 30s
 
     frontend ignition-server
-      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.3 alpn http/1.1
       default_backend ignition_servers
 
     backend ignition_servers
-      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.3 alpn http/1.1
 kind: ConfigMap
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 0e6844cd629f2aafb4bb4f76832422933ebabf1ee339b0e57b29e1735ec3b791
+    hypershift.openshift.io/desired-state-hash: f3fd874c67643ca88f47dda6033477b9fe89093348da117556c4b57e97775826
   name: ignition-server-proxy-config
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
@@ -20,5 +20,8 @@ status:
     type: RolloutComplete
   resources:
   - group: ""
+    kind: ConfigMap
+    name: ignition-server-proxy-config
+  - group: ""
     kind: Service
     name: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 20e5f6e1e5b5db60f7ba7d8cce50caf9998c4769be560d2a75df536ce17ddc75
+    hypershift.openshift.io/desired-state-hash: aa2504e70335653815da6bacf8787512cbe375c54508292c0a7f1d8b7b785334
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: 208be704
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -87,21 +87,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -126,6 +112,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -147,6 +136,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: eb0e8e3ea434d27d405a7461e8ff52ff0228aca9f2dca2c0b35ccab1d68a4f1b
+    hypershift.openshift.io/desired-state-hash: 290122b4433b00bee8820f5ddafc9510019b8a0ac7229b2b97a9ce0cc36a6c95
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -102,6 +102,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_BIND_SERVICE
@@ -118,6 +119,8 @@ spec:
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
+      securityContext:
+        runAsNonRoot: true
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: aa2504e70335653815da6bacf8787512cbe375c54508292c0a7f1d8b7b785334
+    hypershift.openshift.io/desired-state-hash: eb0e8e3ea434d27d405a7461e8ff52ff0228aca9f2dca2c0b35ccab1d68a4f1b
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: 208be704
+        component.hypershift.openshift.io/config-hash: a1d01850
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+kind: ConfigMap
+metadata:
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -8,15 +8,15 @@ data:
       timeout server 30s
 
     frontend ignition-server
-      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
       default_backend ignition_servers
 
     backend ignition_servers
-      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
 kind: ConfigMap
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 0e6844cd629f2aafb4bb4f76832422933ebabf1ee339b0e57b29e1735ec3b791
+    hypershift.openshift.io/desired-state-hash: bad9f3f8ecab6ebbf72b0d19bb0c7b313b4e84138ceb20f02929d821b0e08527
   name: ignition-server-proxy-config
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
+kind: ConfigMap
+metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: 0e6844cd629f2aafb4bb4f76832422933ebabf1ee339b0e57b29e1735ec3b791
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
@@ -20,5 +20,8 @@ status:
     type: RolloutComplete
   resources:
   - group: ""
+    kind: ConfigMap
+    name: ignition-server-proxy-config
+  - group: ""
     kind: Service
     name: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -85,21 +85,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -124,6 +110,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -145,6 +134,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 20e5f6e1e5b5db60f7ba7d8cce50caf9998c4769be560d2a75df536ce17ddc75
+    hypershift.openshift.io/desired-state-hash: aa2504e70335653815da6bacf8787512cbe375c54508292c0a7f1d8b7b785334
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: 208be704
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -87,21 +87,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -126,6 +112,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -147,6 +136,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: aa2504e70335653815da6bacf8787512cbe375c54508292c0a7f1d8b7b785334
+    hypershift.openshift.io/desired-state-hash: cb62d90b55c528ca5ff2447b93f7235f3f2cee7c3b7ec3889f9dc06e7fc327e3
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: 208be704
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: cb62d90b55c528ca5ff2447b93f7235f3f2cee7c3b7ec3889f9dc06e7fc327e3
+    hypershift.openshift.io/desired-state-hash: 9c0d04f42908aae3760cfe4017402ca7b4bf0840cc543c22a705d44544d5fc2a
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -102,6 +102,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_BIND_SERVICE
@@ -118,6 +119,8 @@ spec:
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
+      securityContext:
+        runAsNonRoot: true
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+kind: ConfigMap
+metadata:
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -8,15 +8,15 @@ data:
       timeout server 30s
 
     frontend ignition-server
-      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
       default_backend ignition_servers
 
     backend ignition_servers
-      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
 kind: ConfigMap
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 0e6844cd629f2aafb4bb4f76832422933ebabf1ee339b0e57b29e1735ec3b791
+    hypershift.openshift.io/desired-state-hash: bad9f3f8ecab6ebbf72b0d19bb0c7b313b4e84138ceb20f02929d821b0e08527
   name: ignition-server-proxy-config
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
+kind: ConfigMap
+metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: 0e6844cd629f2aafb4bb4f76832422933ebabf1ee339b0e57b29e1735ec3b791
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
@@ -20,5 +20,8 @@ status:
     type: RolloutComplete
   resources:
   - group: ""
+    kind: ConfigMap
+    name: ignition-server-proxy-config
+  - group: ""
     kind: Service
     name: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -85,21 +85,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -124,6 +110,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -145,6 +134,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 20e5f6e1e5b5db60f7ba7d8cce50caf9998c4769be560d2a75df536ce17ddc75
+    hypershift.openshift.io/desired-state-hash: aa2504e70335653815da6bacf8787512cbe375c54508292c0a7f1d8b7b785334
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: 208be704
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -87,21 +87,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -126,6 +112,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -147,6 +136,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: aa2504e70335653815da6bacf8787512cbe375c54508292c0a7f1d8b7b785334
+    hypershift.openshift.io/desired-state-hash: cb62d90b55c528ca5ff2447b93f7235f3f2cee7c3b7ec3889f9dc06e7fc327e3
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: 208be704
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: cb62d90b55c528ca5ff2447b93f7235f3f2cee7c3b7ec3889f9dc06e7fc327e3
+    hypershift.openshift.io/desired-state-hash: 9c0d04f42908aae3760cfe4017402ca7b4bf0840cc543c22a705d44544d5fc2a
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server-proxy
@@ -102,6 +102,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_BIND_SERVICE
@@ -118,6 +119,8 @@ spec:
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
+      securityContext:
+        runAsNonRoot: true
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -89,6 +89,10 @@ spec:
         - registry=override
         - --platform
         - Azure
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 7290d8d2d2d09a3df3b7f54d451b383aa837d445b2a9313266dc20fdf52eccb9
+    hypershift.openshift.io/desired-state-hash: 5decfb8ef6cd8065b54793219bfbedbc43a27626188a6de6de2b9be59b2349ce
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server
@@ -91,10 +91,8 @@ spec:
         - registry=override
         - --platform
         - Azure
-        - --tls-min-version
-        - VersionTLS12
-        - --tls-cipher-suites
-        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 28f42e725e361a2cc7ed779871e8db3000bbeb4ebf43809079d5c6459cead1e2
+    hypershift.openshift.io/desired-state-hash: 7290d8d2d2d09a3df3b7f54d451b383aa837d445b2a9313266dc20fdf52eccb9
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server
@@ -91,6 +91,10 @@ spec:
         - registry=override
         - --platform
         - Azure
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -89,6 +89,10 @@ spec:
         - registry=override
         - --platform
         - GCP
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 572a7c26908fd03a1ec02547cd7a96261b6338330fd8155a3f27a28ea0659fc0
+    hypershift.openshift.io/desired-state-hash: 9ae4f6c7c41819b41b576aa4f67788be7728d244cce19c256ed83ae7755882dc
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server
@@ -91,6 +91,10 @@ spec:
         - registry=override
         - --platform
         - GCP
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 9ae4f6c7c41819b41b576aa4f67788be7728d244cce19c256ed83ae7755882dc
+    hypershift.openshift.io/desired-state-hash: 57954eeed41f6bebe808addf12d97088914a242c48ccb511193771ad92d52c42
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server
@@ -91,10 +91,8 @@ spec:
         - registry=override
         - --platform
         - GCP
-        - --tls-min-version
-        - VersionTLS12
-        - --tls-cipher-suites
-        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -89,6 +89,10 @@ spec:
         - registry=override
         - --platform
         - IBMCloud
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: c81afa853a8e631acc5b71b23bf7f1fc9d59c37e8b0501f88434af4d6b66f22e
+    hypershift.openshift.io/desired-state-hash: cb857ee2aab78e2629f805311d6793510d049a4338b3dcbde5519d7ea701cefe
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server
@@ -91,10 +91,8 @@ spec:
         - registry=override
         - --platform
         - IBMCloud
-        - --tls-min-version
-        - VersionTLS12
-        - --tls-cipher-suites
-        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: c42c8577c57986cc7e7bbdb35667ad2b05256bda81fdc5b85fbca7f41a29f47f
+    hypershift.openshift.io/desired-state-hash: c81afa853a8e631acc5b71b23bf7f1fc9d59c37e8b0501f88434af4d6b66f22e
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server
@@ -91,6 +91,10 @@ spec:
         - registry=override
         - --platform
         - IBMCloud
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: c23f57d48c04bc8b4b3ec30d7ec1131b7d21644a5be428592ba207832c1305d5
+    hypershift.openshift.io/desired-state-hash: fc8ed65338163f95e4018cda4ebcb3bd00d8c64a9842377348b4ecad1d75aabb
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server
@@ -91,6 +91,8 @@ spec:
         - registry=override
         - --platform
         - AWS
+        - --tls-min-version
+        - VersionTLS13
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/ModernTLS/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: fc8ed65338163f95e4018cda4ebcb3bd00d8c64a9842377348b4ecad1d75aabb
+    hypershift.openshift.io/desired-state-hash: 94a640e26d4ce01fe2e8ca8faee7b937b51054f34fc73944cd88faf9875503ea
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server
@@ -91,8 +91,7 @@ spec:
         - registry=override
         - --platform
         - AWS
-        - --tls-min-version
-        - VersionTLS13
+        - --tls-min-version=VersionTLS13
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -89,6 +89,10 @@ spec:
         - registry=override
         - --platform
         - AWS
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: c7e4ac928a64f030091648cde9ac76d6f600ae92e815ca851ecbc7da23901058
+    hypershift.openshift.io/desired-state-hash: 0a66edafd224b0d22583dbd490e7106cbfeffeab82d34dd179860fd934197094
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server
@@ -91,10 +91,8 @@ spec:
         - registry=override
         - --platform
         - AWS
-        - --tls-min-version
-        - VersionTLS12
-        - --tls-cipher-suites
-        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: ee5935816b0e9d7dee305a8c43592fa1108ebfc30fad46303d3cc7c365a2ae9e
+    hypershift.openshift.io/desired-state-hash: c7e4ac928a64f030091648cde9ac76d6f600ae92e815ca851ecbc7da23901058
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server
@@ -91,6 +91,10 @@ spec:
         - registry=override
         - --platform
         - AWS
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -89,6 +89,10 @@ spec:
         - registry=override
         - --platform
         - AWS
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 7df09364a48afbc090fd02aa7c35e4ddbfc47ea5ad7ff2796baddbac15497bbf
+    hypershift.openshift.io/desired-state-hash: 98ab5d12009b289e64738428ff438826787f51b4a4cc34cf53469010987f41db
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server
@@ -91,10 +91,8 @@ spec:
         - registry=override
         - --platform
         - AWS
-        - --tls-min-version
-        - VersionTLS12
-        - --tls-cipher-suites
-        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: c23f57d48c04bc8b4b3ec30d7ec1131b7d21644a5be428592ba207832c1305d5
+    hypershift.openshift.io/desired-state-hash: 7df09364a48afbc090fd02aa7c35e4ddbfc47ea5ad7ff2796baddbac15497bbf
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: ignition-server
@@ -91,6 +91,10 @@ spec:
         - registry=override
         - --platform
         - AWS
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ignition-server-proxy/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ignition-server-proxy/deployment.yaml
@@ -23,21 +23,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -60,6 +46,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
       volumes:
       - name: serving-cert
         secret:
@@ -69,3 +58,7 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ignition-server-proxy/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ignition-server-proxy/deployment.yaml
@@ -38,6 +38,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_BIND_SERVICE
@@ -49,6 +50,8 @@ spec:
         - mountPath: /etc/haproxy
           name: haproxy-config
           readOnly: true
+      securityContext:
+        runAsNonRoot: true
       volumes:
       - name: serving-cert
         secret:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ignition-server-proxy/haproxy-config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ignition-server-proxy/haproxy-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ignition-server-proxy-config
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
@@ -21,12 +21,19 @@ func (capi *CAPIManagerOptions) adaptDeployment(cpContext component.WorkloadCont
 		return fmt.Errorf("failed to parse version (%s): %w", versionStr, err)
 	}
 
+	tlsArgs, err := config.TLSArgs(cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
+
 	podspec.UpdateContainer("manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		if version.GE(config.Version419) {
 			c.Args = append(c.Args, "--feature-gates=MachineSetPreflightChecks=false")
 		}
 		if version.Major >= 5 || (version.Major == 4 && version.Minor >= 23) {
-			c.Args = append(c.Args, config.TLSArgs(cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile())...)
+			if len(tlsArgs) > 0 {
+				c.Args = append(c.Args, tlsArgs...)
+			}
 		}
 
 		if version.GE(config.Version420) {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/deployment.go
@@ -20,9 +20,15 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	})
 
 	hcp := cpContext.HCP
+	tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
 
 	podspec.UpdateContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
+		}
 	})
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/deployment.go
@@ -18,12 +18,18 @@ const (
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	hcp := cpContext.HCP
+	tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
 
 	podspec.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args,
 			fmt.Sprintf("--cluster-name=%s", cpContext.HCP.Spec.InfraID),
 		)
-		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
+		}
 
 		if azureutil.IsAroHCPByHCP(cpContext.HCP) {
 			c.VolumeMounts = append(c.VolumeMounts,

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/component.go
@@ -59,9 +59,15 @@ func predicate(cpContext component.WorkloadContext) (bool, error) {
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	hcp := cpContext.HCP
+	tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
 
 	podspec.UpdateContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
+		}
 	})
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/deployment.go
@@ -34,11 +34,18 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, buildInfraKubeconfigVolume())
 	}
 
+	tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
+
 	podspec.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args,
 			fmt.Sprintf("--cluster-name=%s", clusterName),
 		)
-		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
+		}
 
 		if isExternalInfra {
 			c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment.go
@@ -32,12 +32,19 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, buildTrustedCAVolume())
 	}
 
+	tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
+
 	podspec.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Env = append(c.Env, corev1.EnvVar{
 			Name:  "OCP_INFRASTRUCTURE_NAME",
 			Value: cpContext.HCP.Spec.InfraID,
 		})
-		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
+		}
 
 		if hasCACert {
 			c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment.go
@@ -21,8 +21,15 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		return fmt.Errorf(".spec.platform.powervs is not defined")
 	}
 
+	tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
+
 	podspec.UpdateContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
+		}
 	})
 
 	podspec.UpdateVolume(cloudCredsVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/clusterpolicy/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/clusterpolicy/config.go
@@ -33,7 +33,9 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 		return err
 	}
 
-	adaptConfig(cmConfig, cpContext.HCP.Spec.Configuration, featureGates)
+	if err := adaptConfig(cmConfig, cpContext.HCP.Spec.Configuration, featureGates); err != nil {
+		return err
+	}
 	configStr, err := k8sutil.SerializeResource(cmConfig, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to serialize openshift cluster policy controller configuration: %w", err)
@@ -43,8 +45,12 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	return nil
 }
 
-func adaptConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, configuration *hyperv1.ClusterConfiguration, fg []string) {
+func adaptConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, configuration *hyperv1.ClusterConfiguration, fg []string) error {
 	cfg.FeatureGates = fg
-	cfg.ServingInfo.MinTLSVersion = config.MinTLSVersion(configuration.GetTLSSecurityProfile())
-	cfg.ServingInfo.CipherSuites = config.CipherSuites(configuration.GetTLSSecurityProfile())
+
+	if err := config.ApplyServingInfoFromTLSProfile(&cfg.ServingInfo.ServingInfo, configuration.GetTLSSecurityProfile()); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/clusterpolicy/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/clusterpolicy/config_test.go
@@ -16,28 +16,30 @@ func TestAdaptConfig(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name            string
-		featureGates    []string
-		configuration   *hyperv1.ClusterConfiguration
-		expectedFG      []string
-		expectedMinTLS  string
-		expectedCiphers []string
+		name              string
+		featureGates      []string
+		configuration     *hyperv1.ClusterConfiguration
+		expectedFG        []string
+		expectedMinTLS    string
+		expectedCiphers   []string
+		expectError       bool
+		expectedErrSubstr string
 	}{
 		{
 			name:            "When feature gates are provided, it should set them on the config",
 			featureGates:    []string{"FeatureA=true", "FeatureB=false"},
 			configuration:   nil,
 			expectedFG:      []string{"FeatureA=true", "FeatureB=false"},
-			expectedMinTLS:  config.MinTLSVersion(nil),
-			expectedCiphers: config.CipherSuites(nil),
+			expectedMinTLS:  string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion),
+			expectedCiphers: config.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers),
 		},
 		{
 			name:            "When feature gates are empty, it should set empty slice",
 			featureGates:    []string{},
 			configuration:   nil,
 			expectedFG:      []string{},
-			expectedMinTLS:  config.MinTLSVersion(nil),
-			expectedCiphers: config.CipherSuites(nil),
+			expectedMinTLS:  string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion),
+			expectedCiphers: config.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers),
 		},
 		{
 			name:            "When configuration is nil, it should set default TLS values",
@@ -45,7 +47,7 @@ func TestAdaptConfig(t *testing.T) {
 			configuration:   nil,
 			expectedFG:      []string{"SomeGate=true"},
 			expectedMinTLS:  string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion),
-			expectedCiphers: config.CipherSuites(nil),
+			expectedCiphers: config.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers),
 		},
 		{
 			name:         "When configuration has a TLS security profile, it should set MinTLSVersion and CipherSuites",
@@ -57,11 +59,22 @@ func TestAdaptConfig(t *testing.T) {
 					},
 				},
 			},
-			expectedFG:     []string{"Gate1=true"},
-			expectedMinTLS: string(configv1.TLSProfiles[configv1.TLSProfileOldType].MinTLSVersion),
-			expectedCiphers: config.CipherSuites(&configv1.TLSSecurityProfile{
-				Type: configv1.TLSProfileOldType,
-			}),
+			expectedFG:      []string{"Gate1=true"},
+			expectedMinTLS:  string(configv1.TLSProfiles[configv1.TLSProfileOldType].MinTLSVersion),
+			expectedCiphers: config.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileOldType].Ciphers),
+		},
+		{
+			name:         "When TLS profile is Custom with nil Custom field, it should return error",
+			featureGates: []string{"Gate1=true"},
+			configuration: &hyperv1.ClusterConfiguration{
+				APIServer: &configv1.APIServerSpec{
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+					},
+				},
+			},
+			expectError:       true,
+			expectedErrSubstr: "Custom but Custom field is nil",
 		},
 	}
 
@@ -74,8 +87,15 @@ func TestAdaptConfig(t *testing.T) {
 				ServingInfo: &configv1.HTTPServingInfo{},
 			}
 
-			adaptConfig(cfg, tc.configuration, tc.featureGates)
+			err := adaptConfig(cfg, tc.configuration, tc.featureGates)
 
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tc.expectedErrSubstr))
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(cfg.FeatureGates).To(Equal(tc.expectedFG))
 			g.Expect(cfg.ServingInfo.MinTLSVersion).To(Equal(tc.expectedMinTLS))
 			g.Expect(cfg.ServingInfo.CipherSuites).To(Equal(tc.expectedCiphers))

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
@@ -103,19 +103,19 @@ func (cvo *clusterVersionOperator) adaptDeployment(cpContext component.WorkloadC
 		})
 	})
 
-	configuration := cpContext.HCP.Spec.Configuration
+	tlsArgs, err := config.TLSArgs(cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
+
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "RELEASE_IMAGE",
 			Value: dataPlaneReleaseImage,
 		})
 
-		tlsProfile := configuration.GetTLSSecurityProfile()
-		if tlsMinVersion := config.MinTLSVersion(tlsProfile); tlsMinVersion != "" {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
-		}
-		if cipherSuites := config.CipherSuites(tlsProfile); len(cipherSuites) != 0 {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
 		}
 
 		if updateService := cpContext.HCP.Spec.UpdateService; updateService != "" {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/etcd_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/etcd_test.go
@@ -227,9 +227,11 @@ func TestMinTLSVersion(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name     string
-		profile  *configv1.TLSSecurityProfile
-		expected tlsutil.TLSVersion
+		name              string
+		profile           *configv1.TLSSecurityProfile
+		expected          tlsutil.TLSVersion
+		expectError       bool
+		expectedErrSubstr string
 	}{
 		{
 			name:     "When TLS profile is nil, it should return TLS 1.2",
@@ -293,6 +295,14 @@ func TestMinTLSVersion(t *testing.T) {
 			},
 			expected: tlsutil.TLSVersion12,
 		},
+		{
+			name: "When TLS profile is Custom with nil Custom field, it should return error",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+			},
+			expectError:       true,
+			expectedErrSubstr: "Custom but Custom field is nil",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -300,7 +310,13 @@ func TestMinTLSVersion(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			result := minTLSVersion(tc.profile)
+			result, err := minTLSVersion(tc.profile)
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tc.expectedErrSubstr))
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(result).To(Equal(tc.expected))
 		})
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
@@ -24,12 +24,16 @@ import (
 
 // minTLSVersion assesses what is the minimum TLS version we should use. This
 // function takes into account that etcd supports only 1.2 and 1.3.
-func minTLSVersion(profile *configv1.TLSSecurityProfile) tlsutil.TLSVersion {
-	switch config.MinTLSVersion(profile) {
+func minTLSVersion(profile *configv1.TLSSecurityProfile) (tlsutil.TLSVersion, error) {
+	minVer, err := config.MinTLSVersion(profile)
+	if err != nil {
+		return "", err
+	}
+	switch minVer {
 	case string(configv1.VersionTLS13):
-		return tlsutil.TLSVersion13
+		return tlsutil.TLSVersion13, nil
 	default:
-		return tlsutil.TLSVersion12
+		return tlsutil.TLSVersion12, nil
 	}
 }
 
@@ -46,8 +50,15 @@ func adaptStatefulSet(cpContext component.WorkloadContext, sts *appsv1.StatefulS
 	// assess what is the min tls version to be used and also the list of
 	// cipher suites. if the cipher list is empty then the go default's
 	// cipher will be used.
-	tlsMinVersion := minTLSVersion(profile)
-	cipherSuites := config.SupportedEtcdCipherSuites(cpContext, config.CipherSuites(profile))
+	tlsMinVersion, err := minTLSVersion(profile)
+	if err != nil {
+		return fmt.Errorf("failed to get min TLS version: %w", err)
+	}
+	ciphers, err := config.CipherSuites(profile)
+	if err != nil {
+		return fmt.Errorf("failed to get cipher suites: %w", err)
+	}
+	cipherSuites := config.SupportedEtcdCipherSuites(cpContext, ciphers)
 
 	podspec.UpdateContainer(ComponentName, sts.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		replicas := component.DefaultReplicas(hcp, &etcd{}, ComponentName)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment.go
@@ -3,10 +3,12 @@ package ignitionserver
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
@@ -21,6 +23,9 @@ import (
 
 func (ign *ignitionServer) adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	hcp := cpContext.HCP
+	profile := hcp.Spec.Configuration.GetTLSSecurityProfile()
+	ianaCiphers := config.CipherSuites(profile)
+	minVersionStr := config.MinTLSVersion(profile)
 
 	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.FeatureGate != nil {
 		featureGate := &configv1.FeatureGate{
@@ -53,6 +58,13 @@ func (ign *ignitionServer) adaptDeployment(cpContext component.WorkloadContext, 
 			"--registry-overrides", util.ConvertRegistryOverridesToCommandLineFlag(ign.releaseProvider.GetRegistryOverrides()),
 			"--platform", string(hcp.Spec.Platform.Type),
 		)
+
+		if minVersionStr != "" {
+			c.Args = append(c.Args, "--tls-min-version", minVersionStr)
+		}
+		if len(ianaCiphers) > 0 {
+			c.Args = append(c.Args, "--tls-cipher-suites", strings.Join(ianaCiphers, ","))
+		}
 
 		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "OPENSHIFT_IMG_OVERRIDES",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment.go
@@ -3,7 +3,6 @@ package ignitionserver
 import (
 	"bytes"
 	"fmt"
-	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
@@ -23,9 +22,10 @@ import (
 
 func (ign *ignitionServer) adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	hcp := cpContext.HCP
-	profile := hcp.Spec.Configuration.GetTLSSecurityProfile()
-	ianaCiphers := config.CipherSuites(profile)
-	minVersionStr := config.MinTLSVersion(profile)
+	tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
 
 	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.FeatureGate != nil {
 		featureGate := &configv1.FeatureGate{
@@ -59,11 +59,8 @@ func (ign *ignitionServer) adaptDeployment(cpContext component.WorkloadContext, 
 			"--platform", string(hcp.Spec.Platform.Type),
 		)
 
-		if minVersionStr != "" {
-			c.Args = append(c.Args, "--tls-min-version", minVersionStr)
-		}
-		if len(ianaCiphers) > 0 {
-			c.Args = append(c.Args, "--tls-cipher-suites", strings.Join(ianaCiphers, ","))
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
 		}
 
 		podspec.UpsertEnvVar(c, corev1.EnvVar{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/component.go
@@ -41,6 +41,7 @@ func NewComponent(defaultIngressDomain string) component.ControlPlaneComponent {
 		WithPredicate(predicate).
 		WithManifestAdapter(
 			"haproxy-config.yaml",
+			component.WithAdaptFunction(adaptHAProxyConfig),
 		).
 		WithManifestAdapter(
 			"service.yaml",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/component.go
@@ -40,6 +40,9 @@ func NewComponent(defaultIngressDomain string) component.ControlPlaneComponent {
 		WithAdaptFunction(adaptDeployment).
 		WithPredicate(predicate).
 		WithManifestAdapter(
+			"haproxy-config.yaml",
+		).
+		WithManifestAdapter(
 			"service.yaml",
 			component.WithAdaptFunction(adaptService),
 		).

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment.go
@@ -1,9 +1,15 @@
 package ignitionserverproxy
 
 import (
+	"fmt"
+	"strings"
+
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/crypto"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -20,5 +26,120 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		podspec.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, deployment)
 	}
 
+	return nil
+}
+
+func tlsVersionToHAProxy(version string) (string, error) {
+	switch version {
+	case "VersionTLS13":
+		return "TLSv1.3", nil
+	case "VersionTLS12":
+		return "TLSv1.2", nil
+	case "VersionTLS11":
+		return "TLSv1.1", nil
+	case "VersionTLS10":
+		return "TLSv1.0", nil
+	default:
+		return "", fmt.Errorf("unknown TLS version %q", version)
+	}
+}
+
+func validateCipherName(cipher string) error {
+	if cipher == "" {
+		return fmt.Errorf("cipher name cannot be empty")
+	}
+	// Validate using library-go's OpenSSL to IANA cipher mapping
+	ianaCiphers := crypto.OpenSSLToIANACipherSuites([]string{cipher})
+	if len(ianaCiphers) == 0 {
+		return fmt.Errorf("unknown OpenSSL cipher name %q", cipher)
+	}
+	return nil
+}
+
+func adaptHAProxyConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap) error {
+	profile := cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile()
+	// TODO(ingvagabund): crypto.DefaultTLSProfileType available in 4.23+
+	if profile == nil {
+		profile = &configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileIntermediateType,
+		}
+	}
+
+	// Skip config.CipherSuites invocation to keep the ciphers in OpenSSL
+	// format to avoid translating them to IANA and back. HAProxy accepts OpenSSL format.
+	var ciphers []string
+	var minVersionStr string
+	if profile.Type == configv1.TLSProfileCustomType {
+		if profile.Custom == nil {
+			return fmt.Errorf("TLS profile type is Custom but Custom field is nil")
+		}
+		ciphers = profile.Custom.Ciphers
+		minVersionStr = string(profile.Custom.MinTLSVersion)
+	} else {
+		profileSpec, ok := configv1.TLSProfiles[profile.Type]
+		if !ok {
+			return fmt.Errorf("unknown TLS profile type: %q", profile.Type)
+		}
+		ciphers = profileSpec.Ciphers
+		minVersionStr = string(profileSpec.MinTLSVersion)
+	}
+
+	var minTLSVersion string
+	if minVersionStr != "" {
+		var err error
+		minTLSVersion, err = tlsVersionToHAProxy(minVersionStr)
+		if err != nil {
+			return fmt.Errorf("failed to convert TLS version: %w", err)
+		}
+	}
+
+	// Filter out TLS 1.3 ciphers (they start with "TLS_") - TLS 1.3 ciphers are not configurable in HAProxy
+	var cipherStr string
+	tls12Ciphers := []string{}
+	for _, cipher := range ciphers {
+		if !strings.HasPrefix(cipher, "TLS_") {
+			if err := validateCipherName(cipher); err != nil {
+				return fmt.Errorf("invalid cipher name: %w", err)
+			}
+			tls12Ciphers = append(tls12Ciphers, cipher)
+		}
+	}
+	if len(tls12Ciphers) > 0 {
+		cipherStr = strings.Join(tls12Ciphers, ":")
+	}
+
+	bindOptions := "bind :::8443 v4v6 ssl crt /tmp/tls.pem"
+	serverOptions := "server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt"
+
+	if minTLSVersion != "" {
+		bindOptions += fmt.Sprintf(" ssl-min-ver %s", minTLSVersion)
+		serverOptions += fmt.Sprintf(" ssl-min-ver %s", minTLSVersion)
+	}
+	if cipherStr != "" {
+		bindOptions += fmt.Sprintf(" ciphers %s", cipherStr)
+		serverOptions += fmt.Sprintf(" ciphers %s", cipherStr)
+	}
+
+	bindOptions += " alpn http/1.1"
+	serverOptions += " alpn http/1.1"
+
+	haproxyConf := fmt.Sprintf(`defaults
+  mode http
+  timeout connect 5s
+  timeout client 30s
+  timeout server 30s
+
+frontend ignition-server
+  %s
+  default_backend ignition_servers
+
+backend ignition_servers
+  %s
+`, bindOptions, serverOptions)
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	cm.Data["haproxy.conf"] = haproxyConf
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment.go
@@ -1,9 +1,15 @@
 package ignitionserverproxy
 
 import (
+	"fmt"
+	"strings"
+
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/crypto"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -20,5 +26,116 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		podspec.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, deployment)
 	}
 
+	return nil
+}
+
+func tlsVersionToHAProxy(version string) (string, error) {
+	switch version {
+	case "VersionTLS13":
+		return "TLSv1.3", nil
+	case "VersionTLS12":
+		return "TLSv1.2", nil
+	case "VersionTLS11":
+		return "TLSv1.1", nil
+	case "VersionTLS10":
+		return "TLSv1.0", nil
+	default:
+		return "", fmt.Errorf("unknown TLS version %q", version)
+	}
+}
+
+// validateCipherName checks if the given cipher is supported by Go's crypto/tls.
+// This matches library-go's behavior of silently filtering out Go-unsupported ciphers.
+func validateCipherName(cipher string) bool {
+	if cipher == "" {
+		return false
+	}
+	// Check using library-go's OpenSSL to IANA cipher mapping
+	ianaCiphers := crypto.OpenSSLToIANACipherSuites([]string{cipher})
+	return len(ianaCiphers) > 0
+}
+
+func adaptHAProxyConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap) error {
+	profile := cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile()
+	// TODO(ingvagabund): crypto.DefaultTLSProfileType available in 4.23+
+	if profile == nil {
+		profile = &configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileIntermediateType,
+		}
+	}
+
+	// Skip config.CipherSuites invocation to keep the ciphers in OpenSSL
+	// format to avoid translating them to IANA and back. HAProxy accepts OpenSSL format.
+	var ciphers []string
+	var minVersionStr string
+	if profile.Type == configv1.TLSProfileCustomType {
+		if profile.Custom == nil {
+			return fmt.Errorf("TLS profile type is Custom but Custom field is nil")
+		}
+		ciphers = profile.Custom.Ciphers
+		minVersionStr = string(profile.Custom.MinTLSVersion)
+	} else {
+		profileSpec, ok := configv1.TLSProfiles[profile.Type]
+		if !ok {
+			return fmt.Errorf("unknown TLS profile type: %q", profile.Type)
+		}
+		ciphers = profileSpec.Ciphers
+		minVersionStr = string(profileSpec.MinTLSVersion)
+	}
+
+	var minTLSVersion string
+	if minVersionStr != "" {
+		var err error
+		minTLSVersion, err = tlsVersionToHAProxy(minVersionStr)
+		if err != nil {
+			return fmt.Errorf("failed to convert TLS version: %w", err)
+		}
+	}
+
+	// Filter out TLS 1.3 ciphers (they start with "TLS_") - TLS 1.3 ciphers are not configurable in HAProxy
+	var cipherStr string
+	tls12Ciphers := []string{}
+	for _, cipher := range ciphers {
+		if !strings.HasPrefix(cipher, "TLS_") && validateCipherName(cipher) {
+			tls12Ciphers = append(tls12Ciphers, cipher)
+		}
+	}
+	if len(tls12Ciphers) > 0 {
+		cipherStr = strings.Join(tls12Ciphers, ":")
+	}
+
+	bindOptions := "bind :::8443 v4v6 ssl crt /tmp/tls.pem"
+	serverOptions := "server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt"
+
+	if minTLSVersion != "" {
+		bindOptions += fmt.Sprintf(" ssl-min-ver %s", minTLSVersion)
+		serverOptions += fmt.Sprintf(" ssl-min-ver %s", minTLSVersion)
+	}
+	if cipherStr != "" {
+		bindOptions += fmt.Sprintf(" ciphers %s", cipherStr)
+		serverOptions += fmt.Sprintf(" ciphers %s", cipherStr)
+	}
+
+	bindOptions += " alpn http/1.1"
+	serverOptions += " alpn http/1.1"
+
+	haproxyConf := fmt.Sprintf(`defaults
+  mode http
+  timeout connect 5s
+  timeout client 30s
+  timeout server 30s
+
+frontend ignition-server
+  %s
+  default_backend ignition_servers
+
+backend ignition_servers
+  %s
+`, bindOptions, serverOptions)
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	cm.Data["haproxy.conf"] = haproxyConf
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment_test.go
@@ -1,6 +1,7 @@
 package ignitionserverproxy
 
 import (
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -9,6 +10,8 @@ import (
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
+
+	configv1 "github.com/openshift/api/config/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -142,4 +145,277 @@ func TestAdaptDeploymentWithProxyEnvVars(t *testing.T) {
 	g.Expect(noProxy).ToNot(BeNil())
 	g.Expect(noProxy.Value).To(ContainSubstring("localhost"))
 	g.Expect(noProxy.Value).To(ContainSubstring("kube-apiserver"))
+}
+
+func TestAdaptHAProxyConfig(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                 string
+		tlsProfile           *configv1.TLSSecurityProfile
+		expectedMinTLSVer    string
+		expectedCiphers      string
+		expectCiphersPresent bool
+	}{
+		{
+			name:                 "Nil profile defaults to Intermediate",
+			expectedMinTLSVer:    "TLSv1.2",
+			expectedCiphers:      "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305",
+			expectCiphersPresent: true,
+		},
+		{
+			name: "Modern profile has TLS13 and no ciphers",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedMinTLSVer: "TLSv1.3",
+		},
+		{
+			name: "Intermediate profile has TLS12 and intermediate ciphers",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectedMinTLSVer:    "TLSv1.2",
+			expectedCiphers:      "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305",
+			expectCiphersPresent: true,
+		},
+		{
+			name: "Old profile has TLS10 and old ciphers",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			expectedMinTLSVer:    "TLSv1.0",
+			expectedCiphers:      "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA",
+			expectCiphersPresent: true,
+		},
+		{
+			name: "Custom profile uses custom TLS version and ciphers",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"ECDHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			},
+			expectedMinTLSVer:    "TLSv1.2",
+			expectedCiphers:      "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384",
+			expectCiphersPresent: true,
+		},
+		{
+			name: "Custom profile filters out TLS13 ciphers",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"TLS_AES_128_GCM_SHA256",
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"TLS_CHACHA20_POLY1305_SHA256",
+							"ECDHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			},
+			expectedMinTLSVer:    "TLSv1.2",
+			expectedCiphers:      "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384",
+			expectCiphersPresent: true,
+		},
+		{
+			name: "Custom profile with all TLS13 ciphers results in no cipher config",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS13,
+						Ciphers: []string{
+							"TLS_AES_128_GCM_SHA256",
+							"TLS_AES_256_GCM_SHA384",
+							"TLS_CHACHA20_POLY1305_SHA256",
+						},
+					},
+				},
+			},
+			expectedMinTLSVer: "TLSv1.3",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-namespace",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{},
+			}
+
+			if tc.tlsProfile != nil {
+				hcp.Spec.Configuration = &hyperv1.ClusterConfiguration{
+					APIServer: &configv1.APIServerSpec{
+						TLSSecurityProfile: tc.tlsProfile,
+					},
+				}
+			}
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+			}
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "haproxy-config",
+					Namespace: "test-namespace",
+				},
+			}
+
+			err := adaptHAProxyConfig(cpContext, cm)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(cm.Data).ToNot(BeNil())
+			g.Expect(cm.Data["haproxy.conf"]).ToNot(BeEmpty())
+
+			config := cm.Data["haproxy.conf"]
+
+			g.Expect(config).To(ContainSubstring("ssl-min-ver " + tc.expectedMinTLSVer))
+			tlsVersionCount := strings.Count(config, "ssl-min-ver "+tc.expectedMinTLSVer)
+			g.Expect(tlsVersionCount).To(Equal(2), "ssl-min-ver should appear twice (bind and server)")
+			totalSSLMinVerCount := strings.Count(config, "ssl-min-ver ")
+			g.Expect(totalSSLMinVerCount).To(Equal(2), "ssl-min-ver should only appear exactly twice total")
+
+			if tc.expectCiphersPresent {
+				g.Expect(config).To(ContainSubstring("ciphers " + tc.expectedCiphers))
+				cipherCount := strings.Count(config, "ciphers "+tc.expectedCiphers)
+				g.Expect(cipherCount).To(Equal(2), "ciphers should appear twice (bind and server)")
+				totalCiphersCount := strings.Count(config, "ciphers ")
+				g.Expect(totalCiphersCount).To(Equal(2), "ciphers should only appear exactly twice total")
+			} else {
+				g.Expect(config).ToNot(ContainSubstring("ciphers "))
+			}
+		})
+	}
+}
+
+func TestAdaptHAProxyConfigErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		tlsProfile        *configv1.TLSSecurityProfile
+		expectedErrSubstr string
+	}{
+		{
+			name: "Custom profile with nil Custom field returns error",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+			},
+			expectedErrSubstr: "Custom but Custom field is nil",
+		},
+		{
+			name: "Unknown profile type returns error",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: "UnknownProfileType",
+			},
+			expectedErrSubstr: "unknown TLS profile type",
+		},
+		{
+			name: "Empty profile type returns error",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: "",
+			},
+			expectedErrSubstr: "unknown TLS profile type",
+		},
+		{
+			name: "Unknown cipher name is rejected",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"UNKNOWN-CIPHER-NAME",
+						},
+					},
+				},
+			},
+			expectedErrSubstr: "unknown OpenSSL cipher name",
+		},
+		{
+			name: "Cipher with injection attempt is rejected",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"MALICIOUS CIPHER",
+						},
+					},
+				},
+			},
+			expectedErrSubstr: "unknown OpenSSL cipher name",
+		},
+		{
+			name: "Empty cipher name is rejected",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"",
+						},
+					},
+				},
+			},
+			expectedErrSubstr: "cipher name cannot be empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-namespace",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: tc.tlsProfile,
+						},
+					},
+				},
+			}
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+			}
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "haproxy-config",
+					Namespace: "test-namespace",
+				},
+			}
+
+			err := adaptHAProxyConfig(cpContext, cm)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring(tc.expectedErrSubstr))
+		})
+	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment_test.go
@@ -1,6 +1,7 @@
 package ignitionserverproxy
 
 import (
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -9,6 +10,8 @@ import (
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
+
+	configv1 "github.com/openshift/api/config/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -142,4 +145,269 @@ func TestAdaptDeploymentWithProxyEnvVars(t *testing.T) {
 	g.Expect(noProxy).ToNot(BeNil())
 	g.Expect(noProxy.Value).To(ContainSubstring("localhost"))
 	g.Expect(noProxy.Value).To(ContainSubstring("kube-apiserver"))
+}
+
+func TestAdaptHAProxyConfig(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                 string
+		tlsProfile           *configv1.TLSSecurityProfile
+		expectedMinTLSVer    string
+		expectedCiphers      string
+		expectCiphersPresent bool
+	}{
+		{
+			name:                 "When TLS profile is nil, it should default to Intermediate with TLSv1.2",
+			expectedMinTLSVer:    "TLSv1.2",
+			expectedCiphers:      "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305",
+			expectCiphersPresent: true,
+		},
+		{
+			name: "When using Modern profile, it should set TLS 1.3 with no ciphers",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedMinTLSVer: "TLSv1.3",
+		},
+		{
+			name: "When using Intermediate profile, it should set TLS 1.2 with intermediate ciphers",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectedMinTLSVer:    "TLSv1.2",
+			expectedCiphers:      "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305",
+			expectCiphersPresent: true,
+		},
+		{
+			name: "When using Old profile, it should set TLS 1.0 with old ciphers",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			expectedMinTLSVer:    "TLSv1.0",
+			expectedCiphers:      "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA",
+			expectCiphersPresent: true,
+		},
+		{
+			name: "When using Custom profile, it should set custom TLS version and ciphers",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"ECDHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			},
+			expectedMinTLSVer:    "TLSv1.2",
+			expectedCiphers:      "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384",
+			expectCiphersPresent: true,
+		},
+		{
+			name: "When Custom profile contains TLS 1.3 ciphers, it should filter them out",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"TLS_AES_128_GCM_SHA256",
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"TLS_CHACHA20_POLY1305_SHA256",
+							"ECDHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			},
+			expectedMinTLSVer:    "TLSv1.2",
+			expectedCiphers:      "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384",
+			expectCiphersPresent: true,
+		},
+		{
+			name: "When Custom profile contains only TLS 1.3 ciphers, it should result in no cipher config",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS13,
+						Ciphers: []string{
+							"TLS_AES_128_GCM_SHA256",
+							"TLS_AES_256_GCM_SHA384",
+							"TLS_CHACHA20_POLY1305_SHA256",
+						},
+					},
+				},
+			},
+			expectedMinTLSVer: "TLSv1.3",
+		},
+		{
+			name: "When Custom profile contains unknown ciphers, it should filter them out",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"UNKNOWN-CIPHER-NAME",
+							"",
+							"ECDHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			},
+			expectedMinTLSVer:    "TLSv1.2",
+			expectedCiphers:      "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384",
+			expectCiphersPresent: true,
+		},
+		{
+			name: "When Custom profile contains Go-unsupported ciphers, it should filter them out",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"ECDHE-ECDSA-AES256-SHA384",
+							"AES256-SHA256",
+							"ECDHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			},
+			expectedMinTLSVer:    "TLSv1.2",
+			expectedCiphers:      "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384",
+			expectCiphersPresent: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-namespace",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{},
+			}
+
+			if tc.tlsProfile != nil {
+				hcp.Spec.Configuration = &hyperv1.ClusterConfiguration{
+					APIServer: &configv1.APIServerSpec{
+						TLSSecurityProfile: tc.tlsProfile,
+					},
+				}
+			}
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+			}
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "haproxy-config",
+					Namespace: "test-namespace",
+				},
+			}
+
+			err := adaptHAProxyConfig(cpContext, cm)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(cm.Data).ToNot(BeNil())
+			g.Expect(cm.Data["haproxy.conf"]).ToNot(BeEmpty())
+
+			config := cm.Data["haproxy.conf"]
+
+			g.Expect(config).To(ContainSubstring("ssl-min-ver " + tc.expectedMinTLSVer))
+			tlsVersionCount := strings.Count(config, "ssl-min-ver "+tc.expectedMinTLSVer)
+			g.Expect(tlsVersionCount).To(Equal(2), "ssl-min-ver should appear twice (bind and server)")
+			totalSSLMinVerCount := strings.Count(config, "ssl-min-ver ")
+			g.Expect(totalSSLMinVerCount).To(Equal(2), "ssl-min-ver should only appear exactly twice total")
+
+			if tc.expectCiphersPresent {
+				g.Expect(config).To(ContainSubstring("ciphers " + tc.expectedCiphers))
+				cipherCount := strings.Count(config, "ciphers "+tc.expectedCiphers)
+				g.Expect(cipherCount).To(Equal(2), "ciphers should appear twice (bind and server)")
+				totalCiphersCount := strings.Count(config, "ciphers ")
+				g.Expect(totalCiphersCount).To(Equal(2), "ciphers should only appear exactly twice total")
+			} else {
+				g.Expect(config).ToNot(ContainSubstring("ciphers "))
+			}
+		})
+	}
+}
+
+func TestAdaptHAProxyConfigErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		tlsProfile        *configv1.TLSSecurityProfile
+		expectedErrSubstr string
+	}{
+		{
+			name: "When Custom profile has nil Custom field, it should return error",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+			},
+			expectedErrSubstr: "Custom but Custom field is nil",
+		},
+		{
+			name: "When profile type is unknown, it should return error",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: "UnknownProfileType",
+			},
+			expectedErrSubstr: "unknown TLS profile type",
+		},
+		{
+			name: "When profile type is empty, it should return error",
+			tlsProfile: &configv1.TLSSecurityProfile{
+				Type: "",
+			},
+			expectedErrSubstr: "unknown TLS profile type",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-namespace",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: tc.tlsProfile,
+						},
+					},
+				},
+			}
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+			}
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "haproxy-config",
+					Namespace: "test-namespace",
+				},
+			}
+
+			err := adaptHAProxyConfig(cpContext, cm)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring(tc.expectedErrSubstr))
+		})
+	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
@@ -89,6 +89,7 @@ func generateConfig(p KubeAPIServerConfigParams) (*kcpv1.KubeAPIServerConfig, er
 	if err != nil {
 		return nil, err
 	}
+
 	config := &kcpv1.KubeAPIServerConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "KubeAPIServerConfig",
@@ -143,8 +144,6 @@ func generateConfig(p KubeAPIServerConfigParams) (*kcpv1.KubeAPIServerConfig, er
 					NamedCertificates: namedCertificates,
 					BindAddress:       fmt.Sprintf("0.0.0.0:%d", p.KASPodPort),
 					BindNetwork:       "tcp4",
-					CipherSuites:      hcpconfig.CipherSuites(p.TLSSecurityProfile),
-					MinTLSVersion:     hcpconfig.MinTLSVersion(p.TLSSecurityProfile),
 				},
 			},
 			CORSAllowedOrigins: corsAllowedOrigins(p.AdditionalCORSAllowedOrigins),
@@ -154,6 +153,10 @@ func generateConfig(p KubeAPIServerConfigParams) (*kcpv1.KubeAPIServerConfig, er
 		ProjectConfig:                projectConfig(p.DefaultNodeSelector),
 		ServiceAccountPublicKeyFiles: []string{cpath(serviceAccountKeyVolumeName, pki.ServiceSignerPublicKey)},
 		ServicesSubnet:               strings.Join(p.ServiceNetwork, ","),
+	}
+
+	if err := hcpconfig.ApplyServingInfoFromTLSProfile(&config.ServingInfo.ServingInfo, p.TLSSecurityProfile); err != nil {
+		return nil, err
 	}
 
 	if !slices.Contains(p.FeatureGates, "OpenShiftPodSecurityAdmission=true") {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment.go
@@ -65,6 +65,11 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	hcp := cpContext.HCP
 	updateMainContainer(&deployment.Spec.Template.Spec, hcp)
 
+	tlsArgs, err := getTLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
+
 	podspec.UpdateContainer("konnectivity-server", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		serverCount := component.DefaultReplicas(hcp, &KubeAPIServer{}, ComponentName)
 		c.Args = append(c.Args,
@@ -72,16 +77,9 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			strconv.Itoa(int(serverCount)),
 		)
 
-		minTLSVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile())
-		if len(minTLSVersion) != 0 {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", minTLSVersion))
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
 		}
-
-		cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile())
-		if len(cipherSuites) != 0 {
-			c.Args = append(c.Args, fmt.Sprintf("--cipher-suites=%s", strings.Join(cipherSuites, ",")))
-		}
-
 	})
 
 	payloadVersion := cpContext.UserReleaseImageProvider.Version()
@@ -131,7 +129,9 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 
 	switch hcp.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
-		applyAWSPodIdentityWebhookContainer(&deployment.Spec.Template.Spec, hcp)
+		if err := applyAWSPodIdentityWebhookContainer(&deployment.Spec.Template.Spec, hcp); err != nil {
+			return fmt.Errorf("failed to apply AWS pod identity webhook container: %w", err)
+		}
 	case hyperv1.AzurePlatform:
 		if hcp.Spec.Platform.Azure == nil {
 			return fmt.Errorf("azure platform type requires spec.platform.azure")
@@ -338,7 +338,7 @@ func updateBootstrapInitContainer(deployment *appsv1.Deployment, hcp *hyperv1.Ho
 	return nil
 }
 
-func applyAWSPodIdentityWebhookContainer(podSpec *corev1.PodSpec, hcp *hyperv1.HostedControlPlane) {
+func applyAWSPodIdentityWebhookContainer(podSpec *corev1.PodSpec, hcp *hyperv1.HostedControlPlane) error {
 	command := []string{
 		"/usr/bin/aws-pod-identity-webhook",
 		"--annotation-prefix=eks.amazonaws.com",
@@ -352,11 +352,13 @@ func applyAWSPodIdentityWebhookContainer(podSpec *corev1.PodSpec, hcp *hyperv1.H
 		"--token-audience=openshift",
 	}
 
-	if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
-		command = append(command, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+	tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
 	}
-	if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
-		command = append(command, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+
+	if len(tlsArgs) > 0 {
+		command = append(command, tlsArgs...)
 	}
 
 	podSpec.Containers = append(podSpec.Containers, corev1.Container{
@@ -390,14 +392,24 @@ func applyAWSPodIdentityWebhookContainer(podSpec *corev1.PodSpec, hcp *hyperv1.H
 			},
 		},
 	)
+	return nil
 }
 
 func applyAzureWorkloadIdentityWebhookContainer(podSpec *corev1.PodSpec, hcp *hyperv1.HostedControlPlane) error {
 	extraCommandLineFlags := map[string]string{}
-	if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+	tlsMinVersion, err := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return fmt.Errorf("failed to get min TLS version: %w", err)
+	}
+	if tlsMinVersion != "" {
 		extraCommandLineFlags["--tls-min-version"] = tlsMinVersion
 	}
-	if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+
+	cipherSuites, err := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return fmt.Errorf("failed to get cipher suites: %w", err)
+	}
+	if len(cipherSuites) != 0 {
 		extraCommandLineFlags["--tls-cipher-suites"] = strings.Join(cipherSuites, ",")
 	}
 
@@ -515,6 +527,30 @@ func addImagePrePullInitContainers(podSpec *corev1.PodSpec) {
 	// Prepend the pre-pull init container to the existing init containers.
 	// This ensures the image is pulled before any other init containers run.
 	podSpec.InitContainers = append([]corev1.Container{prePullInitContainer}, podSpec.InitContainers...)
+}
+
+func getTLSArgs(profile *configv1.TLSSecurityProfile) ([]string, error) {
+	var tlsArgs []string
+
+	minTLSVersion, err := config.MinTLSVersion(profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get min TLS version: %w", err)
+	}
+
+	cipherSuites, err := config.CipherSuites(profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cipher suites: %w", err)
+	}
+
+	if len(minTLSVersion) != 0 {
+		tlsArgs = append(tlsArgs, fmt.Sprintf("--tls-min-version=%s", minTLSVersion))
+	}
+
+	if len(cipherSuites) != 0 {
+		tlsArgs = append(tlsArgs, fmt.Sprintf("--cipher-suites=%s", strings.Join(cipherSuites, ",")))
+	}
+
+	return tlsArgs, nil
 }
 
 const (

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment_test.go
@@ -288,7 +288,8 @@ func TestApplyAWSPodIdentityWebhookContainer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			podSpec := &corev1.PodSpec{}
-			applyAWSPodIdentityWebhookContainer(podSpec, tc.hcp)
+			err := applyAWSPodIdentityWebhookContainer(podSpec, tc.hcp)
+			g.Expect(err).ToNot(HaveOccurred())
 			tc.validatePod(g, podSpec)
 		})
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/deployment.go
@@ -31,6 +31,11 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		return err
 	}
 
+	tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
+
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args,
 			fmt.Sprintf("--cluster-cidr=%s", netutil.FirstClusterCIDR(hcp.Spec.Networking.ClusterNetwork)),
@@ -54,7 +59,10 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			c.Args = append(c.Args, "--node-monitor-grace-period=50s")
 		}
 
-		c.Args = append(c.Args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
+		}
+
 		if util.StringListContains(hcp.Annotations[hyperv1.DisableProfilingAnnotation], ComponentName) {
 			c.Args = append(c.Args, "--profiling=false")
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/deployment_test.go
@@ -270,10 +270,12 @@ func TestAdaptDeployment(t *testing.T) {
 				tlsProfile := &configv1.TLSSecurityProfile{
 					Type: configv1.TLSProfileModernType,
 				}
-				minTLSVersion := config.MinTLSVersion(tlsProfile)
+				minTLSVersion, err := config.MinTLSVersion(tlsProfile)
+				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(container.Args).To(ContainElement(fmt.Sprintf("--tls-min-version=%s", minTLSVersion)))
 
-				cipherSuites := config.CipherSuites(tlsProfile)
+				cipherSuites, err := config.CipherSuites(tlsProfile)
+				g.Expect(err).ToNot(HaveOccurred())
 				if len(cipherSuites) > 0 {
 					g.Expect(container.Args).To(ContainElement(fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ","))))
 				}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/deployment.go
@@ -19,8 +19,17 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		return err
 	}
 	configuration := cpContext.HCP.Spec.Configuration
+
+	tlsArgs, err := config.TLSArgs(configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
+
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		c.Args = append(c.Args, config.TLSArgs(configuration.GetTLSSecurityProfile())...)
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
+		}
+
 		if util.StringListContains(cpContext.HCP.Annotations[hyperv1.DisableProfilingAnnotation], ComponentName) {
 			c.Args = append(c.Args, "--profiling=false")
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/machine_approver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/machine_approver/deployment.go
@@ -13,10 +13,18 @@ import (
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	hcp := cpContext.HCP
-	configuration := hcp.Spec.Configuration
+
+	tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
+
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args, fmt.Sprintf("--machine-namespace=%s", hcp.Namespace))
-		c.Args = append(c.Args, config.TLSArgs(configuration.GetTLSSecurityProfile())...)
+
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
+		}
 	})
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/config.go
@@ -42,7 +42,9 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	if err != nil {
 		return err
 	}
-	adaptConfig(openshiftAPIServerConfig, cpContext.HCP, observedConfig.Project, featureGates)
+	if err := adaptConfig(openshiftAPIServerConfig, cpContext.HCP, observedConfig.Project, featureGates); err != nil {
+		return err
+	}
 	serializedConfig, err := k8sutil.SerializeResource(openshiftAPIServerConfig, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to serialize openshift apiserver configuration: %w", err)
@@ -51,7 +53,7 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	return nil
 }
 
-func adaptConfig(cfg *openshiftcpv1.OpenShiftAPIServerConfig, hcp *hyperv1.HostedControlPlane, projectConfig *configv1.Project, featureGates []string) {
+func adaptConfig(cfg *openshiftcpv1.OpenShiftAPIServerConfig, hcp *hyperv1.HostedControlPlane, projectConfig *configv1.Project, featureGates []string) error {
 	if hcp.Spec.AuditWebhook != nil && len(hcp.Spec.AuditWebhook.Name) > 0 {
 		cfg.APIServerArguments["audit-webhook-config-file"] = []string{path.Join("/etc/kubernetes/auditwebhook", hyperv1.AuditWebhookKubeconfigKey)}
 		cfg.APIServerArguments["audit-webhook-mode"] = []string{"batch"}
@@ -59,8 +61,10 @@ func adaptConfig(cfg *openshiftcpv1.OpenShiftAPIServerConfig, hcp *hyperv1.Hoste
 	}
 
 	configuration := hcp.Spec.Configuration
-	cfg.ServingInfo.MinTLSVersion = config.MinTLSVersion(configuration.GetTLSSecurityProfile())
-	cfg.ServingInfo.CipherSuites = config.CipherSuites(configuration.GetTLSSecurityProfile())
+
+	if err := config.ApplyServingInfoFromTLSProfile(&cfg.ServingInfo.ServingInfo, configuration.GetTLSSecurityProfile()); err != nil {
+		return err
+	}
 
 	if configuration != nil && configuration.Image != nil {
 		cfg.ImagePolicyConfig.ExternalRegistryHostnames = configuration.Image.ExternalRegistryHostnames
@@ -109,4 +113,6 @@ func adaptConfig(cfg *openshiftcpv1.OpenShiftAPIServerConfig, hcp *hyperv1.Hoste
 	// Set WatchList to disabled
 	filteredGates = append(filteredGates, "WatchList=false")
 	cfg.APIServerArguments["feature-gates"] = filteredGates
+
+	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
@@ -65,7 +65,9 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 		return fmt.Errorf("failed to decode existing oauth server configuration: %w", err)
 	}
 
-	adaptOAuthConfig(cpContext, oauthConfig)
+	if err := adaptOAuthConfig(cpContext, oauthConfig); err != nil {
+		return err
+	}
 	serializedConfig, err := k8sutil.SerializeResource(oauthConfig, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to serialize oauth server configuration: %w", err)
@@ -74,13 +76,14 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	return nil
 }
 
-func adaptOAuthConfig(cpContext component.WorkloadContext, cfg *osinv1.OsinServerConfig) {
+func adaptOAuthConfig(cpContext component.WorkloadContext, cfg *osinv1.OsinServerConfig) error {
 	configuration := cpContext.HCP.Spec.Configuration
 
 	cfg.GenericAPIServerConfig.ServingInfo.NamedCertificates = globalconfig.GetConfigNamedCertificates(configuration.GetNamedCertificates(), oauthNamedCertificateMountPathPrefix)
 
-	cfg.ServingInfo.MinTLSVersion = config.MinTLSVersion(configuration.GetTLSSecurityProfile())
-	cfg.ServingInfo.CipherSuites = config.CipherSuites(configuration.GetTLSSecurityProfile())
+	if err := config.ApplyServingInfoFromTLSProfile(&cfg.ServingInfo.ServingInfo, configuration.GetTLSSecurityProfile()); err != nil {
+		return err
+	}
 
 	masterUrl := (&url.URL{
 		Scheme: "https",
@@ -116,6 +119,7 @@ func adaptOAuthConfig(cpContext component.WorkloadContext, cfg *osinv1.OsinServe
 		identityProviders, _, _ := ConvertIdentityProviders(cpContext, configuration.OAuth.IdentityProviders, providerOverrides(cpContext.HCP), cpContext.Client, cpContext.HCP.Namespace)
 		cfg.OAuthConfig.IdentityProviders = identityProviders
 	}
+	return nil
 }
 
 func providerOverrides(hcp *hyperv1.HostedControlPlane) map[string]*ConfigOverride {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/infra"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 
+	configv1 "github.com/openshift/api/config/v1"
 	osinv1 "github.com/openshift/api/osin/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,9 +62,12 @@ func TestAdaptOAuthConfig(t *testing.T) {
 		cpEndpointPort          int32
 		kasDNSName              string
 		loginURLOverride        string
+		tlsProfile              *configv1.TLSSecurityProfile
 		expectedLoginURL        string
 		expectedMasterURL       string
 		expectedMasterPublicURL string
+		expectError             bool
+		expectedErrSubstr       string
 	}{
 		{
 			name:                    "When no custom DNS is set, it should use the control plane endpoint for LoginURL",
@@ -128,6 +132,16 @@ func TestAdaptOAuthConfig(t *testing.T) {
 			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), OAuthServerPort),
 			expectedMasterPublicURL: "https://[2001:db8::2]:443",
 		},
+		{
+			name:              "When TLS profile is Custom with nil Custom field, it should return error",
+			oauthHost:         "oauth.example.com",
+			oauthPort:         443,
+			cpEndpointHost:    "api.example.com",
+			cpEndpointPort:    6443,
+			tlsProfile:        &configv1.TLSSecurityProfile{Type: configv1.TLSProfileCustomType},
+			expectError:       true,
+			expectedErrSubstr: "Custom but Custom field is nil",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -154,6 +168,13 @@ func TestAdaptOAuthConfig(t *testing.T) {
 					hyperv1.OauthLoginURLOverrideAnnotation: tc.loginURLOverride,
 				}
 			}
+			if tc.tlsProfile != nil {
+				hcp.Spec.Configuration = &hyperv1.ClusterConfiguration{
+					APIServer: &configv1.APIServerSpec{
+						TLSSecurityProfile: tc.tlsProfile,
+					},
+				}
+			}
 
 			cpContext := component.WorkloadContext{
 				HCP: hcp,
@@ -166,8 +187,15 @@ func TestAdaptOAuthConfig(t *testing.T) {
 			cfg := &osinv1.OsinServerConfig{}
 			cfg.OAuthConfig = osinv1.OAuthConfig{}
 
-			adaptOAuthConfig(cpContext, cfg)
+			err := adaptOAuthConfig(cpContext, cfg)
 
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tc.expectedErrSubstr))
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(cfg.OAuthConfig.LoginURL).To(Equal(tc.expectedLoginURL))
 			g.Expect(cfg.OAuthConfig.MasterURL).To(Equal(tc.expectedMasterURL))
 			g.Expect(cfg.OAuthConfig.MasterPublicURL).To(Equal(tc.expectedMasterPublicURL))

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
@@ -41,18 +41,27 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		config.AuditWebhookService,
 	}
 
+	configuration := cpContext.HCP.Spec.Configuration
+
+	tlsArgs, err := config.TLSArgs(cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
+
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		etcdURL := config.DefaultEtcdURL
 		if cpContext.HCP.Spec.Etcd.ManagementType == hyperv1.Unmanaged {
 			etcdURL = cpContext.HCP.Spec.Etcd.Unmanaged.Endpoint
 		}
 
-		configuration := cpContext.HCP.Spec.Configuration
 		c.Args = append(c.Args,
 			fmt.Sprintf("--api-audiences=%s", cpContext.HCP.Spec.IssuerURL),
 			fmt.Sprintf("--etcd-servers=%s", etcdURL),
 		)
-		c.Args = append(c.Args, config.TLSArgs(configuration.GetTLSSecurityProfile())...)
+
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
+		}
 
 		if cpContext.HCP.Spec.AuditWebhook != nil && len(cpContext.HCP.Spec.AuditWebhook.Name) > 0 {
 			c.Args = append(c.Args, fmt.Sprintf("--audit-webhook-config-file=%s", path.Join("/etc/kubernetes/auditwebhook", hyperv1.AuditWebhookKubeconfigKey)))

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/config.go
@@ -59,7 +59,9 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	if err != nil {
 		return err
 	}
-	adaptConfig(ocmConfig, cpContext.HCP.Spec.Configuration, cpContext.ReleaseImageProvider, observedConfig.Build, cpContext.HCP.Spec.Capabilities, featureGates, existingControllers)
+	if err := adaptConfig(ocmConfig, cpContext.HCP.Spec.Configuration, cpContext.ReleaseImageProvider, observedConfig.Build, cpContext.HCP.Spec.Capabilities, featureGates, existingControllers); err != nil {
+		return err
+	}
 	configStr, err := k8sutil.SerializeResource(ocmConfig, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to serialize openshift controller manager configuration: %w", err)
@@ -68,7 +70,7 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	return nil
 }
 
-func adaptConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, configuration *hyperv1.ClusterConfiguration, releaseImageProvider imageprovider.ReleaseImageProvider, buildConfig *configv1.Build, caps *hyperv1.Capabilities, featureGates []string, existingControllers []string) {
+func adaptConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, configuration *hyperv1.ClusterConfiguration, releaseImageProvider imageprovider.ReleaseImageProvider, buildConfig *configv1.Build, caps *hyperv1.Capabilities, featureGates []string, existingControllers []string) error {
 	cfg.Build.ImageTemplateFormat.Format = releaseImageProvider.GetImage("docker-builder")
 	cfg.Deployer.ImageTemplateFormat.Format = releaseImageProvider.GetImage("deployer")
 
@@ -123,12 +125,14 @@ func adaptConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, configurat
 		cfg.Ingress.IngressIPNetworkCIDR = cidrs[0]
 	}
 
-	cfg.ServingInfo.MinTLSVersion = config.MinTLSVersion(configuration.GetTLSSecurityProfile())
-	cfg.ServingInfo.CipherSuites = config.CipherSuites(configuration.GetTLSSecurityProfile())
+	if err := config.ApplyServingInfoFromTLSProfile(&cfg.ServingInfo.ServingInfo, configuration.GetTLSSecurityProfile()); err != nil {
+		return err
+	}
 
 	if len(featureGates) > 0 {
 		cfg.FeatureGates = featureGates
 	}
+	return nil
 }
 
 func hasBuildDefaults(cfg *configv1.Build) bool {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/config_test.go
@@ -74,7 +74,10 @@ func TestReconcileOpenShiftControllerManagerConfig(t *testing.T) {
 				t.Fatalf("unable to decode existing openshift controller manager configuration: %v", err)
 			}
 
-			adaptConfig(config, hcp.Spec.Configuration, imageProvider, buildConfig, hcp.Spec.Capabilities, []string{"foo=true", "bar=false"}, nil)
+			err = adaptConfig(config, hcp.Spec.Configuration, imageProvider, buildConfig, hcp.Spec.Capabilities, []string{"foo=true", "bar=false"}, nil)
+			if err != nil {
+				t.Fatalf("failed to adapt config: %v", err)
+			}
 			configStr, err := k8sutil.SerializeResource(config, api.Scheme)
 			if err != nil {
 				t.Fatalf("failed to serialize openshift controller manager configuration: %v", err)
@@ -130,7 +133,10 @@ func TestAdaptConfig_PreservesExistingControllers(t *testing.T) {
 	config.ServingInfo = &v1.HTTPServingInfo{}
 
 	// Adapt config with ImageRegistry capability enabled (not explicitly disabled)
-	adaptConfig(config, hcp.Spec.Configuration, imageProvider, &v1.Build{}, nil, []string{}, existingControllersFromCluster)
+	err := adaptConfig(config, hcp.Spec.Configuration, imageProvider, &v1.Build{}, nil, []string{}, existingControllersFromCluster)
+	if err != nil {
+		t.Fatalf("failed to adapt config: %v", err)
+	}
 
 	// Verify that the Controllers field is preserved
 	if len(config.Controllers) != 2 {
@@ -173,7 +179,10 @@ func TestAdaptConfig_DisabledImageRegistryCapability(t *testing.T) {
 	config.ServingInfo = &v1.HTTPServingInfo{}
 
 	// Adapt config with ImageRegistry capability explicitly disabled
-	adaptConfig(config, hcp.Spec.Configuration, imageProvider, &v1.Build{}, hcp.Spec.Capabilities, []string{}, nil)
+	err := adaptConfig(config, hcp.Spec.Configuration, imageProvider, &v1.Build{}, hcp.Spec.Capabilities, []string{}, nil)
+	if err != nil {
+		t.Fatalf("failed to adapt config: %v", err)
+	}
 
 	// Verify that the Controllers field is set to disable pull secrets controller
 	if len(config.Controllers) != 2 {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/deployment.go
@@ -1,7 +1,6 @@
 package packageserver
 
 import (
-	"fmt"
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -23,17 +22,18 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		noProxy = append(noProxy, "certified-operators", "community-operators", "redhat-operators")
 	}
 
-	tlsProfile := hcp.Spec.Configuration.GetTLSSecurityProfile()
+	tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+	if err != nil {
+		return err
+	}
+
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		podspec.UpsertEnvVars(c, []corev1.EnvVar{
 			{Name: "RELEASE_VERSION", Value: cpContext.UserReleaseImageProvider.Version()},
 			{Name: "NO_PROXY", Value: strings.Join(noProxy, ",")},
 		})
-		if minTLSVersion := config.MinTLSVersion(tlsProfile); minTLSVersion != "" {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", minTLSVersion))
-		}
-		if cipherSuites := config.CipherSuites(tlsProfile); len(cipherSuites) != 0 {
-			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		if len(tlsArgs) > 0 {
+			c.Args = append(c.Args, tlsArgs...)
 		}
 	})
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/config.go
@@ -28,7 +28,9 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 		return fmt.Errorf("unable to decode existing openshift route controller manager configuration: %w", err)
 	}
 
-	adaptConfig(config, cpContext.HCP.Spec.Configuration, cpContext.HCP.Spec.Capabilities)
+	if err := adaptConfig(config, cpContext.HCP.Spec.Configuration, cpContext.HCP.Spec.Capabilities); err != nil {
+		return err
+	}
 	configStr, err := k8sutil.SerializeResource(config, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to serialize openshift route controller manager configuration: %w", err)
@@ -38,12 +40,15 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	return nil
 }
 
-func adaptConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, configuration *hyperv1.ClusterConfiguration, _ *hyperv1.Capabilities) {
+func adaptConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, configuration *hyperv1.ClusterConfiguration, _ *hyperv1.Capabilities) error {
 	// network config
 	if cidrs := configuration.GetAutoAssignCIDRs(); len(cidrs) > 0 {
 		cfg.Ingress.IngressIPNetworkCIDR = cidrs[0]
 	}
 
-	cfg.ServingInfo.MinTLSVersion = config.MinTLSVersion(configuration.GetTLSSecurityProfile())
-	cfg.ServingInfo.CipherSuites = config.CipherSuites(configuration.GetTLSSecurityProfile())
+	if err := config.ApplyServingInfoFromTLSProfile(&cfg.ServingInfo.ServingInfo, configuration.GetTLSSecurityProfile()); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -96,7 +96,13 @@ func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *
 		"--agent-namespace", hcluster.Spec.Platform.Agent.AgentNamespace,
 	}
 	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
-		args = append(args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+		if err != nil {
+			return nil, err
+		}
+		if len(tlsArgs) > 0 {
+			args = append(args, tlsArgs...)
+		}
 	}
 
 	deploymentSpec := &appsv1.DeploymentSpec{

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -127,7 +127,13 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 		fmt.Sprintf("--feature-gates=%s", strings.Join(featureGates, ",")),
 	}
 	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
-		args = append(args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+		if err != nil {
+			return nil, err
+		}
+		if len(tlsArgs) > 0 {
+			args = append(args, tlsArgs...)
+		}
 	}
 
 	defaultMode := int32(0640)

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -109,7 +109,13 @@ func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *
 		"--disable-controllers-or-webhooks=DisableASOSecretController",
 	}
 	if hcp != nil && a.payloadVersion != nil && (a.payloadVersion.Major >= 5 || (a.payloadVersion.Major == 4 && a.payloadVersion.Minor >= 23)) {
-		args = append(args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+		if err != nil {
+			return nil, err
+		}
+		if len(tlsArgs) > 0 {
+			args = append(args, tlsArgs...)
+		}
 	}
 
 	defaultMode := int32(0640)

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -222,7 +222,13 @@ func (p GCP) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 		"--v=2",
 	}
 	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
-		args = append(args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+		if err != nil {
+			return nil, err
+		}
+		if len(tlsArgs) > 0 {
+			args = append(args, tlsArgs...)
+		}
 	}
 
 	containers := []corev1.Container{

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -96,7 +96,13 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hc
 		"--leader-elect=true",
 	}
 	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
-		args = append(args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+		if err != nil {
+			return nil, err
+		}
+		if len(tlsArgs) > 0 {
+			args = append(args, tlsArgs...)
+		}
 	}
 
 	defaultMode := int32(0640)

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
@@ -206,7 +206,13 @@ func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, h
 	}
 
 	if hcp != nil && a.payloadVersion != nil && (a.payloadVersion.Major >= 5 || (a.payloadVersion.Major == 4 && a.payloadVersion.Minor >= 23)) {
-		capoArgs = append(capoArgs, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+		if err != nil {
+			return nil, err
+		}
+		if len(tlsArgs) > 0 {
+			capoArgs = append(capoArgs, tlsArgs...)
+		}
 	}
 
 	allowPrivilegeEscalation := false

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs.go
@@ -97,7 +97,13 @@ func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp
 		"--provider-id-fmt=v2",
 	}
 	if hcp != nil && p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor >= 23)) {
-		args = append(args, config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())...)
+		tlsArgs, err := config.TLSArgs(hcp.Spec.Configuration.GetTLSSecurityProfile())
+		if err != nil {
+			return nil, err
+		}
+		if len(tlsArgs) > 0 {
+			args = append(args, tlsArgs...)
+		}
 	}
 
 	deploymentSpec := &appsv1.DeploymentSpec{

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -22,6 +22,8 @@ import (
 	"github.com/openshift/hypershift/support/supportedversion"
 	"github.com/openshift/hypershift/support/util"
 
+	librarycrypto "github.com/openshift/library-go/pkg/crypto"
+
 	corev1 "k8s.io/api/core/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -55,6 +57,26 @@ func init() {
 	)
 }
 
+func buildTLSConfig(certWatcher *certwatcher.CertWatcher, opts Options) *tls.Config {
+	cfg := &tls.Config{
+		GetCertificate: certWatcher.GetCertificate,
+	}
+
+	if opts.TLSMinVersion != "" {
+		minVersion, err := librarycrypto.TLSVersion(opts.TLSMinVersion)
+		if err != nil {
+			log.Fatalf("invalid TLS min version: %v", err)
+		}
+		cfg.MinVersion = minVersion
+	}
+
+	if len(opts.TLSCipherSuites) > 0 {
+		cfg.CipherSuites = librarycrypto.CipherSuitesOrDie(opts.TLSCipherSuites)
+	}
+
+	return librarycrypto.SecureTLSConfig(cfg)
+}
+
 type Options struct {
 	Addr                string
 	CertFile            string
@@ -64,6 +86,8 @@ type Options struct {
 	WorkDir             string
 	MetricsAddr         string
 	FeatureGateManifest string
+	TLSMinVersion       string
+	TLSCipherSuites     []string
 }
 
 // This is a https server that enable us to satisfy
@@ -97,6 +121,8 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.WorkDir, "work-dir", opts.WorkDir, "Directory in which to store transient working data")
 	cmd.Flags().StringVar(&opts.MetricsAddr, "metrics-addr", opts.MetricsAddr, "The address the metric endpoint binds to.")
 	cmd.Flags().StringVar(&opts.FeatureGateManifest, "feature-gate-manifest", opts.FeatureGateManifest, "Path to a rendered featuregates.config.openshift.io/v1 file")
+	cmd.Flags().StringVar(&opts.TLSMinVersion, "tls-min-version", "", "Minimum TLS version (e.g., VersionTLS12, VersionTLS13)")
+	cmd.Flags().StringSliceVar(&opts.TLSCipherSuites, "tls-cipher-suites", nil, "TLS cipher suites (comma-separated)")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -290,22 +316,7 @@ func run(ctx context.Context, opts Options) error {
 		Handler:      mux,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
-		TLSConfig: &tls.Config{GetCertificate: certWatcher.GetCertificate,
-			MinVersion: tls.VersionTLS12,
-			CipherSuites: []uint16{
-				//TLS 1.3 ciphers from openshift tls modern profile
-				tls.TLS_AES_128_GCM_SHA256,
-				tls.TLS_AES_256_GCM_SHA384,
-				tls.TLS_CHACHA20_POLY1305_SHA256,
-				//TLS 1.2 subset from openshift intermediate tls profile
-				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			},
-		},
+		TLSConfig:    buildTLSConfig(certWatcher, opts),
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
 	}
 

--- a/support/config/cipher.go
+++ b/support/config/cipher.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/crypto"
@@ -35,16 +36,19 @@ var openSSLToIANACiphersMap = map[string]string{
 	"ECDHE-RSA-AES256-SHA":   "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",   // 0xC0,0x14
 }
 
-func MinTLSVersion(securityProfile *configv1.TLSSecurityProfile) string {
+func MinTLSVersion(securityProfile *configv1.TLSSecurityProfile) (string, error) {
 	if securityProfile == nil {
 		securityProfile = &configv1.TLSSecurityProfile{
 			Type: configv1.TLSProfileIntermediateType,
 		}
 	}
 	if securityProfile.Type == configv1.TLSProfileCustomType {
-		return string(securityProfile.Custom.MinTLSVersion)
+		if securityProfile.Custom == nil {
+			return "", fmt.Errorf("TLS profile type is Custom but Custom field is nil")
+		}
+		return string(securityProfile.Custom.MinTLSVersion), nil
 	}
-	return string(configv1.TLSProfiles[securityProfile.Type].MinTLSVersion)
+	return string(configv1.TLSProfiles[securityProfile.Type].MinTLSVersion), nil
 }
 
 // OpenSSLToIANACipherSuites maps input OpenSSL Cipher Suite names to their
@@ -63,7 +67,7 @@ func OpenSSLToIANACipherSuites(ciphers []string) []string {
 	return ianaCiphers
 }
 
-func CipherSuites(securityProfile *configv1.TLSSecurityProfile) []string {
+func CipherSuites(securityProfile *configv1.TLSSecurityProfile) ([]string, error) {
 	if securityProfile == nil {
 		securityProfile = &configv1.TLSSecurityProfile{
 			Type: configv1.TLSProfileIntermediateType,
@@ -71,11 +75,14 @@ func CipherSuites(securityProfile *configv1.TLSSecurityProfile) []string {
 	}
 	var ciphers []string
 	if securityProfile.Type == configv1.TLSProfileCustomType {
+		if securityProfile.Custom == nil {
+			return nil, fmt.Errorf("TLS profile type is Custom but Custom field is nil")
+		}
 		ciphers = securityProfile.Custom.Ciphers
 	} else {
 		ciphers = configv1.TLSProfiles[securityProfile.Type].Ciphers
 	}
-	return OpenSSLToIANACipherSuites(ciphers)
+	return OpenSSLToIANACipherSuites(ciphers), nil
 }
 
 // SupportedEtcdCipherSuites filters the input cipher suites to only those supported by
@@ -98,7 +105,11 @@ func SupportedEtcdCipherSuites(ctx context.Context, cipherSuites []string) []str
 // tls version on a provided tls config struct. If the provided api server has
 // an invalid tls version this function returns an error.
 func SetMinTLSVersionUsingAPIServer(apiServerConfig *configv1.APIServer) (func(*tls.Config), error) {
-	version, err := crypto.TLSVersion(MinTLSVersion(apiServerConfig.Spec.TLSSecurityProfile))
+	minVersion, err := MinTLSVersion(apiServerConfig.Spec.TLSSecurityProfile)
+	if err != nil {
+		return nil, err
+	}
+	version, err := crypto.TLSVersion(minVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -112,8 +123,12 @@ func SetMinTLSVersionUsingAPIServer(apiServerConfig *configv1.APIServer) (func(*
 // input. Returns an error if the provided api server contains an invalid
 // suite.
 func SetCipherSuitesUsingAPIServer(apiServerConfig *configv1.APIServer) (func(*tls.Config), error) {
+	cipherSuites, err := CipherSuites(apiServerConfig.Spec.TLSSecurityProfile)
+	if err != nil {
+		return nil, err
+	}
 	var suites []uint16
-	for _, suiteString := range CipherSuites(apiServerConfig.Spec.TLSSecurityProfile) {
+	for _, suiteString := range cipherSuites {
 		suite, err := crypto.CipherSuite(suiteString)
 		if err != nil {
 			return nil, err

--- a/support/config/cipher_test.go
+++ b/support/config/cipher_test.go
@@ -79,6 +79,17 @@ func TestSetMinTLSVersionUsingAPIServer(t *testing.T) {
 			expectError:   false,
 			expectedValue: tls.VersionTLS12,
 		},
+		{
+			name: "When using custom profile with nil Custom field, it should return error",
+			apiServer: &configv1.APIServer{
+				Spec: configv1.APIServerSpec{
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+					},
+				},
+			},
+			expectError: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -177,6 +188,17 @@ func TestSetCipherSuitesUsingAPIServer(t *testing.T) {
 			apiServer:   &configv1.APIServer{},
 			expectError: false,
 		},
+		{
+			name: "When using custom profile with nil Custom field, it should return error",
+			apiServer: &configv1.APIServer{
+				Spec: configv1.APIServerSpec{
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+					},
+				},
+			},
+			expectError: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -202,6 +224,158 @@ func TestSetCipherSuitesUsingAPIServer(t *testing.T) {
 			}
 
 			g.Expect(tlsConfig.CipherSuites).ToNot(BeEmpty())
+		})
+	}
+}
+
+func TestMinTLSVersion(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		profile     *configv1.TLSSecurityProfile
+		expectedVer string
+		expectError bool
+	}{
+		{
+			name:        "When profile is nil, it should default to Intermediate",
+			profile:     nil,
+			expectedVer: "VersionTLS12",
+		},
+		{
+			name: "When using Intermediate profile, it should return TLS 1.2",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectedVer: "VersionTLS12",
+		},
+		{
+			name: "When using Modern profile, it should return TLS 1.3",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedVer: "VersionTLS13",
+		},
+		{
+			name: "When using Custom profile with valid Custom field, it should return custom version",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectedVer: "VersionTLS12",
+		},
+		{
+			name: "When using Custom profile with nil Custom field, it should return error",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			result, err := MinTLSVersion(tc.profile)
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("Custom but Custom field is nil"))
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result).To(Equal(tc.expectedVer))
+		})
+	}
+}
+
+func TestCipherSuites(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		profile     *configv1.TLSSecurityProfile
+		expected    []string
+		expectError bool
+	}{
+		{
+			name:    "When profile is nil, it should default to Intermediate ciphers",
+			profile: nil,
+			expected: []string{
+				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+				"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+				"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+				"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			},
+		},
+		{
+			name: "When using Intermediate profile, it should return intermediate ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expected: []string{
+				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+				"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+				"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+				"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			},
+		},
+		{
+			name: "When using Modern profile, it should return empty ciphers (TLS 1.3 uses non-configurable ciphers)",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expected: []string{},
+		},
+		{
+			name: "When using Custom profile with valid Custom field, it should return custom ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers: []string{
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"ECDHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			},
+			expected: []string{
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+			},
+		},
+		{
+			name: "When using Custom profile with nil Custom field, it should return error",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			result, err := CipherSuites(tc.profile)
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("Custom but Custom field is nil"))
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result).To(Equal(tc.expected))
 		})
 	}
 }

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -11,13 +11,23 @@ import (
 // It returns a slice of strings containing --tls-min-version and --tls-cipher-suites flags
 // based on the provided profile. The caller is responsible for appending these to their
 // argument list using the spread operator (...).
-func TLSArgs(profile *configv1.TLSSecurityProfile) []string {
+func TLSArgs(profile *configv1.TLSSecurityProfile) ([]string, error) {
 	var tlsArgs []string
-	if tlsMinVersion := MinTLSVersion(profile); tlsMinVersion != "" {
+	tlsMinVersion, err := MinTLSVersion(profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get min TLS version: %w", err)
+	}
+
+	cipherSuites, err := CipherSuites(profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cipher suites: %w", err)
+	}
+
+	if tlsMinVersion != "" {
 		tlsArgs = append(tlsArgs, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
 	}
-	if cipherSuites := CipherSuites(profile); len(cipherSuites) != 0 {
+	if len(cipherSuites) != 0 {
 		tlsArgs = append(tlsArgs, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
 	}
-	return tlsArgs
+	return tlsArgs, nil
 }

--- a/support/config/deployment_test.go
+++ b/support/config/deployment_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -9,37 +11,44 @@ import (
 )
 
 func TestTLSArgs(t *testing.T) {
+	// Helper to build expected args from TLS profile
+	buildExpectedArgs := func(profileType configv1.TLSProfileType) []string {
+		profile := configv1.TLSProfiles[profileType]
+		args := []string{
+			fmt.Sprintf("--tls-min-version=%s", profile.MinTLSVersion),
+		}
+		ciphers := OpenSSLToIANACipherSuites(profile.Ciphers)
+		if len(ciphers) > 0 {
+			args = append(args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(ciphers, ",")))
+		}
+		return args
+	}
+
 	tests := []struct {
-		name         string
-		profile      *configv1.TLSSecurityProfile
-		expectedArgs []string
+		name              string
+		profile           *configv1.TLSSecurityProfile
+		expectedArgs      []string
+		expectError       bool
+		expectedErrSubstr string
 	}{
 		{
-			name:    "When profile is nil it should return intermediate defaults",
-			profile: nil,
-			expectedArgs: []string{
-				"--tls-min-version=VersionTLS12",
-				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-			},
+			name:         "When profile is nil it should return intermediate defaults",
+			profile:      nil,
+			expectedArgs: buildExpectedArgs(configv1.TLSProfileIntermediateType),
 		},
 		{
 			name: "When using Modern profile it should return only min-version",
 			profile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileModernType,
 			},
-			expectedArgs: []string{
-				"--tls-min-version=VersionTLS13",
-			},
+			expectedArgs: buildExpectedArgs(configv1.TLSProfileModernType),
 		},
 		{
 			name: "When using Intermediate profile it should return min-version and cipher-suites",
 			profile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileIntermediateType,
 			},
-			expectedArgs: []string{
-				"--tls-min-version=VersionTLS12",
-				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-			},
+			expectedArgs: buildExpectedArgs(configv1.TLSProfileIntermediateType),
 		},
 		{
 			name: "When using Custom profile with specific ciphers it should return custom TLS args",
@@ -57,18 +66,26 @@ func TestTLSArgs(t *testing.T) {
 			},
 			expectedArgs: []string{
 				"--tls-min-version=VersionTLS12",
-				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(OpenSSLToIANACipherSuites([]string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				}), ",")),
 			},
+		},
+		{
+			name: "When TLS profile is Custom with nil Custom field, it should return error",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+			},
+			expectError:       true,
+			expectedErrSubstr: "Custom but Custom field is nil",
 		},
 		{
 			name: "When using Old profile it should return min-version and cipher-suites",
 			profile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileOldType,
 			},
-			expectedArgs: []string{
-				"--tls-min-version=VersionTLS10",
-				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-			},
+			expectedArgs: buildExpectedArgs(configv1.TLSProfileOldType),
 		},
 	}
 
@@ -76,8 +93,13 @@ func TestTLSArgs(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			result := TLSArgs(test.profile)
-
+			result, err := TLSArgs(test.profile)
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(test.expectedErrSubstr))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(result).To(Equal(test.expectedArgs))
 		})
 	}

--- a/support/config/genericcontrollerconfig.go
+++ b/support/config/genericcontrollerconfig.go
@@ -15,13 +15,22 @@ import (
 // with the specified bind address, bind network, and TLS security profile.
 // This is used by various control plane operators to configure their serving info.
 func BuildGenericControllerConfigData(bindAddress, bindNetwork string, profile *configv1.TLSSecurityProfile) (string, error) {
+	cipherSuites, err := CipherSuites(profile)
+	if err != nil {
+		return "", fmt.Errorf("failed to get cipher suites: %w", err)
+	}
+	minTLSVersion, err := MinTLSVersion(profile)
+	if err != nil {
+		return "", fmt.Errorf("failed to get min TLS version: %w", err)
+	}
+
 	controllerConfig := configv1.GenericControllerConfig{
 		ServingInfo: configv1.HTTPServingInfo{
 			ServingInfo: configv1.ServingInfo{
 				BindAddress:   bindAddress,
 				BindNetwork:   bindNetwork,
-				CipherSuites:  CipherSuites(profile),
-				MinTLSVersion: MinTLSVersion(profile),
+				CipherSuites:  cipherSuites,
+				MinTLSVersion: minTLSVersion,
 			},
 		},
 	}

--- a/support/config/genericcontrollerconfig_test.go
+++ b/support/config/genericcontrollerconfig_test.go
@@ -49,6 +49,8 @@ func TestBuildGenericControllerConfigData(t *testing.T) {
 		profile              *configv1.TLSSecurityProfile
 		expectedMinTLS       string
 		expectedCipherSuites []string
+		expectError          bool
+		expectedErrSubstr    string
 	}{
 		{
 			name:                 "When TLS profile is nil, it should use intermediate defaults",
@@ -130,6 +132,14 @@ func TestBuildGenericControllerConfigData(t *testing.T) {
 			},
 			expectedMinTLS: "VersionTLS12",
 		},
+		{
+			name:              "When TLS profile is Custom with nil Custom field, it should return error",
+			bindAddress:       "0.0.0.0:8443",
+			bindNetwork:       "tcp",
+			profile:           &configv1.TLSSecurityProfile{Type: configv1.TLSProfileCustomType},
+			expectError:       true,
+			expectedErrSubstr: "Custom but Custom field is nil",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -138,6 +148,14 @@ func TestBuildGenericControllerConfigData(t *testing.T) {
 			g := NewWithT(t)
 
 			yamlStr, err := BuildGenericControllerConfigData(tc.bindAddress, tc.bindNetwork, tc.profile)
+
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tc.expectedErrSubstr))
+				g.Expect(yamlStr).To(BeEmpty())
+				return
+			}
+
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(yamlStr).ToNot(BeEmpty())
 
@@ -173,7 +191,10 @@ func TestSetGenericControllerConfig(t *testing.T) {
 	testCases := []struct {
 		name              string
 		existingData      map[string]string
+		profile           *configv1.TLSSecurityProfile
 		shouldPreserveKey string
+		expectError       bool
+		expectedErrSubstr string
 	}{
 		{
 			name: "When ConfigMap is empty, it should set config.yaml",
@@ -182,6 +203,12 @@ func TestSetGenericControllerConfig(t *testing.T) {
 			name:              "When ConfigMap has existing data, it should preserve other keys",
 			existingData:      map[string]string{"other-key": "other-value"},
 			shouldPreserveKey: "other-key",
+		},
+		{
+			name:              "When TLS profile is Custom with nil Custom field, it should return error",
+			profile:           &configv1.TLSSecurityProfile{Type: configv1.TLSProfileCustomType},
+			expectError:       true,
+			expectedErrSubstr: "Custom but Custom field is nil",
 		},
 	}
 
@@ -192,7 +219,14 @@ func TestSetGenericControllerConfig(t *testing.T) {
 
 			cm := &corev1.ConfigMap{Data: tc.existingData}
 
-			err := SetGenericControllerConfig("0.0.0.0:8443", "tcp4", nil, cm)
+			err := SetGenericControllerConfig("0.0.0.0:8443", "tcp4", tc.profile, cm)
+
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tc.expectedErrSubstr))
+				return
+			}
+
 			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(cm.Data).To(HaveKey("config.yaml"))

--- a/support/config/servinginfo.go
+++ b/support/config/servinginfo.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// ApplyServingInfoFromTLSProfile sets the MinTLSVersion and CipherSuites fields on the provided
+// ServingInfo struct based on the given TLS security profile.
+// This is a convenience function for components that use ServingInfo configuration.
+func ApplyServingInfoFromTLSProfile(servingInfo *configv1.ServingInfo, profile *configv1.TLSSecurityProfile) error {
+	minTLSVersion, err := MinTLSVersion(profile)
+	if err != nil {
+		return fmt.Errorf("failed to get min TLS version: %w", err)
+	}
+	servingInfo.MinTLSVersion = minTLSVersion
+
+	cipherSuites, err := CipherSuites(profile)
+	if err != nil {
+		return fmt.Errorf("failed to get cipher suites: %w", err)
+	}
+	servingInfo.CipherSuites = cipherSuites
+
+	return nil
+}

--- a/support/config/servinginfo_test.go
+++ b/support/config/servinginfo_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestApplyServingInfoFromTLSProfile(t *testing.T) {
+	tests := []struct {
+		name                  string
+		profile               *configv1.TLSSecurityProfile
+		expectedMinTLSVersion string
+		expectedCipherSuites  []string
+		expectError           bool
+		expectedErrSubstr     string
+	}{
+		{
+			name:                  "When profile is nil it should apply intermediate defaults",
+			profile:               nil,
+			expectedMinTLSVersion: string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion),
+			expectedCipherSuites:  OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers),
+		},
+		{
+			name: "When using Modern profile it should apply only min-version",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedMinTLSVersion: string(configv1.TLSProfiles[configv1.TLSProfileModernType].MinTLSVersion),
+			expectedCipherSuites:  OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileModernType].Ciphers),
+		},
+		{
+			name: "When using Intermediate profile it should apply min-version and cipher-suites",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectedMinTLSVersion: string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion),
+			expectedCipherSuites:  OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers),
+		},
+		{
+			name: "When using Custom profile with specific ciphers it should apply custom TLS settings",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"ECDHE-RSA-AES128-GCM-SHA256",
+						},
+					},
+				},
+			},
+			expectedMinTLSVersion: string(configv1.VersionTLS12),
+			expectedCipherSuites: OpenSSLToIANACipherSuites([]string{
+				"ECDHE-ECDSA-AES128-GCM-SHA256",
+				"ECDHE-RSA-AES128-GCM-SHA256",
+			}),
+		},
+		{
+			name: "When TLS profile is Custom with nil Custom field, it should return error",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+			},
+			expectError:       true,
+			expectedErrSubstr: "Custom but Custom field is nil",
+		},
+		{
+			name: "When using Old profile it should apply min-version and cipher-suites",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			expectedMinTLSVersion: string(configv1.TLSProfiles[configv1.TLSProfileOldType].MinTLSVersion),
+			expectedCipherSuites:  OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileOldType].Ciphers),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			servingInfo := &configv1.ServingInfo{}
+			err := ApplyServingInfoFromTLSProfile(servingInfo, test.profile)
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(test.expectedErrSubstr))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(servingInfo.MinTLSVersion).To(Equal(test.expectedMinTLSVersion))
+			g.Expect(servingInfo.CipherSuites).To(Equal(test.expectedCipherSuites))
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Have the ignition server components honor the centralized TLS configuration

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI options to configure the Ignition Server’s minimum TLS version and cipher suites.
  * Updated the Ignition Server proxy to use managed HAProxy configuration and TLS security profiles.
  * Strengthened proxy container security with non-root execution and disabled privilege escalation.
* **Bug Fixes**
  * Improved consistent TLS settings across control-plane components and infrastructure providers.
  * Added validation and clearer errors for invalid or incomplete custom TLS profiles.
* **Tests**
  * Added coverage for TLS profiles, cipher filtering, and HAProxy configuration rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->