### PR TITLE
OCPBUGS-89689: (karpenter) use completed release image for unpinned NodeClaims during CP upgrade

### DIFF
--- a/karpenter-operator/controllers/karpenterignition/karpenterignition_controller.go
+++ b/karpenter-operator/controllers/karpenterignition/karpenterignition_controller.go
@@ -120,13 +120,20 @@ func (r *KarpenterIgnitionReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return r.reconcileDeletedNodeClass(ctx, hcp, openshiftEC2NodeClass)
 	}
 
+	// Guard: if the CPO hasn't populated VersionStatus yet, we can't reliably
+	// determine the completed release image. Falling back to Spec.ReleaseImage
+	// would use the desired (new) image during an upgrade, causing premature drift.
+	if hcp.Status.VersionStatus == nil {
+		log.Info("HCP VersionStatus not yet available, requeueing")
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
 	hostedCluster, err := hostedClusterFromHCP(hcp, r.IgnitionEndpoint)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get HostedCluster: %w", err)
 	}
 
-	releaseImage := hcp.Spec.ReleaseImage
-	version := currentClusterVersion(hostedCluster)
+	releaseImage, version := currentClusterReleaseImage(hostedCluster)
 
 	// When the user requests a version for the OpenshiftEC2NodeClass we perform further validation and lookup of the release image.
 	// We only detect skew and if the version is valid in this case, as under normal circumstances we can assume the release image
@@ -341,14 +348,16 @@ func (r *KarpenterIgnitionReconciler) createInMemoryNodePool(
 	}
 }
 
-// currentClusterVersion returns the version of the most recently completed update from the
-// HostedCluster's version history. It searches history entries for the one with state=Completed
-// and the most recent CompletionTime. If no completed entries exist and there is exactly one
-// history entry, it falls back to the desired version. This handles the case where a cluster
-// is still rolling out its initial version.
-func currentClusterVersion(hostedCluster *hyperv1.HostedCluster) string {
+// currentClusterReleaseImage returns the release image and version of the most recently
+// completed update from the HostedCluster's version history. It searches history entries
+// for the one with state=Completed and the most recent CompletionTime.
+// If no completed entries exist, it falls back to the Spec release image and Desired version.
+// This ensures that during a control plane upgrade, unpinned Karpenter NodeClaims use the
+// completed version's release image rather than the desired version, preventing premature
+// drift detection and worker node replacement before the control plane is ready.
+func currentClusterReleaseImage(hostedCluster *hyperv1.HostedCluster) (string, string) {
 	if hostedCluster.Status.Version == nil {
-		return ""
+		return hostedCluster.Spec.Release.Image, ""
 	}
 
 	var latest *configv1.UpdateHistory
@@ -367,16 +376,12 @@ func currentClusterVersion(hostedCluster *hyperv1.HostedCluster) string {
 	}
 
 	if latest != nil {
-		return latest.Version
+		return latest.Image, latest.Version
 	}
 
-	// If there are no completed entries but exactly one history entry exists, the cluster
-	// is likely still rolling out its first version. Fall back to the desired version.
-	if len(hostedCluster.Status.Version.History) == 1 {
-		return hostedCluster.Status.Version.Desired.Version
-	}
-
-	return hostedCluster.Status.Version.Desired.Version
+	// If there are no completed entries, the cluster is likely still rolling out its
+	// first version. Fall back to the spec release image and desired version.
+	return hostedCluster.Spec.Release.Image, hostedCluster.Status.Version.Desired.Version
 }
 
 // validateVersion checks whether the requested version is valid for the given HostedCluster.

--- a/karpenter-operator/controllers/karpenterignition/karpenterignition_controller.go
+++ b/karpenter-operator/controllers/karpenterignition/karpenterignition_controller.go
@@ -120,20 +120,16 @@ func (r *KarpenterIgnitionReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return r.reconcileDeletedNodeClass(ctx, hcp, openshiftEC2NodeClass)
 	}
 
-	// Guard: if the CPO hasn't populated VersionStatus yet, we can't reliably
-	// determine the completed release image. Falling back to Spec.ReleaseImage
-	// would use the desired (new) image during an upgrade, causing premature drift.
-	if hcp.Status.VersionStatus == nil {
-		log.Info("HCP VersionStatus not yet available, requeueing")
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
-
 	hostedCluster, err := hostedClusterFromHCP(hcp, r.IgnitionEndpoint)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get HostedCluster: %w", err)
 	}
 
-	releaseImage, version := currentClusterReleaseImage(hostedCluster)
+	releaseImage, version, requeue := currentClusterRelease(hostedCluster)
+	if requeue && openshiftEC2NodeClass.Spec.Version == "" {
+		log.Info("No version history available for unpinned NodeClass, requeueing")
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
 
 	// When the user requests a version for the OpenshiftEC2NodeClass we perform further validation and lookup of the release image.
 	// We only detect skew and if the version is valid in this case, as under normal circumstances we can assume the release image
@@ -348,16 +344,18 @@ func (r *KarpenterIgnitionReconciler) createInMemoryNodePool(
 	}
 }
 
-// currentClusterReleaseImage returns the release image and version of the most recently
-// completed update from the HostedCluster's version history. It searches history entries
-// for the one with state=Completed and the most recent CompletionTime.
-// If no completed entries exist, it falls back to the Spec release image and Desired version.
+// currentClusterRelease returns the release image and version of the most recently
+// completed update from the HostedCluster's version history, plus a requeue flag.
+// It searches history entries for the one with state=Completed and the most recent
+// CompletionTime. If no completed entries exist, it falls back to the first Partial
+// entry (the version currently being rolled out). If no history entries exist at all,
+// it signals the caller to requeue.
 // This ensures that during a control plane upgrade, unpinned Karpenter NodeClaims use the
 // completed version's release image rather than the desired version, preventing premature
 // drift detection and worker node replacement before the control plane is ready.
-func currentClusterReleaseImage(hostedCluster *hyperv1.HostedCluster) (string, string) {
+func currentClusterRelease(hostedCluster *hyperv1.HostedCluster) (string, string, bool) {
 	if hostedCluster.Status.Version == nil {
-		return hostedCluster.Spec.Release.Image, ""
+		return hostedCluster.Spec.Release.Image, "", false
 	}
 
 	var latest *configv1.UpdateHistory
@@ -370,18 +368,33 @@ func currentClusterReleaseImage(hostedCluster *hyperv1.HostedCluster) (string, s
 			latest = entry
 			continue
 		}
-		if entry.CompletionTime != nil && latest.CompletionTime != nil && entry.CompletionTime.After(latest.CompletionTime.Time) {
+		switch {
+		case entry.CompletionTime == nil:
+			// keep latest; nothing to compare against
+		case latest.CompletionTime == nil:
+			latest = entry
+		case entry.CompletionTime.After(latest.CompletionTime.Time):
 			latest = entry
 		}
 	}
 
 	if latest != nil {
-		return latest.Image, latest.Version
+		return latest.Image, latest.Version, false
 	}
 
-	// If there are no completed entries, the cluster is likely still rolling out its
-	// first version. Fall back to the spec release image and desired version.
-	return hostedCluster.Spec.Release.Image, hostedCluster.Status.Version.Desired.Version
+	// No completed entries: fall back to the first Partial entry if available.
+	// CVO prepends newest entries, so the first Partial is the currently rolling-out version.
+	// This is safer than Spec.Release.Image which flips to the new (desired) version
+	// immediately on upgrade request.
+	for i := range hostedCluster.Status.Version.History {
+		entry := &hostedCluster.Status.Version.History[i]
+		if entry.State == configv1.PartialUpdate {
+			return entry.Image, entry.Version, false
+		}
+	}
+
+	// Empty history: signal caller to requeue — CVO hasn't reported any version yet.
+	return "", "", true
 }
 
 // validateVersion checks whether the requested version is valid for the given HostedCluster.

--- a/karpenter-operator/controllers/karpenterignition/karpenterignition_controller_test.go
+++ b/karpenter-operator/controllers/karpenterignition/karpenterignition_controller_test.go
@@ -122,6 +122,7 @@ func TestReconcile(t *testing.T) {
 					{
 						State:          configv1.CompletedUpdate,
 						Version:        "4.17.0",
+						Image:          "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64",
 						CompletionTime: &metav1.Time{Time: time.Now()},
 					},
 				},
@@ -437,6 +438,7 @@ func TestReconcileVersionResolution(t *testing.T) {
 						{
 							State:          configv1.CompletedUpdate,
 							Version:        "4.17.0",
+							Image:          "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64",
 							CompletionTime: &metav1.Time{Time: time.Now()},
 						},
 					},
@@ -732,6 +734,7 @@ func TestResolveVersion(t *testing.T) {
 						{
 							State:          configv1.CompletedUpdate,
 							Version:        "4.17.0",
+							Image:          "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64",
 							CompletionTime: &metav1.Time{Time: time.Now()},
 						},
 					},
@@ -993,18 +996,22 @@ func TestUpdateVersionStatus(t *testing.T) {
 	})
 }
 
-func TestCurrentClusterVersion(t *testing.T) {
+func TestCurrentClusterReleaseImage(t *testing.T) {
 	completedTime1 := metav1.Now()
 	completedTime2 := metav1.NewTime(completedTime1.Add(time.Hour))
 
 	testCases := []struct {
 		name            string
 		hostedCluster   *hyperv1.HostedCluster
+		expectedImage   string
 		expectedVersion string
 	}{
 		{
-			name: "When there is a single completed history entry it should return that version",
+			name: "When there is a single completed entry, it should return that entry's version and image",
 			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Release: hyperv1.Release{Image: "quay.io/release:4.17.0"},
+				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{Version: "4.17.0"},
@@ -1012,17 +1019,50 @@ func TestCurrentClusterVersion(t *testing.T) {
 							{
 								State:          configv1.CompletedUpdate,
 								Version:        "4.17.0",
+								Image:          "quay.io/release:4.17.0",
 								CompletionTime: &completedTime1,
 							},
 						},
 					},
 				},
 			},
+			expectedImage:   "quay.io/release:4.17.0",
 			expectedVersion: "4.17.0",
 		},
 		{
-			name: "When there are multiple completed entries it should return the one with the most recent CompletionTime",
+			name: "When upgrade is in progress, it should return completed entry, not the partial",
 			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Release: hyperv1.Release{Image: "quay.io/release:4.18.0"},
+				},
+				Status: hyperv1.HostedClusterStatus{
+					Version: &hyperv1.ClusterVersionStatus{
+						Desired: configv1.Release{Version: "4.18.0"},
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.PartialUpdate,
+								Version: "",
+								Image:   "quay.io/release:4.18.0",
+							},
+							{
+								State:          configv1.CompletedUpdate,
+								Version:        "4.17.0",
+								Image:          "quay.io/release:4.17.0",
+								CompletionTime: &completedTime1,
+							},
+						},
+					},
+				},
+			},
+			expectedImage:   "quay.io/release:4.17.0",
+			expectedVersion: "4.17.0",
+		},
+		{
+			name: "When there are multiple completed entries, it should return the most recent by CompletionTime",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Release: hyperv1.Release{Image: "quay.io/release:4.18.0"},
+				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{Version: "4.18.0"},
@@ -1030,22 +1070,28 @@ func TestCurrentClusterVersion(t *testing.T) {
 							{
 								State:          configv1.CompletedUpdate,
 								Version:        "4.17.0",
+								Image:          "quay.io/release:4.17.0",
 								CompletionTime: &completedTime1,
 							},
 							{
 								State:          configv1.CompletedUpdate,
 								Version:        "4.18.0",
+								Image:          "quay.io/release:4.18.0",
 								CompletionTime: &completedTime2,
 							},
 						},
 					},
 				},
 			},
+			expectedImage:   "quay.io/release:4.18.0",
 			expectedVersion: "4.18.0",
 		},
 		{
-			name: "When there is a partial entry and a completed entry it should return the completed entry",
+			name: "When there is a partial entry and a completed entry, it should return the completed entry",
 			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Release: hyperv1.Release{Image: "quay.io/release:4.18.0"},
+				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{Version: "4.18.0"},
@@ -1053,21 +1099,27 @@ func TestCurrentClusterVersion(t *testing.T) {
 							{
 								State:   configv1.PartialUpdate,
 								Version: "4.18.0",
+								Image:   "quay.io/release:4.18.0",
 							},
 							{
 								State:          configv1.CompletedUpdate,
 								Version:        "4.17.0",
+								Image:          "quay.io/release:4.17.0",
 								CompletionTime: &completedTime1,
 							},
 						},
 					},
 				},
 			},
+			expectedImage:   "quay.io/release:4.17.0",
 			expectedVersion: "4.17.0",
 		},
 		{
-			name: "When there are no completed entries and exactly one history entry it should fall back to Desired.Version",
+			name: "When there are no completed entries and exactly one history entry, it should fall back to Spec.Release.Image and Desired.Version",
 			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Release: hyperv1.Release{Image: "quay.io/release:4.17.0"},
+				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{Version: "4.17.0"},
@@ -1075,16 +1127,21 @@ func TestCurrentClusterVersion(t *testing.T) {
 							{
 								State:   configv1.PartialUpdate,
 								Version: "4.17.0",
+								Image:   "quay.io/release:4.17.0",
 							},
 						},
 					},
 				},
 			},
+			expectedImage:   "quay.io/release:4.17.0",
 			expectedVersion: "4.17.0",
 		},
 		{
-			name: "When there are no completed entries and multiple history entries it should fall back to Desired.Version",
+			name: "When there are no completed entries and multiple history entries, it should fall back to Spec.Release.Image and Desired.Version",
 			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Release: hyperv1.Release{Image: "quay.io/release:4.18.0"},
+				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{Version: "4.18.0"},
@@ -1092,20 +1149,26 @@ func TestCurrentClusterVersion(t *testing.T) {
 							{
 								State:   configv1.PartialUpdate,
 								Version: "4.18.0",
+								Image:   "quay.io/release:4.18.0",
 							},
 							{
 								State:   configv1.PartialUpdate,
 								Version: "4.17.0",
+								Image:   "quay.io/release:4.17.0",
 							},
 						},
 					},
 				},
 			},
+			expectedImage:   "quay.io/release:4.18.0",
 			expectedVersion: "4.18.0",
 		},
 		{
-			name: "When history is empty it should fall back to Desired.Version",
+			name: "When history is empty, it should fall back to Spec.Release.Image and Desired.Version",
 			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Release: hyperv1.Release{Image: "quay.io/release:4.17.0"},
+				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{Version: "4.17.0"},
@@ -1113,15 +1176,20 @@ func TestCurrentClusterVersion(t *testing.T) {
 					},
 				},
 			},
+			expectedImage:   "quay.io/release:4.17.0",
 			expectedVersion: "4.17.0",
 		},
 		{
-			name: "When Version is nil it should return empty string",
+			name: "When Version is nil, it should return Spec.Release.Image and empty version",
 			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Release: hyperv1.Release{Image: "quay.io/release:4.17.0"},
+				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: nil,
 				},
 			},
+			expectedImage:   "quay.io/release:4.17.0",
 			expectedVersion: "",
 		},
 	}
@@ -1129,7 +1197,8 @@ func TestCurrentClusterVersion(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			version := currentClusterVersion(tc.hostedCluster)
+			image, version := currentClusterReleaseImage(tc.hostedCluster)
+			g.Expect(image).To(Equal(tc.expectedImage))
 			g.Expect(version).To(Equal(tc.expectedVersion))
 		})
 	}
@@ -1336,6 +1405,7 @@ func TestReconcileKubeletConfigMapOrphanCleanup(t *testing.T) {
 						{
 							State:          configv1.CompletedUpdate,
 							Version:        "4.17.0",
+							Image:          "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64",
 							CompletionTime: &metav1.Time{Time: time.Now()},
 						},
 					},

--- a/karpenter-operator/controllers/karpenterignition/karpenterignition_controller_test.go
+++ b/karpenter-operator/controllers/karpenterignition/karpenterignition_controller_test.go
@@ -996,7 +996,7 @@ func TestUpdateVersionStatus(t *testing.T) {
 	})
 }
 
-func TestCurrentClusterReleaseImage(t *testing.T) {
+func TestCurrentClusterRelease(t *testing.T) {
 	completedTime1 := metav1.Now()
 	completedTime2 := metav1.NewTime(completedTime1.Add(time.Hour))
 
@@ -1005,6 +1005,7 @@ func TestCurrentClusterReleaseImage(t *testing.T) {
 		hostedCluster   *hyperv1.HostedCluster
 		expectedImage   string
 		expectedVersion string
+		expectedRequeue bool
 	}{
 		{
 			name: "When there is a single completed entry, it should return that entry's version and image",
@@ -1115,7 +1116,7 @@ func TestCurrentClusterReleaseImage(t *testing.T) {
 			expectedVersion: "4.17.0",
 		},
 		{
-			name: "When there are no completed entries and exactly one history entry, it should fall back to Spec.Release.Image and Desired.Version",
+			name: "When there are no completed entries and exactly one Partial entry, it should fall back to the Partial entry",
 			hostedCluster: &hyperv1.HostedCluster{
 				Spec: hyperv1.HostedClusterSpec{
 					Release: hyperv1.Release{Image: "quay.io/release:4.17.0"},
@@ -1137,7 +1138,7 @@ func TestCurrentClusterReleaseImage(t *testing.T) {
 			expectedVersion: "4.17.0",
 		},
 		{
-			name: "When there are no completed entries and multiple history entries, it should fall back to Spec.Release.Image and Desired.Version",
+			name: "When there are no completed entries and multiple Partial entries, it should return the first Partial entry",
 			hostedCluster: &hyperv1.HostedCluster{
 				Spec: hyperv1.HostedClusterSpec{
 					Release: hyperv1.Release{Image: "quay.io/release:4.18.0"},
@@ -1164,7 +1165,92 @@ func TestCurrentClusterReleaseImage(t *testing.T) {
 			expectedVersion: "4.18.0",
 		},
 		{
-			name: "When history is empty, it should fall back to Spec.Release.Image and Desired.Version",
+			name: "When Spec image differs from only Partial entry during upgrade, it should return Partial image not Spec",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Release: hyperv1.Release{Image: "quay.io/release:4.18.0"},
+				},
+				Status: hyperv1.HostedClusterStatus{
+					Version: &hyperv1.ClusterVersionStatus{
+						Desired: configv1.Release{Version: "4.18.0"},
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.PartialUpdate,
+								Version: "4.17.0",
+								Image:   "quay.io/release:4.17.0",
+							},
+						},
+					},
+				},
+			},
+			expectedImage:   "quay.io/release:4.17.0",
+			expectedVersion: "4.17.0",
+		},
+		{
+			name: "When multi-upgrade has 2 Completed and 1 Partial, it should return latest Completed not the Partial",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Release: hyperv1.Release{Image: "quay.io/release:4.19.0"},
+				},
+				Status: hyperv1.HostedClusterStatus{
+					Version: &hyperv1.ClusterVersionStatus{
+						Desired: configv1.Release{Version: "4.19.0"},
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.PartialUpdate,
+								Version: "4.19.0",
+								Image:   "quay.io/release:4.19.0",
+							},
+							{
+								State:          configv1.CompletedUpdate,
+								Version:        "4.18.0",
+								Image:          "quay.io/release:4.18.0",
+								CompletionTime: &completedTime2,
+							},
+							{
+								State:          configv1.CompletedUpdate,
+								Version:        "4.17.0",
+								Image:          "quay.io/release:4.17.0",
+								CompletionTime: &completedTime1,
+							},
+						},
+					},
+				},
+			},
+			expectedImage:   "quay.io/release:4.18.0",
+			expectedVersion: "4.18.0",
+		},
+		{
+			name: "When a Completed entry has nil CompletionTime and another has a timestamp, it should prefer the one with a timestamp",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Release: hyperv1.Release{Image: "quay.io/release:4.18.0"},
+				},
+				Status: hyperv1.HostedClusterStatus{
+					Version: &hyperv1.ClusterVersionStatus{
+						Desired: configv1.Release{Version: "4.18.0"},
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.CompletedUpdate,
+								Version: "4.17.0",
+								Image:   "quay.io/release:4.17.0",
+								// nil CompletionTime
+							},
+							{
+								State:          configv1.CompletedUpdate,
+								Version:        "4.18.0",
+								Image:          "quay.io/release:4.18.0",
+								CompletionTime: &completedTime1,
+							},
+						},
+					},
+				},
+			},
+			expectedImage:   "quay.io/release:4.18.0",
+			expectedVersion: "4.18.0",
+		},
+		{
+			name: "When history is empty, it should signal requeue",
 			hostedCluster: &hyperv1.HostedCluster{
 				Spec: hyperv1.HostedClusterSpec{
 					Release: hyperv1.Release{Image: "quay.io/release:4.17.0"},
@@ -1176,8 +1262,7 @@ func TestCurrentClusterReleaseImage(t *testing.T) {
 					},
 				},
 			},
-			expectedImage:   "quay.io/release:4.17.0",
-			expectedVersion: "4.17.0",
+			expectedRequeue: true,
 		},
 		{
 			name: "When Version is nil, it should return Spec.Release.Image and empty version",
@@ -1197,9 +1282,12 @@ func TestCurrentClusterReleaseImage(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			image, version := currentClusterReleaseImage(tc.hostedCluster)
-			g.Expect(image).To(Equal(tc.expectedImage))
-			g.Expect(version).To(Equal(tc.expectedVersion))
+			image, version, requeue := currentClusterRelease(tc.hostedCluster)
+			g.Expect(requeue).To(Equal(tc.expectedRequeue))
+			if !tc.expectedRequeue {
+				g.Expect(image).To(Equal(tc.expectedImage))
+				g.Expect(version).To(Equal(tc.expectedVersion))
+			}
 		})
 	}
 }

--- a/test/e2e/karpenter_control_plane_upgrade_test.go
+++ b/test/e2e/karpenter_control_plane_upgrade_test.go
@@ -81,19 +81,23 @@ func TestKarpenterUpgradeControlPlane(t *testing.T) {
 		})
 		g.Expect(err).NotTo(HaveOccurred(), "failed update hostedcluster image")
 
-		driftChan := make(chan struct{})
-		go func() {
-			defer close(driftChan)
-			for _, nodeClaim := range nodeClaims.Items {
-				waitForNodeClaimDrifted(t, ctx, guestClient, &nodeClaim)
-			}
-		}()
+		// Assert NO drift during CP upgrade. Unpinned NodeClaims should not detect
+		// drift until the control plane upgrade completes, because the ignition config
+		// hash is derived from the completed release image, not the desired one.
+		noDriftCancel, noDriftDone := assertNodeClaimsNotDrifted(t, ctx, guestClient, nodeClaims)
 
 		e2eutil.WaitForImageRollout(t, ctx, mgtClient, hostedCluster)
+		noDriftCancel()
+		<-noDriftDone
+
 		err = mgtClient.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 
-		<-driftChan
+		// After CP upgrade completes, drift should now be detected.
+		t.Logf("Control plane upgrade complete, waiting for NodeClaim drift detection")
+		for _, nodeClaim := range nodeClaims.Items {
+			waitForNodeClaimDrifted(t, ctx, guestClient, &nodeClaim)
+		}
 		t.Logf("Karpenter Nodes drifted")
 
 		preUpgradeRHCOSVersion := extractRHCOSVersion(preUpgradeOSImage)

--- a/test/e2e/karpenter_control_plane_upgrade_test.go
+++ b/test/e2e/karpenter_control_plane_upgrade_test.go
@@ -84,7 +84,7 @@ func TestKarpenterUpgradeControlPlane(t *testing.T) {
 		// Assert NO drift during CP upgrade. Unpinned NodeClaims should not detect
 		// drift until the control plane upgrade completes, because the ignition config
 		// hash is derived from the completed release image, not the desired one.
-		noDriftCancel, noDriftDone := assertNodeClaimsNotDrifted(t, ctx, guestClient, nodeClaims)
+		noDriftCancel, noDriftDone := assertNodeClaimsNotDrifted(t, ctx, guestClient, nodeClaims, cancel)
 
 		e2eutil.WaitForImageRollout(t, ctx, mgtClient, hostedCluster)
 		noDriftCancel()

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -1641,6 +1641,43 @@ func waitForNodeClaimDrifted(t *testing.T, ctx context.Context, client crclient.
 	)
 }
 
+// assertNodeClaimsNotDrifted starts a background goroutine that polls NodeClaims every
+// 10 seconds and fails the test if any NodeClaim has the Drifted condition set to True.
+// Returns a cancel function to stop polling and a channel that closes when the goroutine exits.
+func assertNodeClaimsNotDrifted(t *testing.T, ctx context.Context, client crclient.Client, nodeClaims *karpenterv1.NodeClaimList) (context.CancelFunc, <-chan struct{}) {
+	noDriftCtx, noDriftCancel := context.WithCancel(ctx)
+	noDriftDone := make(chan struct{})
+	go func() {
+		defer close(noDriftDone)
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-noDriftCtx.Done():
+				return
+			case <-ticker.C:
+				for i := range nodeClaims.Items {
+					current := &karpenterv1.NodeClaim{}
+					if err := client.Get(noDriftCtx, crclient.ObjectKeyFromObject(&nodeClaims.Items[i]), current); err != nil {
+						continue
+					}
+					conditions, err := e2eutil.Conditions(current)
+					if err != nil {
+						continue
+					}
+					for _, c := range conditions {
+						if c.Type == karpenterv1.ConditionTypeDrifted && c.Status == metav1.ConditionTrue {
+							t.Errorf("NodeClaim %s detected drift BEFORE CP upgrade completed", nodeClaims.Items[i].Name)
+							return
+						}
+					}
+				}
+			}
+		}
+	}()
+	return noDriftCancel, noDriftDone
+}
+
 // waitForAutoNodeStatusVCPUs polls until HostedCluster.Status.AutoNode.VCPUs
 // converges to the expected value. This checks only the status field (Karpenter-only vCPUs),
 // not the billing metric.

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -1643,8 +1643,10 @@ func waitForNodeClaimDrifted(t *testing.T, ctx context.Context, client crclient.
 
 // assertNodeClaimsNotDrifted starts a background goroutine that polls NodeClaims every
 // 10 seconds and fails the test if any NodeClaim has the Drifted condition set to True.
+// When premature drift is detected, it calls cancelOnDrift (if non-nil) to abort the
+// parent context, avoiding wasted e2e time on a known-failed run.
 // Returns a cancel function to stop polling and a channel that closes when the goroutine exits.
-func assertNodeClaimsNotDrifted(t *testing.T, ctx context.Context, client crclient.Client, nodeClaims *karpenterv1.NodeClaimList) (context.CancelFunc, <-chan struct{}) {
+func assertNodeClaimsNotDrifted(t *testing.T, ctx context.Context, client crclient.Client, nodeClaims *karpenterv1.NodeClaimList, cancelOnDrift context.CancelFunc) (context.CancelFunc, <-chan struct{}) {
 	noDriftCtx, noDriftCancel := context.WithCancel(ctx)
 	noDriftDone := make(chan struct{})
 	go func() {
@@ -1668,6 +1670,9 @@ func assertNodeClaimsNotDrifted(t *testing.T, ctx context.Context, client crclie
 					for _, c := range conditions {
 						if c.Type == karpenterv1.ConditionTypeDrifted && c.Status == metav1.ConditionTrue {
 							t.Errorf("NodeClaim %s detected drift BEFORE CP upgrade completed", nodeClaims.Items[i].Name)
+							if cancelOnDrift != nil {
+								cancelOnDrift()
+							}
 							return
 						}
 					}


### PR DESCRIPTION
## Summary

- During a CP upgrade, `hcp.Spec.ReleaseImage` flips to the desired version immediately. The KarpenterIgnition controller was reading this for unpinned NodeClaims, causing premature drift detection and worker replacement before CP upgrade completed.
- Replace `currentClusterVersion()` with `currentClusterReleaseImage()` that returns both release image and version from the most recently completed history entry.
- Unpinned NodeClaims now wait for CP upgrade to complete before detecting drift. Pinned NodeClaims (with `spec.version`) are unaffected.

## Test plan

- [x] Unit test: `TestCurrentClusterReleaseImage` — 8 cases including upgrade-in-progress scenario (Partial + Completed history entries)
- [x] Unit test: existing `TestReconcile`, `TestReconcileVersionResolution`, `TestResolveVersion`, `TestReconcileKubeletConfigMap` — all pass with updated fixtures
- [x] `go vet` clean
- [ ] E2E: initiate CP upgrade on cluster with unpinned OpenshiftEC2NodeClass, verify NodeClaims do not drift until CP completes

Fixes: [OCPBUGS-89689](https://redhat.atlassian.net/browse/OCPBUGS-89689)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved reconciliation version tracking by deriving both release image and version from the most recently *completed* history entry.
  * Standardized fallback behavior to use desired release image/version when no completed history entries are available.

* **Tests**
  * Updated controller test fixtures to include image for completed history entries and added coverage for release-image+version resolution.
  * Refined control-plane upgrade e2e drift checks to confirm no drift during rollout, then validate drift detection after upgrade (via a new “not drifted” assertion helper).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->