### PR TITLE
CNTRLPLANE-3600: Bump Prow CI build root image to Go 1.26

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.23
+  tag: rhel-9-release-golang-1.26-openshift-4.23


### PR DESCRIPTION
## What this PR does / why we need it:

Bumps the Prow CI build root image from `golang-1.25` to `golang-1.26`.

The k8s v0.36.2 dependency bump in #8695 sets `go 1.26.0` in go.mod. PR #8888 already updated the GHA runner image to Go 1.26.4, but Prow e2e jobs still fail because the build root image has Go 1.25.8:

```
go: go.mod requires go >= 1.26.0 (running go 1.25.8; GOTOOLCHAIN=local)
```

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3600](https://redhat.atlassian.net/browse/CNTRLPLANE-3600)

## Special notes for your reviewer:

Prerequisite for #8695 (k8s bump). The `golang-1.26` image already exists in the CI registry.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build job environment to use a newer Go 1.26-based image, keeping release builds on a current platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->