### PR TITLE
OCPBUGS-97804: Avoid printing errors twice

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 	cmd := &cobra.Command{
 		Use:              "hypershift",
 		SilenceUsage:     true,
+		SilenceErrors:    true,
 		TraverseChildren: true,
 
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## What this PR does / why we need it:
Errors are being printed twice by the CLI, once on main.go and once by the cobra framework.
This fix silences printing errors by the framework, avoiding double printing.

## Special notes for your reviewer:
One line fix.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated command error handling so errors are no longer automatically printed by the CLI framework, resulting in cleaner and more controlled error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->