### PR TITLE
fix(security): update golang and base image for CVE remediation

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.23
+  tag: rhel-9-release-golang-1.26-openshift-4.23

--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 AS builder
 ARG COMMIT_HASH
 
 WORKDIR /hypershift

--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778054913 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.4-1782736563 AS builder
 ARG COMMIT_HASH
 
 WORKDIR /hypershift
@@ -8,7 +8,7 @@ COPY --chown=default . .
 RUN make control-plane-operator \
   && make control-plane-pki-operator
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1777857961
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782191395
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
 COPY --from=builder /hypershift/bin/control-plane-pki-operator /usr/bin/control-plane-pki-operator
 

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778054913 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.4-1782736563 AS builder
 ARG COMMIT_HASH
 
 WORKDIR /hypershift
@@ -9,7 +9,7 @@ RUN make hypershift \
   && make hypershift-operator \
   && make karpenter-operator
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1777857961
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782191395
 COPY --from=builder /hypershift/bin/hypershift \
   /hypershift/bin/hypershift-operator \
   /hypershift/bin/karpenter-operator \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.23 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.26-openshift-4.23 AS builder
 ARG COMMIT_HASH
 
 WORKDIR /hypershift

--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.23 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23 AS builder
 ARG COMMIT_HASH
 
 WORKDIR /hypershift

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 # Disclaimer: The purpose of this Dockerfile is to simplify development tasks by building a container image with all-in-one binaries.
 # The control-plane-operator should not be included in the Hypershift operator image because it is already part of the OpenShift payload.
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.23 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.26-openshift-4.23 AS builder
 ARG COMMIT_HASH
 
 WORKDIR /hypershift

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.23 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.26-openshift-4.23 AS builder
 ARG COMMIT_HASH
 
 WORKDIR /hypershift
@@ -9,7 +9,7 @@ RUN make e2e hypershift e2ev2-create-guests e2ev2-run-tests e2ev2-destroy-guests
 
 # Reuse the same image as builder because we need go command in ci-test-e2e.sh
 # Multi-stage build lets us drop the source code and build cache from the final image
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.23
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.26-openshift-4.23
 
 WORKDIR /hypershift
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hypershift/api
 
-go 1.25.7
+go 1.26.4
 
 require (
 	github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hypershift
 
-go 1.25.7
+go 1.26.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hypershift/hack/tools
 
-go 1.25.7
+go 1.26.4
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0

--- a/hack/workspace/go.work
+++ b/hack/workspace/go.work
@@ -1,4 +1,4 @@
-go 1.25.7
+go 1.26.4
 
 use (
 	./hypershift

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1134,7 +1134,7 @@ github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/control
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
 # github.com/openshift/hypershift/api v0.0.0-20250724113115-0281b49cc465 => ./api
-## explicit; go 1.25.7
+## explicit; go 1.26.4
 github.com/openshift/hypershift/api/auditlogpersistence
 github.com/openshift/hypershift/api/auditlogpersistence/v1alpha1
 github.com/openshift/hypershift/api/certificates


### PR DESCRIPTION
## What this PR does / why we need it:

Updates the ubi-minimal base image used for hypershift operator and other images to make use of ubi-minimal:9.8.

Go mod version is bumped to 1.26.4

these bumps address the below CVEs

CVE-2026-33846
CVE-2026-33845
CVE-2026-42009
CVE-2026-42010
CVE-2026-4878
CVE-2026-33811
CVE-2026-39836
CVE-2026-27145
CVE-2026-42499
CVE-2026-33814
CVE-2026-42504
CVE-2026-39820

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes #[PSHP-316](https://redhat.atlassian.net/browse/PSHP-316)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the build and container images to use newer Go 1.26 and refreshed runtime base images.
* **Chores**
  * Bumped project Go version settings to 1.26.4 across development and build configurations.
  * Aligned CI and Docker build setups with the newer toolchain images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->