### PR TITLE
fix: OCPBUGS-58422: Allow disabling Ingress without Console in HyperShift

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -518,7 +518,6 @@ type Capabilities struct {
 	// +optional
 	// +kubebuilder:validation:MaxItems=25
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Disabled is immutable. Changes might result in unpredictable and disruptive behavior."
-	// +kubebuilder:validation:XValidation:rule="!self.exists(cap, cap == 'Ingress') || self.exists(cap, cap == 'Console')",message="Ingress capability can only be disabled if Console capability is also disabled"
 	Disabled []OptionalCapability `json:"disabled,omitempty"`
 }
 

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/IngressComponentRouteLabels.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/IngressComponentRouteLabels.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryption.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryption.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkObservabilityInstall.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkObservabilityInstall.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSGroupPreferences.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSGroupPreferences.yaml
@@ -462,10 +462,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/IngressComponentRouteLabels.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/IngressComponentRouteLabels.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryption.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryption.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkObservabilityInstall.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkObservabilityInstall.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSGroupPreferences.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSGroupPreferences.yaml
@@ -418,10 +418,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -846,10 +846,8 @@ func (opts *RawCreateOptions) validateCapabilities() error {
 			return fmt.Errorf("unknown enabled capability: %s, accepted values are: %v", capability, acceptedValues.List())
 		}
 	}
-	disabledCaps := sets.NewString(opts.DisableClusterCapabilities...)
-	if disabledCaps.Has(string(hyperv1.IngressCapability)) && !disabledCaps.Has(string(hyperv1.ConsoleCapability)) {
-		return fmt.Errorf("ingress capability can only be disabled if Console capability is also disabled")
-	}
+
+
 	if len(opts.KubeAPIServerDNSName) > 0 {
 		if err := validation.IsDNS1123Subdomain(opts.KubeAPIServerDNSName); len(err) > 0 {
 			return fmt.Errorf("KubeAPIServerDNSName failed DNS validation: %s", strings.Join(err[:], " "))

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -877,10 +877,7 @@ func (opts *RawCreateOptions) validateCapabilities() error {
 			return fmt.Errorf("unknown enabled capability: %s, accepted values are: %v", capability, acceptedValues.List())
 		}
 	}
-	disabledCaps := sets.NewString(opts.DisableClusterCapabilities...)
-	if disabledCaps.Has(string(hyperv1.IngressCapability)) && !disabledCaps.Has(string(hyperv1.ConsoleCapability)) {
-		return fmt.Errorf("ingress capability can only be disabled if Console capability is also disabled")
-	}
+
 	if len(opts.KubeAPIServerDNSName) > 0 {
 		if err := validation.IsDNS1123Subdomain(opts.KubeAPIServerDNSName); len(err) > 0 {
 			return fmt.Errorf("KubeAPIServerDNSName failed DNS validation: %s", strings.Join(err[:], " "))

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -343,7 +343,7 @@ func TestValidate(t *testing.T) {
 			expectedErr: "",
 		},
 		{
-			name: "fails when ingress is disabled but console is not disabled",
+			name: "passes when only ingress is disabled",
 			rawOpts: &RawCreateOptions{
 				Name:                       "test-hc",
 				Namespace:                  "test-hc",
@@ -351,7 +351,7 @@ func TestValidate(t *testing.T) {
 				Arch:                       "amd64",
 				DisableClusterCapabilities: []string{"Ingress"},
 			},
-			expectedErr: "ingress capability can only be disabled if Console capability is also disabled",
+			expectedErr: "",
 		},
 		{
 			name: "passes when both ingress and console are disabled",
@@ -387,7 +387,7 @@ func TestValidate(t *testing.T) {
 			expectedErr: "",
 		},
 		{
-			name: "fails when ingress is disabled with other capabilities but console is not disabled",
+			name: "passes when ingress is disabled with other capabilities but console is not disabled",
 			rawOpts: &RawCreateOptions{
 				Name:                       "test-hc",
 				Namespace:                  "test-hc",
@@ -395,7 +395,7 @@ func TestValidate(t *testing.T) {
 				Arch:                       "amd64",
 				DisableClusterCapabilities: []string{"Ingress", "ImageRegistry"},
 			},
-			expectedErr: "ingress capability can only be disabled if Console capability is also disabled",
+			expectedErr: "",
 		},
 		{
 			name: "passes when disable-multi-network is used with network-type=Other",

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -346,7 +346,7 @@ func TestValidate(t *testing.T) {
 			expectedErr: "",
 		},
 		{
-			name: "fails when ingress is disabled but console is not disabled",
+			name: "passes when only ingress is disabled",
 			rawOpts: &RawCreateOptions{
 				Name:                       "test-hc",
 				Namespace:                  "test-hc",
@@ -354,7 +354,7 @@ func TestValidate(t *testing.T) {
 				Arch:                       "amd64",
 				DisableClusterCapabilities: []string{"Ingress"},
 			},
-			expectedErr: "ingress capability can only be disabled if Console capability is also disabled",
+			expectedErr: "",
 		},
 		{
 			name: "passes when both ingress and console are disabled",
@@ -390,7 +390,7 @@ func TestValidate(t *testing.T) {
 			expectedErr: "",
 		},
 		{
-			name: "fails when ingress is disabled with other capabilities but console is not disabled",
+			name: "passes when ingress is disabled with other capabilities but console is not disabled",
 			rawOpts: &RawCreateOptions{
 				Name:                       "test-hc",
 				Namespace:                  "test-hc",
@@ -398,7 +398,7 @@ func TestValidate(t *testing.T) {
 				Arch:                       "amd64",
 				DisableClusterCapabilities: []string{"Ingress", "ImageRegistry"},
 			},
-			expectedErr: "ingress capability can only be disabled if Console capability is also disabled",
+			expectedErr: "",
 		},
 		{
 			name: "passes when disable-multi-network is used with network-type=Other",

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.capabilities.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.capabilities.testsuite.yaml
@@ -373,8 +373,8 @@ tests:
             route: {}
     expectedError: "Capabilities can not be both enabled and disabled at once."
 
-  # --- Ingress/Console capability dependency ---
-  - name: When Ingress capability is disabled but Console capability is enabled it should fail
+  # --- Ingress/Console capability independence ---
+  - name: When Ingress capability is disabled but Console capability is enabled it should pass
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1
       kind: HostedCluster
@@ -414,7 +414,6 @@ tests:
           servicePublishingStrategy:
             type: Route
             route: {}
-    expectedError: "Ingress capability can only be disabled if Console capability is also disabled"
 
   - name: When both Ingress and Console capabilities are disabled it should pass
     initial: |

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -464,10 +464,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -464,10 +464,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -464,10 +464,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -420,10 +420,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
@@ -420,10 +420,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -420,10 +420,6 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
-                    - message: Ingress capability can only be disabled if Console
-                        capability is also disabled
-                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
-                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -518,7 +518,6 @@ type Capabilities struct {
 	// +optional
 	// +kubebuilder:validation:MaxItems=25
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Disabled is immutable. Changes might result in unpredictable and disruptive behavior."
-	// +kubebuilder:validation:XValidation:rule="!self.exists(cap, cap == 'Ingress') || self.exists(cap, cap == 'Console')",message="Ingress capability can only be disabled if Console capability is also disabled"
 	Disabled []OptionalCapability `json:"disabled,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Remove the validation that requires Console capability to be disabled when Ingress capability is disabled. The console-operator now handles ingress-disabled gracefully (openshift/console-operator#1182), so this constraint is no longer needed.

### Changes

- **api/hypershift/v1beta1/hostedcluster_types.go**: Remove the kubebuilder CEL validation rule that enforced `Ingress disabled → Console disabled`
- **cmd/cluster/core/create.go**: Remove the corresponding CLI validation
- **cmd/cluster/core/create_test.go**: Update tests — cases that expected failure now expect success
- Generated CRD manifests updated accordingly

### Depends on

- openshift/console-operator#1182 (must merge first)

### Test plan

- [x] `go test ./cmd/cluster/core/ -run TestValidate` passes — all ingress-related test cases pass
- [x] Verified on a HyperShift hosted cluster on AWS: after patching both CRDs to remove the validation, a hosted cluster with `--disable-cluster-capabilities Ingress` (Console enabled) was created and the console-operator ran without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed validation so **Ingress** can be disabled independently of **Console**.
  * Cluster creation now accepts configurations that disable **Ingress** alone or alongside other capabilities, such as **Image Registry**.
  * Capability names continue to be validated against the supported set, and existing limits and immutability rules remain unchanged.

* **Tests**
  * Updated validation coverage to confirm the newly accepted capability combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->