### PR TITLE
wip: Tls injection all in one (only for testing purposes)

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -72,6 +72,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -72,6 +72,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -72,6 +72,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -72,6 +72,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_aws_cloud_controller_manager_deployment.yaml
@@ -72,6 +72,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/aws-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/azure-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_azure_cloud_controller_manager_deployment.yaml
@@ -74,6 +74,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --v=4
         - --cluster-name=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/azure-cloud-controller-manager
         image: azure-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: ""
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: cluster-storage-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_controlplanecomponent.yaml
@@ -31,6 +31,9 @@ status:
   - group: secrets-store.csi.x-k8s.io
     kind: SecretProviderClass
     name: managed-azure-file-csi
+  - group: ""
+    kind: ConfigMap
+    name: cluster-storage-operator-config
   - group: rbac.authorization.k8s.io
     kind: Role
     name: cluster-storage-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: a0010a21
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -65,8 +65,10 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         command:
         - cluster-storage-operator
@@ -182,6 +184,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /var/run/configmaps/config
+          name: config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       initContainers:
@@ -220,6 +225,10 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: cluster-storage-operator-config
+        name: config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: ""
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: cluster-storage-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_controlplanecomponent.yaml
@@ -19,6 +19,9 @@ status:
     status: "False"
     type: RolloutComplete
   resources:
+  - group: ""
+    kind: ConfigMap
+    name: cluster-storage-operator-config
   - group: rbac.authorization.k8s.io
     kind: Role
     name: cluster-storage-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: a0010a21
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -65,8 +65,10 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         command:
         - cluster-storage-operator
@@ -179,6 +181,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /var/run/configmaps/config
+          name: config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       initContainers:
@@ -223,6 +228,10 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: cluster-storage-operator-config
+        name: config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: ""
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: cluster-storage-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_controlplanecomponent.yaml
@@ -19,6 +19,9 @@ status:
     status: "False"
     type: RolloutComplete
   resources:
+  - group: ""
+    kind: ConfigMap
+    name: cluster-storage-operator-config
   - group: rbac.authorization.k8s.io
     kind: Role
     name: cluster-storage-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: a0010a21
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -65,8 +65,10 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         command:
         - cluster-storage-operator
@@ -178,6 +180,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /var/run/configmaps/config
+          name: config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       initContainers:
@@ -216,6 +221,10 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: cluster-storage-operator-config
+        name: config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: ""
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: cluster-storage-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_controlplanecomponent.yaml
@@ -19,6 +19,9 @@ status:
     status: "False"
     type: RolloutComplete
   resources:
+  - group: ""
+    kind: ConfigMap
+    name: cluster-storage-operator-config
   - group: rbac.authorization.k8s.io
     kind: Role
     name: cluster-storage-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: a0010a21
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -65,8 +65,10 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         command:
         - cluster-storage-operator
@@ -178,6 +180,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /var/run/configmaps/config
+          name: config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       initContainers:
@@ -216,6 +221,10 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: cluster-storage-operator-config
+        name: config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: ""
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: cluster-storage-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_controlplanecomponent.yaml
@@ -19,6 +19,9 @@ status:
     status: "False"
     type: RolloutComplete
   resources:
+  - group: ""
+    kind: ConfigMap
+    name: cluster-storage-operator-config
   - group: rbac.authorization.k8s.io
     kind: Role
     name: cluster-storage-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: a0010a21
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -65,8 +65,10 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         command:
         - cluster-storage-operator
@@ -178,6 +180,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /var/run/configmaps/config
+          name: config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       initContainers:
@@ -216,6 +221,10 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: cluster-storage-operator-config
+        name: config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/AROSwift/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/AROSwift/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: ""
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: csi-snapshot-controller-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/AROSwift/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/AROSwift/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_controlplanecomponent.yaml
@@ -28,3 +28,6 @@ status:
   - group: rbac.authorization.k8s.io
     kind: RoleBinding
     name: csi-snapshot-controller-operator-role
+  - group: ""
+    kind: ConfigMap
+    name: csi-snapshot-controller-operator-config

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/AROSwift/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/AROSwift/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: a0010a21
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
@@ -64,6 +64,8 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         env:
         - name: OPERAND_IMAGE
@@ -93,6 +95,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /var/run/configmaps/config
+          name: config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       initContainers:
@@ -131,6 +136,10 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: csi-snapshot-controller-operator-config
+        name: config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/GCP/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/GCP/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: ""
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: csi-snapshot-controller-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/GCP/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/GCP/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_controlplanecomponent.yaml
@@ -28,3 +28,6 @@ status:
   - group: rbac.authorization.k8s.io
     kind: RoleBinding
     name: csi-snapshot-controller-operator-role
+  - group: ""
+    kind: ConfigMap
+    name: csi-snapshot-controller-operator-config

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/GCP/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/GCP/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: a0010a21
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
@@ -64,6 +64,8 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         env:
         - name: OPERAND_IMAGE
@@ -94,6 +96,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /var/run/configmaps/config
+          name: config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       initContainers:
@@ -138,6 +143,10 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: csi-snapshot-controller-operator-config
+        name: config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: ""
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: csi-snapshot-controller-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_controlplanecomponent.yaml
@@ -28,3 +28,6 @@ status:
   - group: rbac.authorization.k8s.io
     kind: RoleBinding
     name: csi-snapshot-controller-operator-role
+  - group: ""
+    kind: ConfigMap
+    name: csi-snapshot-controller-operator-config

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: a0010a21
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
@@ -64,6 +64,8 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         env:
         - name: OPERAND_IMAGE
@@ -93,6 +95,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /var/run/configmaps/config
+          name: config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       initContainers:
@@ -131,6 +136,10 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: csi-snapshot-controller-operator-config
+        name: config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: ""
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: csi-snapshot-controller-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_controlplanecomponent.yaml
@@ -28,3 +28,6 @@ status:
   - group: rbac.authorization.k8s.io
     kind: RoleBinding
     name: csi-snapshot-controller-operator-role
+  - group: ""
+    kind: ConfigMap
+    name: csi-snapshot-controller-operator-config

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: a0010a21
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
@@ -64,6 +64,8 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         env:
         - name: OPERAND_IMAGE
@@ -93,6 +95,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /var/run/configmaps/config
+          name: config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       initContainers:
@@ -131,6 +136,10 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: csi-snapshot-controller-operator-config
+        name: config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_config_configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: config.openshift.io/v1
+    authentication: {}
+    authorization: {}
+    kind: GenericControllerConfig
+    leaderElection:
+      leaseDuration: 0s
+      renewDeadline: 0s
+      retryPeriod: 0s
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: ""
+      certFile: ""
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      keyFile: ""
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: csi-snapshot-controller-operator-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_controlplanecomponent.yaml
@@ -28,3 +28,6 @@ status:
   - group: rbac.authorization.k8s.io
     kind: RoleBinding
     name: csi-snapshot-controller-operator-role
+  - group: ""
+    kind: ConfigMap
+    name: csi-snapshot-controller-operator-config

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: a0010a21
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
@@ -64,6 +64,8 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         env:
         - name: OPERAND_IMAGE
@@ -93,6 +95,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /var/run/configmaps/config
+          name: config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       initContainers:
@@ -131,6 +136,10 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: csi-snapshot-controller-operator-config
+        name: config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -73,6 +73,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -73,6 +73,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -73,6 +73,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -73,6 +73,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -73,6 +73,8 @@ spec:
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/gcp-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+kind: ConfigMap
+metadata:
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
@@ -20,5 +20,8 @@ status:
     type: RolloutComplete
   resources:
   - group: ""
+    kind: ConfigMap
+    name: ignition-server-proxy-config
+  - group: ""
     kind: Service
     name: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -85,21 +85,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -124,6 +110,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -145,6 +134,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+kind: ConfigMap
+metadata:
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
@@ -20,5 +20,8 @@ status:
     type: RolloutComplete
   resources:
   - group: ""
+    kind: ConfigMap
+    name: ignition-server-proxy-config
+  - group: ""
     kind: Service
     name: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -85,21 +85,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -128,6 +114,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -149,6 +138,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+kind: ConfigMap
+metadata:
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
@@ -20,5 +20,8 @@ status:
     type: RolloutComplete
   resources:
   - group: ""
+    kind: ConfigMap
+    name: ignition-server-proxy-config
+  - group: ""
     kind: Service
     name: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -85,21 +85,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -124,6 +110,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -145,6 +134,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+kind: ConfigMap
+metadata:
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
@@ -20,5 +20,8 @@ status:
     type: RolloutComplete
   resources:
   - group: ""
+    kind: ConfigMap
+    name: ignition-server-proxy-config
+  - group: ""
     kind: Service
     name: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -85,21 +85,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -124,6 +110,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -145,6 +134,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_config_configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt ssl-min-ver TLSv1.2 ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305 alpn http/1.1
+kind: ConfigMap
+metadata:
+  name: ignition-server-proxy-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_controlplanecomponent.yaml
@@ -20,5 +20,8 @@ status:
     type: RolloutComplete
   resources:
   - group: ""
+    kind: ConfigMap
+    name: ignition-server-proxy-config
+  - group: ""
     kind: Service
     name: ignition-server-proxy

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: ""
+        component.hypershift.openshift.io/config-hash: ea88d9fc
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: ignition-server-proxy
@@ -85,21 +85,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -124,6 +110,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
       priorityClassName: hypershift-control-plane
@@ -145,6 +134,10 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config
       - emptyDir: {}
         name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/AROSwift/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -89,6 +89,10 @@ spec:
         - registry=override
         - --platform
         - Azure
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -89,6 +89,10 @@ spec:
         - registry=override
         - --platform
         - GCP
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/IBMCloud/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -89,6 +89,10 @@ spec:
         - registry=override
         - --platform
         - IBMCloud
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -89,6 +89,10 @@ spec:
         - registry=override
         - --platform
         - AWS
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -89,6 +89,10 @@ spec:
         - registry=override
         - --platform
         - AWS
+        - --tls-min-version
+        - VersionTLS12
+        - --tls-cipher-suites
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/control-plane-operator
         - ignition-server

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -85,6 +85,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -85,6 +85,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -85,6 +85,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -85,6 +85,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_kubevirt_cloud_controller_manager_deployment.yaml
@@ -85,6 +85,8 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup
         - --cluster-name=cluster_name
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/kubevirt-cloud-controller-manager
         image: kubevirt-cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openstack-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_openstack_cloud_controller_manager_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --leader-elect-renew-deadline=107s
         - --leader-elect-retry-period=26s
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /usr/bin/openstack-cloud-controller-manager
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -58,7 +58,10 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
+      - args:
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
         - /bin/ibm-cloud-controller-manager
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -58,7 +58,10 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
+      - args:
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
         - /bin/ibm-cloud-controller-manager
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -58,7 +58,10 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
+      - args:
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
         - /bin/ibm-cloud-controller-manager
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -58,7 +58,10 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
+      - args:
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
         - /bin/ibm-cloud-controller-manager
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/powervs-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_powervs_cloud_controller_manager_deployment.yaml
@@ -58,7 +58,10 @@ spec:
             weight: 100
       automountServiceAccountToken: false
       containers:
-      - command:
+      - args:
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
         - /bin/ibm-cloud-controller-manager
         - --authentication-skip-lookup
         - --bind-address=$(POD_IP_ADDRESS)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-storage-operator/controller-config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-storage-operator/controller-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-storage-operator-config
+data:
+  config.yaml: ""

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-storage-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-storage-operator/deployment.yaml
@@ -20,8 +20,10 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         command:
         - cluster-storage-operator
@@ -132,6 +134,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /var/run/configmaps/config
+          name: config
+          readOnly: true
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -141,3 +146,6 @@ spec:
       - name: guest-kubeconfig
         secret:
           secretName: service-network-admin-kubeconfig
+      - configMap:
+          name: cluster-storage-operator-config
+        name: config

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/csi-snapshot-controller-operator/controller-config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/csi-snapshot-controller-operator/controller-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: csi-snapshot-controller-operator-config
+data:
+  config.yaml: ""

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/csi-snapshot-controller-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/csi-snapshot-controller-operator/deployment.yaml
@@ -21,6 +21,8 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         env:
         - name: OPERAND_IMAGE
@@ -49,6 +51,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /var/run/configmaps/config
+          name: config
+          readOnly: true
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -58,3 +63,6 @@ spec:
       - name: guest-kubeconfig
         secret:
           secretName: service-network-admin-kubeconfig
+      - configMap:
+          name: csi-snapshot-controller-operator-config
+        name: config

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ignition-server-proxy/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ignition-server-proxy/deployment.yaml
@@ -23,21 +23,7 @@ spec:
           #!/bin/bash
           set -e
           cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
-          cat <<EOF > /tmp/haproxy.conf
-          defaults
-            mode http
-            timeout connect 5s
-            timeout client 30s
-            timeout server 30s
-
-          frontend ignition-server
-            bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
-            default_backend ignition_servers
-
-          backend ignition_servers
-            server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1
-          EOF
-          haproxy -f /tmp/haproxy.conf
+          haproxy -f /etc/haproxy/haproxy.conf
         command:
         - /bin/bash
         image: haproxy-router
@@ -60,6 +46,9 @@ spec:
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /etc/haproxy
+          name: haproxy-config
+          readOnly: true
       volumes:
       - name: serving-cert
         secret:
@@ -69,3 +58,7 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: ignition-server-proxy-config
+        name: haproxy-config

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ignition-server-proxy/haproxy-config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ignition-server-proxy/haproxy-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ignition-server-proxy-config
+data:
+  haproxy.conf: |
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 30s
+      timeout server 30s
+
+    frontend ignition-server
+      bind :::8443 v4v6 ssl crt /tmp/tls.pem alpn http/1.1
+      default_backend ignition_servers
+
+    backend ignition_servers
+      server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt alpn http/1.1

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
@@ -2,6 +2,7 @@ package capimanager
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -24,6 +25,13 @@ func (capi *CAPIManagerOptions) adaptDeployment(cpContext component.WorkloadCont
 	podspec.UpdateContainer("manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		if version.GE(config.Version419) {
 			c.Args = append(c.Args, "--feature-gates=MachineSetPreflightChecks=false")
+		}
+
+		if tlsMinVersion := config.MinTLSVersion(cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
 		}
 
 		if len(capi.imageOverride) > 0 {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/component.go
@@ -1,8 +1,16 @@
 package aws
 
 import (
+	"fmt"
+	"strings"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -32,6 +40,7 @@ func (c *awsOptions) NeedsManagementKASAccess() bool {
 func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &awsOptions{}).
 		WithPredicate(predicate).
+		WithAdaptFunction(adaptDeployment).
 		WithManifestAdapter(
 			"config.yaml",
 			component.WithAdaptFunction(adaptConfig),
@@ -46,4 +55,20 @@ func NewComponent() component.ControlPlaneComponent {
 
 func predicate(cpContext component.WorkloadContext) (bool, error) {
 	return cpContext.HCP.Spec.Platform.Type == hyperv1.AWSPlatform, nil
+}
+
+func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
+
+	podspec.UpdateContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		// Add TLS configuration based on cluster TLS security profile
+		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
+	})
+
+	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/deployment.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
@@ -17,10 +18,21 @@ const (
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
+
 	podspec.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args,
 			fmt.Sprintf("--cluster-name=%s", cpContext.HCP.Spec.InfraID),
 		)
+
+		// Add TLS configuration based on cluster TLS security profile
+		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
+
 		if azureutil.IsAroHCPByHCP(cpContext.HCP) {
 			c.VolumeMounts = append(c.VolumeMounts,
 				azureutil.CreateVolumeMountForAzureSecretStoreProviderClass(config.ManagedAzureCloudProviderSecretStoreVolumeName),

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/component.go
@@ -1,8 +1,16 @@
 package gcp
 
 import (
+	"fmt"
+	"strings"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -35,6 +43,7 @@ func NewComponent() component.ControlPlaneComponent {
 	// The deployment.yaml mounts that pre-created secret.
 	return component.NewDeploymentComponent(ComponentName, &gcpOptions{}).
 		WithPredicate(predicate).
+		WithAdaptFunction(adaptDeployment).
 		WithManifestAdapter(
 			"config.yaml",
 			component.WithAdaptFunction(adaptConfig),
@@ -49,4 +58,20 @@ func NewComponent() component.ControlPlaneComponent {
 
 func predicate(cpContext component.WorkloadContext) (bool, error) {
 	return cpContext.HCP.Spec.Platform.Type == hyperv1.GCPPlatform, nil
+}
+
+func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
+
+	podspec.UpdateContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		// Add TLS configuration based on cluster TLS security profile
+		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
+	})
+
+	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/deployment.go
@@ -2,8 +2,10 @@ package kubevirt
 
 import (
 	"fmt"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
@@ -37,6 +39,14 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		c.Args = append(c.Args,
 			fmt.Sprintf("--cluster-name=%s", clusterName),
 		)
+
+		// Add TLS configuration based on cluster TLS security profile
+		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
 
 		if isExternalInfra {
 			c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment.go
@@ -1,7 +1,11 @@
 package openstack
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
@@ -20,6 +24,7 @@ const (
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
 	credentialsSecret, err := getCredentialsSecret(cpContext)
 	if err != nil {
 		return err
@@ -35,6 +40,14 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			Name:  "OCP_INFRASTRUCTURE_NAME",
 			Value: cpContext.HCP.Spec.InfraID,
 		})
+
+		// Add TLS configuration based on cluster TLS security profile
+		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
 
 		if hasCACert {
 			c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment.go
@@ -2,7 +2,9 @@ package powervs
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
@@ -19,6 +21,16 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	if hcp.Spec.Platform.PowerVS == nil {
 		return fmt.Errorf(".spec.platform.powervs is not defined")
 	}
+
+	podspec.UpdateContainer("cloud-controller-manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		// Add TLS configuration based on cluster TLS security profile
+		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
+	})
 
 	podspec.UpdateVolume(cloudCredsVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 		v.Secret.SecretName = hcp.Spec.Platform.PowerVS.KubeCloudControllerCreds.Name

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment.go
@@ -3,10 +3,12 @@ package ignitionserver
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
@@ -21,6 +23,9 @@ import (
 
 func (ign *ignitionServer) adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	hcp := cpContext.HCP
+	profile := hcp.Spec.Configuration.GetTLSSecurityProfile()
+	ianaCiphers := config.CipherSuites(profile)
+	minVersionStr := config.MinTLSVersion(profile)
 
 	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.FeatureGate != nil {
 		featureGate := &configv1.FeatureGate{
@@ -53,6 +58,13 @@ func (ign *ignitionServer) adaptDeployment(cpContext component.WorkloadContext, 
 			"--registry-overrides", util.ConvertRegistryOverridesToCommandLineFlag(ign.releaseProvider.GetRegistryOverrides()),
 			"--platform", string(hcp.Spec.Platform.Type),
 		)
+
+		if minVersionStr != "" {
+			c.Args = append(c.Args, "--tls-min-version", minVersionStr)
+		}
+		if len(ianaCiphers) > 0 {
+			c.Args = append(c.Args, "--tls-cipher-suites", strings.Join(ianaCiphers, ","))
+		}
 
 		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "OPENSHIFT_IMG_OVERRIDES",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/component.go
@@ -41,6 +41,7 @@ func NewComponent(defaultIngressDomain string) component.ControlPlaneComponent {
 		WithPredicate(predicate).
 		WithManifestAdapter(
 			"haproxy-config.yaml",
+			component.WithAdaptFunction(adaptHAProxyConfig),
 		).
 		WithManifestAdapter(
 			"service.yaml",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/component.go
@@ -40,6 +40,9 @@ func NewComponent(defaultIngressDomain string) component.ControlPlaneComponent {
 		WithAdaptFunction(adaptDeployment).
 		WithPredicate(predicate).
 		WithManifestAdapter(
+			"haproxy-config.yaml",
+		).
+		WithManifestAdapter(
 			"service.yaml",
 			component.WithAdaptFunction(adaptService),
 		).

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment.go
@@ -1,9 +1,14 @@
 package ignitionserverproxy
 
 import (
+	"fmt"
+	"strings"
+
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
+
+	configv1 "github.com/openshift/api/config/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -20,5 +25,98 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		podspec.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, deployment)
 	}
 
+	return nil
+}
+
+func tlsVersionToHAProxy(version string) (string, error) {
+	switch version {
+	case "VersionTLS13":
+		return "TLSv1.3", nil
+	case "VersionTLS12":
+		return "TLSv1.2", nil
+	case "VersionTLS11":
+		return "TLSv1.1", nil
+	case "VersionTLS10":
+		return "TLSv1.0", nil
+	default:
+		return "", fmt.Errorf("unknown TLS version %q", version)
+	}
+}
+
+func adaptHAProxyConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap) error {
+	profile := cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile()
+	// TODO(ingvagabund): crypto.DefaultTLSProfileType available in 4.23+
+	if profile == nil {
+		profile = &configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileIntermediateType,
+		}
+	}
+
+	// Skip config.CipherSuites invocation to keep the ciphers in OpenSSL
+	// format to avoid translating them to IANA and back. HAProxy accepts OpenSSL format.
+	var ciphers []string
+	var minVersionStr string
+	if profile.Type == configv1.TLSProfileCustomType {
+		ciphers = profile.Custom.Ciphers
+		minVersionStr = string(profile.Custom.MinTLSVersion)
+	} else {
+		ciphers = configv1.TLSProfiles[profile.Type].Ciphers
+		minVersionStr = string(configv1.TLSProfiles[profile.Type].MinTLSVersion)
+	}
+
+	var minTLSVersion string
+	if minVersionStr != "" {
+		var err error
+		minTLSVersion, err = tlsVersionToHAProxy(minVersionStr)
+		if err != nil {
+			return fmt.Errorf("failed to convert TLS version: %w", err)
+		}
+	}
+
+	// Filter out TLS 1.3 ciphers (they start with "TLS_") - TLS 1.3 ciphers are not configurable in HAProxy
+	var cipherStr string
+	tls12Ciphers := []string{}
+	for _, cipher := range ciphers {
+		if !strings.HasPrefix(cipher, "TLS_") {
+			tls12Ciphers = append(tls12Ciphers, cipher)
+		}
+	}
+	if len(tls12Ciphers) > 0 {
+		cipherStr = strings.Join(tls12Ciphers, ":")
+	}
+
+	bindOptions := "bind :::8443 v4v6 ssl crt /tmp/tls.pem"
+	serverOptions := "server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt"
+
+	if minTLSVersion != "" {
+		bindOptions += fmt.Sprintf(" ssl-min-ver %s", minTLSVersion)
+		serverOptions += fmt.Sprintf(" ssl-min-ver %s", minTLSVersion)
+	}
+	if cipherStr != "" {
+		bindOptions += fmt.Sprintf(" ciphers %s", cipherStr)
+		serverOptions += fmt.Sprintf(" ciphers %s", cipherStr)
+	}
+
+	bindOptions += " alpn http/1.1"
+	serverOptions += " alpn http/1.1"
+
+	haproxyConf := fmt.Sprintf(`defaults
+  mode http
+  timeout connect 5s
+  timeout client 30s
+  timeout server 30s
+
+frontend ignition-server
+  %s
+  default_backend ignition_servers
+
+backend ignition_servers
+  %s
+`, bindOptions, serverOptions)
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	cm.Data["haproxy.conf"] = haproxyConf
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/snapshotcontroller/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/snapshotcontroller/component.go
@@ -42,6 +42,10 @@ func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &snapshotController{}).
 		WithAdaptFunction(adaptDeployment).
 		WithPredicate(isStorageAndCSIManaged).
+		WithManifestAdapter(
+			"controller-config.yaml",
+			component.WithAdaptFunction(adaptControllerConfig),
+		).
 		WithDependencies(oapiv2.ComponentName).
 		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{
 			KubeconfigVolumeName: "guest-kubeconfig",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/snapshotcontroller/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/snapshotcontroller/deployment.go
@@ -1,13 +1,20 @@
 package snapshotcontroller
 
 import (
+	"encoding/json"
+	"fmt"
 	"strconv"
 
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/yaml"
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
@@ -29,5 +36,43 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		}
 	})
 
+	return nil
+}
+
+func adaptControllerConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap) error {
+	profile := cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile()
+	controllerConfig := configv1.GenericControllerConfig{
+		ServingInfo: configv1.HTTPServingInfo{
+			ServingInfo: configv1.ServingInfo{
+				BindAddress:   "0.0.0.0:8443",
+				CipherSuites:  config.CipherSuites(profile),
+				MinTLSVersion: config.MinTLSVersion(profile),
+			},
+		},
+	}
+
+	asJSON, err := json.Marshal(controllerConfig)
+	if err != nil {
+		return fmt.Errorf("failed to json marshal config: %w", err)
+	}
+
+	asMap := map[string]any{}
+	if err := json.Unmarshal(asJSON, &asMap); err != nil {
+		return fmt.Errorf("failed to json unmarshal config: %w", err)
+	}
+
+	asMap["apiVersion"] = configv1.GroupVersion.String()
+	asMap["kind"] = "GenericControllerConfig"
+
+	data, err := yaml.Marshal(asMap)
+	if err != nil {
+		return fmt.Errorf("failed to yaml marshal config: %w", err)
+	}
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+
+	cm.Data["config.yaml"] = string(data)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/component.go
@@ -64,6 +64,10 @@ func NewComponent() component.ControlPlaneComponent {
 			component.WithAdaptFunction(adaptAzureCSIFileSecretProvider),
 			component.WithPredicate(isAroHCP),
 		).
+		WithManifestAdapter(
+			"controller-config.yaml",
+			component.WithAdaptFunction(adaptControllerConfig),
+		).
 		WithDependencies(oapiv2.ComponentName).
 		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{
 			KubeconfigVolumeName: "guest-kubeconfig",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"encoding/json"
+	"fmt"
 	"strconv"
 
 	"github.com/openshift/hypershift/support/azureutil"
@@ -8,8 +10,12 @@ import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/yaml"
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
@@ -39,5 +45,43 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		}
 	})
 
+	return nil
+}
+
+func adaptControllerConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap) error {
+	profile := cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile()
+	controllerConfig := configv1.GenericControllerConfig{
+		ServingInfo: configv1.HTTPServingInfo{
+			ServingInfo: configv1.ServingInfo{
+				BindAddress:   "0.0.0.0:8443",
+				CipherSuites:  config.CipherSuites(profile),
+				MinTLSVersion: config.MinTLSVersion(profile),
+			},
+		},
+	}
+
+	asJSON, err := json.Marshal(controllerConfig)
+	if err != nil {
+		return fmt.Errorf("failed to json marshal config: %w", err)
+	}
+
+	asMap := map[string]any{}
+	if err := json.Unmarshal(asJSON, &asMap); err != nil {
+		return fmt.Errorf("failed to json unmarshal config: %w", err)
+	}
+
+	asMap["apiVersion"] = configv1.GroupVersion.String()
+	asMap["kind"] = "GenericControllerConfig"
+
+	data, err := yaml.Marshal(asMap)
+	if err != nil {
+		return fmt.Errorf("failed to yaml marshal config: %w", err)
+	}
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+
+	cm.Data["config.yaml"] = string(data)
 	return nil
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
@@ -63,7 +65,7 @@ func (p Agent) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, create
 	return agentCluster, nil
 }
 
-func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := imageCAPAgent
 	if envImage := os.Getenv(images.AgentCAPIProviderEnvVar); len(envImage) > 0 {
 		providerImage = envImage
@@ -71,6 +73,26 @@ func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIAgentProviderImage]; ok {
 		providerImage = override
 	}
+
+	// Build container args with TLS configuration
+	args := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--health-probe-bind-address=:8081",
+		"--metrics-bind-address=127.0.0.1:8080",
+		"--leader-elect",
+		"--agent-namespace", hcluster.Spec.Platform.Agent.AgentNamespace,
+	}
+
+	// Add TLS configuration based on cluster TLS security profile
+	if hcp != nil {
+		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			args = append(args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			args = append(args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
+	}
+
 	deploymentSpec := &appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
 		Template: corev1.PodTemplateSpec{
@@ -91,13 +113,7 @@ func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 							},
 						},
 						Command: []string{"/manager"},
-						Args: []string{
-							"--namespace", "$(MY_NAMESPACE)",
-							"--health-probe-bind-address=:8081",
-							"--metrics-bind-address=127.0.0.1:8080",
-							"--leader-elect",
-							"--agent-namespace", hcluster.Spec.Platform.Agent.AgentNamespace,
-						},
+						Args:    args,
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
 
@@ -100,7 +101,7 @@ func (p AWS) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOr
 	return awsCluster, nil
 }
 
-func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := p.capiProviderImage
 	if envImage := os.Getenv(images.AWSCAPIProviderEnvVar); len(envImage) > 0 {
 		// Only override CAPA image with env var if payload version < 4.12
@@ -117,6 +118,24 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hype
 	}
 	if p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor > 15)) {
 		featureGates = append(featureGates, "ROSA=false")
+	}
+
+	// Build container args with TLS configuration
+	args := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--v=4",
+		"--leader-elect=true",
+		fmt.Sprintf("--feature-gates=%s", strings.Join(featureGates, ",")),
+	}
+
+	// Add TLS configuration based on cluster TLS security profile
+	if hcp != nil {
+		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			args = append(args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			args = append(args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
 	}
 
 	defaultMode := int32(0640)
@@ -211,11 +230,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hype
 								Value: "true",
 							},
 						},
-						Args: []string{"--namespace", "$(MY_NAMESPACE)",
-							"--v=4",
-							"--leader-elect=true",
-							fmt.Sprintf("--feature-gates=%s", strings.Join(featureGates, ",")),
-						},
+						Args: args,
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "healthz",

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -89,7 +89,7 @@ func (a Azure) ReconcileCAPIInfraCR(
 	return azureCluster, nil
 }
 
-func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	image := a.capiProviderImage
 	if envImage := os.Getenv(images.AzureCAPIProviderEnvVar); len(envImage) > 0 {
 		image = envImage
@@ -97,6 +97,25 @@ func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIAzureProviderImage]; ok {
 		image = override
 	}
+
+	// Build container args with TLS configuration
+	args := []string{
+		"--namespace=$(MY_NAMESPACE)",
+		"--leader-elect=true",
+		"--feature-gates=MachinePool=false,ASOAPI=false",
+		"--disable-controllers-or-webhooks=DisableASOSecretController",
+	}
+
+	// Add TLS configuration based on cluster TLS security profile
+	if hcp != nil {
+		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			args = append(args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			args = append(args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
+	}
+
 	defaultMode := int32(0640)
 	deploymentSpec := &appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
@@ -108,12 +127,7 @@ func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 						Name:            "manager",
 						Image:           image,
 						ImagePullPolicy: corev1.PullIfNotPresent,
-						Args: []string{
-							"--namespace=$(MY_NAMESPACE)",
-							"--leader-elect=true",
-							"--feature-gates=MachinePool=false,ASOAPI=false",
-							"--disable-controllers-or-webhooks=DisableASOSecretController",
-						},
+						Args:            args,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/gcputil"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/k8sutil"
@@ -177,7 +178,7 @@ func (p GCP) reconcileGCPCluster(gcpCluster *capigcp.GCPCluster, hcluster *hyper
 // CAPIProviderDeploymentSpec implements CAPG controller deployment specification.
 // This method creates a deployment spec for the CAPG (Cluster API Provider GCP)
 // controller with proper image handling, feature gates, and WIF preparation.
-func (p GCP) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p GCP) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	// Validate GCP platform configuration is present
 	if hcluster.Spec.Platform.GCP == nil {
 		return nil, fmt.Errorf("GCP platform configuration is missing")
@@ -202,11 +203,27 @@ func (p GCP) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hype
 		"MachinePool=false", // Disable for Phase 1
 	}
 
+	// Version-conditional feature gates (future-proofing)
+	if p.payloadVersion != nil && p.payloadVersion.Major == 4 && p.payloadVersion.Minor > 16 {
+		featureGates = append(featureGates, "ClusterResourceSet=false") // Example
+	}
+
+	// Build container args with TLS configuration
 	args := []string{
 		"--namespace=$(MY_NAMESPACE)",
 		"--leader-elect=true",
 		fmt.Sprintf("--feature-gates=%s", strings.Join(featureGates, ",")),
 		"--v=2",
+	}
+
+	// Add TLS configuration based on cluster TLS security profile
+	if hcp != nil {
+		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			args = append(args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			args = append(args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
 	}
 
 	containers := []corev1.Container{

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
 
@@ -68,7 +70,7 @@ func reconcileKubevirtCluster(kubevirtCluster *capikubevirt.KubevirtCluster, hcl
 	kubevirtCluster.Status.Ready = true
 }
 
-func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := ""
 	if envImage := os.Getenv(images.KubevirtCAPIProviderEnvVar); len(envImage) > 0 {
 		providerImage = envImage
@@ -79,6 +81,24 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ 
 	if providerImage == "" {
 		return nil, fmt.Errorf("kubevirt CAPI provider image not specified by environment variable %s or annotation %s", images.KubevirtCAPIProviderEnvVar, hyperv1.ClusterAPIKubeVirtProviderImage)
 	}
+
+	// Build container args with TLS configuration
+	args := []string{
+		"--namespace", "$(MY_NAMESPACE)",
+		"--v=4",
+		"--leader-elect=true",
+	}
+
+	// Add TLS configuration based on cluster TLS security profile
+	if hcp != nil {
+		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			args = append(args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			args = append(args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
+	}
+
 	defaultMode := int32(0640)
 	return &appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
@@ -131,11 +151,7 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ 
 							},
 						},
 						Command: []string{"/manager"},
-						Args: []string{
-							"--namespace", "$(MY_NAMESPACE)",
-							"--v=4",
-							"--leader-elect=true",
-						},
+						Args:    args,
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "healthz",

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/openstackutil"
 	"github.com/openshift/hypershift/support/upsert"
@@ -174,7 +176,7 @@ func reconcileOpenStackClusterSpec(hcluster *hyperv1.HostedCluster, openStackClu
 	return nil
 }
 
-func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	capoImage := a.capiProviderImage
 	if envImage := os.Getenv(images.OpenStackCAPIProviderEnvVar); len(envImage) > 0 {
 		capoImage = envImage
@@ -189,6 +191,32 @@ func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _
 	if override, ok := hcluster.Annotations[hyperv1.OpenStackResourceControllerImage]; ok {
 		orcImage = override
 	}
+
+	// Build container args with TLS configuration
+	capoArgs := []string{
+		"--namespace=$(MY_NAMESPACE)",
+		"--leader-elect",
+		"--v=2",
+		// HyperShift runs CAPO in a namespace-scoped deployment and manages CRDs
+		// itself. CAPO v0.14 introduced a crdmigrator controller that requires
+		// cluster-scoped RBAC (list openstackclusteridentities, patch
+		// customresourcedefinitions) that we do not and cannot grant. Skipping
+		// all phases causes crdmigrator.SetupWithManager to return early without
+		// registering the controller, eliminating the spurious RBAC errors.
+		"--skip-crd-migration-phases=StorageVersionMigration",
+		"--skip-crd-migration-phases=CleanupManagedFields",
+	}
+
+	// Add TLS configuration based on cluster TLS security profile
+	if hcp != nil {
+		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			capoArgs = append(capoArgs, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			capoArgs = append(capoArgs, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
+	}
+
 	allowPrivilegeEscalation := false
 	defaultMode := int32(0640)
 	deploymentSpec := appsv1.DeploymentSpec{
@@ -221,19 +249,7 @@ func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _
 					Image:           capoImage,
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         []string{"/manager"},
-					Args: []string{
-						"--namespace=$(MY_NAMESPACE)",
-						"--leader-elect",
-						"--v=2",
-						// HyperShift runs CAPO in a namespace-scoped deployment and manages CRDs
-						// itself. CAPO v0.14 introduced a crdmigrator controller that requires
-						// cluster-scoped RBAC (list openstackclusteridentities, patch
-						// customresourcedefinitions) that we do not and cannot grant. Skipping
-						// all phases causes crdmigrator.SetupWithManager to return early without
-						// registering the controller, eliminating the spurious RBAC errors.
-						"--skip-crd-migration-phases=StorageVersionMigration",
-						"--skip-crd-migration-phases=CleanupManagedFields",
-					},
+					Args:            capoArgs,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
 
@@ -75,7 +77,7 @@ func (p PowerVS) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, crea
 	return ibmCluster, nil
 }
 
-func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	defaultMode := int32(416)
 
 	providerImage := p.capiProviderImage
@@ -84,6 +86,23 @@ func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *
 	}
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIPowerVSProviderImage]; ok {
 		providerImage = override
+	}
+
+	// Build container args with TLS configuration
+	args := []string{"--namespace", "$(MY_NAMESPACE)",
+		"--v=4",
+		"--leader-elect=true",
+		"--provider-id-fmt=v2",
+	}
+
+	// Add TLS configuration based on cluster TLS security profile
+	if hcp != nil {
+		if tlsMinVersion := config.MinTLSVersion(hcp.Spec.Configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			args = append(args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(hcp.Spec.Configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			args = append(args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
 	}
 
 	deploymentSpec := &appsv1.DeploymentSpec{
@@ -146,11 +165,7 @@ func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *
 							},
 						},
 						Command: []string{"/bin/cluster-api-provider-ibmcloud-controller-manager"},
-						Args: []string{"--namespace", "$(MY_NAMESPACE)",
-							"--v=4",
-							"--leader-elect=true",
-							"--provider-id-fmt=v2",
-						},
+						Args:    args,
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "healthz",

--- a/hypershift-operator/controllers/hostedcluster/testdata/capi-provider/zz_fixture_TestReconcileComponents.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/capi-provider/zz_fixture_TestReconcileComponents.yaml
@@ -62,6 +62,8 @@ spec:
         - --v=4
         - --leader-elect=true
         - --feature-gates=EKS=false,ROSA=false
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         env:
         - name: MY_NAMESPACE
           valueFrom:

--- a/hypershift-operator/controllers/hostedcluster/testdata/cluster-api/zz_fixture_TestReconcileComponents.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/cluster-api/zz_fixture_TestReconcileComponents.yaml
@@ -68,6 +68,8 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-retry-period=26s
         - --leader-elect-renew-deadline=107s
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         env:
         - name: MY_NAMESPACE
           valueFrom:

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -22,6 +22,8 @@ import (
 	"github.com/openshift/hypershift/support/supportedversion"
 	"github.com/openshift/hypershift/support/util"
 
+	librarycrypto "github.com/openshift/library-go/pkg/crypto"
+
 	corev1 "k8s.io/api/core/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -55,6 +57,26 @@ func init() {
 	)
 }
 
+func buildTLSConfig(certWatcher *certwatcher.CertWatcher, opts Options) *tls.Config {
+	cfg := &tls.Config{
+		GetCertificate: certWatcher.GetCertificate,
+	}
+
+	if opts.TLSMinVersion != "" {
+		minVersion, err := librarycrypto.TLSVersion(opts.TLSMinVersion)
+		if err != nil {
+			log.Fatalf("invalid TLS min version: %v", err)
+		}
+		cfg.MinVersion = minVersion
+	}
+
+	if len(opts.TLSCipherSuites) > 0 {
+		cfg.CipherSuites = librarycrypto.CipherSuitesOrDie(opts.TLSCipherSuites)
+	}
+
+	return librarycrypto.SecureTLSConfig(cfg)
+}
+
 type Options struct {
 	Addr                string
 	CertFile            string
@@ -64,6 +86,8 @@ type Options struct {
 	WorkDir             string
 	MetricsAddr         string
 	FeatureGateManifest string
+	TLSMinVersion       string
+	TLSCipherSuites     []string
 }
 
 // This is a https server that enable us to satisfy
@@ -97,6 +121,8 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.WorkDir, "work-dir", opts.WorkDir, "Directory in which to store transient working data")
 	cmd.Flags().StringVar(&opts.MetricsAddr, "metrics-addr", opts.MetricsAddr, "The address the metric endpoint binds to.")
 	cmd.Flags().StringVar(&opts.FeatureGateManifest, "feature-gate-manifest", opts.FeatureGateManifest, "Path to a rendered featuregates.config.openshift.io/v1 file")
+	cmd.Flags().StringVar(&opts.TLSMinVersion, "tls-min-version", "", "Minimum TLS version (e.g., VersionTLS12, VersionTLS13)")
+	cmd.Flags().StringSliceVar(&opts.TLSCipherSuites, "tls-cipher-suites", nil, "TLS cipher suites (comma-separated)")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -290,22 +316,7 @@ func run(ctx context.Context, opts Options) error {
 		Handler:      mux,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
-		TLSConfig: &tls.Config{GetCertificate: certWatcher.GetCertificate,
-			MinVersion: tls.VersionTLS12,
-			CipherSuites: []uint16{
-				//TLS 1.3 ciphers from openshift tls modern profile
-				tls.TLS_AES_128_GCM_SHA256,
-				tls.TLS_AES_256_GCM_SHA384,
-				tls.TLS_CHACHA20_POLY1305_SHA256,
-				//TLS 1.2 subset from openshift intermediate tls profile
-				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			},
-		},
+		TLSConfig:    buildTLSConfig(certWatcher, opts),
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
 	}
 


### PR DESCRIPTION
/hold

Only to produce the cpo and ho images for local testing.

Picks up:
- https://github.com/openshift/hypershift/pull/8910
- https://github.com/openshift/hypershift/pull/8887
- https://github.com/openshift/hypershift/pull/8864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cluster-driven TLS configuration (minimum TLS version and cipher suites) across control plane services, cloud controller managers, and CAPI provider components.
  * Ignition server proxy now uses a prebuilt HAProxy configuration from a ConfigMap and supports TLS-aware startup.
  * Snapshot, storage, and related operators now generate and mount TLS-aware controller configuration via ConfigMaps.

* **Bug Fixes**
  * Updated ignition server and proxy components to honor configured TLS settings instead of fixed defaults, improving consistent TLS behavior end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->