### PR TITLE
feat(gcp): GCP-504 NodePool Platform Conditions

### DIFF
--- a/hypershift-operator/controllers/nodepool/conditions.go
+++ b/hypershift-operator/controllers/nodepool/conditions.go
@@ -169,6 +169,8 @@ func (r *NodePoolReconciler) setPlatformConditions(ctx context.Context, hcluster
 		return r.setPowerVSconditions(ctx, nodePool, hcluster, controlPlaneNamespace, releaseImage)
 	case hyperv1.OpenStackPlatform:
 		return r.setOpenStackConditions(ctx, nodePool, hcluster, controlPlaneNamespace, releaseImage)
+	case hyperv1.GCPPlatform:
+		return r.setGCPConditions(ctx, nodePool, hcluster, controlPlaneNamespace, releaseImage)
 	default:
 		return nil
 	}
@@ -778,7 +780,6 @@ func (r *NodePoolReconciler) setCIDRConflictCondition(nodePool *hyperv1.NodePool
 	if len(messages) > 0 {
 		message := ""
 		for _, entry := range messages {
-
 			if len(message) == 0 {
 				message = entry
 			} else if len(entry)+len(message) < maxMessageLength {

--- a/hypershift-operator/controllers/nodepool/gcp.go
+++ b/hypershift-operator/controllers/nodepool/gcp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -15,6 +16,40 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func (r *NodePoolReconciler) setGCPConditions(
+	_ context.Context, nodePool *hyperv1.NodePool,
+	hcluster *hyperv1.HostedCluster, _ string,
+	releaseImage *releaseinfo.ReleaseImage,
+) error {
+	if nodePool.Spec.Platform.Type != hyperv1.GCPPlatform ||
+		nodePool.Spec.Platform.GCP == nil {
+		return nil
+	}
+	if hcluster.Spec.Platform.GCP == nil {
+		return fmt.Errorf("the HostedCluster for this NodePool has no .Spec.Platform.GCP, this is unsupported")
+	}
+
+	if img, err := resolveGCPImage(nodePool, releaseImage); err != nil {
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			Type:               hyperv1.NodePoolValidPlatformImageType,
+			Status:             corev1.ConditionFalse,
+			Reason:             hyperv1.NodePoolValidationFailedReason,
+			Message:            fmt.Sprintf("Couldn't discover a GCP machine image for release image %q: %s", nodePool.Spec.Release.Image, err.Error()),
+			ObservedGeneration: nodePool.Generation,
+		})
+		return fmt.Errorf("couldn't discover a GCP machine image for release image: %w", err)
+	} else {
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			Type:               hyperv1.NodePoolValidPlatformImageType,
+			Status:             corev1.ConditionTrue,
+			Reason:             hyperv1.AsExpectedReason,
+			Message:            fmt.Sprintf("Bootstrap GCP machine image is %q", img),
+			ObservedGeneration: nodePool.Generation,
+		})
+	}
+	return nil
+}
 
 // gcpMachineTemplate creates a GCPMachineTemplate for the given NodePool.
 // This follows the AWS and Azure patterns for CAPI machine template generation.

--- a/hypershift-operator/controllers/nodepool/gcp_test.go
+++ b/hypershift-operator/controllers/nodepool/gcp_test.go
@@ -10,6 +10,7 @@ import (
 
 	imageapi "github.com/openshift/api/image/v1"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -784,6 +785,141 @@ func TestConfigureGCPNetworkTags(t *testing.T) {
 			} else {
 				g.Expect(result).To(Equal(tc.expectedTags))
 			}
+		})
+	}
+}
+
+func TestNodePoolReconciler_setGCPConditions(t *testing.T) {
+	testCases := []struct {
+		name         string
+		nodePool     *hyperv1.NodePool
+		hcluster     *hyperv1.HostedCluster
+		releaseImage *releaseinfo.ReleaseImage
+		check        func(t *testing.T, nodePool *hyperv1.NodePool, err error)
+	}{
+		{
+			name: "Not a GCP NodePool",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.AWSPlatform,
+					},
+				},
+			},
+			check: func(t *testing.T, nodePool *hyperv1.NodePool, err error) {
+				t.Helper()
+				g := NewWithT(t)
+				g.Expect(err).ToNot(HaveOccurred())
+				cond := FindStatusCondition(nodePool.Status.Conditions, hyperv1.NodePoolValidPlatformImageType)
+				g.Expect(cond).To(BeNil())
+			},
+		},
+		{
+			name: "Missing GCP config in NodePool",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.GCPPlatform,
+					},
+				},
+			},
+			check: func(t *testing.T, nodePool *hyperv1.NodePool, err error) {
+				t.Helper()
+				g := NewWithT(t)
+				g.Expect(err).ToNot(HaveOccurred())
+				cond := FindStatusCondition(nodePool.Status.Conditions, hyperv1.NodePoolValidPlatformImageType)
+				g.Expect(cond).To(BeNil())
+			},
+		},
+		{
+			name: "Missing GCP config in HostedCluster",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.GCPPlatform,
+						GCP:  &hyperv1.GCPNodePoolPlatform{},
+					},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{},
+				},
+			},
+			check: func(t *testing.T, nodePool *hyperv1.NodePool, err error) {
+				t.Helper()
+				g := NewWithT(t)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(Equal("the HostedCluster for this NodePool has no .Spec.Platform.GCP, this is unsupported"))
+
+				cond := FindStatusCondition(nodePool.Status.Conditions, hyperv1.NodePoolValidPlatformImageType)
+				g.Expect(cond).To(BeNil())
+			},
+		},
+		{
+			name: "Could not discover release image",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.GCPPlatform,
+						GCP:  &hyperv1.GCPNodePoolPlatform{},
+					},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						GCP: &hyperv1.GCPPlatformSpec{},
+					},
+				},
+			},
+			check: func(t *testing.T, nodePool *hyperv1.NodePool, err error) {
+				t.Helper()
+				g := NewWithT(t)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(Equal("couldn't discover a GCP machine image for release image: couldn't discover a GCP image for release image: release image is nil, cannot determine GCP image"))
+
+				cond := FindStatusCondition(nodePool.Status.Conditions, hyperv1.NodePoolValidPlatformImageType)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Status).To(Equal(corev1.ConditionFalse))
+			},
+		},
+		{
+			name: "success",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.GCPPlatform,
+						GCP: &hyperv1.GCPNodePoolPlatform{
+							Image: "i-am-a-gcp-image!",
+						},
+					},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						GCP: &hyperv1.GCPPlatformSpec{},
+					},
+				},
+			},
+			check: func(t *testing.T, nodePool *hyperv1.NodePool, err error) {
+				t.Helper()
+				g := NewWithT(t)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				cond := FindStatusCondition(nodePool.Status.Conditions, hyperv1.NodePoolValidPlatformImageType)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Status).To(Equal(corev1.ConditionTrue))
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			npr := &NodePoolReconciler{}
+			err := npr.setGCPConditions(t.Context(), testCase.nodePool, testCase.hcluster, "test", testCase.releaseImage)
+			testCase.check(t, testCase.nodePool, err)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
Add GCP-specific conditions to NodePool status, to allow users to diagnose image resolution failures.

This functionality is modeled after the AWS implementation.

## Which issue(s) this PR fixes:

Fixes #[GCP-504](https://redhat.atlassian.net/browse/GCP-504)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced status reporting for GCP-based node pools, indicating whether the platform image type is valid and ready.

* **Bug Fixes**
  * Improved reporting for GCP node pool validation failures when required platform configuration or image resolution is unavailable.
  * Refined network CIDR conflict messaging to present overlapping details more clearly.

* **Tests**
  * Added coverage for GCP node pool platform image condition behavior across success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->