### PR TITLE
CNTRLPLANE-3771: fix /rebase GHA workflow for fork PRs

### DIFF
--- a/.github/workflows/address-review-comments.yaml
+++ b/.github/workflows/address-review-comments.yaml
@@ -21,6 +21,11 @@ jobs:
     with:
       command-name: address-review-comments
       status-message: "Addressing review comments"
-      claude-prompt: "/openshift-developer:address-review-pr ${{ github.event.issue.number }}"
+      claude-prompt: >-
+        /openshift-developer:address-review-pr ${{ github.event.issue.number }}
+        NOTE: If git push fails with a permission or authentication error, post a PR comment using
+        'gh pr comment' explaining that the changes were made locally but the push failed because
+        the PR does not allow maintainer edits, and ask the author to enable 'Allow edits from
+        maintainers'.
       max-turns: 200
     secrets: inherit

--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -21,7 +21,22 @@ jobs:
     with:
       command-name: rebase
       status-message: "Rebasing PR onto main"
-      claude-prompt: "Rebase this branch onto the latest main and force push. You are running in CI. Force push with --force-with-lease when done without asking for confirmation. Steps: 1) git fetch origin main 2) git rebase origin/main 3) If there are conflicts, resolve them while preserving the intent of the PR changes 4) git push --force-with-lease. Report what was done."
+      claude-prompt: >-
+        Rebase this branch onto the latest upstream main and force push.
+        You are running in CI. Force push with --force-with-lease when done without asking for confirmation.
+        The 'origin' remote may point to a fork; the workflow has already added an 'upstream' remote for fork PRs.
+        Steps:
+        1) Run 'git remote -v' to identify remotes
+        2) Determine the main-branch remote: if 'upstream' remote exists use 'upstream', otherwise use 'origin'
+        3) git fetch <chosen-remote> main
+        4) git rebase <chosen-remote>/main
+        5) If there are conflicts, resolve them while preserving the intent of the PR changes
+        6) git push --force-with-lease origin
+        If the push fails with a permission or authentication error, post a PR comment using
+        'gh pr comment' explaining that the rebase succeeded locally but the push failed because
+        the PR does not allow maintainer edits, and ask the author to enable 'Allow edits from
+        maintainers' and retry /rebase. Do NOT report success if the push failed.
+        Report what was done.
       max-turns: 50
       allowed-tools: "Bash Read Write Edit Grep Glob"
     secrets: inherit

--- a/.github/workflows/restructure-commits.yaml
+++ b/.github/workflows/restructure-commits.yaml
@@ -21,6 +21,11 @@ jobs:
     with:
       command-name: restructure-commits
       status-message: "Restructuring commits"
-      claude-prompt: "/restructure-commits -- You are running in CI. Force push with --force-with-lease when done without asking for confirmation."
+      claude-prompt: >-
+        /restructure-commits -- You are running in CI. Force push with --force-with-lease when done without asking for confirmation.
+        If the push fails with a permission or authentication error, post a PR comment using
+        'gh pr comment' explaining that the restructuring succeeded locally but the push failed because
+        the PR does not allow maintainer edits, and ask the author to enable 'Allow edits from
+        maintainers' and retry /restructure-commits.
       max-turns: 200
     secrets: inherit

--- a/.github/workflows/reusable-claude-on-pr.yaml
+++ b/.github/workflows/reusable-claude-on-pr.yaml
@@ -80,6 +80,16 @@ jobs:
           persist-credentials: true
           fetch-depth: 0
 
+      - name: Add upstream remote
+        env:
+          PR_REPO: ${{ steps.pr.outputs.repo }}
+        run: |
+          if [[ "$PR_REPO" != "${{ github.repository }}" ]]; then
+            git remote add upstream "https://github.com/${{ github.repository }}.git"
+            git fetch upstream main
+            git update-ref refs/heads/main refs/remotes/upstream/main
+          fi
+
       - name: Authenticate to GCP via WIF
         id: gcp-auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0


### PR DESCRIPTION
## What this PR does / why we need it:

The `/rebase` GitHub Actions command silently failed on fork PRs. When triggered on PR #8802 (from `stevekuznetsov/hypershift`), the workflow reported success but the PR was not actually rebased.

**Root cause:** `actions/checkout` sets `origin` to the fork repo. The rebase prompt told Claude to `git fetch origin main` / `git rebase origin/main`, which fetched the fork's stale `main` — making the rebase a no-op.

**Fix (two layers):**

1. **Infrastructure (`reusable-claude-on-pr.yaml`):** Added "Add upstream remote" step after checkout. For fork PRs, adds `upstream` → `openshift/hypershift`, fetches main, and creates a local `main` branch pointing at `upstream/main` (needed by `/restructure-commits` which uses bare `git merge-base main HEAD`).

2. **Prompts (`rebase.yaml`, `restructure-commits.yaml`, `address-review-comments.yaml`):** Updated to use the pre-configured `upstream` remote, and added push-failure error handling — if push to a user fork fails because "Allow edits from maintainers" is disabled, Claude posts an informative PR comment instead of silently failing.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3771](https://redhat.atlassian.net/browse/CNTRLPLANE-3771)

## Special notes for your reviewer:

Traced through all three PR scenarios to verify no regressions:
- **Community fork** (`hypershift-community/hypershift`): upstream remote added, app token used for push — works
- **User fork** (e.g., `stevekuznetsov/hypershift`): upstream remote added, push may fail without "Allow edits from maintainers" — now reports error clearly
- **Same-repo** (`openshift/hypershift`): upstream step skipped entirely — no behavior change

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when automated PR updates can’t be published due to permission/authentication limits, including clearer PR guidance on enabling maintainer edits.
  * Enhanced rebase and commit-restructure automation with safer, more explicit push behavior (only reporting success after a successful push) and clearer failure messaging.
* **New Features**
  * Added conditional remote setup for PR builds to ensure the correct upstream branch is used when the PR originates from a different repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->