### PR TITLE
OCPBUGS-97830: Add wait-for-etcd init container to oauth-apiserver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -261,6 +261,24 @@ spec:
         name: availability-prober
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+      - args:
+        - -c
+        - |
+          #!/bin/sh
+          while ! nslookup etcd-client.$(POD_NAMESPACE).svc; do sleep 1; done
+        command:
+        - /bin/bash
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: wait-for-etcd
+        resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: hypershift-api-critical
       terminationGracePeriodSeconds: 120
       tolerations:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/GCP/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/GCP/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -287,6 +287,30 @@ spec:
             - ALL
           runAsNonRoot: true
         terminationMessagePolicy: FallbackToLogsOnError
+      - args:
+        - -c
+        - |
+          #!/bin/sh
+          while ! nslookup etcd-client.$(POD_NAMESPACE).svc; do sleep 1; done
+        command:
+        - /bin/bash
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: wait-for-etcd
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: hypershift-api-critical
       terminationGracePeriodSeconds: 120
       tolerations:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -261,6 +261,24 @@ spec:
         name: availability-prober
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+      - args:
+        - -c
+        - |
+          #!/bin/sh
+          while ! nslookup etcd-client.$(POD_NAMESPACE).svc; do sleep 1; done
+        command:
+        - /bin/bash
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: wait-for-etcd
+        resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: hypershift-api-critical
       terminationGracePeriodSeconds: 120
       tolerations:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -261,6 +261,24 @@ spec:
         name: availability-prober
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+      - args:
+        - -c
+        - |
+          #!/bin/sh
+          while ! nslookup etcd-client.$(POD_NAMESPACE).svc; do sleep 1; done
+        command:
+        - /bin/bash
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: wait-for-etcd
+        resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: hypershift-api-critical
       terminationGracePeriodSeconds: 120
       tolerations:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -261,6 +261,24 @@ spec:
         name: availability-prober
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+      - args:
+        - -c
+        - |
+          #!/bin/sh
+          while ! nslookup etcd-client.$(POD_NAMESPACE).svc; do sleep 1; done
+        command:
+        - /bin/bash
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: wait-for-etcd
+        resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: hypershift-api-critical
       terminationGracePeriodSeconds: 120
       tolerations:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-oauth-apiserver/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-oauth-apiserver/deployment.yaml
@@ -126,6 +126,23 @@ spec:
         volumeMounts:
         - mountPath: /var/log/openshift-oauth-apiserver
           name: work-logs
+      initContainers:
+      - args:
+        - -c
+        - |
+          #!/bin/sh
+          while ! nslookup etcd-client.$(POD_NAMESPACE).svc; do sleep 1; done
+        command:
+        - /bin/bash
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: wait-for-etcd
       terminationGracePeriodSeconds: 120
       volumes:
       - emptyDir: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
@@ -32,7 +32,9 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		if err != nil {
 			return err
 		}
+		podspec.RemoveInitContainer("wait-for-etcd", &deployment.Spec.Template.Spec)
 	}
+
 	noProxy := []string{
 		manifests.KubeAPIServerService("").Name,
 		etcdHostname,


### PR DESCRIPTION
## Summary

- Add `wait-for-etcd` init container to the oauth-apiserver deployment, mirroring the existing kube-apiserver pattern
- The init container DNS-polls `etcd-client.$NAMESPACE.svc` until it resolves before the main container starts
- For unmanaged etcd, the init container is removed at reconciliation time (same guard as KAS)

## Problem

The `openshift-oauth-apiserver` pod frequently restarts once during HCP startup because it attempts to connect to etcd before the `etcd-client` service is routable. The container exits with `"error building REST storage: context deadline exceeded"` after a 20-second connection timeout, gets restarted, and succeeds on the second attempt.

This is the primary flake in the AKS e2e CI job (`pull-ci-openshift-hypershift-main-e2e-aks`), causing `EnsureNoCrashingPods` to fail when it sees `restartCount=1`. The job has a ~50% failure rate due to this issue.

## Root Cause

The `kube-apiserver` has a `wait-for-etcd` init container that prevents this exact race condition. The `openshift-oauth-apiserver` connects to etcd the same way but lacked this init container. The `WithDependencies` controller chain only gates Deployment _creation_ at the controller level, not pod-level startup — so the etcd Service can exist but not yet be routable when the oauth-apiserver container starts.

### Log evidence

**PR #8849** — pod `openshift-oauth-apiserver-66b8fdb877-vr549` ([artifacts](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_hypershift/8849/pull-ci-openshift-hypershift-main-e2e-aks/2074105729261768704/artifacts/e2e-aks/hypershift-azure-run-e2e/artifacts/TestAzureScheduler/namespaces/e2e-clusters-dcd6v-azure-scheduler-rfhbf/core/pods/openshift-oauth-apiserver-66b8fdb877-vr549.yaml)):

Previous container logs (ran exactly 20s before crashing):
```
W0706 13:01:23.962078  1 logging.go:55] [core] [Channel #7 SubChannel #8]grpc: addrConn.createTransport failed to connect to {Addr: "etcd-client:2379", ...}. Err: connection error: desc = "transport: Error while dialing: dial tcp: lookup etcd-client: operation was canceled"
W0706 13:01:43.452877  1 logging.go:55] [core] [Channel #1 SubChannel #3]grpc: addrConn.createTransport failed to connect to {Addr: "etcd-client:2379", ...}. Err: connection error: desc = "transport: Error while dialing: dial tcp 10.0.68.198:2379: operation was canceled"
E0706 13:01:43.960390  1 run.go:72] "command failed" err="error building REST storage: context deadline exceeded"
```

```yaml
lastState:
  terminated:
    exitCode: 1
    reason: Error
    startedAt: "2026-07-06T13:01:23Z"
    finishedAt: "2026-07-06T13:01:43Z"
restartCount: 1
```

**PR #8924** — pod `openshift-oauth-apiserver-55785bf8cc-z2sxz` ([artifacts](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_hypershift/8924/pull-ci-openshift-hypershift-main-e2e-aks/2074034587968737280/artifacts/e2e-aks/hypershift-azure-run-e2e/artifacts/TestCreateClusterCustomConfig/namespaces/e2e-clusters-84s4n-custom-config-kd55x/core/pods/openshift-oauth-apiserver-55785bf8cc-z2sxz.yaml)):

Previous container logs (ran 22s before crashing):
```
W0706 08:14:42.800789  1 logging.go:55] [core] [Channel #3 SubChannel #5]grpc: addrConn.createTransport failed to connect to {Addr: "etcd-client:2379", ...}. Err: connection error: desc = "transport: Error while dialing: dial tcp 10.0.143.145:2379: operation was canceled"
W0706 08:14:44.060546  1 logging.go:55] [core] [Channel #7 SubChannel #9]grpc: addrConn.createTransport failed to connect to {Addr: "etcd-client:2379", ...}. Err: connection error: desc = "transport: Error while dialing: dial tcp 10.0.143.145:2379: i/o timeout"
E0706 08:14:44.060879  1 run.go:72] "command failed" err="error building REST storage: context deadline exceeded"
```

```yaml
lastState:
  terminated:
    exitCode: 1
    reason: Error
    startedAt: "2026-07-06T08:14:22Z"
    finishedAt: "2026-07-06T08:14:44Z"
restartCount: 1
```

Both crashes follow the same sequence: oauth-apiserver starts → gRPC connections to `etcd-client:2379` fail (DNS lookup canceled or TCP dial timeout) → 20s etcd client context expires → fatal `"error building REST storage: context deadline exceeded"` → exit code 1 → restart succeeds. Both PRs (#8849 is a dependabot update, #8924 is an unrelated nil-map guard fix) are completely unrelated to this failure.

## Test plan

- [x] `make lint-fix` passes (0 issues)
- [x] `make verify` passes (pre-existing `verify-crd-schema` failure unrelated to this change)
- [ ] AKS e2e job should stop flaking on `EnsureNoCrashingPods` for oauth-apiserver restarts

/jira:OCPBUGS-97830

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability for the OAuth API server by adding an init step that waits until the required etcd service can be discovered before the server starts.
  * Updated deployment behavior for environments with externally managed etcd to skip the waiting step, avoiding unnecessary delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->