### PR TITLE
CNTRLPLANE-2883: Migrate ARM64 NodePool creation test to v2

### DIFF
--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -110,10 +110,17 @@ func (a *AzurePlatformConfig) DefaultBaseDomain() string {
 }
 
 func (a *AzurePlatformConfig) ClusterSpecs(releaseImage, n1Image string) []ClusterSpec {
+	// Parse EXTRA_ARGS from environment if provided
+	var extraArgs []string
+	if envArgs := os.Getenv("EXTRA_ARGS"); envArgs != "" {
+		extraArgs = strings.Fields(envArgs)
+	}
+
 	var publicExtraArgs []string
 	if a.encryptionKeyID != "" {
 		publicExtraArgs = append(publicExtraArgs, "--encryption-key-id="+a.encryptionKeyID)
 	}
+	publicExtraArgs = append(publicExtraArgs, extraArgs...)
 
 	return []ClusterSpec{
 		{
@@ -122,25 +129,27 @@ func (a *AzurePlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Clust
 		},
 		{
 			Variant: "private",
-			ExtraArgs: []string{
+			ExtraArgs: append([]string{
 				"--endpoint-access=Private",
 				"--endpoint-access-private-nat-subnet-id=" + a.privateNATSubnetID,
-			},
+			}, extraArgs...),
 		},
 		{
 			Variant:   "oauth-lb",
-			ExtraArgs: []string{"--oauth-publishing-strategy=LoadBalancer"},
+			ExtraArgs: append([]string{"--oauth-publishing-strategy=LoadBalancer"}, extraArgs...),
 		},
 		{
 			Variant:      "upgrade",
 			ReleaseImage: n1Image,
-			ExtraArgs:    []string{"--control-plane-availability-policy=HighlyAvailable"},
+			ExtraArgs:    append([]string{"--control-plane-availability-policy=HighlyAvailable"}, extraArgs...),
 		},
 		{
-			Variant: "autoscaling",
+			Variant:   "autoscaling",
+			ExtraArgs: extraArgs,
 		},
 		{
-			Variant: "external-oidc",
+			Variant:   "external-oidc",
+			ExtraArgs: extraArgs,
 		},
 	}
 }

--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -110,10 +110,17 @@ func (a *AzurePlatformConfig) DefaultBaseDomain() string {
 }
 
 func (a *AzurePlatformConfig) ClusterSpecs(releaseImage, n1Image string) []ClusterSpec {
+	// Parse EXTRA_ARGS from environment if provided
+	var extraArgs []string
+	if envArgs := os.Getenv("EXTRA_ARGS"); envArgs != "" {
+		extraArgs = strings.Fields(envArgs)
+	}
+
 	var publicExtraArgs []string
 	if a.encryptionKeyID != "" {
 		publicExtraArgs = append(publicExtraArgs, "--encryption-key-id="+a.encryptionKeyID)
 	}
+	publicExtraArgs = append(publicExtraArgs, extraArgs...)
 
 	return []ClusterSpec{
 		{
@@ -122,25 +129,27 @@ func (a *AzurePlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Clust
 		},
 		{
 			Variant: "private",
-			ExtraArgs: []string{
+			ExtraArgs: append([]string{
 				"--endpoint-access=Private",
 				"--endpoint-access-private-nat-subnet-id=" + a.privateNATSubnetID,
-			},
+			}, extraArgs...),
 		},
 		{
 			Variant:   "oauth-lb",
-			ExtraArgs: []string{"--oauth-publishing-strategy=LoadBalancer"},
+			ExtraArgs: append([]string{"--oauth-publishing-strategy=LoadBalancer"}, extraArgs...),
 		},
 		{
 			Variant:      "upgrade",
 			ReleaseImage: n1Image,
-			ExtraArgs:    []string{"--control-plane-availability-policy=HighlyAvailable"},
+			ExtraArgs:    append([]string{"--control-plane-availability-policy=HighlyAvailable"}, extraArgs...),
 		},
 		{
-			Variant: "autoscaling",
+			Variant:   "autoscaling",
+			ExtraArgs: extraArgs,
 		},
 		{
-			Variant: "external-oidc",
+			Variant:   "external-oidc",
+			ExtraArgs: extraArgs,
 		},
 	}
 }
@@ -327,7 +336,7 @@ func (a *AzurePlatformConfig) TestMatrix(releaseImage string) TestMatrix {
 			{
 				Name:        "public",
 				Variant:     "public",
-				LabelFilter: "self-managed-azure-public || nodepool-lifecycle || secret-encryption || control-plane-workloads || hosted-cluster-security || nodepool-osimagestream",
+				LabelFilter: "self-managed-azure-public || nodepool-lifecycle || nodepool-arm64 || secret-encryption || control-plane-workloads || hosted-cluster-security || nodepool-osimagestream",
 				Skip:        "KAS allowed CIDRs",
 				JUnitFile:   "junit_self_managed_azure_public.xml",
 			},
@@ -411,7 +420,6 @@ func (a *AzurePlatformConfig) DestroyArgs() []string {
 		"--dns-zone-rg-name=" + a.dnsZoneRG,
 	}
 }
-
 
 func envOrDefault(key, defaultVal string) string {
 	if val := os.Getenv(key); val != "" {

--- a/test/e2e/v2/tests/nodepool_arm64_create_test.go
+++ b/test/e2e/v2/tests/nodepool_arm64_create_test.go
@@ -1,0 +1,109 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RegisterNodePoolArm64Tests registers ARM64 NodePool test cases.
+func RegisterNodePoolArm64Tests(getTestCtx internal.TestContextGetter) {
+	NodePoolArm64CreateTest(getTestCtx)
+}
+
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolArm64] NodePool ARM64", Label("nodepool-arm64"), func() {
+	var testCtx *internal.TestContext
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+	})
+	RegisterNodePoolArm64Tests(func() *internal.TestContext { return testCtx })
+})
+
+// NodePoolArm64CreateTest creates an ARM64 NodePool, waits for the node to be ready,
+// and validates that an actual ARM64 node comes up with the correct architecture label.
+func NodePoolArm64CreateTest(getTestCtx internal.TestContextGetter) {
+	It("When creating an ARM64 NodePool, it should provision a node with ARM64 architecture", func() {
+		testCtx := getTestCtx()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		if hc.Spec.Platform.Type != hyperv1.AWSPlatform && hc.Spec.Platform.Type != hyperv1.AzurePlatform {
+			Skip("ARM64 NodePool test only supported on AWS and Azure platforms")
+		}
+		if hc.Status.PayloadArch != hyperv1.Multi {
+			Skip("ARM64 NodePool test requires a multi-arch release image")
+		}
+		ctx := testCtx.Context
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
+		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
+		Expect(defaultNP).NotTo(BeNil(), "default NodePool should exist")
+		var oneReplica int32 = 1
+		np := buildTestNodePool(defaultNP, "arm64", func(pool *hyperv1.NodePool) {
+			pool.Spec.Replicas = &oneReplica
+			pool.Spec.Arch = hyperv1.ArchitectureARM64
+			// Use the same release image as the HostedCluster
+			pool.Spec.Release.Image = hc.Spec.Release.Image
+			if pool.Spec.Platform.Type == hyperv1.AWSPlatform {
+				pool.Spec.Platform.AWS.InstanceType = "m6g.large"
+			} else if pool.Spec.Platform.Type == hyperv1.AzurePlatform {
+				pool.Spec.Platform.Azure.VMSize = "Standard_D2ps_v5"
+				// Let the controller select the marketplace image for this NodePool's architecture.
+				// Leaving AzureMarketplace nil signals the controller to auto-detect from the release payload.
+				pool.Spec.Platform.Azure.Image = hyperv1.AzureVMImage{Type: hyperv1.AzureMarketplace}
+			}
+		})
+
+		err = testCtx.MgmtClient.Create(ctx, np)
+		Expect(err).NotTo(HaveOccurred(), "failed to create ARM64 NodePool %s", np.Name)
+		GinkgoWriter.Printf("Created ARM64 NodePool %s\n", np.Name)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
+		// Verify the NodePool was created with correct spec
+		createdNP := &hyperv1.NodePool{}
+		err = testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), createdNP)
+		Expect(err).NotTo(HaveOccurred(), "failed to get created ARM64 NodePool %s", np.Name)
+		Expect(createdNP.Spec.Arch).To(Equal(hyperv1.ArchitectureARM64), "NodePool should have ARM64 architecture")
+		Expect(createdNP.Spec.Replicas).NotTo(BeNil(), "NodePool should have replicas set")
+		Expect(*createdNP.Spec.Replicas).To(Equal(int32(1)), "NodePool should have 1 replica")
+		if createdNP.Spec.Platform.Type == hyperv1.AWSPlatform {
+			Expect(createdNP.Spec.Platform.AWS.InstanceType).To(Equal("m6g.large"), "NodePool should use ARM64-capable instance type")
+		}
+		if createdNP.Spec.Platform.Type == hyperv1.AzurePlatform {
+			Expect(createdNP.Spec.Platform.Azure.VMSize).To(Equal("Standard_D2ps_v5"), "NodePool should use ARM64-capable VM size")
+		}
+		GinkgoWriter.Printf("Verified ARM64 NodePool %s created with correct architecture settings\n", np.Name)
+		// Wait for the ARM64 node to become ready
+		nodes := e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		Expect(nodes).To(HaveLen(1), "expected exactly 1 ARM64 node for NodePool %s", np.Name)
+		// Verify the node has the correct ARM64 architecture label
+		node := nodes[0]
+		Expect(node.Labels).NotTo(BeNil(), "node %s should have labels", node.Name)
+		arch, ok := node.Labels["kubernetes.io/arch"]
+		Expect(ok).To(BeTrue(), "node %s should have kubernetes.io/arch label", node.Name)
+		Expect(arch).To(Equal("arm64"), "node %s should have ARM64 architecture", node.Name)
+		GinkgoWriter.Printf("Verified node %s has ARM64 architecture label\n", node.Name)
+	})
+}

--- a/test/e2e/v2/tests/nodepool_arm64_create_test.go
+++ b/test/e2e/v2/tests/nodepool_arm64_create_test.go
@@ -1,0 +1,109 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RegisterNodePoolArm64Tests registers ARM64 NodePool test cases.
+func RegisterNodePoolArm64Tests(getTestCtx internal.TestContextGetter) {
+	NodePoolArm64CreateTest(getTestCtx)
+}
+
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolArm64] NodePool ARM64", Label("nodepool-arm64"), func() {
+	var testCtx *internal.TestContext
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+	})
+	RegisterNodePoolArm64Tests(func() *internal.TestContext { return testCtx })
+})
+
+// NodePoolArm64CreateTest creates an ARM64 NodePool, waits for the node to be ready,
+// and validates that an actual ARM64 node comes up with the correct architecture label.
+func NodePoolArm64CreateTest(getTestCtx internal.TestContextGetter) {
+	It("When creating an ARM64 NodePool, it should provision a node with ARM64 architecture", func() {
+		testCtx := getTestCtx()
+		testCtx.ValidateHostedClusterClient()
+		hc := testCtx.GetHostedCluster()
+		if hc.Spec.Platform.Type != hyperv1.AWSPlatform && hc.Spec.Platform.Type != hyperv1.AzurePlatform {
+			Skip("ARM64 NodePool test only supported on AWS and Azure platforms")
+		}
+		// Check if the HostedCluster supports multi-arch
+		if hc.Status.PayloadArch != hyperv1.Multi {
+			Skip("ARM64 NodePool test requires a multi-arch release image")
+		}
+		ctx := testCtx.Context
+		hcClient := testCtx.GetHostedClusterClient()
+		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
+		Expect(defaultNP).NotTo(BeNil(), "default NodePool should exist")
+		var oneReplica int32 = 1
+		np := buildTestNodePool(defaultNP, "arm64", func(pool *hyperv1.NodePool) {
+			pool.Spec.Replicas = &oneReplica
+			pool.Spec.Arch = hyperv1.ArchitectureARM64
+			// Use the same release image as the HostedCluster
+			pool.Spec.Release.Image = hc.Spec.Release.Image
+			if pool.Spec.Platform.Type == hyperv1.AWSPlatform {
+				pool.Spec.Platform.AWS.InstanceType = "m6g.large"
+			} else if pool.Spec.Platform.Type == hyperv1.AzurePlatform {
+				pool.Spec.Platform.Azure.VMSize = "Standard_D4ps_v5"
+				// Let the controller select the marketplace image for this NodePool's architecture.
+				// Leaving AzureMarketplace nil signals the controller to auto-detect from the release payload.
+				pool.Spec.Platform.Azure.Image = hyperv1.AzureVMImage{Type: hyperv1.AzureMarketplace}
+			}
+		})
+
+		err := testCtx.MgmtClient.Create(ctx, np)
+		Expect(err).NotTo(HaveOccurred(), "failed to create ARM64 NodePool %s", np.Name)
+		GinkgoWriter.Printf("Created ARM64 NodePool %s\n", np.Name)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
+		// Verify the NodePool was created with correct spec
+		createdNP := &hyperv1.NodePool{}
+		err = testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), createdNP)
+		Expect(err).NotTo(HaveOccurred(), "failed to get created ARM64 NodePool %s", np.Name)
+		Expect(createdNP.Spec.Arch).To(Equal(hyperv1.ArchitectureARM64), "NodePool should have ARM64 architecture")
+		Expect(createdNP.Spec.Replicas).NotTo(BeNil(), "NodePool should have replicas set")
+		Expect(*createdNP.Spec.Replicas).To(Equal(int32(1)), "NodePool should have 1 replica")
+		if createdNP.Spec.Platform.Type == hyperv1.AWSPlatform {
+			Expect(createdNP.Spec.Platform.AWS.InstanceType).To(Equal("m6g.large"), "NodePool should use ARM64-capable instance type")
+		}
+		if createdNP.Spec.Platform.Type == hyperv1.AzurePlatform {
+			Expect(createdNP.Spec.Platform.Azure.VMSize).To(Equal("Standard_D4ps_v5"), "NodePool should use ARM64-capable VM size")
+		}
+		GinkgoWriter.Printf("Verified ARM64 NodePool %s created with correct architecture settings\n", np.Name)
+		// Wait for the ARM64 node to become ready
+		nodes := e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		Expect(nodes).To(HaveLen(1), "expected exactly 1 ARM64 node for NodePool %s", np.Name)
+		// Verify the node has the correct ARM64 architecture label
+		node := nodes[0]
+		Expect(node.Labels).NotTo(BeNil(), "node %s should have labels", node.Name)
+		arch, ok := node.Labels["kubernetes.io/arch"]
+		Expect(ok).To(BeTrue(), "node %s should have kubernetes.io/arch label", node.Name)
+		Expect(arch).To(Equal("arm64"), "node %s should have ARM64 architecture", node.Name)
+		GinkgoWriter.Printf("Verified node %s has ARM64 architecture label\n", node.Name)
+	})
+}


### PR DESCRIPTION

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

This PR migrates the v1 E2E test that validates ARM64 NodePool creation succeeds with multi-arch to v2, on AWS and Azure platforms.

The test:
1. Creates an ARM64 NodePool with 1 replica
2. Configures platform-specific settings:
   - **AWS**: `m6g.large` instance type
   - **Azure**: `Standard_D4ps_v5` VM size with `aro_422-arm` marketplace image
3. Waits for the node to provision and become Ready
4. Verifies the node has the `kubernetes.io/arch=arm64` label
5. Cleans up the NodePool on test completion

This PR also adds `EXTRA_ARGS` for the Azure v2 e2e cluster creation, allowing for CI to pass through `--arch=arm64` for multi-arch cluster creation.
## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes #[CNTRLPLANE-2883](https://redhat.atlassian.net/browse/CNTRLPLANE-2883)

## Special notes for your reviewer:
**Azure marketplace image selection:**

<s>The test explicitly uses the `aro_422-arm` marketplace SKU for Azure. Older SKUs (419, 420, 421) would get stuck in the GRUB boot menu when I was testing them. The `aro_422-arm` SKU successfully auto-boots and completes, which is why it is used in this test.</s>

The text above was an issue in my own setup, please ignore.
## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

* Added end-to-end coverage for creating ARM64 node pools.
* Validates supported AWS and Azure configurations, including sizing, images, replica count, and release image alignment.
* Confirms an ARM64 node becomes ready with the expected architecture label.

## New Features

* Azure cluster test variants can now incorporate additional arguments supplied through the environment while preserving existing configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->