### PR TITLE
NO-JIRA: isolate NewSession tests from ambient AWS env vars

### DIFF
--- a/cmd/infra/aws/util/util_test.go
+++ b/cmd/infra/aws/util/util_test.go
@@ -45,7 +45,9 @@ func TestNewSession(t *testing.T) {
 			region:       "us-west-2",
 			expectNonNil: true,
 			setupFunc: func(t *testing.T) string {
-				// Create a temporary credentials file
+				for _, env := range []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_SHARED_CREDENTIALS_FILE", "AWS_CONFIG_FILE", "AWS_PROFILE", "AWS_DEFAULT_PROFILE"} {
+					t.Setenv(env, "")
+				}
 				tmpDir := t.TempDir()
 				credsFile := filepath.Join(tmpDir, "credentials")
 				content := `[default]
@@ -74,7 +76,7 @@ aws_secret_access_key = test-secret-key
 			expectNonNil: true,
 			setupFunc: func(t *testing.T) string {
 				// Ensure AWS env vars don't shadow the file credentials.
-				for _, env := range []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_SHARED_CREDENTIALS_FILE", "AWS_CONFIG_FILE"} {
+				for _, env := range []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_SHARED_CREDENTIALS_FILE", "AWS_CONFIG_FILE", "AWS_PROFILE", "AWS_DEFAULT_PROFILE"} {
 					t.Setenv(env, "")
 				}
 				tmpDir := t.TempDir()
@@ -204,6 +206,9 @@ func TestGetSession(t *testing.T) {
 			agent:  "test-agent",
 			region: "us-east-1",
 			setupFunc: func(t *testing.T) string {
+				for _, env := range []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_SHARED_CREDENTIALS_FILE", "AWS_CONFIG_FILE", "AWS_PROFILE", "AWS_DEFAULT_PROFILE"} {
+					t.Setenv(env, "")
+				}
 				tmpDir := t.TempDir()
 				credsFile := filepath.Join(tmpDir, "credentials")
 				content := `[default]


### PR DESCRIPTION
## Summary
- Clear `AWS_PROFILE` and `AWS_DEFAULT_PROFILE` in `TestNewSession` setup so `config.LoadDefaultConfig` doesn't pick up the host's profile and fail silently (the error is discarded on `util.go:116`, producing a zero-value config with empty Region and nil Credentials)

## Test plan
- [x] `go test ./cmd/infra/aws/util/ -run TestNewSession -v` passes with `AWS_PROFILE` set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved AWS session test setup to clear additional environment variables, reducing interference from local credentials and making file-based credential tests more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->