### PR TITLE
CNTRLPLANE-3604: Capi v1beta2 storage migration

### DIFF
--- a/cmd/install/assets/crds/assets.go
+++ b/cmd/install/assets/crds/assets.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"path/filepath"
+	"slices"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -26,26 +27,45 @@ var CRDS embed.FS
 
 const capiLabel = "cluster.x-k8s.io/v1beta1"
 
-// CAPICRDOverrides configures CAPI CRDs that have both v1beta1 and v1beta2 versions.
-// These CRDs need storage version overrides and conversion webhooks.
-// Key is the CRD name (e.g., "clusters.cluster.x-k8s.io").
-// TODO(bclement): remove StorageVersion override once storage version is v1beta2.
-var CAPICRDOverrides = map[string]struct {
+// CAPICRDOverrideEntry configures a CAPI CRD that has both v1beta1 and v1beta2 versions.
+type CAPICRDOverrideEntry struct {
 	StorageVersion  string
 	NeedsConversion bool
-}{
-	"clusterclasses.cluster.x-k8s.io":                    {StorageVersion: "v1beta1", NeedsConversion: true},
-	"clusters.cluster.x-k8s.io":                          {StorageVersion: "v1beta1", NeedsConversion: true},
-	"machinedeployments.cluster.x-k8s.io":                {StorageVersion: "v1beta1", NeedsConversion: true},
-	"machinedrainrules.cluster.x-k8s.io":                 {StorageVersion: "v1beta1", NeedsConversion: true},
-	"machinehealthchecks.cluster.x-k8s.io":               {StorageVersion: "v1beta1", NeedsConversion: true},
-	"machinepools.cluster.x-k8s.io":                      {StorageVersion: "v1beta1", NeedsConversion: true},
-	"machines.cluster.x-k8s.io":                          {StorageVersion: "v1beta1", NeedsConversion: true},
-	"machinesets.cluster.x-k8s.io":                       {StorageVersion: "v1beta1", NeedsConversion: true},
-	"ipaddressclaims.ipam.cluster.x-k8s.io":              {StorageVersion: "v1beta1", NeedsConversion: true},
-	"ipaddresses.ipam.cluster.x-k8s.io":                  {StorageVersion: "v1beta1", NeedsConversion: true},
-	"clusterresourcesetbindings.addons.cluster.x-k8s.io": {StorageVersion: "v1beta1", NeedsConversion: true},
-	"clusterresourcesets.addons.cluster.x-k8s.io":        {StorageVersion: "v1beta1", NeedsConversion: true},
+}
+
+// capiCRDNames lists all CAPI CRDs that need storage version overrides and conversion webhooks.
+var capiCRDNames = []string{
+	"clusterclasses.cluster.x-k8s.io",
+	"clusters.cluster.x-k8s.io",
+	"machinedeployments.cluster.x-k8s.io",
+	"machinedrainrules.cluster.x-k8s.io",
+	"machinehealthchecks.cluster.x-k8s.io",
+	"machinepools.cluster.x-k8s.io",
+	"machines.cluster.x-k8s.io",
+	"machinesets.cluster.x-k8s.io",
+	"ipaddressclaims.ipam.cluster.x-k8s.io",
+	"ipaddresses.ipam.cluster.x-k8s.io",
+	"clusterresourcesetbindings.addons.cluster.x-k8s.io",
+	"clusterresourcesets.addons.cluster.x-k8s.io",
+}
+
+// CAPICRDNames returns the list of CAPI CRD names that are managed by HyperShift.
+func CAPICRDNames() []string {
+	return slices.Clone(capiCRDNames)
+}
+
+// CAPICRDOverrides returns the override map for CAPI CRDs with the default v1beta1 storage version.
+func CAPICRDOverrides() map[string]CAPICRDOverrideEntry {
+	return CAPICRDOverridesWithStorageVersion("v1beta1")
+}
+
+// CAPICRDOverridesWithStorageVersion returns the override map with the specified storage version.
+func CAPICRDOverridesWithStorageVersion(storageVersion string) map[string]CAPICRDOverrideEntry {
+	overrides := make(map[string]CAPICRDOverrideEntry, len(capiCRDNames))
+	for _, name := range capiCRDNames {
+		overrides[name] = CAPICRDOverrideEntry{StorageVersion: storageVersion, NeedsConversion: true}
+	}
+	return overrides
 }
 
 // capiResources specifies which CRDs should get labeled with capiLabel
@@ -102,8 +122,10 @@ func getContents(fs embed.FS, file string) []byte {
 	return b
 }
 
-// CustomResourceDefinitions returns all existing CRDs as controller-runtime objects
-func CustomResourceDefinitions(include func(path string, crd *apiextensionsv1.CustomResourceDefinition) bool, transform func(*apiextensionsv1.CustomResourceDefinition)) []crclient.Object {
+// CustomResourceDefinitions returns all existing CRDs as controller-runtime objects.
+// capiStorageVersion controls which version is set as storage for CAPI CRDs (e.g., "v1beta1" or "v1beta2").
+func CustomResourceDefinitions(capiStorageVersion string, include func(path string, crd *apiextensionsv1.CustomResourceDefinition) bool, transform func(*apiextensionsv1.CustomResourceDefinition)) []crclient.Object {
+	overrides := CAPICRDOverridesWithStorageVersion(capiStorageVersion)
 	var allCrds []crclient.Object
 	err := fs.WalkDir(CRDS, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -112,7 +134,7 @@ func CustomResourceDefinitions(include func(path string, crd *apiextensionsv1.Cu
 		if filepath.Ext(path) != ".yaml" {
 			return nil
 		}
-		crd := getCustomResourceDefinition(CRDS, path)
+		crd := getCustomResourceDefinition(CRDS, path, overrides)
 		if include(path, crd) {
 
 			if transform != nil {
@@ -131,7 +153,7 @@ func CustomResourceDefinitions(include func(path string, crd *apiextensionsv1.Cu
 // getCustomResourceDefinition unmarshals a CRD from file. Note there's a hack
 // here to strip leading YAML document separator which controller-gen creates
 // even though there's only one object in the document.
-func getCustomResourceDefinition(files embed.FS, file string) *apiextensionsv1.CustomResourceDefinition {
+func getCustomResourceDefinition(files embed.FS, file string, overrides map[string]CAPICRDOverrideEntry) *apiextensionsv1.CustomResourceDefinition {
 	b := getContents(files, file)
 	repaired := bytes.Replace(b, []byte("\n---\n"), []byte(""), 1)
 	crd := apiextensionsv1.CustomResourceDefinition{}
@@ -145,8 +167,7 @@ func getCustomResourceDefinition(files embed.FS, file string) *apiextensionsv1.C
 		crd.Labels[capiLabel] = label
 	}
 
-	// Override storage version if specified in CAPICRDOverrides
-	if override, ok := CAPICRDOverrides[crd.Name]; ok && override.StorageVersion != "" {
+	if override, ok := overrides[crd.Name]; ok && override.StorageVersion != "" {
 		for i := range crd.Spec.Versions {
 			crd.Spec.Versions[i].Storage = crd.Spec.Versions[i].Name == override.StorageVersion
 		}

--- a/cmd/install/assets/crds/assets_test.go
+++ b/cmd/install/assets/crds/assets_test.go
@@ -4,7 +4,99 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
+
+func TestCAPICRDOverridesWithStorageVersion(t *testing.T) {
+	t.Run("When requesting v1beta1 overrides, it should return all CRDs with v1beta1 storage", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		overrides := CAPICRDOverridesWithStorageVersion("v1beta1")
+		g.Expect(overrides).To(HaveLen(len(capiCRDNames)))
+		for _, name := range capiCRDNames {
+			entry, ok := overrides[name]
+			g.Expect(ok).To(BeTrue(), "missing CRD %s", name)
+			g.Expect(entry.StorageVersion).To(Equal("v1beta1"))
+			g.Expect(entry.NeedsConversion).To(BeTrue())
+		}
+	})
+
+	t.Run("When requesting v1beta2 overrides, it should return all CRDs with v1beta2 storage", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		overrides := CAPICRDOverridesWithStorageVersion("v1beta2")
+		g.Expect(overrides).To(HaveLen(len(capiCRDNames)))
+		for _, name := range capiCRDNames {
+			entry, ok := overrides[name]
+			g.Expect(ok).To(BeTrue(), "missing CRD %s", name)
+			g.Expect(entry.StorageVersion).To(Equal("v1beta2"))
+			g.Expect(entry.NeedsConversion).To(BeTrue())
+		}
+	})
+
+	t.Run("When using default CAPICRDOverrides, it should return v1beta1 storage", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		overrides := CAPICRDOverrides()
+		for _, name := range capiCRDNames {
+			g.Expect(overrides[name].StorageVersion).To(Equal("v1beta1"))
+		}
+	})
+}
+
+func TestCustomResourceDefinitionsStorageVersion(t *testing.T) {
+	t.Run("When selecting v1beta2 storage version, it should set v1beta2 as storage and v1beta1 as non-storage", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		capiNames := make(map[string]bool, len(capiCRDNames))
+		for _, name := range capiCRDNames {
+			capiNames[name] = true
+		}
+
+		crds := CustomResourceDefinitions("v1beta2",
+			func(path string, crd *apiextensionsv1.CustomResourceDefinition) bool { return true },
+			nil,
+		)
+		for _, obj := range crds {
+			crd := obj.(*apiextensionsv1.CustomResourceDefinition)
+			if !capiNames[crd.Name] {
+				continue
+			}
+			for _, v := range crd.Spec.Versions {
+				switch v.Name {
+				case "v1beta2":
+					g.Expect(v.Storage).To(BeTrue(), "CRD %s version v1beta2 should be storage", crd.Name)
+				case "v1beta1":
+					g.Expect(v.Storage).To(BeFalse(), "CRD %s version v1beta1 should not be storage when v1beta2 is selected", crd.Name)
+				}
+			}
+		}
+	})
+
+	t.Run("When selecting v1beta1 storage version, it should set v1beta1 as storage and v1beta2 as non-storage", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		capiNames := make(map[string]bool, len(capiCRDNames))
+		for _, name := range capiCRDNames {
+			capiNames[name] = true
+		}
+
+		crds := CustomResourceDefinitions("v1beta1",
+			func(path string, crd *apiextensionsv1.CustomResourceDefinition) bool { return true },
+			nil,
+		)
+		for _, obj := range crds {
+			crd := obj.(*apiextensionsv1.CustomResourceDefinition)
+			if !capiNames[crd.Name] {
+				continue
+			}
+			for _, v := range crd.Spec.Versions {
+				switch v.Name {
+				case "v1beta1":
+					g.Expect(v.Storage).To(BeTrue(), "CRD %s version v1beta1 should be storage", crd.Name)
+				case "v1beta2":
+					g.Expect(v.Storage).To(BeFalse(), "CRD %s version v1beta2 should not be storage when v1beta1 is selected", crd.Name)
+				}
+			}
+		}
+	})
+}
 
 func TestCapiResources(t *testing.T) {
 	t.Run("When loading all capiResources paths they should exist and parse correctly", func(t *testing.T) {
@@ -12,7 +104,7 @@ func TestCapiResources(t *testing.T) {
 		for path := range capiResources {
 			// getCustomResourceDefinition panics if file doesn't exist or can't be parsed
 			g.Expect(func() {
-				crd := getCustomResourceDefinition(CRDS, path)
+				crd := getCustomResourceDefinition(CRDS, path, CAPICRDOverrides())
 				g.Expect(crd).ToNot(BeNil())
 			}).ToNot(Panic(), "path %s should exist and parse", path)
 		}
@@ -21,7 +113,7 @@ func TestCapiResources(t *testing.T) {
 	t.Run("When loading a non-existent path it should panic", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		g.Expect(func() {
-			getCustomResourceDefinition(CRDS, "cluster-api-provider-fake/nonexistent.yaml")
+			getCustomResourceDefinition(CRDS, "cluster-api-provider-fake/nonexistent.yaml", CAPICRDOverrides())
 		}).To(Panic())
 	})
 }

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -15,6 +15,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	cmdutil "github.com/openshift/hypershift/cmd/util"
 	controlplaneoperatoroverrides "github.com/openshift/hypershift/hypershift-operator/controlplaneoperator-overrides"
+	capicrdmigrator "github.com/openshift/hypershift/support/capi-crdmigrator"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/metrics"
@@ -558,6 +559,7 @@ type HyperShiftOperatorDeployment struct {
 	ScaleFromZeroSecret                     *corev1.Secret
 	ScaleFromZeroSecretKey                  string
 	ScaleFromZeroProvider                   string
+	CAPIStorageVersion                      string
 	HCPEgressBlockCIDRs                     []string
 }
 
@@ -864,6 +866,9 @@ func (o HyperShiftOperatorDeployment) buildEnvVars() []corev1.EnvVar {
 	}
 	if o.EnableCPOOverrides {
 		envVars = append(envVars, corev1.EnvVar{Name: controlplaneoperatoroverrides.CPOOverridesEnvVar, Value: "1"})
+	}
+	if len(o.CAPIStorageVersion) > 0 {
+		envVars = append(envVars, corev1.EnvVar{Name: capicrdmigrator.CAPIStorageVersionEnvVar, Value: o.CAPIStorageVersion})
 	}
 	if len(o.PlatformsInstalled) > 0 {
 		envVars = append(envVars, corev1.EnvVar{Name: "PLATFORMS_INSTALLED", Value: o.PlatformsInstalled})
@@ -1271,7 +1276,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{"apiextensions.k8s.io"},
-				Resources: []string{"customresourcedefinitions"},
+				Resources: []string{"customresourcedefinitions", "customresourcedefinitions/status"},
 				Verbs:     []string{rbacv1.VerbAll},
 			},
 			{

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -15,6 +15,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	cmdutil "github.com/openshift/hypershift/cmd/util"
 	controlplaneoperatoroverrides "github.com/openshift/hypershift/hypershift-operator/controlplaneoperator-overrides"
+	capicrdmigrator "github.com/openshift/hypershift/support/capi-crdmigrator"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
@@ -397,7 +398,8 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 				Value: "us-east-1",
 			})
 		if o.UseWebIdentity {
-			deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+			deployment.Spec.Template.Spec.Containers[0].Env = append(
+				deployment.Spec.Template.Spec.Containers[0].Env,
 				corev1.EnvVar{Name: "AWS_SDK_LOAD_CONFIG", Value: "1"},
 			)
 			deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(
@@ -426,7 +428,8 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 				},
 			)
 		}
-		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args,
+		deployment.Spec.Template.Spec.Containers[0].Args = append(
+			deployment.Spec.Template.Spec.Containers[0].Args,
 			"--aws-zone-type=public",
 			"--aws-batch-change-interval=10s",
 			fmt.Sprintf("--aws-zones-cache-duration=%s", awsZonesCacheDuration),
@@ -440,7 +443,8 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 				Name:  "AZURE_SDK_MAX_RETRIES",
 				Value: "5",
 			})
-		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args,
+		deployment.Spec.Template.Spec.Containers[0].Args = append(
+			deployment.Spec.Template.Spec.Containers[0].Args,
 			"--azure-config-file=/etc/provider/credentials",
 		)
 	case GCPExternalDNSProvider:
@@ -560,6 +564,7 @@ type HyperShiftOperatorDeployment struct {
 	ScaleFromZeroSecret                     *corev1.Secret
 	ScaleFromZeroSecretKey                  string
 	ScaleFromZeroProvider                   string
+	CAPIStorageVersion                      string
 	HCPEgressBlockCIDRs                     []string
 }
 
@@ -870,6 +875,9 @@ func (o HyperShiftOperatorDeployment) buildEnvVars() []corev1.EnvVar {
 	if o.EnableKarpenterOperator {
 		envVars = append(envVars, corev1.EnvVar{Name: karpenterutil.EnableStandaloneKarpenterOperatorEnvVar, Value: "1"})
 	}
+	if len(o.CAPIStorageVersion) > 0 {
+		envVars = append(envVars, corev1.EnvVar{Name: capicrdmigrator.CAPIStorageVersionEnvVar, Value: o.CAPIStorageVersion})
+	}
 	if len(o.PlatformsInstalled) > 0 {
 		envVars = append(envVars, corev1.EnvVar{Name: "PLATFORMS_INSTALLED", Value: o.PlatformsInstalled})
 	}
@@ -913,7 +921,8 @@ func (o HyperShiftOperatorDeployment) addOIDCResources(args *[]string, volumeMou
 		o.OIDCStorageProviderS3Secret == nil || len(o.OIDCStorageProviderS3Secret.Name) == 0 {
 		return
 	}
-	*args = append(*args,
+	*args = append(
+		*args,
 		"--oidc-storage-provider-s3-bucket-name="+o.OIDCBucketName,
 		"--oidc-storage-provider-s3-region="+o.OIDCBucketRegion,
 		"--oidc-storage-provider-s3-credentials=/etc/oidc-storage-provider-s3-creds/"+o.OIDCStorageProviderS3SecretKey,
@@ -936,7 +945,8 @@ func (o HyperShiftOperatorDeployment) addScaleFromZeroResources(args *[]string, 
 	if o.ScaleFromZeroSecret == nil || len(o.ScaleFromZeroSecret.Name) == 0 || len(o.ScaleFromZeroSecretKey) == 0 || len(o.ScaleFromZeroProvider) == 0 {
 		return
 	}
-	*args = append(*args,
+	*args = append(
+		*args,
 		"--scale-from-zero-provider="+o.ScaleFromZeroProvider,
 		"--scale-from-zero-creds=/etc/scale-from-zero-creds/"+o.ScaleFromZeroSecretKey,
 	)
@@ -994,7 +1004,8 @@ func (o HyperShiftOperatorDeployment) addPrivatePlatformResources(envVars *[]cor
 			Name:      "credentials",
 			MountPath: "/etc/provider",
 		})
-		*envVars = append(*envVars,
+		*envVars = append(
+			*envVars,
 			corev1.EnvVar{Name: "AWS_SHARED_CREDENTIALS_FILE", Value: "/etc/provider/" + o.AWSPrivateSecretKey},
 			corev1.EnvVar{Name: "AWS_REGION", Value: o.AWSPrivateRegion},
 			corev1.EnvVar{Name: "AWS_SDK_LOAD_CONFIG", Value: "1"},
@@ -1276,7 +1287,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{"apiextensions.k8s.io"},
-				Resources: []string{"customresourcedefinitions"},
+				Resources: []string{"customresourcedefinitions", "customresourcedefinitions/status"},
 				Verbs:     []string{rbacv1.VerbAll},
 			},
 			{
@@ -1560,7 +1571,8 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 
 	// Add audit log persistence RBAC if enabled
 	if o.EnableAuditLogPersistence {
-		role.Rules = append(role.Rules,
+		role.Rules = append(
+			role.Rules,
 			rbacv1.PolicyRule{
 				APIGroups: []string{""},
 				Resources: []string{"persistentvolumeclaims"},
@@ -2182,7 +2194,8 @@ func (o HyperShiftMutatingWebhookConfiguration) Build() *admissionregistrationv1
 			},
 		}
 
-		mutatingWebhookConfiguration.Webhooks = append(mutatingWebhookConfiguration.Webhooks,
+		mutatingWebhookConfiguration.Webhooks = append(
+			mutatingWebhookConfiguration.Webhooks,
 			admissionregistrationv1.MutatingWebhook{
 				Name: "pods.auditlogpersistence.hypershift.openshift.io",
 				Rules: []admissionregistrationv1.RuleWithOperations{

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -990,6 +990,15 @@ func TestBuildEnvVars(t *testing.T) {
 			},
 		},
 		{
+			name: "When CAPI migration is enabled, it should include CAPI_STORAGE_VERSION env var",
+			deployment: HyperShiftOperatorDeployment{
+				CAPIStorageVersion: "v1beta2",
+			},
+			expectContains: []corev1.EnvVar{
+				{Name: "CAPI_STORAGE_VERSION", Value: "v1beta2"},
+			},
+		},
+		{
 			name: "When no optional features are enabled, it should not include optional env vars",
 			deployment: HyperShiftOperatorDeployment{
 				CertRotationScale: 24 * time.Hour,
@@ -1000,6 +1009,7 @@ func TestBuildEnvVars(t *testing.T) {
 				"MANAGED_SERVICE",
 				"ENABLE_SIZE_TAGGING",
 				"MONITORING_DASHBOARDS",
+				"CAPI_STORAGE_VERSION",
 			},
 		},
 	}

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/sharedingress"
 	hyperapi "github.com/openshift/hypershift/support/api"
+	capicrdmigrator "github.com/openshift/hypershift/support/capi-crdmigrator"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
@@ -447,7 +448,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.EnableValidatingWebhook, "enable-validating-webhook", opts.EnableValidatingWebhook, "Enable webhook for validating hypershift API types")
 	cmd.PersistentFlags().BoolVar(&opts.EnableConversionWebhook, "enable-conversion-webhook", opts.EnableConversionWebhook, "Enable webhook for converting hypershift API types")
 	cmd.PersistentFlags().BoolVar(&opts.DisableCAPIConversionWebhook, "disable-capi-conversion-webhook", opts.DisableCAPIConversionWebhook, "Disable conversion webhook for CAPI CRDs during v1beta1/v1beta2 transition")
-	cmd.PersistentFlags().BoolVar(&opts.DisableCAPIMigration, "disable-capi-migration", opts.DisableCAPIMigration, "Placeholder flag for upcoming feature: Disable automatic CAPI CRD storage version migration from v1beta1 to v1beta2")
+	cmd.PersistentFlags().BoolVar(&opts.DisableCAPIMigration, "disable-capi-migration", opts.DisableCAPIMigration, "Disable automatic CAPI CRD storage version migration from v1beta1 to v1beta2")
 	cmd.PersistentFlags().BoolVar(&opts.ExcludeEtcdManifests, "exclude-etcd", opts.ExcludeEtcdManifests, "Leave out etcd manifests")
 	cmd.PersistentFlags().Var(&opts.PlatformMonitoring, "platform-monitoring", "Select an option for enabling platform cluster monitoring. Valid values are: None, OperatorOnly, All")
 	cmd.PersistentFlags().BoolVar(&opts.EnableCIDebugOutput, "enable-ci-debug-output", opts.EnableCIDebugOutput, "If extra CI debug output should be enabled")
@@ -1012,24 +1013,39 @@ func crdIncludeFilter(opts Options, existingIPAMCRDs set.Set[string]) func(strin
 	}
 }
 
+func capiStorageVersionForOpts(opts Options) string {
+	if opts.DisableCAPIMigration {
+		return capicrdmigrator.CurrentStorageVersion
+	}
+	return capicrdmigrator.TargetStorageVersion
+}
+
 func setupCRDs(ctx context.Context, client crclient.Client, opts Options, operatorNamespace *corev1.Namespace, operatorService *corev1.Service) ([]crclient.Object, error) {
 	existingIPAMCRDs := set.New[string]()
 	if client != nil {
-		for crdName := range ipamCRDNames {
-			existing := &apiextensionsv1.CustomResourceDefinition{}
-			err := client.Get(ctx, crclient.ObjectKey{Name: crdName}, existing)
-			if err == nil {
-				existingIPAMCRDs.Insert(crdName)
-				fmt.Printf("Skipping existing IPAM CRD %s\n", crdName)
-			} else if !apierrors.IsNotFound(err) {
-				return nil, fmt.Errorf("failed to check if CRD %s exists: %w", crdName, err)
+		// Skip IPAM CRDs only when migration is disabled.
+		// During migration, IPAM CRDs must be updated to set v1beta2 as the storage version.
+		if opts.DisableCAPIMigration {
+			for crdName := range ipamCRDNames {
+				existing := &apiextensionsv1.CustomResourceDefinition{}
+				err := client.Get(ctx, crclient.ObjectKey{Name: crdName}, existing)
+				if err == nil {
+					existingIPAMCRDs.Insert(crdName)
+					fmt.Printf("Skipping existing IPAM CRD %s\n", crdName)
+				} else if !apierrors.IsNotFound(err) {
+					return nil, fmt.Errorf("failed to check if CRD %s exists: %w", crdName, err)
+				}
 			}
 		}
 	}
 
+	capiStorageVersion := capiStorageVersionForOpts(opts)
+	capiOverrides := crdassets.CAPICRDOverridesWithStorageVersion(capiStorageVersion)
+
 	var crds []crclient.Object
 	crds = append(
 		crds, crdassets.CustomResourceDefinitions(
+			capiStorageVersion,
 			crdIncludeFilter(opts, existingIPAMCRDs),
 			func(crd *apiextensionsv1.CustomResourceDefinition) {
 				// Check if this CRD needs a conversion webhook
@@ -1043,7 +1059,7 @@ func setupCRDs(ctx context.Context, client crclient.Client, opts Options, operat
 
 					// CAPI conversion is required during v1beta1 -> v1beta2 transition period
 				} else if !opts.DisableCAPIConversionWebhook {
-					if override, ok := crdassets.CAPICRDOverrides[crd.Name]; ok && override.NeedsConversion {
+					if override, ok := capiOverrides[crd.Name]; ok && override.NeedsConversion {
 						needsConversion = true
 						conversionReviewVersions = []string{"v1beta1", "v1beta2"}
 					}
@@ -1172,7 +1188,8 @@ func ensureUnmanagedCRDs(ctx context.Context, out io.Writer, c crclient.Client, 
 			UnmanagedCustomResourceDefinitions: capiCRDNames.SortedList(),
 		},
 	}
-	if err := c.Patch(ctx, clusterAPI, crclient.RawPatch(types.ApplyPatchType, patchData),
+	if err := c.Patch(
+		ctx, clusterAPI, crclient.RawPatch(types.ApplyPatchType, patchData),
 		crclient.ForceOwnership, crclient.FieldOwner("hypershift"),
 	); err != nil {
 		return 0, fmt.Errorf("failed to apply ClusterAPI config: %w", err)
@@ -1229,7 +1246,8 @@ func dryRunValidateCRDs(ctx context.Context, out io.Writer, crds []crclient.Obje
 		// Use a deep copy so the dry-run response (which includes managedFields)
 		// does not mutate the original CRD objects passed to apply().
 		crdCopy := crd.DeepCopyObject().(crclient.Object)
-		if err := client.Patch(ctx, crdCopy, crclient.RawPatch(types.ApplyPatchType, objectBytes.Bytes()),
+		if err := client.Patch(
+			ctx, crdCopy, crclient.RawPatch(types.ApplyPatchType, objectBytes.Bytes()),
 			crclient.ForceOwnership, crclient.FieldOwner("hypershift"), crclient.DryRunAll,
 		); err != nil {
 			errs = append(errs, fmt.Errorf("dry-run validation failed for CRD %s: %w", crd.GetName(), err))
@@ -1396,6 +1414,7 @@ func setupOperatorResources(opts Options, userCABundleCM *corev1.ConfigMap, trus
 		ScaleFromZeroSecret:                     scaleFromZeroSecret,
 		ScaleFromZeroSecretKey:                  opts.ScaleFromZeroCredentialsSecretKey,
 		ScaleFromZeroProvider:                   opts.ScaleFromZeroProvider,
+		CAPIStorageVersion:                      capiStorageVersionForOpts(opts),
 		HCPEgressBlockCIDRs:                     opts.HCPEgressBlockCIDRs,
 	}.Build()
 	operatorService := assets.HyperShiftOperatorService{
@@ -1438,7 +1457,8 @@ func setupExternalDNS(ctx context.Context, opts Options, operatorNamespace *core
 	externalDNSClusterRole := assets.ExternalDNSClusterRole{}.Build()
 	if opts.ExternalDNSProvider == "google" {
 		// GCP-386: Allow external-dns to read/update DNSEndpoint resources for ingress zone delegation
-		externalDNSClusterRole.Rules = append(externalDNSClusterRole.Rules,
+		externalDNSClusterRole.Rules = append(
+			externalDNSClusterRole.Rules,
 			rbacv1.PolicyRule{
 				APIGroups: []string{"externaldns.k8s.io"},
 				Resources: []string{"dnsendpoints"},

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/sharedingress"
 	hyperapi "github.com/openshift/hypershift/support/api"
+	capicrdmigrator "github.com/openshift/hypershift/support/capi-crdmigrator"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
@@ -446,7 +447,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.EnableValidatingWebhook, "enable-validating-webhook", opts.EnableValidatingWebhook, "Enable webhook for validating hypershift API types")
 	cmd.PersistentFlags().BoolVar(&opts.EnableConversionWebhook, "enable-conversion-webhook", opts.EnableConversionWebhook, "Enable webhook for converting hypershift API types")
 	cmd.PersistentFlags().BoolVar(&opts.DisableCAPIConversionWebhook, "disable-capi-conversion-webhook", opts.DisableCAPIConversionWebhook, "Disable conversion webhook for CAPI CRDs during v1beta1/v1beta2 transition")
-	cmd.PersistentFlags().BoolVar(&opts.DisableCAPIMigration, "disable-capi-migration", opts.DisableCAPIMigration, "Placeholder flag for upcoming feature: Disable automatic CAPI CRD storage version migration from v1beta1 to v1beta2")
+	cmd.PersistentFlags().BoolVar(&opts.DisableCAPIMigration, "disable-capi-migration", opts.DisableCAPIMigration, "Disable automatic CAPI CRD storage version migration from v1beta1 to v1beta2")
 	cmd.PersistentFlags().BoolVar(&opts.ExcludeEtcdManifests, "exclude-etcd", opts.ExcludeEtcdManifests, "Leave out etcd manifests")
 	cmd.PersistentFlags().Var(&opts.PlatformMonitoring, "platform-monitoring", "Select an option for enabling platform cluster monitoring. Valid values are: None, OperatorOnly, All")
 	cmd.PersistentFlags().BoolVar(&opts.EnableCIDebugOutput, "enable-ci-debug-output", opts.EnableCIDebugOutput, "If extra CI debug output should be enabled")
@@ -1010,24 +1011,39 @@ func crdIncludeFilter(opts Options, existingIPAMCRDs set.Set[string]) func(strin
 	}
 }
 
+func capiStorageVersionForOpts(opts Options) string {
+	if opts.DisableCAPIMigration {
+		return capicrdmigrator.CurrentStorageVersion
+	}
+	return capicrdmigrator.TargetStorageVersion
+}
+
 func setupCRDs(ctx context.Context, client crclient.Client, opts Options, operatorNamespace *corev1.Namespace, operatorService *corev1.Service) ([]crclient.Object, error) {
 	existingIPAMCRDs := set.New[string]()
 	if client != nil {
-		for crdName := range ipamCRDNames {
-			existing := &apiextensionsv1.CustomResourceDefinition{}
-			err := client.Get(ctx, crclient.ObjectKey{Name: crdName}, existing)
-			if err == nil {
-				existingIPAMCRDs.Insert(crdName)
-				fmt.Printf("Skipping existing IPAM CRD %s\n", crdName)
-			} else if !apierrors.IsNotFound(err) {
-				return nil, fmt.Errorf("failed to check if CRD %s exists: %w", crdName, err)
+		// Skip IPAM CRDs only when migration is disabled.
+		// During migration, IPAM CRDs must be updated to set v1beta2 as the storage version.
+		if opts.DisableCAPIMigration {
+			for crdName := range ipamCRDNames {
+				existing := &apiextensionsv1.CustomResourceDefinition{}
+				err := client.Get(ctx, crclient.ObjectKey{Name: crdName}, existing)
+				if err == nil {
+					existingIPAMCRDs.Insert(crdName)
+					fmt.Printf("Skipping existing IPAM CRD %s\n", crdName)
+				} else if !apierrors.IsNotFound(err) {
+					return nil, fmt.Errorf("failed to check if CRD %s exists: %w", crdName, err)
+				}
 			}
 		}
 	}
 
+	capiStorageVersion := capiStorageVersionForOpts(opts)
+	capiOverrides := crdassets.CAPICRDOverridesWithStorageVersion(capiStorageVersion)
+
 	var crds []crclient.Object
 	crds = append(
 		crds, crdassets.CustomResourceDefinitions(
+			capiStorageVersion,
 			crdIncludeFilter(opts, existingIPAMCRDs),
 			func(crd *apiextensionsv1.CustomResourceDefinition) {
 				// Check if this CRD needs a conversion webhook
@@ -1041,7 +1057,7 @@ func setupCRDs(ctx context.Context, client crclient.Client, opts Options, operat
 
 					// CAPI conversion is required during v1beta1 -> v1beta2 transition period
 				} else if !opts.DisableCAPIConversionWebhook {
-					if override, ok := crdassets.CAPICRDOverrides[crd.Name]; ok && override.NeedsConversion {
+					if override, ok := capiOverrides[crd.Name]; ok && override.NeedsConversion {
 						needsConversion = true
 						conversionReviewVersions = []string{"v1beta1", "v1beta2"}
 					}
@@ -1170,7 +1186,8 @@ func ensureUnmanagedCRDs(ctx context.Context, out io.Writer, c crclient.Client, 
 			UnmanagedCustomResourceDefinitions: capiCRDNames.SortedList(),
 		},
 	}
-	if err := c.Patch(ctx, clusterAPI, crclient.RawPatch(types.ApplyPatchType, patchData),
+	if err := c.Patch(
+		ctx, clusterAPI, crclient.RawPatch(types.ApplyPatchType, patchData),
 		crclient.ForceOwnership, crclient.FieldOwner("hypershift"),
 	); err != nil {
 		return 0, fmt.Errorf("failed to apply ClusterAPI config: %w", err)
@@ -1227,7 +1244,8 @@ func dryRunValidateCRDs(ctx context.Context, out io.Writer, crds []crclient.Obje
 		// Use a deep copy so the dry-run response (which includes managedFields)
 		// does not mutate the original CRD objects passed to apply().
 		crdCopy := crd.DeepCopyObject().(crclient.Object)
-		if err := client.Patch(ctx, crdCopy, crclient.RawPatch(types.ApplyPatchType, objectBytes.Bytes()),
+		if err := client.Patch(
+			ctx, crdCopy, crclient.RawPatch(types.ApplyPatchType, objectBytes.Bytes()),
 			crclient.ForceOwnership, crclient.FieldOwner("hypershift"), crclient.DryRunAll,
 		); err != nil {
 			errs = append(errs, fmt.Errorf("dry-run validation failed for CRD %s: %w", crd.GetName(), err))
@@ -1393,6 +1411,7 @@ func setupOperatorResources(opts Options, userCABundleCM *corev1.ConfigMap, trus
 		ScaleFromZeroSecret:                     scaleFromZeroSecret,
 		ScaleFromZeroSecretKey:                  opts.ScaleFromZeroCredentialsSecretKey,
 		ScaleFromZeroProvider:                   opts.ScaleFromZeroProvider,
+		CAPIStorageVersion:                      capiStorageVersionForOpts(opts),
 		HCPEgressBlockCIDRs:                     opts.HCPEgressBlockCIDRs,
 	}.Build()
 	operatorService := assets.HyperShiftOperatorService{
@@ -1435,7 +1454,8 @@ func setupExternalDNS(ctx context.Context, opts Options, operatorNamespace *core
 	externalDNSClusterRole := assets.ExternalDNSClusterRole{}.Build()
 	if opts.ExternalDNSProvider == "google" {
 		// GCP-386: Allow external-dns to read/update DNSEndpoint resources for ingress zone delegation
-		externalDNSClusterRole.Rules = append(externalDNSClusterRole.Rules,
+		externalDNSClusterRole.Rules = append(
+			externalDNSClusterRole.Rules,
 			rbacv1.PolicyRule{
 				APIGroups: []string{"externaldns.k8s.io"},
 				Resources: []string{"dnsendpoints"},

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -30,6 +30,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/set"
 
@@ -38,6 +39,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOptions_Validate(t *testing.T) {
@@ -2416,7 +2419,7 @@ func TestHyperShiftOperatorManifests_WebhookFlags(t *testing.T) {
 				if !ok {
 					continue
 				}
-				override, isCAPICRD := crdassets.CAPICRDOverrides[crd.Name]
+				override, isCAPICRD := crdassets.CAPICRDOverrides()[crd.Name]
 				if !isCAPICRD || !override.NeedsConversion {
 					continue
 				}
@@ -2643,6 +2646,78 @@ func TestComplete(t *testing.T) {
 				if test.validate != nil {
 					test.validate(g, opts)
 				}
+			}
+		})
+	}
+}
+
+func TestSetupCRDs_CAPIStorageVersionMigrationGuard(t *testing.T) {
+	makeCAPICRD := func(name string, storedVersions ...string) *apiextensionsv1.CustomResourceDefinition {
+		return &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+					{Name: "v1beta1"},
+					{Name: "v1beta2"},
+				},
+			},
+			Status: apiextensionsv1.CustomResourceDefinitionStatus{
+				StoredVersions: storedVersions,
+			},
+		}
+	}
+	tests := []struct {
+		name        string
+		opts        Options
+		existing    []crclient.Object
+		expectError string
+	}{
+		{
+			name: "When installing with default options and no existing CRDs, it should set v1beta2 as storage version",
+			opts: Options{},
+		},
+		{
+			name: "When installing with default options and existing v1beta1 CRDs, it should set v1beta2 as storage version",
+			opts: Options{},
+			existing: []crclient.Object{
+				makeCAPICRD("clusters.cluster.x-k8s.io", "v1beta1"),
+			},
+		},
+		{
+			name: "When installing with default options and already-migrated CRDs, it should succeed without error",
+			opts: Options{},
+			existing: []crclient.Object{
+				makeCAPICRD("clusters.cluster.x-k8s.io", "v1beta2"),
+			},
+		},
+		{
+			name: "When installing with disable-capi-migration flag, it should not override storage version",
+			opts: Options{DisableCAPIMigration: true},
+		},
+		{
+			name: "When installing with disable-capi-migration on already-migrated cluster, it should succeed as no-op",
+			opts: Options{DisableCAPIMigration: true},
+			existing: []crclient.Object{
+				makeCAPICRD("clusters.cluster.x-k8s.io", "v1beta2"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, apiextensionsv1.AddToScheme(scheme))
+			clientBuilder := fake.NewClientBuilder().WithScheme(scheme)
+			if tc.existing != nil {
+				clientBuilder = clientBuilder.WithObjects(tc.existing...)
+			}
+			fakeClient := clientBuilder.Build()
+			_, err := setupCRDs(context.Background(), fakeClient, tc.opts, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "hypershift"}}, &corev1.Service{})
+			if tc.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectError)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/codecov.yml
+++ b/codecov.yml
@@ -61,6 +61,8 @@ ignore:
   - "pkg/etcdcli/interfaces.go"
   - "hypershift-operator/controllers/nodepool/instancetype/instancetype.go"
   - "api/ibmcapi/types.go"
+  # CRD migrator adapted from upstream CAPI — tested via e2e (not unit tests)
+  - "support/capi-crdmigrator/crd_migrator.go"
 
 comment:
   layout: "condensed_header, diff, files, flags, components"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
@@ -26,6 +26,13 @@ func (capi *CAPIManagerOptions) adaptDeployment(cpContext component.WorkloadCont
 			c.Args = append(c.Args, "--feature-gates=MachineSetPreflightChecks=false")
 		}
 
+		if version.GE(config.Version420) {
+			c.Args = append(c.Args,
+				"--skip-crd-migration-phases=StorageVersionMigration",
+				"--skip-crd-migration-phases=CleanupManagedFields",
+			)
+		}
+
 		if len(capi.imageOverride) > 0 {
 			c.Image = capi.imageOverride
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
@@ -29,6 +29,13 @@ func (capi *CAPIManagerOptions) adaptDeployment(cpContext component.WorkloadCont
 			c.Args = append(c.Args, config.TLSArgs(cpContext.HCP.Spec.Configuration.GetTLSSecurityProfile())...)
 		}
 
+		if version.GE(config.Version420) {
+			c.Args = append(c.Args,
+				"--skip-crd-migration-phases=StorageVersionMigration",
+				"--skip-crd-migration-phases=CleanupManagedFields",
+			)
+		}
+
 		if len(capi.imageOverride) > 0 {
 			c.Image = capi.imageOverride
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment_test.go
@@ -29,29 +29,46 @@ func TestAdaptDeployment(t *testing.T) {
 		expectedAnnotKey string
 	}{
 		{
-			name:          "When version is 4.19.0, it should add MachineSetPreflightChecks feature gate",
-			version:       "4.19.0",
-			expectedArgs:  []string{"--feature-gates=MachineSetPreflightChecks=false"},
+			name:    "When version is 4.18.0, it should not add feature gate or skip CRD migration flags",
+			version: "4.18.0",
+			unexpectedArgs: []string{
+				"--feature-gates=MachineSetPreflightChecks=false",
+				"--skip-crd-migration-phases=StorageVersionMigration",
+				"--skip-crd-migration-phases=CleanupManagedFields",
+			},
 			expectedImage: "cluster-capi-controllers",
 		},
 		{
-			name:          "When version is 4.20.0, it should add MachineSetPreflightChecks feature gate",
-			version:       "4.20.0",
-			expectedArgs:  []string{"--feature-gates=MachineSetPreflightChecks=false"},
+			name:    "When version is 4.19.0, it should add feature gate but not skip CRD migration phases",
+			version: "4.19.0",
+			expectedArgs: []string{
+				"--feature-gates=MachineSetPreflightChecks=false",
+			},
+			unexpectedArgs: []string{
+				"--skip-crd-migration-phases=StorageVersionMigration",
+				"--skip-crd-migration-phases=CleanupManagedFields",
+			},
 			expectedImage: "cluster-capi-controllers",
 		},
 		{
-			name:           "When version is 4.18.0, it should not add MachineSetPreflightChecks feature gate",
-			version:        "4.18.0",
-			expectedArgs:   []string{},
-			unexpectedArgs: []string{"--feature-gates=MachineSetPreflightChecks=false"},
-			expectedImage:  "cluster-capi-controllers",
+			name:    "When version is 4.20.0, it should add feature gate and skip CRD migration flags",
+			version: "4.20.0",
+			expectedArgs: []string{
+				"--feature-gates=MachineSetPreflightChecks=false",
+				"--skip-crd-migration-phases=StorageVersionMigration",
+				"--skip-crd-migration-phases=CleanupManagedFields",
+			},
+			expectedImage: "cluster-capi-controllers",
 		},
 		{
 			name:          "When imageOverride is set, it should use the override image",
-			version:       "4.19.0",
+			version:       "4.20.0",
 			imageOverride: "quay.io/custom/capi:v1.0.0",
-			expectedArgs:  []string{"--feature-gates=MachineSetPreflightChecks=false"},
+			expectedArgs: []string{
+				"--feature-gates=MachineSetPreflightChecks=false",
+				"--skip-crd-migration-phases=StorageVersionMigration",
+				"--skip-crd-migration-phases=CleanupManagedFields",
+			},
 			expectedImage: "quay.io/custom/capi:v1.0.0",
 		},
 		{
@@ -60,7 +77,9 @@ func TestAdaptDeployment(t *testing.T) {
 			hcpAnnotations: map[string]string{
 				k8sutil.HostedClusterAnnotation: "test-namespace/test-cluster",
 			},
-			expectedArgs:     []string{"--feature-gates=MachineSetPreflightChecks=false"},
+			expectedArgs: []string{
+				"--feature-gates=MachineSetPreflightChecks=false",
+			},
 			expectedImage:    "cluster-capi-controllers",
 			expectedAnnotKey: k8sutil.HostedClusterAnnotation,
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment_test.go
@@ -32,29 +32,46 @@ func TestAdaptDeployment(t *testing.T) {
 		expectedAnnotKey string
 	}{
 		{
-			name:          "When version is 4.19.0, it should add MachineSetPreflightChecks feature gate",
-			version:       "4.19.0",
-			expectedArgs:  []string{"--feature-gates=MachineSetPreflightChecks=false"},
+			name:    "When version is 4.18.0, it should not add feature gate or skip CRD migration flags",
+			version: "4.18.0",
+			unexpectedArgs: []string{
+				"--feature-gates=MachineSetPreflightChecks=false",
+				"--skip-crd-migration-phases=StorageVersionMigration",
+				"--skip-crd-migration-phases=CleanupManagedFields",
+			},
 			expectedImage: "cluster-capi-controllers",
 		},
 		{
-			name:          "When version is 4.20.0, it should add MachineSetPreflightChecks feature gate",
-			version:       "4.20.0",
-			expectedArgs:  []string{"--feature-gates=MachineSetPreflightChecks=false"},
+			name:    "When version is 4.19.0, it should add feature gate but not skip CRD migration phases",
+			version: "4.19.0",
+			expectedArgs: []string{
+				"--feature-gates=MachineSetPreflightChecks=false",
+			},
+			unexpectedArgs: []string{
+				"--skip-crd-migration-phases=StorageVersionMigration",
+				"--skip-crd-migration-phases=CleanupManagedFields",
+			},
 			expectedImage: "cluster-capi-controllers",
 		},
 		{
-			name:           "When version is 4.18.0, it should not add MachineSetPreflightChecks feature gate",
-			version:        "4.18.0",
-			expectedArgs:   []string{},
-			unexpectedArgs: []string{"--feature-gates=MachineSetPreflightChecks=false"},
-			expectedImage:  "cluster-capi-controllers",
+			name:    "When version is 4.20.0, it should add feature gate and skip CRD migration flags",
+			version: "4.20.0",
+			expectedArgs: []string{
+				"--feature-gates=MachineSetPreflightChecks=false",
+				"--skip-crd-migration-phases=StorageVersionMigration",
+				"--skip-crd-migration-phases=CleanupManagedFields",
+			},
+			expectedImage: "cluster-capi-controllers",
 		},
 		{
 			name:          "When imageOverride is set, it should use the override image",
-			version:       "4.19.0",
+			version:       "4.20.0",
 			imageOverride: "quay.io/custom/capi:v1.0.0",
-			expectedArgs:  []string{"--feature-gates=MachineSetPreflightChecks=false"},
+			expectedArgs: []string{
+				"--feature-gates=MachineSetPreflightChecks=false",
+				"--skip-crd-migration-phases=StorageVersionMigration",
+				"--skip-crd-migration-phases=CleanupManagedFields",
+			},
 			expectedImage: "quay.io/custom/capi:v1.0.0",
 		},
 		{
@@ -63,7 +80,9 @@ func TestAdaptDeployment(t *testing.T) {
 			hcpAnnotations: map[string]string{
 				k8sutil.HostedClusterAnnotation: "test-namespace/test-cluster",
 			},
-			expectedArgs:     []string{"--feature-gates=MachineSetPreflightChecks=false"},
+			expectedArgs: []string{
+				"--feature-gates=MachineSetPreflightChecks=false",
+			},
 			expectedImage:    "cluster-capi-controllers",
 			expectedAnnotKey: k8sutil.HostedClusterAnnotation,
 		},

--- a/docs/content/how-to/capi-storage-migration.md
+++ b/docs/content/how-to/capi-storage-migration.md
@@ -1,0 +1,157 @@
+# CAPI CRD Storage Version Migration
+
+## Overview
+
+HyperShift uses Cluster API (CAPI) Custom Resource Definitions (CRDs) to manage hosted cluster infrastructure. These CRDs are transitioning their storage version from `v1beta1` to `v1beta2`. The storage version determines how Kubernetes persists resources in etcd.
+
+Migrating the storage version ensures all existing CAPI resources are re-stored using the new `v1beta2` schema. This is required before the `v1beta1` API version can be removed in a future CAPI release.
+
+The migration happens automatically on `hypershift install` — no special flags are needed. To opt out, use the `--disable-capi-migration` flag.
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--disable-capi-migration` | `false` | Disables automatic CAPI CRD storage version migration. When set, CRDs are installed without overriding their storage version and the migrator controller is not started. |
+
+### How it works
+
+By default, `hypershift install`:
+
+1. Applies the CAPI CRDs with `v1beta2` as the storage version.
+2. The HyperShift Operator starts a CRD migrator controller that performs a no-op server-side apply on every existing CAPI custom resource, forcing the API server to re-store each object in `v1beta2`.
+3. Once all resources are re-stored, the migrator updates each CRD's `status.storedVersions` to `["v1beta2"]`, removing `v1beta1`.
+4. The migrator also disables CAPI's built-in migrator in the CAPI manager deployment to avoid conflicts and keep migration control centralised in the hypershift operator.
+
+## Scenarios
+
+### 1. Standard install (migration enabled by default)
+
+On both fresh clusters and existing clusters with `v1beta1` resources, migration happens automatically:
+
+```bash
+hypershift install \
+  [... other flags ...]
+```
+
+On a fresh cluster, the CRDs are created directly with `v1beta2` as the storage version. The migrator controller starts but has no work to do since `storedVersions` is already `["v1beta2"]`.
+
+On an existing cluster, the migrator re-stores all CAPI resources at `v1beta2`.
+
+### 2. Verifying migration completed
+
+Wait for the CRD migrator controller to finish. Check that all CAPI CRDs have `storedVersions: ["v1beta2"]`:
+
+```bash
+for crd in clusters.cluster.x-k8s.io clusterclasses.cluster.x-k8s.io machinedeployments.cluster.x-k8s.io machines.cluster.x-k8s.io machinesets.cluster.x-k8s.io machinepools.cluster.x-k8s.io machinehealthchecks.cluster.x-k8s.io machinedrainrules.cluster.x-k8s.io ipaddressclaims.ipam.cluster.x-k8s.io ipaddresses.ipam.cluster.x-k8s.io clusterresourcesets.addons.cluster.x-k8s.io clusterresourcesetbindings.addons.cluster.x-k8s.io; do
+  echo "$crd: $(kubectl get crd $crd -o jsonpath='{.status.storedVersions}')"
+done
+```
+
+Expected output after migration:
+
+```text
+clusters.cluster.x-k8s.io: ["v1beta2"]
+clusterclasses.cluster.x-k8s.io: ["v1beta2"]
+...
+```
+
+You can also verify the migration annotation is set on each CRD:
+
+```bash
+kubectl get crd clusters.cluster.x-k8s.io -o jsonpath='{.metadata.annotations.crd-migration\.cluster\.x-k8s\.io/observed-generation}'
+```
+
+Finally, the migrator will keep an up to date status at all times on a ConfigMap in the operator namespace. To check the status:
+```bash
+kubectl get cm -n hypershift capi-migration-status -o jsonpath='{.data.status}' | jq .
+```
+
+By running the above command on a completed migration you will get an output such as:
+```json
+{
+  "totalCRDs": 12,
+  "migratedCRDs": 12,
+  "conditions": [
+    {
+      "type": "MigrationComplete",
+      "status": "True",
+      "lastTransitionTime": "2026-07-20T19:05:37Z",
+      "reason": "MigrationComplete",
+      "message": "All 12 CRDs have been migrated"
+    },
+    {
+      "type": "Progressing",
+      "status": "False",
+      "lastTransitionTime": "2026-07-20T19:05:37Z",
+      "reason": "MigrationComplete",
+      "message": "Migration has completed"
+    },
+    {
+      "type": "Degraded",
+      "status": "False",
+      "lastTransitionTime": "2026-07-20T19:05:37Z",
+      "reason": "NoErrors",
+      "message": "No migration errors"
+    }
+  ]
+}
+```
+
+
+### 3. Re-install on an already migrated cluster
+
+If the cluster has already completed migration (`storedVersions: ["v1beta2"]`), running `hypershift install` again is safe. The migrator controller starts but skips all CRDs since their `storedVersions` already equals `["v1beta2"]`.
+
+### 4. Disabling migration
+
+To install without triggering the storage version migration, use the `--disable-capi-migration` flag:
+
+```bash
+hypershift install \
+  --disable-capi-migration \
+  [... other flags ...]
+```
+
+When this flag is set, CRDs are installed without overriding their storage version and the CRD migrator controller is not started. The behavior depends on the cluster state:
+
+- **Existing cluster with `v1beta1` CRDs**: The migrator does not start and CRDs remain untouched at `v1beta1`. Everything stays as-is.
+- **Already-migrated cluster (migrator was running)**: The migrator is not started on the new operator pods, effectively stopping it. CRDs remain at `v1beta2` — no downgrade occurs.
+- **Fresh install (empty cluster)**: CRDs are installed with their default embedded storage version (`v1beta1`). No migration is performed.
+
+## E2E Testing
+
+The `TestCAPIStorageVersionMigration` e2e test validates the full migration flow on a live cluster. It creates a hosted cluster, verifies pre-migration state, reinstalls the HyperShift Operator (which triggers migration by default), waits for migration to complete, and checks cluster health.
+
+### Running the test
+
+Build the e2e binary:
+
+```bash
+make e2e
+```
+
+Run the migration test:
+
+```bash
+./bin/test-e2e \
+  -e2e.platform AWS \
+  -e2e.base-domain $BASE_DOMAIN \
+  -e2e.pull-secret-file $PULL_SECRET \
+  -e2e.aws-credentials-file $AWS_CREDS \
+  -e2e.aws-private-credentials-file $AWS_CREDS \
+  -e2e.external-dns-credentials $AWS_CREDS \
+  -e2e.aws-region $REGION \
+  -e2e.availability-zones "${REGION}a,${REGION}b,${REGION}c" \
+  -e2e.aws-oidc-s3-bucket-name $BUCKET_NAME \
+  -e2e.aws-oidc-s3-credentials $AWS_CREDS \
+  -e2e.hypershift-operator-latest-image $HO_IMAGE \
+  -capi-migration.run-tests \
+  -test.run TestCAPIStorageVersionMigration \
+  -test.timeout 0 \
+  -test.v
+```
+
+The `-e2e.hypershift-operator-latest-image` flag must point to an image that includes the CRD migrator controller code. In CI, this is the image built from the PR branch. For local testing, build and push your own image.
+
+The `-capi-migration.run-tests` flag enables the migration test. Without it, the test is skipped. This allows the test to be run as a separate CI job.

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -13829,6 +13829,169 @@ This section of the HyperShift documentation contains pages related to troublesh
 
 ---
 
+## Source: docs/content/how-to/capi-storage-migration.md
+
+# CAPI CRD Storage Version Migration
+
+## Overview
+
+HyperShift uses Cluster API (CAPI) Custom Resource Definitions (CRDs) to manage hosted cluster infrastructure. These CRDs are transitioning their storage version from `v1beta1` to `v1beta2`. The storage version determines how Kubernetes persists resources in etcd.
+
+Migrating the storage version ensures all existing CAPI resources are re-stored using the new `v1beta2` schema. This is required before the `v1beta1` API version can be removed in a future CAPI release.
+
+The migration happens automatically on `hypershift install` — no special flags are needed. To opt out, use the `--disable-capi-migration` flag.
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--disable-capi-migration` | `false` | Disables automatic CAPI CRD storage version migration. When set, CRDs are installed without overriding their storage version and the migrator controller is not started. |
+
+### How it works
+
+By default, `hypershift install`:
+
+1. Applies the CAPI CRDs with `v1beta2` as the storage version.
+2. The HyperShift Operator starts a CRD migrator controller that performs a no-op server-side apply on every existing CAPI custom resource, forcing the API server to re-store each object in `v1beta2`.
+3. Once all resources are re-stored, the migrator updates each CRD's `status.storedVersions` to `["v1beta2"]`, removing `v1beta1`.
+4. The migrator also disables CAPI's built-in migrator in the CAPI manager deployment to avoid conflicts and keep migration control centralised in the hypershift operator.
+
+## Scenarios
+
+### 1. Standard install (migration enabled by default)
+
+On both fresh clusters and existing clusters with `v1beta1` resources, migration happens automatically:
+
+```bash
+hypershift install \
+  [... other flags ...]
+```
+
+On a fresh cluster, the CRDs are created directly with `v1beta2` as the storage version. The migrator controller starts but has no work to do since `storedVersions` is already `["v1beta2"]`.
+
+On an existing cluster, the migrator re-stores all CAPI resources at `v1beta2`.
+
+### 2. Verifying migration completed
+
+Wait for the CRD migrator controller to finish. Check that all CAPI CRDs have `storedVersions: ["v1beta2"]`:
+
+```bash
+for crd in clusters.cluster.x-k8s.io clusterclasses.cluster.x-k8s.io machinedeployments.cluster.x-k8s.io machines.cluster.x-k8s.io machinesets.cluster.x-k8s.io machinepools.cluster.x-k8s.io machinehealthchecks.cluster.x-k8s.io machinedrainrules.cluster.x-k8s.io ipaddressclaims.ipam.cluster.x-k8s.io ipaddresses.ipam.cluster.x-k8s.io clusterresourcesets.addons.cluster.x-k8s.io clusterresourcesetbindings.addons.cluster.x-k8s.io; do
+  echo "$crd: $(kubectl get crd $crd -o jsonpath='{.status.storedVersions}')"
+done
+```
+
+Expected output after migration:
+
+```text
+clusters.cluster.x-k8s.io: ["v1beta2"]
+clusterclasses.cluster.x-k8s.io: ["v1beta2"]
+...
+```
+
+You can also verify the migration annotation is set on each CRD:
+
+```bash
+kubectl get crd clusters.cluster.x-k8s.io -o jsonpath='{.metadata.annotations.crd-migration\.cluster\.x-k8s\.io/observed-generation}'
+```
+
+Finally, the migrator will keep an up to date status at all times on a ConfigMap in the operator namespace. To check the status:
+```bash
+kubectl get cm -n hypershift capi-migration-status -o jsonpath='{.data.status}' | jq .
+```
+
+By running the above command on a completed migration you will get an output such as:
+```json
+{
+  "totalCRDs": 12,
+  "migratedCRDs": 12,
+  "conditions": [
+    {
+      "type": "MigrationComplete",
+      "status": "True",
+      "lastTransitionTime": "2026-07-20T19:05:37Z",
+      "reason": "MigrationComplete",
+      "message": "All 12 CRDs have been migrated"
+    },
+    {
+      "type": "Progressing",
+      "status": "False",
+      "lastTransitionTime": "2026-07-20T19:05:37Z",
+      "reason": "MigrationComplete",
+      "message": "Migration has completed"
+    },
+    {
+      "type": "Degraded",
+      "status": "False",
+      "lastTransitionTime": "2026-07-20T19:05:37Z",
+      "reason": "NoErrors",
+      "message": "No migration errors"
+    }
+  ]
+}
+```
+
+
+### 3. Re-install on an already migrated cluster
+
+If the cluster has already completed migration (`storedVersions: ["v1beta2"]`), running `hypershift install` again is safe. The migrator controller starts but skips all CRDs since their `storedVersions` already equals `["v1beta2"]`.
+
+### 4. Disabling migration
+
+To install without triggering the storage version migration, use the `--disable-capi-migration` flag:
+
+```bash
+hypershift install \
+  --disable-capi-migration \
+  [... other flags ...]
+```
+
+When this flag is set, CRDs are installed without overriding their storage version and the CRD migrator controller is not started. The behavior depends on the cluster state:
+
+- **Existing cluster with `v1beta1` CRDs**: The migrator does not start and CRDs remain untouched at `v1beta1`. Everything stays as-is.
+- **Already-migrated cluster (migrator was running)**: The migrator is not started on the new operator pods, effectively stopping it. CRDs remain at `v1beta2` — no downgrade occurs.
+- **Fresh install (empty cluster)**: CRDs are installed with their default embedded storage version (`v1beta1`). No migration is performed.
+
+## E2E Testing
+
+The `TestCAPIStorageVersionMigration` e2e test validates the full migration flow on a live cluster. It creates a hosted cluster, verifies pre-migration state, reinstalls the HyperShift Operator (which triggers migration by default), waits for migration to complete, and checks cluster health.
+
+### Running the test
+
+Build the e2e binary:
+
+```bash
+make e2e
+```
+
+Run the migration test:
+
+```bash
+./bin/test-e2e \
+  -e2e.platform AWS \
+  -e2e.base-domain $BASE_DOMAIN \
+  -e2e.pull-secret-file $PULL_SECRET \
+  -e2e.aws-credentials-file $AWS_CREDS \
+  -e2e.aws-private-credentials-file $AWS_CREDS \
+  -e2e.external-dns-credentials $AWS_CREDS \
+  -e2e.aws-region $REGION \
+  -e2e.availability-zones "${REGION}a,${REGION}b,${REGION}c" \
+  -e2e.aws-oidc-s3-bucket-name $BUCKET_NAME \
+  -e2e.aws-oidc-s3-credentials $AWS_CREDS \
+  -e2e.hypershift-operator-latest-image $HO_IMAGE \
+  -capi-migration.run-tests \
+  -test.run TestCAPIStorageVersionMigration \
+  -test.timeout 0 \
+  -test.v
+```
+
+The `-e2e.hypershift-operator-latest-image` flag must point to an image that includes the CRD migrator controller code. In CI, this is the image built from the PR branch. For local testing, build and push your own image.
+
+The `-capi-migration.run-tests` flag enables the migration test. Without it, the test is skipped. This allows the test to be run as a separate CI job.
+
+
+---
+
 ## Source: docs/content/how-to/ci/ai-assisted-ci-jobs.md
 
 # AI-Assisted CI Jobs

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -13990,6 +13990,169 @@ This section of the HyperShift documentation contains pages related to troublesh
 
 ---
 
+## Source: docs/content/how-to/capi-storage-migration.md
+
+# CAPI CRD Storage Version Migration
+
+## Overview
+
+HyperShift uses Cluster API (CAPI) Custom Resource Definitions (CRDs) to manage hosted cluster infrastructure. These CRDs are transitioning their storage version from `v1beta1` to `v1beta2`. The storage version determines how Kubernetes persists resources in etcd.
+
+Migrating the storage version ensures all existing CAPI resources are re-stored using the new `v1beta2` schema. This is required before the `v1beta1` API version can be removed in a future CAPI release.
+
+The migration happens automatically on `hypershift install` — no special flags are needed. To opt out, use the `--disable-capi-migration` flag.
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--disable-capi-migration` | `false` | Disables automatic CAPI CRD storage version migration. When set, CRDs are installed without overriding their storage version and the migrator controller is not started. |
+
+### How it works
+
+By default, `hypershift install`:
+
+1. Applies the CAPI CRDs with `v1beta2` as the storage version.
+2. The HyperShift Operator starts a CRD migrator controller that performs a no-op server-side apply on every existing CAPI custom resource, forcing the API server to re-store each object in `v1beta2`.
+3. Once all resources are re-stored, the migrator updates each CRD's `status.storedVersions` to `["v1beta2"]`, removing `v1beta1`.
+4. The migrator also disables CAPI's built-in migrator in the CAPI manager deployment to avoid conflicts and keep migration control centralised in the hypershift operator.
+
+## Scenarios
+
+### 1. Standard install (migration enabled by default)
+
+On both fresh clusters and existing clusters with `v1beta1` resources, migration happens automatically:
+
+```bash
+hypershift install \
+  [... other flags ...]
+```
+
+On a fresh cluster, the CRDs are created directly with `v1beta2` as the storage version. The migrator controller starts but has no work to do since `storedVersions` is already `["v1beta2"]`.
+
+On an existing cluster, the migrator re-stores all CAPI resources at `v1beta2`.
+
+### 2. Verifying migration completed
+
+Wait for the CRD migrator controller to finish. Check that all CAPI CRDs have `storedVersions: ["v1beta2"]`:
+
+```bash
+for crd in clusters.cluster.x-k8s.io clusterclasses.cluster.x-k8s.io machinedeployments.cluster.x-k8s.io machines.cluster.x-k8s.io machinesets.cluster.x-k8s.io machinepools.cluster.x-k8s.io machinehealthchecks.cluster.x-k8s.io machinedrainrules.cluster.x-k8s.io ipaddressclaims.ipam.cluster.x-k8s.io ipaddresses.ipam.cluster.x-k8s.io clusterresourcesets.addons.cluster.x-k8s.io clusterresourcesetbindings.addons.cluster.x-k8s.io; do
+  echo "$crd: $(kubectl get crd $crd -o jsonpath='{.status.storedVersions}')"
+done
+```
+
+Expected output after migration:
+
+```text
+clusters.cluster.x-k8s.io: ["v1beta2"]
+clusterclasses.cluster.x-k8s.io: ["v1beta2"]
+...
+```
+
+You can also verify the migration annotation is set on each CRD:
+
+```bash
+kubectl get crd clusters.cluster.x-k8s.io -o jsonpath='{.metadata.annotations.crd-migration\.cluster\.x-k8s\.io/observed-generation}'
+```
+
+Finally, the migrator will keep an up to date status at all times on a ConfigMap in the operator namespace. To check the status:
+```bash
+kubectl get cm -n hypershift capi-migration-status -o jsonpath='{.data.status}' | jq .
+```
+
+By running the above command on a completed migration you will get an output such as:
+```json
+{
+  "totalCRDs": 12,
+  "migratedCRDs": 12,
+  "conditions": [
+    {
+      "type": "MigrationComplete",
+      "status": "True",
+      "lastTransitionTime": "2026-07-20T19:05:37Z",
+      "reason": "MigrationComplete",
+      "message": "All 12 CRDs have been migrated"
+    },
+    {
+      "type": "Progressing",
+      "status": "False",
+      "lastTransitionTime": "2026-07-20T19:05:37Z",
+      "reason": "MigrationComplete",
+      "message": "Migration has completed"
+    },
+    {
+      "type": "Degraded",
+      "status": "False",
+      "lastTransitionTime": "2026-07-20T19:05:37Z",
+      "reason": "NoErrors",
+      "message": "No migration errors"
+    }
+  ]
+}
+```
+
+
+### 3. Re-install on an already migrated cluster
+
+If the cluster has already completed migration (`storedVersions: ["v1beta2"]`), running `hypershift install` again is safe. The migrator controller starts but skips all CRDs since their `storedVersions` already equals `["v1beta2"]`.
+
+### 4. Disabling migration
+
+To install without triggering the storage version migration, use the `--disable-capi-migration` flag:
+
+```bash
+hypershift install \
+  --disable-capi-migration \
+  [... other flags ...]
+```
+
+When this flag is set, CRDs are installed without overriding their storage version and the CRD migrator controller is not started. The behavior depends on the cluster state:
+
+- **Existing cluster with `v1beta1` CRDs**: The migrator does not start and CRDs remain untouched at `v1beta1`. Everything stays as-is.
+- **Already-migrated cluster (migrator was running)**: The migrator is not started on the new operator pods, effectively stopping it. CRDs remain at `v1beta2` — no downgrade occurs.
+- **Fresh install (empty cluster)**: CRDs are installed with their default embedded storage version (`v1beta1`). No migration is performed.
+
+## E2E Testing
+
+The `TestCAPIStorageVersionMigration` e2e test validates the full migration flow on a live cluster. It creates a hosted cluster, verifies pre-migration state, reinstalls the HyperShift Operator (which triggers migration by default), waits for migration to complete, and checks cluster health.
+
+### Running the test
+
+Build the e2e binary:
+
+```bash
+make e2e
+```
+
+Run the migration test:
+
+```bash
+./bin/test-e2e \
+  -e2e.platform AWS \
+  -e2e.base-domain $BASE_DOMAIN \
+  -e2e.pull-secret-file $PULL_SECRET \
+  -e2e.aws-credentials-file $AWS_CREDS \
+  -e2e.aws-private-credentials-file $AWS_CREDS \
+  -e2e.external-dns-credentials $AWS_CREDS \
+  -e2e.aws-region $REGION \
+  -e2e.availability-zones "${REGION}a,${REGION}b,${REGION}c" \
+  -e2e.aws-oidc-s3-bucket-name $BUCKET_NAME \
+  -e2e.aws-oidc-s3-credentials $AWS_CREDS \
+  -e2e.hypershift-operator-latest-image $HO_IMAGE \
+  -capi-migration.run-tests \
+  -test.run TestCAPIStorageVersionMigration \
+  -test.timeout 0 \
+  -test.v
+```
+
+The `-e2e.hypershift-operator-latest-image` flag must point to an image that includes the CRD migrator controller code. In CI, this is the image built from the PR branch. For local testing, build and push your own image.
+
+The `-capi-migration.run-tests` flag enables the migration test. Without it, the test is skipped. This allows the test to be run as a separate CI job.
+
+
+---
+
 ## Source: docs/content/how-to/ci/ai-assisted-ci-jobs.md
 
 # AI-Assisted CI Jobs

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
     - how-to/automated-machine-management/scale-to-zero-dataplane.md
     - 'Spot Instances': how-to/automated-machine-management/spot-instances.md
   - how-to/autoscaling.md
+  - 'CAPI Storage Migration': how-to/capi-storage-migration.md
   - 'CI':
     - 'AI-Assisted CI Jobs': how-to/ci/ai-assisted-ci-jobs.md
     - 'Jira Agent Onboarding': how-to/ci/jira-agent-onboarding.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
     - how-to/automated-machine-management/scale-to-zero-dataplane.md
     - 'Spot Instances': how-to/automated-machine-management/spot-instances.md
   - how-to/autoscaling.md
+  - 'CAPI Storage Migration': how-to/capi-storage-migration.md
   - 'CI':
     - 'AI-Assisted CI Jobs': how-to/ci/ai-assisted-ci-jobs.md
     - 'Jira Agent Onboarding': how-to/ci/jira-agent-onboarding.md

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -58,6 +58,7 @@ import (
 	"github.com/openshift/hypershift/support/awsapi"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/capabilities"
+	capicrdmigrator "github.com/openshift/hypershift/support/capi-crdmigrator"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/gcpapi"
 	"github.com/openshift/hypershift/support/globalconfig"
@@ -91,8 +92,12 @@ import (
 	"k8s.io/utils/ptr"
 	"k8s.io/utils/set"
 
+	capiaddonsv1beta2 "sigs.k8s.io/cluster-api/api/addons/v1beta2"
+	capiv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	ipamv1beta2 "sigs.k8s.io/cluster-api/api/ipam/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -344,7 +349,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		return err
 	}
 
-	if err := setupSupportControllers(mgr, opts, mgmtClusterCaps, operatorImage, createOrUpdate, registryProvider, log); err != nil {
+	if err := setupSupportControllers(ctx, mgr, opts, mgmtClusterCaps, operatorImage, createOrUpdate, registryProvider, log); err != nil {
 		return err
 	}
 
@@ -837,7 +842,7 @@ func resolveAzureCredentials(cloudConfig cloud.Configuration, log logr.Logger) (
 	return creds, nil
 }
 
-func setupSupportControllers(mgr ctrl.Manager, opts *StartOptions, mgmtClusterCaps *capabilities.ManagementClusterCapabilities, operatorImage string, createOrUpdate upsert.CreateOrUpdateProvider, registryProvider globalconfig.CommonRegistryProvider, log logr.Logger) error {
+func setupSupportControllers(ctx context.Context, mgr ctrl.Manager, opts *StartOptions, mgmtClusterCaps *capabilities.ManagementClusterCapabilities, operatorImage string, createOrUpdate upsert.CreateOrUpdateProvider, registryProvider globalconfig.CommonRegistryProvider, log logr.Logger) error {
 	if err := hosupportedversion.New(mgr.GetClient(), createOrUpdate, opts.Namespace).
 		SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create supported version controller: %w", err)
@@ -869,6 +874,42 @@ func setupSupportControllers(mgr ctrl.Manager, opts *StartOptions, mgmtClusterCa
 		if err := etcdBackupReconciler.SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create etcd backup controller: %w", err)
 		}
+	}
+
+	// TODO(bclement): Once all management clusters have completed the CAPI storage migration,
+	// remove the CAPI storage version migration scaffolding:
+	//   - CAPI_STORAGE_VERSION env var check and CRDMigrator setup (this block)
+	//   - support/capi-crdmigrator/ package
+	//   - CAPICRDOverridesWithStorageVersion, CAPICRDOverrides, CAPICRDNames (cmd/install/assets/crds/assets.go) — default to v1beta2
+	//   - --disable-capi-migration flag and capiStorageVersionForOpts() (cmd/install/install.go)
+	//   - CAPI_STORAGE_VERSION env var plumbing (cmd/install/assets/hypershift_operator.go, cmd/install/install.go)
+	//   - --skip-crd-migration-phases args on CAPI manager (control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go)
+	//   - IPAM skip override in setupCRDs() (cmd/install/install.go)
+	if os.Getenv(capicrdmigrator.CAPIStorageVersionEnvVar) == capicrdmigrator.TargetStorageVersion {
+		capicrdmigrator.RegisterMigrationMetrics(mgr.GetAPIReader(), opts.Namespace)
+		migrator := &capicrdmigrator.CRDMigrator{
+			Client:    mgr.GetClient(),
+			APIReader: mgr.GetAPIReader(),
+			Namespace: opts.Namespace,
+			Config: map[crclient.Object]capicrdmigrator.ByObjectConfig{
+				&capiv1beta2.Cluster{}:                         {},
+				&capiv1beta2.ClusterClass{}:                    {},
+				&capiv1beta2.MachineDeployment{}:               {},
+				&capiv1beta2.MachineDrainRule{}:                {},
+				&capiv1beta2.MachineHealthCheck{}:              {},
+				&capiv1beta2.MachinePool{}:                     {},
+				&capiv1beta2.Machine{}:                         {},
+				&capiv1beta2.MachineSet{}:                      {},
+				&ipamv1beta2.IPAddressClaim{}:                  {},
+				&ipamv1beta2.IPAddress{}:                       {},
+				&capiaddonsv1beta2.ClusterResourceSetBinding{}: {},
+				&capiaddonsv1beta2.ClusterResourceSet{}:        {},
+			},
+		}
+		if err := migrator.SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+			return fmt.Errorf("unable to create CRD migrator controller: %w", err)
+		}
+		log.Info("CAPI CRD storage version migrator controller enabled")
 	}
 
 	if sharedingress.UseSharedIngress() {

--- a/support/capi-crdmigrator/crd_migrator.go
+++ b/support/capi-crdmigrator/crd_migrator.go
@@ -1,0 +1,536 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+Adapted for HyperShift — original source:
+https://github.com/kubernetes-sigs/cluster-api/blob/v1.12.7/controllers/crdmigrator/crd_migrator.go
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capicrdmigrator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// CRDMigrationObservedGenerationAnnotation indicates on a CRD for which generation CRD migration is completed.
+	CRDMigrationObservedGenerationAnnotation = "crd-migration.cluster.x-k8s.io/observed-generation"
+)
+
+// Phase is a phase of the CRD migration.
+type Phase string
+
+var (
+	// StorageVersionMigrationPhase re-writes all CRs so they are stored in the current storageVersion in etcd.
+	StorageVersionMigrationPhase Phase = "StorageVersionMigration"
+
+	// CleanupManagedFieldsPhase removes managedFields referencing API versions that are no longer served.
+	CleanupManagedFieldsPhase Phase = "CleanupManagedFields"
+)
+
+// CRDMigrator migrates CRDs.
+type CRDMigrator struct {
+	Client    client.Client
+	APIReader client.Reader
+	Namespace string
+
+	SkipCRDMigrationPhases  []Phase
+	crdMigrationPhasesToRun sets.Set[Phase]
+
+	Config          map[client.Object]ByObjectConfig
+	configByCRDName map[string]ByObjectConfig
+
+	migrationCache  *ttlCache
+	migrationStatus *StatusReporter
+}
+
+// ByObjectConfig contains object-specific config for the CRD migration.
+type ByObjectConfig struct {
+	UseCache                            bool
+	UseStatusForStorageVersionMigration bool
+}
+
+func (r *CRDMigrator) SetupWithManager(ctx context.Context, mgr ctrl.Manager, controllerOptions controller.Options) error {
+	if err := r.setup(mgr.GetScheme()); err != nil {
+		return err
+	}
+
+	if len(r.crdMigrationPhasesToRun) == 0 {
+		return nil
+	}
+
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&apiextensionsv1.CustomResourceDefinition{},
+			builder.OnlyMetadata,
+			builder.WithPredicates(
+				predicate.GenerationChangedPredicate{},
+			),
+		).
+		Named("crdmigrator").
+		WithOptions(controllerOptions).
+		Complete(r)
+	if err != nil {
+		return errors.Wrap(err, "failed setting up with a controller manager")
+	}
+
+	return nil
+}
+
+func (r *CRDMigrator) setup(scheme *runtime.Scheme) error {
+	if r.Client == nil || r.APIReader == nil || len(r.Config) == 0 {
+		return errors.New("Client and APIReader must not be nil and Config must not be empty")
+	}
+
+	r.crdMigrationPhasesToRun = sets.Set[Phase]{}.Insert(StorageVersionMigrationPhase, CleanupManagedFieldsPhase)
+	for _, skipPhase := range r.SkipCRDMigrationPhases {
+		switch skipPhase {
+		case StorageVersionMigrationPhase:
+			r.crdMigrationPhasesToRun.Delete(StorageVersionMigrationPhase)
+		case CleanupManagedFieldsPhase:
+			r.crdMigrationPhasesToRun.Delete(CleanupManagedFieldsPhase)
+		default:
+			return errors.Errorf("invalid phase %s specified in SkipCRDMigrationPhases", skipPhase)
+		}
+	}
+
+	r.configByCRDName = map[string]ByObjectConfig{}
+	for obj, cfg := range r.Config {
+		gvk, err := apiutil.GVKForObject(obj, scheme)
+		if err != nil {
+			return errors.Wrap(err, "failed to get GVK for object")
+		}
+
+		r.configByCRDName[calculateCRDName(gvk.Group, gvk.Kind)] = cfg
+	}
+
+	r.migrationCache = newTTLCache(1 * time.Hour)
+	r.migrationStatus = NewStatusReporter(r.Client, r.Namespace, r.configByCRDName)
+	return nil
+}
+
+// calculateCRDName returns the CRD name for a given group and kind.
+func calculateCRDName(group, kind string) string {
+	return strings.ToLower(flect(kind)) + "." + group
+}
+
+// flect is a minimal pluralizer for CAPI kind names.
+func flect(kind string) string {
+	if strings.HasSuffix(strings.ToLower(kind), "s") {
+		return kind + "es"
+	}
+	return kind + "s"
+}
+
+func (r *CRDMigrator) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	migrationConfig, ok := r.configByCRDName[req.Name]
+	if !ok {
+		return ctrl.Result{}, nil
+	}
+
+	crdPartial := &metav1.PartialObjectMetadata{}
+	crdPartial.SetGroupVersionKind(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+	if err := r.Client.Get(ctx, req.NamespacedName, crdPartial); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	currentGeneration := strconv.FormatInt(crdPartial.GetGeneration(), 10)
+	if observedGeneration, ok := crdPartial.Annotations[CRDMigrationObservedGenerationAnnotation]; ok &&
+		currentGeneration == observedGeneration {
+		r.migrationStatus.SetCRDMigrated(req.Name)
+		if err := r.migrationStatus.Reconcile(ctx, nil); err != nil {
+			ctrl.LoggerFrom(ctx).Error(err, "Failed to report migration status")
+		}
+		return ctrl.Result{}, nil
+	}
+
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := r.APIReader.Get(ctx, req.NamespacedName, crd); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	currentGeneration = strconv.FormatInt(crd.GetGeneration(), 10)
+
+	storageVersion, err := storageVersionForCRD(crd)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	defer func() {
+		if reterr == nil {
+			originalCRD := crd.DeepCopy()
+			if crd.Annotations == nil {
+				crd.Annotations = map[string]string{}
+			}
+			crd.Annotations[CRDMigrationObservedGenerationAnnotation] = currentGeneration
+			if err := r.Client.Patch(ctx, crd, client.MergeFrom(originalCRD)); err != nil {
+				reterr = kerrors.NewAggregate([]error{reterr, errors.Wrapf(err, "failed to patch CustomResourceDefinition %s", crd.Name)})
+			} else {
+				r.migrationStatus.SetCRDMigrated(req.Name)
+			}
+		}
+
+		if err := r.migrationStatus.Reconcile(ctx, reterr); err != nil {
+			log := ctrl.LoggerFrom(ctx)
+			log.Error(err, "Failed to report migration status")
+		}
+	}()
+
+	var customResourceObjects []client.Object
+	if r.crdMigrationPhasesToRun.Has(StorageVersionMigrationPhase) && storageVersionMigrationRequired(crd, storageVersion) ||
+		r.crdMigrationPhasesToRun.Has(CleanupManagedFieldsPhase) {
+		var err error
+		customResourceObjects, err = r.listCustomResources(ctx, crd, migrationConfig, storageVersion)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	if r.crdMigrationPhasesToRun.Has(StorageVersionMigrationPhase) && storageVersionMigrationRequired(crd, storageVersion) {
+		if err := r.reconcileStorageVersionMigration(ctx, crd, migrationConfig, customResourceObjects, storageVersion); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		originalCRD := crd.DeepCopy()
+		crd.Status.StoredVersions = []string{storageVersion}
+		if err := r.Client.Status().Patch(ctx, crd, client.MergeFromWithOptions(originalCRD, client.MergeFromWithOptimisticLock{})); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "failed to patch CustomResourceDefinition %s", crd.Name)
+		}
+	}
+
+	if r.crdMigrationPhasesToRun.Has(CleanupManagedFieldsPhase) {
+		if err := r.reconcileCleanupManagedFields(ctx, crd, customResourceObjects, migrationConfig, storageVersion); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func storageVersionForCRD(crd *apiextensionsv1.CustomResourceDefinition) (string, error) {
+	for _, v := range crd.Spec.Versions {
+		if v.Storage {
+			return v.Name, nil
+		}
+	}
+	return "", errors.Errorf("could not find storage version for CustomResourceDefinition %s", crd.Name)
+}
+
+func storageVersionMigrationRequired(crd *apiextensionsv1.CustomResourceDefinition, storageVersion string) bool {
+	if len(crd.Status.StoredVersions) == 1 && crd.Status.StoredVersions[0] == storageVersion {
+		return false
+	}
+	return true
+}
+
+func (r *CRDMigrator) listCustomResources(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, migrationConfig ByObjectConfig, storageVersion string) ([]client.Object, error) {
+	var objs []client.Object
+
+	listGVK := schema.GroupVersionKind{
+		Group:   crd.Spec.Group,
+		Version: storageVersion,
+		Kind:    crd.Spec.Names.ListKind,
+	}
+
+	if migrationConfig.UseCache {
+		object, err := r.Client.Scheme().New(listGVK)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list %s: failed to create %s object", crd.Spec.Names.Kind, crd.Spec.Names.ListKind)
+		}
+		objectList, ok := object.(client.ObjectList)
+		if !ok {
+			return nil, errors.Errorf("failed to list %s: %s object is not an ObjectList", crd.Spec.Names.Kind, crd.Spec.Names.ListKind)
+		}
+		objects, err := listObjectsFromCachedClient(ctx, r.Client, objectList)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list %s via cached client", crd.Spec.Names.Kind)
+		}
+		objs = append(objs, objects...)
+	} else {
+		objectList := &metav1.PartialObjectMetadataList{}
+		objectList.SetGroupVersionKind(listGVK)
+		objects, err := listObjectsFromAPIReader(ctx, r.APIReader, objectList)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list %s via live client", crd.Spec.Names.Kind)
+		}
+		objs = append(objs, objects...)
+	}
+
+	return objs, nil
+}
+
+func listObjectsFromCachedClient(ctx context.Context, c client.Client, objectList client.ObjectList) ([]client.Object, error) {
+	objs := []client.Object{}
+
+	if err := c.List(ctx, objectList); err != nil {
+		return nil, err
+	}
+
+	objectListItems, err := meta.ExtractList(objectList)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to extract list items")
+	}
+	for _, obj := range objectListItems {
+		objs = append(objs, obj.(client.Object))
+	}
+
+	return objs, nil
+}
+
+func listObjectsFromAPIReader(ctx context.Context, c client.Reader, objectList client.ObjectList) ([]client.Object, error) {
+	objs := []client.Object{}
+
+	for {
+		listOpts := []client.ListOption{
+			client.Continue(objectList.GetContinue()),
+			client.Limit(500),
+		}
+		if err := c.List(ctx, objectList, listOpts...); err != nil {
+			return nil, err
+		}
+
+		objectListItems, err := meta.ExtractList(objectList)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to extract list items")
+		}
+		for _, obj := range objectListItems {
+			objs = append(objs, obj.(client.Object))
+		}
+
+		if objectList.GetContinue() == "" {
+			break
+		}
+	}
+
+	return objs, nil
+}
+
+func (r *CRDMigrator) reconcileStorageVersionMigration(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, migrationConfig ByObjectConfig, customResourceObjects []client.Object, storageVersion string) error {
+	if len(customResourceObjects) == 0 {
+		return nil
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	log.Info(fmt.Sprintf("Running storage version migration to apiVersion %s (for %d objects)", storageVersion, len(customResourceObjects)))
+
+	gvk := schema.GroupVersionKind{
+		Group:   crd.Spec.Group,
+		Version: storageVersion,
+		Kind:    crd.Spec.Names.Kind,
+	}
+
+	errs := []error{}
+	for _, obj := range customResourceObjects {
+		cacheKey := fmt.Sprintf("%s %s/%s %d", gvk.Kind, obj.GetNamespace(), obj.GetName(), crd.Generation)
+
+		if r.migrationCache.has(cacheKey) {
+			r.migrationCache.add(cacheKey)
+			continue
+		}
+
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(gvk)
+		u.SetNamespace(obj.GetNamespace())
+		u.SetName(obj.GetName())
+		u.SetUID(obj.GetUID())
+		u.SetResourceVersion(obj.GetResourceVersion())
+
+		log.V(4).Info("Migrating to new storage version", gvk.Kind, klog.KObj(u))
+		var err error
+		if migrationConfig.UseStatusForStorageVersionMigration {
+			err = r.Client.Status().Patch(ctx, u, client.Apply, client.FieldOwner("crdmigrator"))
+		} else {
+			err = r.Client.Apply(ctx, client.ApplyConfigurationFromUnstructured(u), client.FieldOwner("crdmigrator"))
+		}
+		if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsConflict(err) {
+			errs = append(errs, errors.Wrap(err, klog.KObj(u).String()))
+			continue
+		}
+
+		r.migrationCache.add(cacheKey)
+	}
+
+	if len(errs) > 0 {
+		return errors.Wrapf(kerrors.NewAggregate(errs), "failed to migrate storage version of %s objects", gvk.Kind)
+	}
+
+	return nil
+}
+
+func (r *CRDMigrator) reconcileCleanupManagedFields(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, customResourceObjects []client.Object, migrationConfig ByObjectConfig, storageVersion string) error {
+	if len(customResourceObjects) == 0 {
+		return nil
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	log.Info(fmt.Sprintf("Running managedField cleanup (for %d objects)", len(customResourceObjects)))
+
+	servedGroupVersions := sets.Set[string]{}
+	for _, v := range crd.Spec.Versions {
+		if v.Served {
+			servedGroupVersions.Insert(fmt.Sprintf("%s/%s", crd.Spec.Group, v.Name))
+		}
+	}
+
+	errs := []error{}
+	for _, obj := range customResourceObjects {
+		if len(obj.GetManagedFields()) == 0 {
+			continue
+		}
+
+		var getErr error
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			getErr = nil
+
+			managedFields, removed := removeManagedFieldsWithNotServedGroupVersion(obj, servedGroupVersions)
+			if !removed {
+				return nil
+			}
+
+			if len(managedFields) == 0 {
+				fieldV1Map := map[string]interface{}{
+					"f:metadata": map[string]interface{}{
+						"f:name": map[string]interface{}{},
+					},
+				}
+				fieldV1, err := json.Marshal(fieldV1Map)
+				if err != nil {
+					return errors.Wrap(err, "failed to create seeding managedField entry")
+				}
+				managedFields = append(managedFields, metav1.ManagedFieldsEntry{
+					Manager:    obj.GetManagedFields()[0].Manager,
+					Operation:  obj.GetManagedFields()[0].Operation,
+					APIVersion: schema.GroupVersion{Group: crd.Spec.Group, Version: storageVersion}.String(),
+					Time:       ptr.To(metav1.Now()),
+					FieldsType: "FieldsV1",
+					FieldsV1:   &metav1.FieldsV1{Raw: fieldV1},
+				})
+			}
+
+			jsonPatch := []map[string]interface{}{
+				{
+					"op":    "replace",
+					"path":  "/metadata/managedFields",
+					"value": managedFields,
+				},
+				{
+					"op":    "replace",
+					"path":  "/metadata/resourceVersion",
+					"value": obj.GetResourceVersion(),
+				},
+			}
+			patch, err := json.Marshal(jsonPatch)
+			if err != nil {
+				return errors.Wrap(err, "failed to marshal patch")
+			}
+
+			log.V(4).Info("Cleaning up managedFields", crd.Spec.Names.Kind, klog.KObj(obj))
+			err = r.Client.Patch(ctx, obj, client.RawPatch(types.JSONPatchType, patch))
+			if err == nil || apierrors.IsNotFound(err) {
+				return nil
+			}
+
+			if apierrors.IsConflict(err) {
+				if migrationConfig.UseCache {
+					getErr = r.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+				} else {
+					getErr = r.APIReader.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+				}
+			}
+			return err
+		}); err != nil {
+			errs = append(errs, errors.Wrap(kerrors.NewAggregate([]error{err, getErr}), klog.KObj(obj).String()))
+			continue
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Wrapf(kerrors.NewAggregate(errs), "failed to cleanup managedFields of %s objects", crd.Spec.Names.Kind)
+	}
+
+	return nil
+}
+
+func removeManagedFieldsWithNotServedGroupVersion(obj client.Object, servedGroupVersions sets.Set[string]) ([]metav1.ManagedFieldsEntry, bool) {
+	removedManagedFields := false
+	managedFields := []metav1.ManagedFieldsEntry{}
+	for _, managedField := range obj.GetManagedFields() {
+		if servedGroupVersions.Has(managedField.APIVersion) {
+			managedFields = append(managedFields, managedField)
+			continue
+		}
+		removedManagedFields = true
+	}
+	return managedFields, removedManagedFields
+}
+
+// ttlCache is a simple TTL-based cache replacing CAPI's util/cache.Cache.
+type ttlCache struct {
+	mu      sync.Mutex
+	entries map[string]time.Time
+	ttl     time.Duration
+}
+
+func newTTLCache(ttl time.Duration) *ttlCache {
+	return &ttlCache{
+		entries: make(map[string]time.Time),
+		ttl:     ttl,
+	}
+}
+
+func (c *ttlCache) add(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = time.Now()
+}
+
+func (c *ttlCache) has(key string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t, ok := c.entries[key]
+	if !ok {
+		return false
+	}
+	if time.Since(t) > c.ttl {
+		delete(c.entries, key)
+		return false
+	}
+	return true
+}

--- a/support/capi-crdmigrator/crd_migrator_test.go
+++ b/support/capi-crdmigrator/crd_migrator_test.go
@@ -1,0 +1,432 @@
+//go:build envtest
+
+package capicrdmigrator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// testCRD returns a minimal CRD with two versions for testing migration.
+// v1alpha1 is the old storage version, v1beta1 is the new storage version.
+func testCRD() *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "widgets.testing.crdmigrator.io",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "testing.crdmigrator.io",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     "Widget",
+				ListKind: "WidgetList",
+				Plural:   "widgets",
+				Singular: "widget",
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: false,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:                   "object",
+							XPreserveUnknownFields: boolPtr(true),
+						},
+					},
+				},
+				{
+					Name:    "v1beta1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:                   "object",
+							XPreserveUnknownFields: boolPtr(true),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// widgetGVK is a synthetic type registered with the scheme so the migrator's setup() can resolve it.
+type Widget struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+func (w *Widget) DeepCopyObject() runtime.Object {
+	cp := *w
+	return &cp
+}
+
+func setupTestEnv(t *testing.T) (client.Client, *envtest.Environment) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	env := &envtest.Environment{}
+	cfg, err := env.Start()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cfg).ToNot(BeNil())
+
+	t.Cleanup(func() {
+		g.Expect(env.Stop()).To(Succeed())
+	})
+
+	s := runtime.NewScheme()
+	g.Expect(apiextensionsv1.AddToScheme(s)).To(Succeed())
+	s.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group:   "testing.crdmigrator.io",
+		Version: "v1beta1",
+		Kind:    "Widget",
+	}, &Widget{})
+
+	c, err := client.New(cfg, client.Options{Scheme: s})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	return c, env
+}
+
+func installCRD(t *testing.T, c client.Client, crd *apiextensionsv1.CustomResourceDefinition) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	g.Expect(c.Create(ctx, crd)).To(Succeed())
+
+	g.Eventually(func() bool {
+		existing := &apiextensionsv1.CustomResourceDefinition{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(crd), existing); err != nil {
+			return false
+		}
+		for _, cond := range existing.Status.Conditions {
+			if cond.Type == apiextensionsv1.Established && cond.Status == apiextensionsv1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}, "30s", "100ms").Should(BeTrue(), "CRD should become established")
+}
+
+func createWidget(t *testing.T, c client.Client, name, namespace string) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	ns := &unstructured.Unstructured{}
+	ns.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Namespace"})
+	ns.SetName(namespace)
+	_ = c.Create(ctx, ns)
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "testing.crdmigrator.io",
+		Version: "v1beta1",
+		Kind:    "Widget",
+	})
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	g.Expect(c.Create(ctx, obj)).To(Succeed())
+}
+
+func TestCRDMigratorReconcile_SkipsUnknownCRD(t *testing.T) {
+	g := NewGomegaWithT(t)
+	c, _ := setupTestEnv(t)
+
+	migrator := &CRDMigrator{
+		Client:    c,
+		APIReader: c,
+		Config: map[client.Object]ByObjectConfig{
+			&Widget{}: {},
+		},
+	}
+	s := runtime.NewScheme()
+	g.Expect(apiextensionsv1.AddToScheme(s)).To(Succeed())
+	s.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "testing.crdmigrator.io", Version: "v1beta1", Kind: "Widget",
+	}, &Widget{})
+	g.Expect(migrator.setup(s)).To(Succeed())
+
+	result, err := migrator.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: "unknown.crd.io"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+}
+
+func TestCRDMigratorReconcile_StorageVersionMigration(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+	c, _ := setupTestEnv(t)
+
+	crd := testCRD()
+	installCRD(t, c, crd)
+
+	createWidget(t, c, "widget-1", "default")
+	createWidget(t, c, "widget-2", "default")
+
+	// Simulate storedVersions containing old version (apiserver sets this)
+	existing := &apiextensionsv1.CustomResourceDefinition{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(crd), existing)).To(Succeed())
+
+	// Verify storedVersions includes v1beta1 (apiserver should set this since v1beta1 is storage)
+	g.Expect(existing.Status.StoredVersions).To(ContainElement("v1beta1"))
+
+	// Patch storedVersions to simulate pre-migration state with both versions
+	existing.Status.StoredVersions = []string{"v1alpha1", "v1beta1"}
+	g.Expect(c.Status().Update(ctx, existing)).To(Succeed())
+
+	s := runtime.NewScheme()
+	g.Expect(apiextensionsv1.AddToScheme(s)).To(Succeed())
+	s.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "testing.crdmigrator.io", Version: "v1beta1", Kind: "Widget",
+	}, &Widget{})
+
+	migrator := &CRDMigrator{
+		Client:    c,
+		APIReader: c,
+		Config: map[client.Object]ByObjectConfig{
+			&Widget{}: {},
+		},
+	}
+	g.Expect(migrator.setup(s)).To(Succeed())
+
+	result, err := migrator.Reconcile(ctx, ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: "widgets.testing.crdmigrator.io"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	// Verify storedVersions was updated to only contain the storage version
+	updated := &apiextensionsv1.CustomResourceDefinition{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(crd), updated)).To(Succeed())
+	g.Expect(updated.Status.StoredVersions).To(Equal([]string{"v1beta1"}))
+
+	// Verify observed generation annotation was set
+	g.Expect(updated.Annotations).To(HaveKey(CRDMigrationObservedGenerationAnnotation))
+}
+
+func TestCRDMigratorReconcile_AlreadyMigrated(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+	c, _ := setupTestEnv(t)
+
+	crd := testCRD()
+	installCRD(t, c, crd)
+
+	// storedVersions should already be [v1beta1] from apiserver
+	existing := &apiextensionsv1.CustomResourceDefinition{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(crd), existing)).To(Succeed())
+
+	// Ensure storedVersions is exactly [v1beta1] (already migrated state)
+	existing.Status.StoredVersions = []string{"v1beta1"}
+	g.Expect(c.Status().Update(ctx, existing)).To(Succeed())
+
+	s := runtime.NewScheme()
+	g.Expect(apiextensionsv1.AddToScheme(s)).To(Succeed())
+	s.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "testing.crdmigrator.io", Version: "v1beta1", Kind: "Widget",
+	}, &Widget{})
+
+	migrator := &CRDMigrator{
+		Client:    c,
+		APIReader: c,
+		Config: map[client.Object]ByObjectConfig{
+			&Widget{}: {},
+		},
+	}
+	g.Expect(migrator.setup(s)).To(Succeed())
+
+	result, err := migrator.Reconcile(ctx, ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: "widgets.testing.crdmigrator.io"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	// Verify storedVersions unchanged
+	updated := &apiextensionsv1.CustomResourceDefinition{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(crd), updated)).To(Succeed())
+	g.Expect(updated.Status.StoredVersions).To(Equal([]string{"v1beta1"}))
+
+	// Verify observed generation annotation was still set (reconcile completed successfully)
+	g.Expect(updated.Annotations).To(HaveKey(CRDMigrationObservedGenerationAnnotation))
+}
+
+func TestCRDMigratorReconcile_SkipsOnMatchingObservedGeneration(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+	c, _ := setupTestEnv(t)
+
+	crd := testCRD()
+	installCRD(t, c, crd)
+
+	// Set the observed generation annotation to match current generation
+	existing := &apiextensionsv1.CustomResourceDefinition{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(crd), existing)).To(Succeed())
+
+	gen := existing.Generation
+	if existing.Annotations == nil {
+		existing.Annotations = map[string]string{}
+	}
+	existing.Annotations[CRDMigrationObservedGenerationAnnotation] = fmt.Sprintf("%d", gen)
+	g.Expect(c.Update(ctx, existing)).To(Succeed())
+
+	// Set storedVersions to something that would trigger migration if reconcile ran
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(crd), existing)).To(Succeed())
+	existing.Status.StoredVersions = []string{"v1alpha1", "v1beta1"}
+	g.Expect(c.Status().Update(ctx, existing)).To(Succeed())
+
+	s := runtime.NewScheme()
+	g.Expect(apiextensionsv1.AddToScheme(s)).To(Succeed())
+	s.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "testing.crdmigrator.io", Version: "v1beta1", Kind: "Widget",
+	}, &Widget{})
+
+	migrator := &CRDMigrator{
+		Client:    c,
+		APIReader: c,
+		Config: map[client.Object]ByObjectConfig{
+			&Widget{}: {},
+		},
+	}
+	g.Expect(migrator.setup(s)).To(Succeed())
+
+	result, err := migrator.Reconcile(ctx, ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: "widgets.testing.crdmigrator.io"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	// storedVersions should NOT have been changed (reconcile was skipped)
+	updated := &apiextensionsv1.CustomResourceDefinition{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(crd), updated)).To(Succeed())
+	g.Expect(updated.Status.StoredVersions).To(Equal([]string{"v1alpha1", "v1beta1"}))
+}
+
+func TestCRDMigratorReconcile_NoResourcesMigration(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+	c, _ := setupTestEnv(t)
+
+	crd := testCRD()
+	installCRD(t, c, crd)
+
+	existing := &apiextensionsv1.CustomResourceDefinition{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(crd), existing)).To(Succeed())
+	existing.Status.StoredVersions = []string{"v1alpha1", "v1beta1"}
+	g.Expect(c.Status().Update(ctx, existing)).To(Succeed())
+
+	s := runtime.NewScheme()
+	g.Expect(apiextensionsv1.AddToScheme(s)).To(Succeed())
+	s.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "testing.crdmigrator.io", Version: "v1beta1", Kind: "Widget",
+	}, &Widget{})
+
+	migrator := &CRDMigrator{
+		Client:    c,
+		APIReader: c,
+		Config: map[client.Object]ByObjectConfig{
+			&Widget{}: {},
+		},
+	}
+	g.Expect(migrator.setup(s)).To(Succeed())
+
+	result, err := migrator.Reconcile(ctx, ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: "widgets.testing.crdmigrator.io"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	// storedVersions should be updated even with no CRs to migrate
+	updated := &apiextensionsv1.CustomResourceDefinition{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(crd), updated)).To(Succeed())
+	g.Expect(updated.Status.StoredVersions).To(Equal([]string{"v1beta1"}))
+}
+
+func TestCRDMigratorReconcile_CleanupManagedFields(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+	c, _ := setupTestEnv(t)
+
+	crd := testCRD()
+	installCRD(t, c, crd)
+
+	createWidget(t, c, "widget-mf", "default")
+
+	// Add a managedFields entry with a no-longer-served version
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "testing.crdmigrator.io", Version: "v1beta1", Kind: "Widget",
+	})
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: "widget-mf", Namespace: "default"}, obj)).To(Succeed())
+
+	staleMF := metav1.ManagedFieldsEntry{
+		Manager:    "stale-manager",
+		Operation:  metav1.ManagedFieldsOperationApply,
+		APIVersion: "testing.crdmigrator.io/v1alpha0",
+		FieldsType: "FieldsV1",
+		FieldsV1:   &metav1.FieldsV1{Raw: []byte("{}")},
+	}
+	obj.SetManagedFields(append(obj.GetManagedFields(), staleMF))
+	g.Expect(c.Update(ctx, obj)).To(Succeed())
+
+	// Verify stale entry exists
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: "widget-mf", Namespace: "default"}, obj)).To(Succeed())
+	hasStaleMF := false
+	for _, mf := range obj.GetManagedFields() {
+		if mf.APIVersion == "testing.crdmigrator.io/v1alpha0" {
+			hasStaleMF = true
+		}
+	}
+	g.Expect(hasStaleMF).To(BeTrue(), "stale managedFields entry should exist before cleanup")
+
+	// Set storedVersions to already migrated so only cleanup phase runs
+	existing := &apiextensionsv1.CustomResourceDefinition{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(crd), existing)).To(Succeed())
+	existing.Status.StoredVersions = []string{"v1beta1"}
+	g.Expect(c.Status().Update(ctx, existing)).To(Succeed())
+
+	s := runtime.NewScheme()
+	g.Expect(apiextensionsv1.AddToScheme(s)).To(Succeed())
+	s.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "testing.crdmigrator.io", Version: "v1beta1", Kind: "Widget",
+	}, &Widget{})
+
+	migrator := &CRDMigrator{
+		Client:    c,
+		APIReader: c,
+		Config: map[client.Object]ByObjectConfig{
+			&Widget{}: {},
+		},
+	}
+	g.Expect(migrator.setup(s)).To(Succeed())
+
+	result, err := migrator.Reconcile(ctx, ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: "widgets.testing.crdmigrator.io"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	// Verify stale managedFields entry was removed
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: "widget-mf", Namespace: "default"}, obj)).To(Succeed())
+	for _, mf := range obj.GetManagedFields() {
+		g.Expect(mf.APIVersion).ToNot(Equal("testing.crdmigrator.io/v1alpha0"),
+			"stale managedFields entry should have been cleaned up")
+	}
+}

--- a/support/capi-crdmigrator/metrics.go
+++ b/support/capi-crdmigrator/metrics.go
@@ -1,0 +1,71 @@
+package capicrdmigrator
+
+import (
+	"context"
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	capiMigrationTotalCRDsDesc = prometheus.NewDesc(
+		"hypershift_capi_migration_total_crds",
+		"Total number of CAPI CRDs configured for storage version migration.",
+		nil, nil,
+	)
+	capiMigrationMigratedCRDsDesc = prometheus.NewDesc(
+		"hypershift_capi_migration_migrated_crds",
+		"Number of CAPI CRDs that have completed storage version migration.",
+		nil, nil,
+	)
+)
+
+type migrationMetricsCollector struct {
+	client    client.Reader
+	namespace string
+}
+
+func RegisterMigrationMetrics(c client.Reader, namespace string) {
+	metrics.Registry.MustRegister(&migrationMetricsCollector{
+		client:    c,
+		namespace: namespace,
+	})
+}
+
+func (c *migrationMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- capiMigrationTotalCRDsDesc
+	ch <- capiMigrationMigratedCRDsDesc
+}
+
+func (c *migrationMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	log := ctrllog.Log
+
+	cm := &corev1.ConfigMap{}
+	if err := c.client.Get(context.Background(), client.ObjectKey{
+		Namespace: c.namespace,
+		Name:      StatusConfigMapName,
+	}, cm); err != nil {
+		log.V(4).Info("Failed to get migration status ConfigMap for metrics", "error", err)
+		return
+	}
+
+	data, ok := cm.Data[statusDataKey]
+	if !ok {
+		return
+	}
+
+	var status CAPIMigrationStatus
+	if err := json.Unmarshal([]byte(data), &status); err != nil {
+		log.Error(err, "Failed to unmarshal migration status for metrics")
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(capiMigrationTotalCRDsDesc, prometheus.GaugeValue, float64(status.TotalCRDs))
+	ch <- prometheus.MustNewConstMetric(capiMigrationMigratedCRDsDesc, prometheus.GaugeValue, float64(status.MigratedCRDs))
+}

--- a/support/capi-crdmigrator/status.go
+++ b/support/capi-crdmigrator/status.go
@@ -1,0 +1,148 @@
+package capicrdmigrator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	StatusConfigMapName = "capi-migration-status"
+	statusDataKey       = "status"
+)
+
+type StatusReporter struct {
+	client         client.Client
+	namespace      string
+	totalCRDs      int
+	migrationState map[string]bool
+}
+
+func NewStatusReporter(c client.Client, namespace string, configByCRDName map[string]ByObjectConfig) *StatusReporter {
+	state := make(map[string]bool, len(configByCRDName))
+	for name := range configByCRDName {
+		state[name] = false
+	}
+	return &StatusReporter{
+		client:         c,
+		namespace:      namespace,
+		totalCRDs:      len(configByCRDName),
+		migrationState: state,
+	}
+}
+
+func (s *StatusReporter) SetCRDMigrated(crdName string) {
+	s.migrationState[crdName] = true
+}
+
+func (s *StatusReporter) Reconcile(ctx context.Context, reconcileErr error) error {
+	status := s.computeStatus()
+
+	s.setConditions(status, reconcileErr)
+
+	data, err := json.Marshal(status)
+	if err != nil {
+		return fmt.Errorf("failed to marshal migration status: %w", err)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      StatusConfigMapName,
+			Namespace: s.namespace,
+		},
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, s.client, cm, func() error {
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		cm.Data[statusDataKey] = string(data)
+		return nil
+	})
+	return err
+}
+
+func (s *StatusReporter) setConditions(status *CAPIMigrationStatus, reconcileErr error) {
+	now := metav1.Now()
+	complete := status.TotalCRDs > 0 && status.MigratedCRDs == status.TotalCRDs
+
+	if complete {
+		setCondition(&status.Conditions, metav1.Condition{
+			Type:               MigrationCompleteCondition,
+			Status:             metav1.ConditionTrue,
+			Reason:             "MigrationComplete",
+			Message:            fmt.Sprintf("All %d CRDs have been migrated", status.TotalCRDs),
+			LastTransitionTime: now,
+		})
+		setCondition(&status.Conditions, metav1.Condition{
+			Type:               ProgressingCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             "MigrationComplete",
+			Message:            "Migration has completed",
+			LastTransitionTime: now,
+		})
+	} else {
+		setCondition(&status.Conditions, metav1.Condition{
+			Type:               MigrationCompleteCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             "MigrationInProgress",
+			Message:            fmt.Sprintf("%d/%d CRDs migrated", status.MigratedCRDs, status.TotalCRDs),
+			LastTransitionTime: now,
+		})
+		setCondition(&status.Conditions, metav1.Condition{
+			Type:               ProgressingCondition,
+			Status:             metav1.ConditionTrue,
+			Reason:             "MigrationInProgress",
+			Message:            fmt.Sprintf("%d/%d CRDs migrated", status.MigratedCRDs, status.TotalCRDs),
+			LastTransitionTime: now,
+		})
+	}
+
+	if reconcileErr != nil {
+		setCondition(&status.Conditions, metav1.Condition{
+			Type:               DegradedCondition,
+			Status:             metav1.ConditionTrue,
+			Reason:             "MigrationError",
+			Message:            reconcileErr.Error(),
+			LastTransitionTime: now,
+		})
+	} else {
+		setCondition(&status.Conditions, metav1.Condition{
+			Type:               DegradedCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             "NoErrors",
+			Message:            "No migration errors",
+			LastTransitionTime: now,
+		})
+	}
+}
+
+func setCondition(conditions *[]metav1.Condition, condition metav1.Condition) {
+	for i, existing := range *conditions {
+		if existing.Type == condition.Type {
+			if existing.Status == condition.Status {
+				condition.LastTransitionTime = existing.LastTransitionTime
+			}
+			(*conditions)[i] = condition
+			return
+		}
+	}
+	*conditions = append(*conditions, condition)
+}
+
+func (s *StatusReporter) computeStatus() *CAPIMigrationStatus {
+	status := &CAPIMigrationStatus{
+		TotalCRDs: s.totalCRDs,
+	}
+	for _, migrated := range s.migrationState {
+		if migrated {
+			status.MigratedCRDs++
+		}
+	}
+	return status
+}

--- a/support/capi-crdmigrator/status_test.go
+++ b/support/capi-crdmigrator/status_test.go
@@ -1,0 +1,170 @@
+package capicrdmigrator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fakeScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	return s
+}
+
+func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+func TestStatusReporter_Reconcile(t *testing.T) {
+	const namespace = "hypershift"
+
+	tests := []struct {
+		name             string
+		configByCRDName  map[string]ByObjectConfig
+		migratedCRDs     []string
+		existing         []client.Object
+		reconcileErr     error
+		expectedTotal    int
+		expectedMigrated int
+		expectedComplete metav1.ConditionStatus
+		expectedProgress metav1.ConditionStatus
+		expectedDegraded metav1.ConditionStatus
+	}{
+		{
+			name: "When all CRDs are migrated, it should report complete",
+			configByCRDName: map[string]ByObjectConfig{
+				"clusters.cluster.x-k8s.io": {},
+				"machines.cluster.x-k8s.io": {},
+			},
+			migratedCRDs:     []string{"clusters.cluster.x-k8s.io", "machines.cluster.x-k8s.io"},
+			expectedTotal:    2,
+			expectedMigrated: 2,
+			expectedComplete: metav1.ConditionTrue,
+			expectedProgress: metav1.ConditionFalse,
+			expectedDegraded: metav1.ConditionFalse,
+		},
+		{
+			name: "When no CRDs are migrated, it should report progressing",
+			configByCRDName: map[string]ByObjectConfig{
+				"clusters.cluster.x-k8s.io": {},
+				"machines.cluster.x-k8s.io": {},
+			},
+			migratedCRDs:     nil,
+			expectedTotal:    2,
+			expectedMigrated: 0,
+			expectedComplete: metav1.ConditionFalse,
+			expectedProgress: metav1.ConditionTrue,
+			expectedDegraded: metav1.ConditionFalse,
+		},
+		{
+			name: "When some CRDs are migrated, it should report partial progress",
+			configByCRDName: map[string]ByObjectConfig{
+				"clusters.cluster.x-k8s.io":    {},
+				"machines.cluster.x-k8s.io":    {},
+				"machinesets.cluster.x-k8s.io": {},
+			},
+			migratedCRDs:     []string{"clusters.cluster.x-k8s.io", "machinesets.cluster.x-k8s.io"},
+			expectedTotal:    3,
+			expectedMigrated: 2,
+			expectedComplete: metav1.ConditionFalse,
+			expectedProgress: metav1.ConditionTrue,
+			expectedDegraded: metav1.ConditionFalse,
+		},
+		{
+			name: "When ConfigMap already exists, it should update it",
+			configByCRDName: map[string]ByObjectConfig{
+				"clusters.cluster.x-k8s.io": {},
+			},
+			migratedCRDs: []string{"clusters.cluster.x-k8s.io"},
+			existing: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      StatusConfigMapName,
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						statusDataKey: `{"totalCRDs":1,"migratedCRDs":0}`,
+					},
+				},
+			},
+			expectedTotal:    1,
+			expectedMigrated: 1,
+			expectedComplete: metav1.ConditionTrue,
+			expectedProgress: metav1.ConditionFalse,
+			expectedDegraded: metav1.ConditionFalse,
+		},
+		{
+			name: "When reconcile error is present, it should set degraded condition",
+			configByCRDName: map[string]ByObjectConfig{
+				"clusters.cluster.x-k8s.io": {},
+			},
+			migratedCRDs:     nil,
+			reconcileErr:     fmt.Errorf("failed to migrate storage version"),
+			expectedTotal:    1,
+			expectedMigrated: 0,
+			expectedComplete: metav1.ConditionFalse,
+			expectedProgress: metav1.ConditionTrue,
+			expectedDegraded: metav1.ConditionTrue,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().
+				WithScheme(fakeScheme()).
+				WithObjects(tc.existing...).
+				Build()
+
+			reporter := NewStatusReporter(c, namespace, tc.configByCRDName)
+			for _, name := range tc.migratedCRDs {
+				reporter.SetCRDMigrated(name)
+			}
+			err := reporter.Reconcile(context.Background(), tc.reconcileErr)
+			require.NoError(t, err)
+
+			cm := &corev1.ConfigMap{}
+			err = c.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: StatusConfigMapName}, cm)
+			require.NoError(t, err)
+
+			var status CAPIMigrationStatus
+			err = json.Unmarshal([]byte(cm.Data[statusDataKey]), &status)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedTotal, status.TotalCRDs)
+			assert.Equal(t, tc.expectedMigrated, status.MigratedCRDs)
+
+			complete := findCondition(status.Conditions, MigrationCompleteCondition)
+			require.NotNil(t, complete, "MigrationComplete condition missing")
+			assert.Equal(t, tc.expectedComplete, complete.Status)
+
+			progressing := findCondition(status.Conditions, ProgressingCondition)
+			require.NotNil(t, progressing, "Progressing condition missing")
+			assert.Equal(t, tc.expectedProgress, progressing.Status)
+
+			degraded := findCondition(status.Conditions, DegradedCondition)
+			require.NotNil(t, degraded, "Degraded condition missing")
+			assert.Equal(t, tc.expectedDegraded, degraded.Status)
+
+			if tc.reconcileErr != nil {
+				assert.Contains(t, degraded.Message, tc.reconcileErr.Error())
+			}
+		})
+	}
+}

--- a/support/capi-crdmigrator/types.go
+++ b/support/capi-crdmigrator/types.go
@@ -1,0 +1,25 @@
+package capicrdmigrator
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+const (
+	CurrentStorageVersion = "v1beta1"
+	TargetStorageVersion  = "v1beta2"
+
+	CAPIStorageVersionEnvVar = "CAPI_STORAGE_VERSION"
+
+	// MigrationCompleteCondition is True when all configured CRDs have been migrated.
+	MigrationCompleteCondition = "MigrationComplete"
+	// ProgressingCondition is True while migration is actively running.
+	ProgressingCondition = "Progressing"
+	// DegradedCondition is True when errors occurred during migration.
+	DegradedCondition = "Degraded"
+)
+
+type CAPIMigrationStatus struct {
+	// Total number of CRDs configured for migration.
+	TotalCRDs int `json:"totalCRDs"`
+	// Number of CRDs that have completed migration (have the observed-generation annotation set).
+	MigratedCRDs int                `json:"migratedCRDs"`
+	Conditions   []metav1.Condition `json:"conditions,omitempty"`
+}

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -135,4 +135,5 @@ const (
 
 var (
 	Version419 = semver.MustParse("4.19.0")
+	Version420 = semver.MustParse("4.20.0")
 )

--- a/test/e2e/capi_storage_migration_test.go
+++ b/test/e2e/capi_storage_migration_test.go
@@ -1,0 +1,263 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	dto "github.com/prometheus/client_model/go"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	crdassets "github.com/openshift/hypershift/cmd/install/assets/crds"
+	capicrdmigrator "github.com/openshift/hypershift/support/capi-crdmigrator"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestCAPIStorageVersionMigration validates that the CAPI CRD storage version migration
+// from v1beta1 to v1beta2 completes successfully on a cluster with existing CAPI resources
+// and that the hosted cluster remains healthy after migration.
+func TestCAPIStorageVersionMigration(t *testing.T) {
+	if !globalOpts.RunCAPIMigrationTest {
+		t.SkipNow()
+	}
+
+	t.Parallel()
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
+
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
+
+	t.Log("Starting CAPI storage version migration test")
+
+	// Install HO with migration disabled so CRDs start at v1beta1.
+	g := gomega.NewWithT(t)
+	disabledOpts := globalOpts.HOInstallationOptions
+	disabledOpts.DisableCAPIMigration = true
+	err := e2eutil.InstallHyperShiftOperator(ctx, disabledOpts)
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "installing HO with migration disabled")
+	t.Log("HO installed with CAPI migration disabled")
+
+	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g gomega.Gomega, mc crclient.Client, hc *hyperv1.HostedCluster) {
+		t.Logf("HostedCluster %s created", crclient.ObjectKeyFromObject(hc))
+		_ = e2eutil.WaitForGuestClient(t, ctx, mc, hc)
+		t.Log("Hosted cluster is ready")
+
+		// Verify pre-migration state: CAPI CRDs should have v1beta1 in storedVersions
+		g.Expect(t.Run("When checking pre-migration CRD state, it should have v1beta1 storedVersions", func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			for _, crdName := range crdassets.CAPICRDNames() {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+				err := mc.Get(ctx, crclient.ObjectKey{Name: crdName}, crd)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "getting CRD %s", crdName)
+				g.Expect(crd.Status.StoredVersions).To(gomega.ContainElement("v1beta1"),
+					"CRD %s should have v1beta1 in storedVersions before migration", crdName)
+				t.Logf("CRD %s storedVersions: %v", crdName, crd.Status.StoredVersions)
+			}
+		})).To(gomega.BeTrue())
+
+		// Reinstall HO to trigger default v1beta2 storage migration
+		g.Expect(t.Run("When reinstalling HO with default CAPI migration, it should succeed", func(t *testing.T) {
+			t.Log("Reinstalling HyperShift Operator with default CAPI storage migration")
+			installOpts := globalOpts.HOInstallationOptions
+			err := e2eutil.InstallHyperShiftOperator(ctx, installOpts)
+			g.Expect(err).ToNot(gomega.HaveOccurred(), "reinstalling HO with v1beta2 storage version")
+		})).To(gomega.BeTrue())
+
+		// Wait for migration to complete: storedVersions should become ["v1beta2"] only
+		g.Expect(t.Run("When waiting for migration, it should update storedVersions to v1beta2", func(t *testing.T) {
+			gt := gomega.NewWithT(t)
+			for _, crdName := range crdassets.CAPICRDNames() {
+				t.Logf("Waiting for CRD %s storedVersions to be migrated", crdName)
+				gt.Eventually(func(g gomega.Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					err := mc.Get(ctx, crclient.ObjectKey{Name: crdName}, crd)
+					g.Expect(err).ToNot(gomega.HaveOccurred())
+					g.Expect(crd.Status.StoredVersions).To(gomega.Equal([]string{"v1beta2"}),
+						"CRD %s storedVersions should be [v1beta2] after migration", crdName)
+				}, "15m", "5s").Should(gomega.Succeed(), "CRD %s migration should complete", crdName)
+			}
+		})).To(gomega.BeTrue())
+
+		// Verify migration annotation is set
+		g.Expect(t.Run("When checking migration annotations, it should have observed-generation set", func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			for _, crdName := range crdassets.CAPICRDNames() {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+				err := mc.Get(ctx, crclient.ObjectKey{Name: crdName}, crd)
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+				_, hasAnnotation := crd.Annotations[capicrdmigrator.CRDMigrationObservedGenerationAnnotation]
+				g.Expect(hasAnnotation).To(gomega.BeTrue(),
+					"CRD %s should have migration observed-generation annotation", crdName)
+				t.Logf("CRD %s has migration annotation", crdName)
+			}
+		})).To(gomega.BeTrue())
+
+		// Verify migration status ConfigMap
+		g.Expect(t.Run("When checking migration status ConfigMap, it should report complete", func(t *testing.T) {
+			gt := gomega.NewWithT(t)
+			expectedTotal := len(crdassets.CAPICRDNames())
+			gt.Eventually(func(g gomega.Gomega) {
+				cm := &corev1.ConfigMap{}
+				err := mc.Get(ctx, crclient.ObjectKey{Namespace: "hypershift", Name: capicrdmigrator.StatusConfigMapName}, cm)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "getting migration status ConfigMap")
+
+				var status capicrdmigrator.CAPIMigrationStatus
+				err = json.Unmarshal([]byte(cm.Data["status"]), &status)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "unmarshalling migration status")
+
+				g.Expect(status.TotalCRDs).To(gomega.Equal(expectedTotal),
+					"TotalCRDs should match number of configured CAPI CRDs")
+				g.Expect(status.MigratedCRDs).To(gomega.Equal(expectedTotal),
+					"MigratedCRDs should equal TotalCRDs after migration")
+
+				complete := findConditionInStatus(status.Conditions, capicrdmigrator.MigrationCompleteCondition)
+				g.Expect(complete).ToNot(gomega.BeNil(), "MigrationComplete condition should exist")
+				g.Expect(complete.Status).To(gomega.Equal(metav1.ConditionTrue), "MigrationComplete should be True")
+
+				progressing := findConditionInStatus(status.Conditions, capicrdmigrator.ProgressingCondition)
+				g.Expect(progressing).ToNot(gomega.BeNil(), "Progressing condition should exist")
+				g.Expect(progressing.Status).To(gomega.Equal(metav1.ConditionFalse), "Progressing should be False")
+
+				degraded := findConditionInStatus(status.Conditions, capicrdmigrator.DegradedCondition)
+				g.Expect(degraded).ToNot(gomega.BeNil(), "Degraded condition should exist")
+				g.Expect(degraded.Status).To(gomega.Equal(metav1.ConditionFalse), "Degraded should be False")
+
+				t.Logf("Migration status: %d/%d CRDs migrated, MigrationComplete=%s",
+					status.MigratedCRDs, status.TotalCRDs, complete.Status)
+			}, "5m", "5s").Should(gomega.Succeed(), "migration status ConfigMap should report complete")
+		})).To(gomega.BeTrue())
+
+		// Verify migration metrics
+		g.Expect(t.Run("When checking migration metrics, it should report accurate values", func(t *testing.T) {
+			gt := gomega.NewWithT(t)
+			expectedTotal := float64(len(crdassets.CAPICRDNames()))
+			gt.Eventually(func(g gomega.Gomega) {
+				mf, err := e2eutil.GetMetricsFromPod(ctx, mc, "operator", "operator", "hypershift", "9000")
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "getting metrics from operator pod")
+
+				var migrationMetrics []string
+				for name := range mf {
+					if strings.Contains(name, "migration") {
+						migrationMetrics = append(migrationMetrics, name)
+					}
+				}
+				t.Logf("Found %d total metric families, migration-related: %v", len(mf), migrationMetrics)
+
+				totalCRDs := getGaugeValue(mf, "hypershift_capi_migration_total_crds")
+				g.Expect(totalCRDs).ToNot(gomega.BeNil(), "hypershift_capi_migration_total_crds metric should exist")
+				g.Expect(*totalCRDs).To(gomega.Equal(expectedTotal),
+					"total CRDs metric should match configured CAPI CRDs count")
+
+				migratedCRDs := getGaugeValue(mf, "hypershift_capi_migration_migrated_crds")
+				g.Expect(migratedCRDs).ToNot(gomega.BeNil(), "hypershift_capi_migration_migrated_crds metric should exist")
+				g.Expect(*migratedCRDs).To(gomega.Equal(expectedTotal),
+					"migrated CRDs metric should equal total after migration")
+
+				t.Logf("Migration metrics: total=%.0f, migrated=%.0f", *totalCRDs, *migratedCRDs)
+			}, "5m", "5s").Should(gomega.Succeed(), "migration metrics should report accurate values")
+		})).To(gomega.BeTrue())
+
+		// Check HO logs for CRD migrator errors
+		g.Expect(t.Run("When checking HO logs, it should have no CRD migrator errors", func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			checkHOLogsForMigratorErrors(ctx, t, g)
+		})).To(gomega.BeTrue())
+
+		// Verify hosted cluster is still healthy
+		g.Expect(t.Run("When verifying post-migration cluster health, it should still be operational", func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			// NodePools should still exist and be healthy
+			nodePools := &hyperv1.NodePoolList{}
+			err := mc.List(ctx, nodePools, crclient.InNamespace(hc.Namespace))
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(nodePools.Items).ToNot(gomega.BeEmpty(), "should have NodePools after migration")
+
+			for _, np := range nodePools.Items {
+				t.Logf("NodePool %s: replicas=%d, ready=%d",
+					np.Name, *np.Spec.Replicas, np.Status.Replicas)
+				g.Expect(np.Status.Replicas).To(gomega.Equal(*np.Spec.Replicas),
+					"NodePool %s should have all replicas ready", np.Name)
+			}
+
+			// Guest client should still work
+			_ = e2eutil.WaitForGuestClient(t, ctx, mc, hc)
+			t.Log("Hosted cluster is still accessible after migration")
+		})).To(gomega.BeTrue())
+	}).WithHOUpgrade().Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "capi-storage-migration", globalOpts.ServiceAccountSigningKey)
+}
+
+func findConditionInStatus(conditions []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+func getGaugeValue(mf map[string]*dto.MetricFamily, name string) *float64 {
+	family, ok := mf[name]
+	if !ok || family == nil {
+		return nil
+	}
+	for _, m := range family.GetMetric() {
+		if g := m.GetGauge(); g != nil {
+			v := g.GetValue()
+			return &v
+		}
+	}
+	return nil
+}
+
+func checkHOLogsForMigratorErrors(ctx context.Context, t *testing.T, g gomega.Gomega) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		cfg, err = e2eutil.GetConfig()
+		g.Expect(err).ToNot(gomega.HaveOccurred(), "getting kubeconfig")
+	}
+	kubeClient, err := kubeclient.NewForConfig(cfg)
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "creating kube client")
+
+	pods, err := kubeClient.CoreV1().Pods("hypershift").List(ctx, metav1.ListOptions{
+		LabelSelector: "name=operator",
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "listing HO pods")
+	g.Expect(pods.Items).ToNot(gomega.BeEmpty(), "should find HO pods")
+
+	for _, pod := range pods.Items {
+		req := kubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
+		stream, err := req.Stream(ctx)
+		g.Expect(err).ToNot(gomega.HaveOccurred(), "streaming logs from pod %s", pod.Name)
+
+		scanner := bufio.NewScanner(stream)
+		var migratorErrors []string
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.Contains(line, `"controller":"crdmigrator"`) && strings.Contains(line, `"level":"error"`) {
+				migratorErrors = append(migratorErrors, line)
+			}
+		}
+		stream.Close()
+		g.Expect(scanner.Err()).ToNot(gomega.HaveOccurred(), "scanning HO logs")
+
+		g.Expect(migratorErrors).To(gomega.BeEmpty(),
+			fmt.Sprintf("HO pod %s should have no CRD migrator errors, found:\n%s",
+				pod.Name, strings.Join(migratorErrors, "\n")))
+		t.Logf("HO pod %s: no CRD migrator errors found in logs", pod.Name)
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -93,6 +93,7 @@ func TestMain(m *testing.M) {
 	flag.BoolVar(&globalOpts.HOInstallationOptions.EnableCIDebugOutput, "e2e.ho-enable-ci-debug-output", false, "Install the HyperShift Operator with extra CI debug output enabled. This is a HyperShift Operator installation option")
 	flag.StringVar(&globalOpts.HOInstallationOptions.PlatformMonitoring, "e2e.platform-monitoring", "All", "The option for enabling platform cluster monitoring when installing the HyperShift Operator. Valid values are: None, OperatorOnly, All. This is a HyperShift Operator installation option")
 	flag.BoolVar(&globalOpts.RunUpgradeTest, "upgrade.run-tests", false, "Run HyperShift Operator upgrade test")
+	flag.BoolVar(&globalOpts.RunCAPIMigrationTest, "capi-migration.run-tests", false, "Run CAPI storage version migration test")
 	flag.StringVar(&globalOpts.ExternalCNIProvider, "e2e.external-cni-provider", "", fmt.Sprintf("The option supports the following CNI providers: %s", e2eutil.CiliumCNIProvider))
 	flag.StringVar(&globalOpts.AdditionalPullSecretFile, "e2e.additional-pull-secret-file", "", "path to a pull secret file for the EnsureGlobalPullSecret test")
 

--- a/test/e2e/util/install.go
+++ b/test/e2e/util/install.go
@@ -14,7 +14,6 @@ import (
 // InstallHyperShiftOperator generates and applies the manifests needed to install the HyperShift Operator starting
 // with the all the HyperShift CRDs. It will wait for the HyperShift Operator to be ready before it returns.
 func InstallHyperShiftOperator(ctx context.Context, opts HyperShiftOperatorInstallOptions) error {
-
 	installOpts := getInstallOptions(opts)
 
 	if opts.DryRun {
@@ -32,7 +31,6 @@ func GetHyperShiftOperatorImage(ctx context.Context, client crclient.Client, opt
 	var image string
 	installOpts := getInstallOptions(opts)
 	deployment, err := install.WaitUntilAvailable(ctx, installOpts)
-
 	if err != nil {
 		return image, err
 	}
@@ -66,6 +64,7 @@ func getInstallOptions(opts HyperShiftOperatorInstallOptions) install.Options {
 	installOpts.EnableDedicatedRequestServingIsolation = opts.EnableDedicatedRequestServingIsolation
 	installOpts.EnableCPOOverrides = opts.EnableCPOOverrides
 	installOpts.EnableEtcdRecovery = opts.EnableEtcdRecovery
+	installOpts.DisableCAPIMigration = opts.DisableCAPIMigration
 
 	return installOpts
 }

--- a/test/e2e/util/install.go
+++ b/test/e2e/util/install.go
@@ -14,6 +14,7 @@ import (
 // InstallHyperShiftOperator generates and applies the manifests needed to install the HyperShift Operator starting
 // with the all the HyperShift CRDs. It will wait for the HyperShift Operator to be ready before it returns.
 func InstallHyperShiftOperator(ctx context.Context, opts HyperShiftOperatorInstallOptions) error {
+
 	installOpts := getInstallOptions(opts)
 
 	if opts.DryRun {
@@ -31,6 +32,7 @@ func GetHyperShiftOperatorImage(ctx context.Context, client crclient.Client, opt
 	var image string
 	installOpts := getInstallOptions(opts)
 	deployment, err := install.WaitUntilAvailable(ctx, installOpts)
+
 	if err != nil {
 		return image, err
 	}

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -83,6 +83,8 @@ type Options struct {
 	HOInstallationOptions HyperShiftOperatorInstallOptions
 	// RunUpgradeTest is set to run HyperShift Operator upgrade test
 	RunUpgradeTest bool
+	// RunCAPIMigrationTest is set to run CAPI storage version migration test
+	RunCAPIMigrationTest bool
 
 	// external oidc for authentication in spec.configurations
 	ExternalOIDCProvider        string
@@ -473,6 +475,7 @@ func (o *Options) DefaultGCPOptions() hypershiftgcp.RawCreateOptions {
 // Complete is intended to be called after flags have been bound and sets
 // up additional contextual defaulting.
 func (o *Options) Complete() error {
+
 	if shouldTestCPOOverride() {
 		o.LatestReleaseImage, o.PreviousReleaseImage = controlplaneoperatoroverrides.LatestOverrideTestReleases(string(o.Platform))
 	}

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -119,6 +119,7 @@ type HyperShiftOperatorInstallOptions struct {
 	EnableDedicatedRequestServingIsolation bool
 	EnableCPOOverrides                     bool
 	EnableEtcdRecovery                     bool
+	DisableCAPIMigration                   bool
 	DryRun                                 bool
 	DryRunDir                              string
 }
@@ -472,7 +473,6 @@ func (o *Options) DefaultGCPOptions() hypershiftgcp.RawCreateOptions {
 // Complete is intended to be called after flags have been bound and sets
 // up additional contextual defaulting.
 func (o *Options) Complete() error {
-
 	if shouldTestCPOOverride() {
 		o.LatestReleaseImage, o.PreviousReleaseImage = controlplaneoperatoroverrides.LatestOverrideTestReleases(string(o.Platform))
 	}

--- a/test/envtest/generator.go
+++ b/test/envtest/generator.go
@@ -137,6 +137,7 @@ func loadCRDFromFile(filename string) (*apiextensionsv1.CustomResourceDefinition
 // function as setupCRDs in cmd/install/install.go.
 func allCRDsForFeatureSet(featureSet string) []*apiextensionsv1.CustomResourceDefinition {
 	crdObjects := crdassets.CustomResourceDefinitions(
+		"v1beta2",
 		func(path string, crd *apiextensionsv1.CustomResourceDefinition) bool {
 			// Exclude non-CRD files (featuregates, test suites).
 			if strings.Contains(path, "payload-manifests") || strings.Contains(path, "tests/") {


### PR DESCRIPTION
## What this PR does / why we need it:
This PR enables CAPI CRD storage version migration from v1beta1 to v1beta2. The migration is necessary because upstream Cluster API is deprecating v1beta1, and all existing CAPI resources stored in etcd must be re-stored using the v1beta2 schema before v1beta1 can be removed.
Additionally, keeping the old storage version also has shown to block the ability to migrate clients to the new API because of various conversion issues.

Upstream, the supported path is migrating the storage version first while clients stay on the old API and afterwards migrating the clients. Therefore, we will follow the same procedure.

When a user runs `hypershift install`, the CLI applies all CAPI CRDs with v1beta2 as the storage version, and the hypershift operator starts a CRD migrator controller that performs no-op server-side applies on every existing CAPI resource to force re storage. CAPI's built-in migrator is disabled on the CAPI manager deployment to avoid conflicts and managing the process centrally on the hypershift operator, gated by the flags and guardrails described.

The migration can be disabled by passing the `--disable-capi-migration` flag.

## Which issue(s) this PR fixes:
Fixes [CNTRLPLANE-3604](https://redhat.atlassian.net/browse/CNTRLPLANE-3604)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conditional CAPI CRD storage version migration support during operator startup and CRD installation.
  * Introduced a `--disable-capi-migration` installation flag and optional `CAPI_STORAGE_VERSION` wiring for the migrator.
* **Bug Fixes**
  * Improved CRD override generation to apply storage-version-specific behavior and adjusted migration guards for safer updates.
  * Updated manager startup args to skip specific CRD migration phases.
* **Tests**
  * Expanded unit coverage for storage-version overrides, migration status reporting, and added gated e2e validation.
* **Documentation**
  * Replaced the storage migration guide with updated default behavior and how to disable it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->