### PR TITLE
OCPBUGS-98654: delete_hosted_cluster.sh fails to run with no --dns-zone-rg-name flag

### DIFF
--- a/contrib/managed-azure/delete_hosted_cluster.sh
+++ b/contrib/managed-azure/delete_hosted_cluster.sh
@@ -21,6 +21,7 @@ fi
 AZURE_CREDS=${AZURE_CREDS:?"Error: AZURE_CREDS is not set. Please check your user-vars.sh file."}
 HYPERSHIFT_BINARY_PATH=${HYPERSHIFT_BINARY_PATH:?"Error: HYPERSHIFT_BINARY_PATH is not set. Please check your user-vars.sh file."}
 PREFIX=${PREFIX:?"Error: PREFIX is not set. Please check your user-vars.sh file."}
+PERSISTENT_RG_NAME=${PERSISTENT_RG_NAME:?"Error: PERSISTENT_RG_NAME is not set. Please check the vars.sh file."}
 
 # Local variables following the same pattern as create_basic_hosted_cluster.sh
 MANAGED_RG_NAME="${PREFIX}-managed-rg"
@@ -32,7 +33,8 @@ CLUSTER_NAME="${PREFIX}-hc"
 ${HYPERSHIFT_BINARY_PATH}/hypershift destroy cluster azure \
     --name "$CLUSTER_NAME" \
     --azure-creds "$AZURE_CREDS" \
-    --resource-group-name "$MANAGED_RG_NAME"
+    --resource-group-name "$MANAGED_RG_NAME" \
+    --dns-zone-rg-name "$PERSISTENT_RG_NAME"
 
 if [ $? -ne 0 ]; then
     echo "Error: Failed to destroy hosted cluster $CLUSTER_NAME"


### PR DESCRIPTION

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

`contrib/managed-azure/delete_hosted_cluster.sh` needs the `--dns-zone-rg-name` flag in `${HYPERSHIFT_BINARY_PATH}/hypershift destroy cluster azure` since it is required in the CLI.

```
Error: required flag(s) "dns-zone-rg-name" not set                                                                                                           
required flag(s) "dns-zone-rg-name" not set 
```

This PR adds this flag to the script so it runs as intended.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 
#[OCPBUGS-98654](https://redhat.atlassian.net/browse/OCPBUGS-98654)
## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hosted cluster deletion for Azure by including the DNS zone resource group name during cleanup, helping ensure deletions complete more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->