### PR TITLE
CNTRLPLANE-3820: add cleanleaked tool for AWS leaked resource cleanup

### DIFF
--- a/.claude/skills/triage-leaked-infra/SKILL.md
+++ b/.claude/skills/triage-leaked-infra/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: triage-leaked-infra
+description: "Assess whether an AWS VPC or infra set from HyperShift CI is safe to delete. Use when the user pastes cleanleaked output and asks 'can I delete this?', 'is this safe to remove?', 'triage this infra', asks about a LEAKED or UNCERTAIN verdict, provides a VPC ID or infraID and wants to know if it's orphaned, or says 'check this VPC'. Also use when the user asks 'should I delete this?' about any AWS resource in the HyperShift CI account."
+---
+
+# Triage Leaked Infrastructure
+
+Assess whether an AWS infrastructure set (VPC + associated resources) from HyperShift CI is safe to delete. Every claim must be backed by an empirical AWS query — never assume, always verify.
+
+## Input
+
+The user provides one of:
+- cleanleaked tool output (an infra set block)
+- A VPC ID (e.g., `vpc-0abc123...`)
+- An infraID (e.g., `00ab3695c5f73d4354b9` or `node-pool-78vcg`)
+
+Extract the **infraID** and **VPC ID** from the input. If only one is given, derive the other:
+- VPC ID → `aws ec2 describe-vpcs --vpc-ids <VPC> --query 'Vpcs[0].Tags'` → extract infraID from `kubernetes.io/cluster/<infraID>` tag or `Name` tag (strip `-vpc` suffix)
+- infraID → `aws ec2 describe-vpcs --filters "Name=tag:Name,Values=<infraID>-vpc"` → get VPC ID
+
+## Checks
+
+Run these in order. For each, report **PASS** (safe signal), **FAIL** (do NOT delete), or **UNKNOWN** (could not determine). Use `--region us-east-1` for all commands.
+
+### 1. Protection tags
+```bash
+aws ec2 describe-vpcs --vpc-ids <VPC> --query 'Vpcs[0].Tags' --output json
+```
+- Check for `hypershift.openshift.io/do-not-delete=true` → if present: **FAIL**
+- Check for `hypershift.openshift.io/ci-cluster` → if present: **FAIL** (this is a management cluster)
+
+### 2. Protected VPC name
+From the `Name` tag: if it is `hypershift-ci-2-vpc`, `hypershift-ci-3-vpc`, or `hypershift-ci-metrics-vpc` → **FAIL**
+
+### 3. Protected user
+Check if the infraID contains any of these usernames: `aabdelre`, `agarcial`, `ahmed`, `alamela`, `alesross`, `bclement`, `brcox`, `celebdor`, `cewong`, `dario`, `dari2o`, `dmace`, `glipceanu`, `jiezhao`, `jparrill`, `mbhalodi`, `mbrown`, `meha`, `mgencur`, `mulham`, `mraee`, `rkshirsa`, `sdminonne`, `sjenning`, `tsegura`, `vismishr`
+
+If match → **FAIL** (developer cluster, contact the owner)
+
+### 4. Expiration date / Age
+From the VPC tags, check `expirationDate`:
+- If present and **not yet expired** → **FAIL**
+- If present and **expired** → **PASS**
+- If absent → check resource age instead (the `expirationDate` tag only exists on resources created in the last ~2 weeks)
+
+When `expirationDate` is absent, determine age from the earliest timestamped sub-resource:
+```bash
+aws ec2 describe-vpc-endpoints --region us-east-1 --filters "Name=vpc-id,Values=<VPC>" --query 'VpcEndpoints[*].CreationTimestamp' --output text
+aws ec2 describe-network-interfaces --region us-east-1 --filters "Name=vpc-id,Values=<VPC>" --query 'NetworkInterfaces[*].Attachment.AttachTime' --output text
+```
+Take the earliest timestamp found. If the resource is **older than 24 hours** AND the CI pattern check (step 5) is **PASS** → **PASS**. If younger than 24 hours → **FAIL**. If no timestamp found at all → **UNKNOWN**.
+
+### 5. CI pattern match
+Does the infraID match a known CI test pattern?
+- **Hex ID** (20+ lowercase hex chars, e.g., `00ab3695c5f73d4354b9`) → CI generic e2e → **PASS**
+- **Named test**: `create-cluster-*`, `node-pool-*`, `control-plane-upgrade-*`, `autoscaling-*`, `karpenter-*`, `karpenter-upgrade-control-plane-*`, `scale-from-zero-*`, `kms-verify-*`, `request-serving-*`, `private-*`, `proxy-*`, `spot-demo-*`, `ha-break-glass-creds-*`, `custom-config-*`, `ho-upgrade-*`, `multi-hop-upgrade-*` → **PASS**
+- **None of the above** (e.g., `hc1-*`, `clust-*`, `dev-*`, `test-dev-*`) → **UNKNOWN** (might be a developer cluster)
+
+### 6. OIDC S3 liveness
+```bash
+aws s3api head-object --bucket hypershift-ci-oidc --key "<infraID>/.well-known/openid-configuration" --region us-east-1
+aws s3api head-object --bucket hypershift-ci-2-oidc --key "<infraID>/.well-known/openid-configuration" --region us-east-1
+aws s3api head-object --bucket hypershift-ci-3-oidc --key "<infraID>/.well-known/openid-configuration" --region us-east-1
+```
+If any returns 200 → **FAIL** (cluster still active). If all return 404/error → **PASS**.
+
+### 7. EC2 instances
+```bash
+aws ec2 describe-instances --region us-east-1 \
+  --filters "Name=tag:kubernetes.io/cluster/<infraID>,Values=owned" \
+           "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+  --query 'Reservations[*].Instances[*].[InstanceId,State.Name,Tags[?Key==`Name`].Value|[0]]' --output text
+```
+If any instances returned → **FAIL**. If none → **PASS**.
+
+### 8. red-hat-managed check
+```bash
+aws ec2 describe-instances --region us-east-1 \
+  --filters "Name=vpc-id,Values=<VPC>" "Name=tag:red-hat-managed,Values=true" \
+  --query 'Reservations[*].Instances[*].InstanceId' --output text
+```
+If any instances returned → **FAIL** (ROSA managed infrastructure). If none → **PASS**.
+
+### 9. Sub-resources inventory (VPC-scoped)
+Query each and report **ID + Name** for every resource, not just counts:
+```bash
+aws elbv2 describe-load-balancers --region us-east-1 --query "LoadBalancers[?VpcId=='<VPC>'].[LoadBalancerName,Type,Scheme,DNSName]" --output text
+aws ec2 describe-vpc-endpoints --region us-east-1 --filters "Name=vpc-id,Values=<VPC>" --query 'VpcEndpoints[*].[VpcEndpointId,VpcEndpointType,ServiceName,State]' --output text
+aws ec2 describe-vpc-endpoint-service-configurations --region us-east-1 --output json | # filter by kubernetes.io/cluster/<infraID> tag
+aws ec2 describe-nat-gateways --region us-east-1 --filter "Name=vpc-id,Values=<VPC>" --query 'NatGateways[*].[NatGatewayId,State,Tags[?Key==`Name`].Value|[0],NatGatewayAddresses[0].PublicIp]' --output text
+aws ec2 describe-internet-gateways --region us-east-1 --filters "Name=attachment.vpc-id,Values=<VPC>" --query 'InternetGateways[*].[InternetGatewayId,Tags[?Key==`Name`].Value|[0]]' --output text
+aws ec2 describe-subnets --region us-east-1 --filters "Name=vpc-id,Values=<VPC>" --query 'Subnets[*].[SubnetId,CidrBlock,AvailabilityZone,Tags[?Key==`Name`].Value|[0]]' --output text
+aws ec2 describe-security-groups --region us-east-1 --filters "Name=vpc-id,Values=<VPC>" --query 'SecurityGroups[*].[GroupId,GroupName]' --output text
+aws ec2 describe-network-interfaces --region us-east-1 --filters "Name=vpc-id,Values=<VPC>" --query 'NetworkInterfaces[*].[NetworkInterfaceId,InterfaceType,Description]' --output text
+aws ec2 describe-route-tables --region us-east-1 --filters "Name=vpc-id,Values=<VPC>" --query 'RouteTables[*].[RouteTableId,Associations[0].Main,Tags[?Key==`Name`].Value|[0]]' --output text
+aws ec2 describe-addresses --region us-east-1 --filters "Name=domain,Values=vpc" --output text | # cross-check with NAT gateway EIPs
+```
+This check is informational — always **PASS** but list every resource with its ID and name.
+
+### 10. Route53 zones
+```bash
+aws route53 list-hosted-zones --output text --query 'HostedZones[*].[Id,Name,Config.PrivateZone,ResourceRecordSetCount]'
+```
+Search for zones matching `<infraID>.ci.hypershift.devcluster.openshift.com` and `<infraID>.hypershift.local`. For each found zone, list its records:
+```bash
+aws route53 list-resource-record-sets --hosted-zone-id <ZONE_ID> --query 'ResourceRecordSets[*].[Name,Type]' --output text
+```
+Report zone IDs, names, private/public, and record count. Informational — always **PASS**.
+
+### 11. OIDC IAM provider
+```bash
+aws iam list-open-id-connect-providers --output json
+```
+Search for providers whose ARN contains the infraID (pattern: `oidc-provider/hypershift-ci-*-oidc.s3.*.amazonaws.com/<infraID>`). Report if found — this is an orphaned IAM resource that should be cleaned up with the infra set.
+
+### 12. IAM roles (by infraID prefix)
+```bash
+aws iam list-roles --query "Roles[?starts_with(RoleName, '<infraID>')].[RoleName,CreateDate]" --output text
+```
+Report any IAM roles whose name starts with the infraID. These are orphaned OIDC-type roles (cloud-controller, ebs-csi, ingress, etc.) that belong to this infra set.
+
+## Output
+
+Present the report in this format:
+
+```
+## Triage: <infraID>
+
+| # | Check | Result | Detail |
+|---|-------|--------|--------|
+| 1 | Protection tags | PASS | No do-not-delete or ci-cluster tag |
+| 2 | Protected VPC name | PASS | Name is "abcdef1234-vpc" |
+| 3 | Protected user | PASS | No username match |
+| 4 | Expiration date | PASS | Expired 2026-07-03 (5 days ago) |
+| 5 | CI pattern match | PASS | Hex infraID (e2e-generic) |
+| 6 | OIDC S3 liveness | PASS | Not found in any bucket |
+| 7 | EC2 instances | PASS | 0 instances |
+| 8 | red-hat-managed | PASS | No managed instances |
+| 9 | Sub-resources | INFO | 1 IGW, 1 subnet, 1 RTB |
+| 10 | Route53 zones | INFO | 2 zones found |
+| 11 | OIDC IAM provider | INFO | 1 orphaned provider found |
+| 12 | IAM roles | INFO | 0 orphaned roles |
+
+### Verdict: SAFE TO DELETE
+This infra set has no protection tags, no running instances, no OIDC document,
+and the infraID matches a CI hex pattern. All deletion checks pass.
+```
+
+## Verdict rules
+
+These are non-negotiable:
+
+- Any **FAIL** → verdict is **DO NOT DELETE** (explain which check failed and why)
+- All checks **PASS** and CI pattern matches → **SAFE TO DELETE**
+- All checks **PASS** but CI pattern is **UNKNOWN** → **UNCERTAIN** (could be a developer cluster)
+- If CI pattern is **PASS** and age/expiration is **PASS** (older than 24h or expired), remaining UNKNOWN checks do not block → **SAFE TO DELETE** (a confirmed CI resource older than 24h with no OIDC, no instances, and no protection tags is leaked)
+- If CI pattern is **UNKNOWN** and ANY check is **UNKNOWN** → **UNCERTAIN — REQUIRES HUMAN DECISION**

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,6 +18,7 @@ flags:
 ignore:
   - "test/**"
   - "hack/**"
+  - "contrib/aws-leaked-resources/**"
   - "client/**"
   - "vendor/**"
   - "support/thirdparty/**"

--- a/contrib/aws-leaked-resources/.gitignore
+++ b/contrib/aws-leaked-resources/.gitignore
@@ -1,0 +1,2 @@
+output/
+bin/

--- a/contrib/aws-leaked-resources/Makefile
+++ b/contrib/aws-leaked-resources/Makefile
@@ -1,0 +1,25 @@
+BINARY := cleanleaked
+REPO_ROOT := $(shell git rev-parse --show-toplevel)
+PKG := ./contrib/aws-leaked-resources
+
+.PHONY: build test vet clean scan dry-run
+
+build:
+	@mkdir -p bin
+	cd $(REPO_ROOT) && go build -o $(PKG)/bin/$(BINARY) $(PKG)
+	@echo "Built: bin/$(BINARY)"
+
+test:
+	cd $(REPO_ROOT) && go test $(PKG)/... -count=1 -timeout 120s -v
+
+vet:
+	cd $(REPO_ROOT) && go vet $(PKG)/...
+
+clean:
+	rm -rf bin
+
+scan:
+	cd $(REPO_ROOT) && go run $(PKG) scan
+
+dry-run:
+	cd $(REPO_ROOT) && go run $(PKG) delete --dry-run

--- a/contrib/aws-leaked-resources/README.md
+++ b/contrib/aws-leaked-resources/README.md
@@ -1,0 +1,175 @@
+# cleanleaked
+
+Detect and clean leaked AWS resources left behind by failed HyperShift CI test runs.
+
+Replaces the previous bash scripts (`detect-leaked-vpcs.sh`, `detect-leaked-hosted-zones.sh`, etc.) with a single Go tool that is testable, safe by design, and consolidates all detection logic.
+
+## Quick Start
+
+```bash
+# From the repo root
+make -C contrib/aws-leaked-resources build
+
+# Scan — report only, no deletions
+./contrib/aws-leaked-resources/cleanleaked scan
+
+# Preview what would be deleted
+./contrib/aws-leaked-resources/cleanleaked delete --dry-run
+
+# Delete interactively, 5 at a time
+./contrib/aws-leaked-resources/cleanleaked delete --limit 5 --interactive
+```
+
+Or run directly with `go run`:
+
+```bash
+go run ./contrib/aws-leaked-resources/ scan
+go run ./contrib/aws-leaked-resources/ delete --dry-run
+```
+
+## Classification Gates
+
+Each VPC passes through a series of gates in order. The first gate that matches determines the verdict.
+
+| Gate | Check | Verdict if matched |
+|------|-------|--------------------|
+| **0. Protection** | `do-not-delete=true` tag, protected VPC name, protected username in infraID | **PROTECTED** |
+| **1. Age** | `expirationDate` tag not expired, or VPCE/ENI creation < `--min-age` | **TOO_YOUNG** |
+| **2. OIDC/S3** | S3 discovery document exists in any allowed OIDC bucket | **ACTIVE** |
+| **3. EC2 Instances** | Running/pending/stopped instances tagged with this infraID | **ACTIVE** |
+| **4. CI Pattern** | infraID does not match any known CI test pattern | **UNCERTAIN** |
+| **5. (all gates pass)** | No OIDC, no instances, matches CI pattern, old enough | **LEAKED** |
+
+### Protection (Gate 0)
+
+Three layers of protection, checked in order:
+
+1. **Tag-based**: VPC has `hypershift.openshift.io/do-not-delete=true`
+2. **Name-based**: VPC name is `hypershift-ci-2-vpc`, `hypershift-ci-3-vpc`, or `hypershift-ci-metrics-vpc`
+3. **User-based**: infraID contains a protected team member username
+
+Protected resources are **never** deleted regardless of other signals.
+
+### Age (Gate 1)
+
+Two sources of age information:
+
+- **`expirationDate` tag** (preferred): Set by newer CI jobs. If present and not expired, the VPC is `TOO_YOUNG`.
+- **VPCE/ENI timestamps** (fallback): For older resources without the tag, the earliest `CreationTimestamp` from VPC Endpoints or `AttachTime` from ENIs is used. Must be older than `--min-age` (default 24h).
+
+### CI Pattern Match (Gate 4)
+
+Known CI test patterns:
+- Hex infraIDs (20+ lowercase hex chars): `00ab3695c5f73d4354b9`
+- Named test prefixes: `create-cluster-*`, `node-pool-*`, `control-plane-upgrade-*`, `autoscaling-*`, `karpenter-*`, `scale-from-zero-*`, `kms-verify-*`, `request-serving-*`, `private-*`, `proxy-*`, `spot-demo-*`, `ha-break-glass-creds-*`, `custom-config-*`, `ho-upgrade-*`, `multi-hop-upgrade-*`
+
+InfraIDs that don't match (e.g., `hc1-*`, `clust-*`, `dev-*`) are classified as `UNCERTAIN`.
+
+## Verdicts
+
+| Verdict | Meaning | Deletable? |
+|---------|---------|------------|
+| `PROTECTED` | Management cluster, developer resource, or `do-not-delete` tag | Never |
+| `TOO_YOUNG` | Created less than `--min-age` ago or `expirationDate` not reached | No |
+| `ACTIVE` | OIDC S3 doc exists or EC2 instances running | No |
+| `UNCERTAIN` | No CI pattern match — may belong to a developer | Only manually with `--interactive` |
+| `LEAKED` | No OIDC, no instances, matches CI pattern, old enough | Yes |
+
+## Delete Modes
+
+| Command | Behavior |
+|---------|----------|
+| `delete` | Prompt once at the start, then delete all LEAKED |
+| `delete --confirm` | No prompts, delete all LEAKED immediately |
+| `delete --interactive` | Show full resource inventory per infra set, prompt for each |
+| `delete --dry-run` | Show what would be deleted, delete nothing |
+
+### Cascade Order
+
+When deleting a VPC, sub-resources are removed in this order:
+
+1. ELBs/NLBs
+2. VPC Endpoint Services (by infraID tag)
+3. VPC Endpoints
+4. NAT Gateways → wait 15s for ENI release
+5. Elastic IPs (only those from the NAT gateways)
+6. Internet Gateways
+7. Route Tables (non-main only)
+8. Network Interfaces
+9. Subnets
+10. Security Groups (non-default only, revoke rules first)
+11. VPC
+
+Additionally per infra set: Route53 zones, OIDC IAM providers, IAM roles.
+
+Each delete operation retries up to 10 times with 2s delay. Ctrl+C interrupts immediately.
+
+## Flags
+
+### `scan` command
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--region` | `us-east-1` | AWS region |
+| `--min-age` | `24h` | Minimum VPC age to consider for deletion |
+| `--target` | *(none)* | Scan a single infraID or VPC ID instead of all VPCs |
+| `--output` | `table` | Output format: `table` or `json` |
+| `--output-dir` | `output` | Directory for timestamped report files (empty to disable) |
+
+### `delete` command
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--region` | `us-east-1` | AWS region |
+| `--min-age` | `24h` | Minimum VPC age to consider for deletion |
+| `--target` | *(none)* | Delete a single infraID or VPC ID instead of all leaked |
+| `--dry-run` | `false` | Show what would be deleted without deleting |
+| `--confirm` | `false` | No prompts, delete all LEAKED immediately |
+| `--interactive`, `-i` | `false` | Prompt before each infra set with full inventory |
+| `--limit` | `0` | Max infra sets to delete (0 = no limit) |
+| `--output` | `table` | Output format: `table` or `json` |
+| `--output-dir` | `output` | Directory for timestamped report files (empty to disable) |
+
+### `--target` usage
+
+Accepts a VPC ID (`vpc-*`) or an infraID. If an infraID is given, it searches for a VPC with the Name tag `<infraID>-vpc`.
+
+```bash
+# By VPC ID
+cleanleaked scan --target vpc-066231b8dc5a4400f
+
+# By infraID
+cleanleaked scan --target node-pool-78vcg
+
+# Also accepts the -vpc suffix (stripped automatically)
+cleanleaked scan --target node-pool-78vcg-vpc
+
+# Delete a specific target interactively
+cleanleaked delete --target 00ab3695c5f73d4354b9 --interactive
+```
+
+## Prow Correlation
+
+For each LEAKED infra set, the tool infers:
+- **Test type**: from the infraID pattern (e.g., `node-pool`, `create-cluster`, `e2e-generic`)
+- **HC namespace**: from Route53 `service.ci` zone TXT records
+- **Prow link**: direct job URL if `hypershift.openshift.io/prow-job-id` tag exists (PR #8909), otherwise a Prow deck search URL
+
+## Safety
+
+- **Default SG** (`GroupName=default`) is never deleted
+- **Main route table** is never deleted (auto-deleted with VPC)
+- **EIPs** are scoped: only EIPs from NAT gateways of the target VPC are released
+- **ELBs** are filtered by VPC ID before deletion
+- All delete operations check `ctx.Done()` between steps — Ctrl+C works immediately
+
+## Development
+
+```bash
+make build    # Build binary
+make test     # Run unit tests
+make vet      # Run go vet
+make scan     # Run scan against real AWS
+make dry-run  # Run delete --dry-run against real AWS
+make clean    # Remove binary
+```

--- a/contrib/aws-leaked-resources/clients.go
+++ b/contrib/aws-leaked-resources/clients.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type EC2API interface {
+	DescribeVpcs(ctx context.Context, params *ec2.DescribeVpcsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error)
+	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+	DescribeVpcEndpoints(ctx context.Context, params *ec2.DescribeVpcEndpointsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointsOutput, error)
+	DescribeVpcEndpointServiceConfigurations(ctx context.Context, params *ec2.DescribeVpcEndpointServiceConfigurationsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error)
+	DescribeNatGateways(ctx context.Context, params *ec2.DescribeNatGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNatGatewaysOutput, error)
+	DescribeInternetGateways(ctx context.Context, params *ec2.DescribeInternetGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInternetGatewaysOutput, error)
+	DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)
+	DescribeSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error)
+	DescribeRouteTables(ctx context.Context, params *ec2.DescribeRouteTablesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error)
+	DescribeNetworkInterfaces(ctx context.Context, params *ec2.DescribeNetworkInterfacesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error)
+	DescribeAddresses(ctx context.Context, params *ec2.DescribeAddressesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeAddressesOutput, error)
+
+	DeleteVpcEndpoints(ctx context.Context, params *ec2.DeleteVpcEndpointsInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVpcEndpointsOutput, error)
+	DeleteVpcEndpointServiceConfigurations(ctx context.Context, params *ec2.DeleteVpcEndpointServiceConfigurationsInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVpcEndpointServiceConfigurationsOutput, error)
+	DeleteNatGateway(ctx context.Context, params *ec2.DeleteNatGatewayInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNatGatewayOutput, error)
+	DetachInternetGateway(ctx context.Context, params *ec2.DetachInternetGatewayInput, optFns ...func(*ec2.Options)) (*ec2.DetachInternetGatewayOutput, error)
+	DeleteInternetGateway(ctx context.Context, params *ec2.DeleteInternetGatewayInput, optFns ...func(*ec2.Options)) (*ec2.DeleteInternetGatewayOutput, error)
+	DeleteSubnet(ctx context.Context, params *ec2.DeleteSubnetInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSubnetOutput, error)
+	DeleteSecurityGroup(ctx context.Context, params *ec2.DeleteSecurityGroupInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error)
+	RevokeSecurityGroupIngress(ctx context.Context, params *ec2.RevokeSecurityGroupIngressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error)
+	RevokeSecurityGroupEgress(ctx context.Context, params *ec2.RevokeSecurityGroupEgressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error)
+	DisassociateRouteTable(ctx context.Context, params *ec2.DisassociateRouteTableInput, optFns ...func(*ec2.Options)) (*ec2.DisassociateRouteTableOutput, error)
+	DeleteRouteTable(ctx context.Context, params *ec2.DeleteRouteTableInput, optFns ...func(*ec2.Options)) (*ec2.DeleteRouteTableOutput, error)
+	DetachNetworkInterface(ctx context.Context, params *ec2.DetachNetworkInterfaceInput, optFns ...func(*ec2.Options)) (*ec2.DetachNetworkInterfaceOutput, error)
+	DeleteNetworkInterface(ctx context.Context, params *ec2.DeleteNetworkInterfaceInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNetworkInterfaceOutput, error)
+	DeleteVpc(ctx context.Context, params *ec2.DeleteVpcInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVpcOutput, error)
+	ReleaseAddress(ctx context.Context, params *ec2.ReleaseAddressInput, optFns ...func(*ec2.Options)) (*ec2.ReleaseAddressOutput, error)
+}
+
+type ELBv2API interface {
+	DescribeLoadBalancers(ctx context.Context, params *elbv2.DescribeLoadBalancersInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeLoadBalancersOutput, error)
+	DeleteLoadBalancer(ctx context.Context, params *elbv2.DeleteLoadBalancerInput, optFns ...func(*elbv2.Options)) (*elbv2.DeleteLoadBalancerOutput, error)
+}
+
+type Route53API interface {
+	ListHostedZones(ctx context.Context, params *route53.ListHostedZonesInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error)
+	GetHostedZone(ctx context.Context, params *route53.GetHostedZoneInput, optFns ...func(*route53.Options)) (*route53.GetHostedZoneOutput, error)
+	ListResourceRecordSets(ctx context.Context, params *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error)
+	ChangeResourceRecordSets(ctx context.Context, params *route53.ChangeResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error)
+	DeleteHostedZone(ctx context.Context, params *route53.DeleteHostedZoneInput, optFns ...func(*route53.Options)) (*route53.DeleteHostedZoneOutput, error)
+}
+
+type IAMAPI interface {
+	ListOpenIDConnectProviders(ctx context.Context, params *iam.ListOpenIDConnectProvidersInput, optFns ...func(*iam.Options)) (*iam.ListOpenIDConnectProvidersOutput, error)
+	GetOpenIDConnectProvider(ctx context.Context, params *iam.GetOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.GetOpenIDConnectProviderOutput, error)
+	ListRoles(ctx context.Context, params *iam.ListRolesInput, optFns ...func(*iam.Options)) (*iam.ListRolesOutput, error)
+	DeleteOpenIDConnectProvider(ctx context.Context, params *iam.DeleteOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.DeleteOpenIDConnectProviderOutput, error)
+	ListAttachedRolePolicies(ctx context.Context, params *iam.ListAttachedRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error)
+	DetachRolePolicy(ctx context.Context, params *iam.DetachRolePolicyInput, optFns ...func(*iam.Options)) (*iam.DetachRolePolicyOutput, error)
+	ListRolePolicies(ctx context.Context, params *iam.ListRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error)
+	DeleteRolePolicy(ctx context.Context, params *iam.DeleteRolePolicyInput, optFns ...func(*iam.Options)) (*iam.DeleteRolePolicyOutput, error)
+	ListInstanceProfilesForRole(ctx context.Context, params *iam.ListInstanceProfilesForRoleInput, optFns ...func(*iam.Options)) (*iam.ListInstanceProfilesForRoleOutput, error)
+	RemoveRoleFromInstanceProfile(ctx context.Context, params *iam.RemoveRoleFromInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.RemoveRoleFromInstanceProfileOutput, error)
+	DeleteInstanceProfile(ctx context.Context, params *iam.DeleteInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.DeleteInstanceProfileOutput, error)
+	DeleteRole(ctx context.Context, params *iam.DeleteRoleInput, optFns ...func(*iam.Options)) (*iam.DeleteRoleOutput, error)
+}
+
+type S3API interface {
+	HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
+}

--- a/contrib/aws-leaked-resources/delete.go
+++ b/contrib/aws-leaked-resources/delete.go
@@ -1,0 +1,859 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+const (
+	maxRetries = 10
+	retryDelay = 2 * time.Second
+)
+
+type ConfirmMode int
+
+const (
+	ConfirmAll  ConfirmMode = iota // delete without per-resource prompts
+	ConfirmEach                    // prompt before each resource
+)
+
+type Deleter struct {
+	EC2     EC2API
+	ELBv2   ELBv2API
+	Route53 Route53API
+	IAM     IAMAPI
+}
+
+func (d *Deleter) DeleteAll(ctx context.Context, leaked []InfraSet, mode ConfirmMode) error {
+	deletedVPCs := 0
+	failedVPCs := 0
+	deletedZones := 0
+	failedZones := 0
+	deletedOIDC := 0
+	skipped := 0
+
+	for _, infra := range leaked {
+		if err := ctx.Err(); err != nil {
+			fmt.Fprintf(os.Stderr, "\nCanceled.\n")
+			break
+		}
+
+		if infra.Verdict != VerdictLeaked {
+			continue
+		}
+
+		fmt.Fprintf(os.Stderr, "\n=== Infra set: %s ===\n", infra.InfraID)
+
+		if mode == ConfirmEach {
+			d.printDetailedInventory(ctx, infra)
+			if !promptYN(fmt.Sprintf("Delete ALL resources for %s?", infra.InfraID)) {
+				fmt.Fprintf(os.Stderr, "  Skipped.\n")
+				skipped++
+				continue
+			}
+		}
+
+		for _, zone := range infra.HostedZones {
+			if err := d.deleteHostedZone(ctx, zone.ZoneID, zone.Name); err != nil {
+				fmt.Fprintf(os.Stderr, "  FAILED zone %s (%s): %v\n", zone.ZoneID, zone.Name, err)
+				failedZones++
+			} else {
+				fmt.Fprintf(os.Stderr, "  Deleted zone: %s (%s)\n", zone.ZoneID, zone.Name)
+				deletedZones++
+			}
+		}
+
+		for _, oidcARN := range infra.OIDCProviders {
+			if err := d.deleteOIDCProvider(ctx, oidcARN); err != nil {
+				fmt.Fprintf(os.Stderr, "  FAILED OIDC provider %s: %v\n", oidcARN, err)
+			} else {
+				fmt.Fprintf(os.Stderr, "  Deleted OIDC provider: %s\n", oidcARN)
+				deletedOIDC++
+			}
+		}
+
+		for _, roleName := range infra.IAMRoles {
+			if err := ctx.Err(); err != nil {
+				break
+			}
+			if err := d.deleteIAMRole(ctx, roleName); err != nil {
+				fmt.Fprintf(os.Stderr, "  FAILED IAM role %s: %v\n", roleName, err)
+			} else {
+				fmt.Fprintf(os.Stderr, "  Deleted IAM role: %s\n", roleName)
+			}
+		}
+
+		for _, vpc := range infra.VPCs {
+			if err := d.deleteVPC(ctx, vpc.VPCID, infra.InfraID); err != nil {
+				fmt.Fprintf(os.Stderr, "  FAILED VPC %s (%s): %v\n", vpc.VPCID, vpc.Name, err)
+				failedVPCs++
+			} else {
+				fmt.Fprintf(os.Stderr, "  Deleted VPC: %s (%s)\n", vpc.VPCID, vpc.Name)
+				deletedVPCs++
+			}
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "\n==============================\n")
+	fmt.Fprintf(os.Stderr, "  Deletion results\n")
+	fmt.Fprintf(os.Stderr, "==============================\n")
+	fmt.Fprintf(os.Stderr, "  VPCs:     %d deleted, %d failed\n", deletedVPCs, failedVPCs)
+	fmt.Fprintf(os.Stderr, "  Zones:    %d deleted, %d failed\n", deletedZones, failedZones)
+	fmt.Fprintf(os.Stderr, "  OIDC:     %d deleted\n", deletedOIDC)
+	if skipped > 0 {
+		fmt.Fprintf(os.Stderr, "  Skipped:  %d infra sets\n", skipped)
+	}
+	fmt.Fprintf(os.Stderr, "==============================\n")
+
+	if failedVPCs > 0 || failedZones > 0 {
+		return fmt.Errorf("%d VPCs and %d zones failed to delete", failedVPCs, failedZones)
+	}
+
+	return nil
+}
+
+// retryDelete executes fn up to maxRetries times with retryDelay between attempts.
+// Respects context cancellation between retries so Ctrl+C works immediately.
+func retryDelete(ctx context.Context, desc string, fn func() error) error {
+	var lastErr error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("%s canceled: %w", desc, err)
+		}
+		if err := fn(); err != nil {
+			lastErr = err
+			if attempt < maxRetries {
+				fmt.Fprintf(os.Stderr, "      retry %d/%d %s: %v\n", attempt, maxRetries, desc, err)
+				if err := sleepWithContext(ctx, retryDelay); err != nil {
+					return fmt.Errorf("%s canceled during retry: %w", desc, err)
+				}
+			}
+			continue
+		}
+		if attempt > 1 {
+			fmt.Fprintf(os.Stderr, "      %s succeeded on attempt %d/%d\n", desc, attempt, maxRetries)
+		}
+		return nil
+	}
+	return fmt.Errorf("%s failed after %d attempts: %w", desc, maxRetries, lastErr)
+}
+
+// deleteVPC removes a VPC and ALL its dependent resources in the correct order.
+// Cascade: ELBs → VPC Endpoint Services → VPCE → NAT → (wait) → EIPs → IGW → RTB → ENI → Subnets → SG → VPC
+func (d *Deleter) deleteVPC(ctx context.Context, vpcID, infraID string) error {
+	fmt.Fprintf(os.Stderr, "    Cleaning sub-resources for %s...\n", vpcID)
+
+	steps := []struct {
+		name string
+		fn   func()
+	}{
+		{"ELBs", func() { d.deleteLoadBalancers(ctx, vpcID) }},
+		{"VPCE services", func() { d.deleteVPCEndpointServices(ctx, infraID) }},
+		{"VPCE", func() { d.deleteVPCEndpoints(ctx, vpcID) }},
+	}
+
+	for _, step := range steps {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("canceled during %s: %w", step.name, err)
+		}
+		step.fn()
+	}
+
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("canceled: %w", err)
+	}
+
+	natEIPs := d.collectNATGatewayEIPs(ctx, vpcID)
+	if natDeleted := d.deleteNATGateways(ctx, vpcID); natDeleted > 0 {
+		if err := d.waitForNATGatewaysDrained(ctx, vpcID); err != nil {
+			return fmt.Errorf("canceled during NAT wait: %w", err)
+		}
+	}
+
+	postNATSteps := []struct {
+		name string
+		fn   func()
+	}{
+		{"EIPs", func() { d.releaseEIPs(ctx, natEIPs) }},
+		{"IGWs", func() { d.deleteInternetGateways(ctx, vpcID) }},
+		{"RTBs", func() { d.deleteRouteTables(ctx, vpcID) }},
+		{"ENIs", func() { d.deleteNetworkInterfaces(ctx, vpcID) }},
+		{"subnets", func() { d.deleteSubnets(ctx, vpcID) }},
+		{"SGs", func() { d.deleteSecurityGroups(ctx, vpcID) }},
+	}
+
+	for _, step := range postNATSteps {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("canceled during %s: %w", step.name, err)
+		}
+		step.fn()
+	}
+
+	return retryDelete(ctx, "VPC "+vpcID, func() error {
+		_, err := d.EC2.DeleteVpc(ctx, &ec2.DeleteVpcInput{VpcId: aws.String(vpcID)})
+		return err
+	})
+}
+
+func formatDurationShort(d time.Duration) string {
+	hours := int(d.Hours())
+	if hours < 48 {
+		return fmt.Sprintf("%dh", hours)
+	}
+	return fmt.Sprintf("%dd%dh", hours/24, hours%24)
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}
+
+func (d *Deleter) deleteLoadBalancers(ctx context.Context, vpcID string) {
+	if d.ELBv2 == nil {
+		return
+	}
+
+	var marker *string
+	for {
+		out, err := d.ELBv2.DescribeLoadBalancers(ctx, &elbv2.DescribeLoadBalancersInput{Marker: marker})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "      WARN: list ELBs: %v\n", err)
+			return
+		}
+
+		for _, lb := range out.LoadBalancers {
+			if aws.ToString(lb.VpcId) != vpcID {
+				continue
+			}
+			name := aws.ToString(lb.LoadBalancerName)
+			arn := aws.ToString(lb.LoadBalancerArn)
+			if err := retryDelete(ctx, "ELB "+name, func() error {
+				_, err := d.ELBv2.DeleteLoadBalancer(ctx, &elbv2.DeleteLoadBalancerInput{LoadBalancerArn: aws.String(arn)})
+				return err
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "      %v\n", err)
+			} else {
+				fmt.Fprintf(os.Stderr, "      Deleted ELB: %s\n", name)
+			}
+		}
+
+		if out.NextMarker == nil {
+			break
+		}
+		marker = out.NextMarker
+	}
+}
+
+func (d *Deleter) deleteVPCEndpointServices(ctx context.Context, infraID string) {
+	var serviceIDs []string
+	var nextToken *string
+	for {
+		out, err := d.EC2.DescribeVpcEndpointServiceConfigurations(ctx, &ec2.DescribeVpcEndpointServiceConfigurationsInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "      WARN: list VPCE services: %v\n", err)
+			return
+		}
+
+		for _, svc := range out.ServiceConfigurations {
+			for _, tag := range svc.Tags {
+				key := aws.ToString(tag.Key)
+				if strings.HasPrefix(key, "kubernetes.io/cluster/") {
+					if strings.TrimPrefix(key, "kubernetes.io/cluster/") == infraID {
+						serviceIDs = append(serviceIDs, aws.ToString(svc.ServiceId))
+					}
+					break
+				}
+			}
+		}
+
+		if out.NextToken == nil {
+			break
+		}
+		nextToken = out.NextToken
+	}
+
+	if len(serviceIDs) > 0 {
+		if err := retryDelete(ctx, fmt.Sprintf("VPCE services (%d)", len(serviceIDs)), func() error {
+			_, err := d.EC2.DeleteVpcEndpointServiceConfigurations(ctx, &ec2.DeleteVpcEndpointServiceConfigurationsInput{ServiceIds: serviceIDs})
+			return err
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "      %v\n", err)
+		} else {
+			for _, id := range serviceIDs {
+				fmt.Fprintf(os.Stderr, "      Deleted VPCE service: %s\n", id)
+			}
+		}
+	}
+}
+
+func (d *Deleter) deleteVPCEndpoints(ctx context.Context, vpcID string) {
+	out, err := d.EC2.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "      WARN: list VPCE: %v\n", err)
+		return
+	}
+
+	var ids []string
+	for _, ep := range out.VpcEndpoints {
+		ids = append(ids, aws.ToString(ep.VpcEndpointId))
+	}
+
+	if len(ids) > 0 {
+		if err := retryDelete(ctx, fmt.Sprintf("VPCE (%d)", len(ids)), func() error {
+			_, err := d.EC2.DeleteVpcEndpoints(ctx, &ec2.DeleteVpcEndpointsInput{VpcEndpointIds: ids})
+			return err
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "      %v\n", err)
+		}
+	}
+}
+
+func (d *Deleter) deleteNATGateways(ctx context.Context, vpcID string) int {
+	out, err := d.EC2.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+		Filter: []ec2types.Filter{
+			{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+			{Name: aws.String("state"), Values: []string{"available", "pending", "failed"}},
+		},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "      WARN: list NAT: %v\n", err)
+		return 0
+	}
+
+	deleted := 0
+	for _, nat := range out.NatGateways {
+		natID := aws.ToString(nat.NatGatewayId)
+		if err := retryDelete(ctx, "NAT "+natID, func() error {
+			_, err := d.EC2.DeleteNatGateway(ctx, &ec2.DeleteNatGatewayInput{NatGatewayId: aws.String(natID)})
+			return err
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "      %v\n", err)
+		} else {
+			deleted++
+		}
+	}
+
+	return deleted
+}
+
+const (
+	natDrainRetries  = 12
+	natDrainInterval = 5 * time.Second
+)
+
+func (d *Deleter) waitForNATGatewaysDrained(ctx context.Context, vpcID string) error {
+	fmt.Fprintf(os.Stderr, "      Waiting for NAT gateways to release ENIs...\n")
+	for attempt := 1; attempt <= natDrainRetries; attempt++ {
+		if err := sleepWithContext(ctx, natDrainInterval); err != nil {
+			return err
+		}
+		out, err := d.EC2.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+			Filter: []ec2types.Filter{
+				{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+				{Name: aws.String("state"), Values: []string{"deleting"}},
+			},
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "      WARN: check NAT state: %v\n", err)
+			continue
+		}
+		if len(out.NatGateways) == 0 {
+			fmt.Fprintf(os.Stderr, "      NAT gateways drained after %d checks\n", attempt)
+			return nil
+		}
+		fmt.Fprintf(os.Stderr, "      %d NAT gateways still draining (check %d/%d)...\n", len(out.NatGateways), attempt, natDrainRetries)
+	}
+	fmt.Fprintf(os.Stderr, "      WARN: NAT gateways did not fully drain after %d checks, proceeding anyway\n", natDrainRetries)
+	return nil
+}
+
+// collectNATGatewayEIPs returns the AllocationIDs of EIPs used by NAT gateways in this VPC.
+// Must be called BEFORE deleting the NAT gateways.
+func (d *Deleter) collectNATGatewayEIPs(ctx context.Context, vpcID string) []string {
+	out, err := d.EC2.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+		Filter: []ec2types.Filter{
+			{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+		},
+	})
+	if err != nil {
+		return nil
+	}
+
+	var allocIDs []string
+	for _, nat := range out.NatGateways {
+		for _, addr := range nat.NatGatewayAddresses {
+			if addr.AllocationId != nil {
+				allocIDs = append(allocIDs, aws.ToString(addr.AllocationId))
+			}
+		}
+	}
+	return allocIDs
+}
+
+// releaseEIPs releases only the EIPs identified by the given AllocationIDs.
+func (d *Deleter) releaseEIPs(ctx context.Context, allocIDs []string) {
+	for _, allocID := range allocIDs {
+		out, err := d.EC2.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{
+			AllocationIds: []string{allocID},
+		})
+		if err != nil {
+			continue
+		}
+		for _, addr := range out.Addresses {
+			ip := aws.ToString(addr.PublicIp)
+			if err := retryDelete(ctx, "EIP "+ip, func() error {
+				_, err := d.EC2.ReleaseAddress(ctx, &ec2.ReleaseAddressInput{AllocationId: aws.String(allocID)})
+				return err
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "      %v\n", err)
+			} else {
+				fmt.Fprintf(os.Stderr, "      Released EIP: %s (%s)\n", allocID, ip)
+			}
+		}
+	}
+}
+
+func (d *Deleter) deleteInternetGateways(ctx context.Context, vpcID string) {
+	out, err := d.EC2.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{
+		Filters: []ec2types.Filter{{Name: aws.String("attachment.vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "      WARN: list IGW: %v\n", err)
+		return
+	}
+
+	for _, igw := range out.InternetGateways {
+		igwID := aws.ToString(igw.InternetGatewayId)
+		_ = retryDelete(ctx, "detach IGW "+igwID, func() error {
+			_, err := d.EC2.DetachInternetGateway(ctx, &ec2.DetachInternetGatewayInput{
+				InternetGatewayId: aws.String(igwID), VpcId: aws.String(vpcID),
+			})
+			return err
+		})
+		if err := retryDelete(ctx, "IGW "+igwID, func() error {
+			_, err := d.EC2.DeleteInternetGateway(ctx, &ec2.DeleteInternetGatewayInput{InternetGatewayId: aws.String(igwID)})
+			return err
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "      %v\n", err)
+		}
+	}
+}
+
+func (d *Deleter) deleteRouteTables(ctx context.Context, vpcID string) {
+	out, err := d.EC2.DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "      WARN: list RTB: %v\n", err)
+		return
+	}
+
+	for _, rt := range out.RouteTables {
+		isMain := false
+		for _, a := range rt.Associations {
+			if aws.ToBool(a.Main) {
+				isMain = true
+				break
+			}
+		}
+		if isMain {
+			continue
+		}
+
+		rtID := aws.ToString(rt.RouteTableId)
+		for _, a := range rt.Associations {
+			if !aws.ToBool(a.Main) {
+				_, _ = d.EC2.DisassociateRouteTable(ctx, &ec2.DisassociateRouteTableInput{
+					AssociationId: a.RouteTableAssociationId,
+				})
+			}
+		}
+
+		if err := retryDelete(ctx, "RTB "+rtID, func() error {
+			_, err := d.EC2.DeleteRouteTable(ctx, &ec2.DeleteRouteTableInput{RouteTableId: aws.String(rtID)})
+			return err
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "      %v\n", err)
+		}
+	}
+}
+
+func (d *Deleter) deleteNetworkInterfaces(ctx context.Context, vpcID string) {
+	out, err := d.EC2.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "      WARN: list ENI: %v\n", err)
+		return
+	}
+
+	for _, eni := range out.NetworkInterfaces {
+		eniID := aws.ToString(eni.NetworkInterfaceId)
+		if eni.Attachment != nil && eni.Attachment.AttachmentId != nil {
+			_ = retryDelete(ctx, "detach ENI "+eniID, func() error {
+				_, err := d.EC2.DetachNetworkInterface(ctx, &ec2.DetachNetworkInterfaceInput{
+					AttachmentId: eni.Attachment.AttachmentId, Force: aws.Bool(true),
+				})
+				return err
+			})
+		}
+		if err := retryDelete(ctx, "ENI "+eniID, func() error {
+			_, err := d.EC2.DeleteNetworkInterface(ctx, &ec2.DeleteNetworkInterfaceInput{NetworkInterfaceId: aws.String(eniID)})
+			return err
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "      %v\n", err)
+		}
+	}
+}
+
+func (d *Deleter) deleteSubnets(ctx context.Context, vpcID string) {
+	out, err := d.EC2.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "      WARN: list subnets: %v\n", err)
+		return
+	}
+
+	for _, subnet := range out.Subnets {
+		subID := aws.ToString(subnet.SubnetId)
+		if err := retryDelete(ctx, "subnet "+subID, func() error {
+			_, err := d.EC2.DeleteSubnet(ctx, &ec2.DeleteSubnetInput{SubnetId: aws.String(subID)})
+			return err
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "      %v\n", err)
+		}
+	}
+}
+
+func (d *Deleter) deleteSecurityGroups(ctx context.Context, vpcID string) {
+	out, err := d.EC2.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "      WARN: list SG: %v\n", err)
+		return
+	}
+
+	// First pass: revoke rules
+	for _, sg := range out.SecurityGroups {
+		if aws.ToString(sg.GroupName) == "default" {
+			continue
+		}
+		sgID := aws.ToString(sg.GroupId)
+		if len(sg.IpPermissions) > 0 {
+			_, _ = d.EC2.RevokeSecurityGroupIngress(ctx, &ec2.RevokeSecurityGroupIngressInput{
+				GroupId: aws.String(sgID), IpPermissions: sg.IpPermissions,
+			})
+		}
+		if len(sg.IpPermissionsEgress) > 0 {
+			_, _ = d.EC2.RevokeSecurityGroupEgress(ctx, &ec2.RevokeSecurityGroupEgressInput{
+				GroupId: aws.String(sgID), IpPermissions: sg.IpPermissionsEgress,
+			})
+		}
+	}
+
+	// Second pass: delete
+	for _, sg := range out.SecurityGroups {
+		if aws.ToString(sg.GroupName) == "default" {
+			continue
+		}
+		sgID := aws.ToString(sg.GroupId)
+		if err := retryDelete(ctx, "SG "+sgID, func() error {
+			_, err := d.EC2.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{GroupId: aws.String(sgID)})
+			return err
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "      %v\n", err)
+		}
+	}
+}
+
+func (d *Deleter) deleteHostedZone(ctx context.Context, zoneID, zoneName string) error {
+	var changes []route53types.Change
+	input := &route53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	}
+	for {
+		rrOut, err := d.Route53.ListResourceRecordSets(ctx, input)
+		if err != nil {
+			return err
+		}
+
+		for _, rr := range rrOut.ResourceRecordSets {
+			if rr.Type == route53types.RRTypeNs || rr.Type == route53types.RRTypeSoa {
+				continue
+			}
+			changes = append(changes, route53types.Change{
+				Action: route53types.ChangeActionDelete, ResourceRecordSet: &rr,
+			})
+		}
+
+		if !rrOut.IsTruncated {
+			break
+		}
+		input.StartRecordName = rrOut.NextRecordName
+		input.StartRecordType = rrOut.NextRecordType
+		input.StartRecordIdentifier = rrOut.NextRecordIdentifier
+	}
+
+	if len(changes) > 0 {
+		if err := retryDelete(ctx, "records in "+zoneName, func() error {
+			_, err := d.Route53.ChangeResourceRecordSets(ctx, &route53.ChangeResourceRecordSetsInput{
+				HostedZoneId: aws.String(zoneID),
+				ChangeBatch:  &route53types.ChangeBatch{Changes: changes},
+			})
+			return err
+		}); err != nil {
+			return err
+		}
+	}
+
+	return retryDelete(ctx, "zone "+zoneName, func() error {
+		_, err := d.Route53.DeleteHostedZone(ctx, &route53.DeleteHostedZoneInput{Id: aws.String(zoneID)})
+		return err
+	})
+}
+
+func (d *Deleter) deleteOIDCProvider(ctx context.Context, arn string) error {
+	return retryDelete(ctx, "OIDC "+arn, func() error {
+		_, err := d.IAM.DeleteOpenIDConnectProvider(ctx, &iam.DeleteOpenIDConnectProviderInput{
+			OpenIDConnectProviderArn: aws.String(arn),
+		})
+		return err
+	})
+}
+
+//nolint:gocyclo // sequential AWS inventory queries
+func (d *Deleter) printDetailedInventory(ctx context.Context, infra InfraSet) {
+	if infra.TestType != "" {
+		fmt.Fprintf(os.Stderr, "  Test type: %s\n", infra.TestType)
+	}
+	if infra.Namespace != "" {
+		fmt.Fprintf(os.Stderr, "  Namespace: %s\n", infra.Namespace)
+	}
+	if infra.ProwLink != "" {
+		fmt.Fprintf(os.Stderr, "  Prow:      %s\n", infra.ProwLink)
+	}
+	if oldest := oldestVPC(infra.VPCs); !oldest.IsZero() {
+		age := time.Since(oldest)
+		hours := int(age.Hours())
+		ageStr := fmt.Sprintf("%dh", hours)
+		if hours >= 48 {
+			ageStr = fmt.Sprintf("%dd%dh", hours/24, hours%24)
+		}
+		fmt.Fprintf(os.Stderr, "  Created:   %s (%s ago)\n", oldest.Format("2006-01-02 15:04 UTC"), ageStr)
+	} else {
+		fmt.Fprintf(os.Stderr, "  Created:   unable to determine (no timestamped sub-resources found)\n")
+	}
+	for _, vpc := range infra.VPCs {
+		if !vpc.ExpirationDate.IsZero() {
+			if time.Now().After(vpc.ExpirationDate) {
+				fmt.Fprintf(os.Stderr, "  Expired:   %s (expired %s ago)\n", vpc.ExpirationDate.Format("2006-01-02 15:04 UTC"), formatDurationShort(time.Since(vpc.ExpirationDate)))
+			} else {
+				fmt.Fprintf(os.Stderr, "  Expires:   %s (in %s)\n", vpc.ExpirationDate.Format("2006-01-02 15:04 UTC"), formatDurationShort(time.Until(vpc.ExpirationDate)))
+			}
+			break
+		}
+	}
+	fmt.Fprintf(os.Stderr, "  Resources to delete:\n")
+
+	for _, vpc := range infra.VPCs {
+		fmt.Fprintf(os.Stderr, "    VPC: %s (%s)\n", vpc.VPCID, vpc.Name)
+		vpcID := vpc.VPCID
+
+		if d.ELBv2 != nil {
+			if out, err := d.ELBv2.DescribeLoadBalancers(ctx, &elbv2.DescribeLoadBalancersInput{}); err == nil {
+				for _, lb := range out.LoadBalancers {
+					if aws.ToString(lb.VpcId) == vpcID {
+						fmt.Fprintf(os.Stderr, "      ELB:     %s (%s, %s)\n",
+							aws.ToString(lb.LoadBalancerName), string(lb.Type), string(lb.Scheme))
+					}
+				}
+			}
+		}
+
+		if out, err := d.EC2.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+		}); err == nil {
+			for _, ep := range out.VpcEndpoints {
+				fmt.Fprintf(os.Stderr, "      VPCE:    %s (%s, %s)\n",
+					aws.ToString(ep.VpcEndpointId), string(ep.VpcEndpointType), aws.ToString(ep.ServiceName))
+			}
+		}
+
+		if out, err := d.EC2.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+			Filter: []ec2types.Filter{
+				{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+				{Name: aws.String("state"), Values: []string{"available", "pending", "failed"}},
+			},
+		}); err == nil {
+			for _, nat := range out.NatGateways {
+				name := ""
+				for _, t := range nat.Tags {
+					if aws.ToString(t.Key) == "Name" {
+						name = aws.ToString(t.Value)
+					}
+				}
+				ip := ""
+				if len(nat.NatGatewayAddresses) > 0 {
+					ip = aws.ToString(nat.NatGatewayAddresses[0].PublicIp)
+				}
+				fmt.Fprintf(os.Stderr, "      NAT:     %s (%s, ip=%s)\n", aws.ToString(nat.NatGatewayId), name, ip)
+			}
+		}
+
+		if out, err := d.EC2.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{
+			Filters: []ec2types.Filter{{Name: aws.String("attachment.vpc-id"), Values: []string{vpcID}}},
+		}); err == nil {
+			for _, igw := range out.InternetGateways {
+				name := ""
+				for _, t := range igw.Tags {
+					if aws.ToString(t.Key) == "Name" {
+						name = aws.ToString(t.Value)
+					}
+				}
+				fmt.Fprintf(os.Stderr, "      IGW:     %s (%s)\n", aws.ToString(igw.InternetGatewayId), name)
+			}
+		}
+
+		if out, err := d.EC2.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+		}); err == nil {
+			for _, sn := range out.Subnets {
+				name := ""
+				for _, t := range sn.Tags {
+					if aws.ToString(t.Key) == "Name" {
+						name = aws.ToString(t.Value)
+					}
+				}
+				fmt.Fprintf(os.Stderr, "      Subnet:  %s (%s, %s)\n", aws.ToString(sn.SubnetId), name, aws.ToString(sn.CidrBlock))
+			}
+		}
+
+		if out, err := d.EC2.DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{
+			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+		}); err == nil {
+			for _, rt := range out.RouteTables {
+				isMain := false
+				for _, a := range rt.Associations {
+					if aws.ToBool(a.Main) {
+						isMain = true
+					}
+				}
+				if isMain {
+					continue
+				}
+				name := ""
+				for _, t := range rt.Tags {
+					if aws.ToString(t.Key) == "Name" {
+						name = aws.ToString(t.Value)
+					}
+				}
+				fmt.Fprintf(os.Stderr, "      RTB:     %s (%s)\n", aws.ToString(rt.RouteTableId), name)
+			}
+		}
+
+		if out, err := d.EC2.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+		}); err == nil {
+			for _, sg := range out.SecurityGroups {
+				if aws.ToString(sg.GroupName) == "default" {
+					continue
+				}
+				fmt.Fprintf(os.Stderr, "      SG:      %s (%s)\n", aws.ToString(sg.GroupId), aws.ToString(sg.GroupName))
+			}
+		}
+
+		if out, err := d.EC2.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+		}); err == nil {
+			for _, eni := range out.NetworkInterfaces {
+				desc := aws.ToString(eni.Description)
+				if desc == "" {
+					desc = string(eni.InterfaceType)
+				}
+				fmt.Fprintf(os.Stderr, "      ENI:     %s (%s)\n", aws.ToString(eni.NetworkInterfaceId), desc)
+			}
+		}
+	}
+
+	for _, z := range infra.HostedZones {
+		zType := "public"
+		if z.Private {
+			zType = "private"
+		}
+		fmt.Fprintf(os.Stderr, "    Zone: %s (%s, %s, %d records)\n", z.Name, z.ZoneID, zType, z.Records)
+	}
+	for _, arn := range infra.OIDCProviders {
+		fmt.Fprintf(os.Stderr, "    OIDC: %s\n", arn)
+	}
+	for _, role := range infra.IAMRoles {
+		fmt.Fprintf(os.Stderr, "    IAM role: %s\n", role)
+	}
+	fmt.Fprintf(os.Stderr, "\n")
+}
+
+func (d *Deleter) deleteIAMRole(ctx context.Context, roleName string) error {
+	// Detach managed policies
+	if polOut, err := d.IAM.ListAttachedRolePolicies(ctx, &iam.ListAttachedRolePoliciesInput{
+		RoleName: aws.String(roleName),
+	}); err == nil {
+		for _, pol := range polOut.AttachedPolicies {
+			_, _ = d.IAM.DetachRolePolicy(ctx, &iam.DetachRolePolicyInput{
+				RoleName:  aws.String(roleName),
+				PolicyArn: pol.PolicyArn,
+			})
+		}
+	}
+
+	// Delete inline policies
+	if polOut, err := d.IAM.ListRolePolicies(ctx, &iam.ListRolePoliciesInput{
+		RoleName: aws.String(roleName),
+	}); err == nil {
+		for _, polName := range polOut.PolicyNames {
+			_, _ = d.IAM.DeleteRolePolicy(ctx, &iam.DeleteRolePolicyInput{
+				RoleName:   aws.String(roleName),
+				PolicyName: aws.String(polName),
+			})
+		}
+	}
+
+	// Remove from instance profiles and delete them
+	if profOut, err := d.IAM.ListInstanceProfilesForRole(ctx, &iam.ListInstanceProfilesForRoleInput{
+		RoleName: aws.String(roleName),
+	}); err == nil {
+		for _, prof := range profOut.InstanceProfiles {
+			_, _ = d.IAM.RemoveRoleFromInstanceProfile(ctx, &iam.RemoveRoleFromInstanceProfileInput{
+				RoleName:            aws.String(roleName),
+				InstanceProfileName: prof.InstanceProfileName,
+			})
+			_, _ = d.IAM.DeleteInstanceProfile(ctx, &iam.DeleteInstanceProfileInput{
+				InstanceProfileName: prof.InstanceProfileName,
+			})
+		}
+	}
+
+	return retryDelete(ctx, "IAM role "+roleName, func() error {
+		_, err := d.IAM.DeleteRole(ctx, &iam.DeleteRoleInput{RoleName: aws.String(roleName)})
+		return err
+	})
+}

--- a/contrib/aws-leaked-resources/delete_test.go
+++ b/contrib/aws-leaked-resources/delete_test.go
@@ -1,0 +1,810 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// trackingEC2 wraps mockEC2 and records which resources are deleted.
+type trackingEC2 struct {
+	natGateways []ec2types.NatGateway
+	addresses   []ec2types.Address
+	sgGroups    []ec2types.SecurityGroup
+	subnets     []ec2types.Subnet
+	endpoints   []ec2types.VpcEndpoint
+	igws        []ec2types.InternetGateway
+	rtbs        []ec2types.RouteTable
+	enis        []ec2types.NetworkInterface
+
+	releasedEIPs    []string
+	deletedNATs     []string
+	deletedSGs      []string
+	deletedSubnets  []string
+	deletedVPCEs    []string
+	deletedIGWs     []string
+	deletedRTBs     []string
+	deletedENIs     []string
+	deletedVPCs     []string
+	deletedVPCESvcs []string
+}
+
+func (t *trackingEC2) DescribeVpcs(_ context.Context, _ *ec2.DescribeVpcsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+	return &ec2.DescribeVpcsOutput{}, nil
+}
+func (t *trackingEC2) DescribeInstances(_ context.Context, _ *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	return &ec2.DescribeInstancesOutput{}, nil
+}
+func (t *trackingEC2) DescribeVpcEndpoints(_ context.Context, _ *ec2.DescribeVpcEndpointsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointsOutput, error) {
+	return &ec2.DescribeVpcEndpointsOutput{VpcEndpoints: t.endpoints}, nil
+}
+func (t *trackingEC2) DescribeNatGateways(_ context.Context, _ *ec2.DescribeNatGatewaysInput, _ ...func(*ec2.Options)) (*ec2.DescribeNatGatewaysOutput, error) {
+	return &ec2.DescribeNatGatewaysOutput{NatGateways: t.natGateways}, nil
+}
+func (t *trackingEC2) DescribeInternetGateways(_ context.Context, _ *ec2.DescribeInternetGatewaysInput, _ ...func(*ec2.Options)) (*ec2.DescribeInternetGatewaysOutput, error) {
+	return &ec2.DescribeInternetGatewaysOutput{InternetGateways: t.igws}, nil
+}
+func (t *trackingEC2) DescribeSubnets(_ context.Context, _ *ec2.DescribeSubnetsInput, _ ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+	return &ec2.DescribeSubnetsOutput{Subnets: t.subnets}, nil
+}
+func (t *trackingEC2) DescribeSecurityGroups(_ context.Context, _ *ec2.DescribeSecurityGroupsInput, _ ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+	return &ec2.DescribeSecurityGroupsOutput{SecurityGroups: t.sgGroups}, nil
+}
+func (t *trackingEC2) DescribeRouteTables(_ context.Context, _ *ec2.DescribeRouteTablesInput, _ ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error) {
+	return &ec2.DescribeRouteTablesOutput{RouteTables: t.rtbs}, nil
+}
+func (t *trackingEC2) DescribeNetworkInterfaces(_ context.Context, _ *ec2.DescribeNetworkInterfacesInput, _ ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	return &ec2.DescribeNetworkInterfacesOutput{NetworkInterfaces: t.enis}, nil
+}
+func (t *trackingEC2) DescribeAddresses(_ context.Context, input *ec2.DescribeAddressesInput, _ ...func(*ec2.Options)) (*ec2.DescribeAddressesOutput, error) {
+	var matched []ec2types.Address
+	if len(input.AllocationIds) > 0 {
+		for _, addr := range t.addresses {
+			for _, id := range input.AllocationIds {
+				if aws.ToString(addr.AllocationId) == id {
+					matched = append(matched, addr)
+				}
+			}
+		}
+	} else {
+		matched = t.addresses
+	}
+	return &ec2.DescribeAddressesOutput{Addresses: matched}, nil
+}
+func (t *trackingEC2) DescribeVpcEndpointServiceConfigurations(_ context.Context, _ *ec2.DescribeVpcEndpointServiceConfigurationsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error) {
+	return &ec2.DescribeVpcEndpointServiceConfigurationsOutput{}, nil
+}
+
+func (t *trackingEC2) ReleaseAddress(_ context.Context, input *ec2.ReleaseAddressInput, _ ...func(*ec2.Options)) (*ec2.ReleaseAddressOutput, error) {
+	t.releasedEIPs = append(t.releasedEIPs, aws.ToString(input.AllocationId))
+	return &ec2.ReleaseAddressOutput{}, nil
+}
+func (t *trackingEC2) DeleteNatGateway(_ context.Context, input *ec2.DeleteNatGatewayInput, _ ...func(*ec2.Options)) (*ec2.DeleteNatGatewayOutput, error) {
+	t.deletedNATs = append(t.deletedNATs, aws.ToString(input.NatGatewayId))
+	return &ec2.DeleteNatGatewayOutput{}, nil
+}
+func (t *trackingEC2) DeleteSecurityGroup(_ context.Context, input *ec2.DeleteSecurityGroupInput, _ ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error) {
+	t.deletedSGs = append(t.deletedSGs, aws.ToString(input.GroupId))
+	return &ec2.DeleteSecurityGroupOutput{}, nil
+}
+func (t *trackingEC2) DeleteSubnet(_ context.Context, input *ec2.DeleteSubnetInput, _ ...func(*ec2.Options)) (*ec2.DeleteSubnetOutput, error) {
+	t.deletedSubnets = append(t.deletedSubnets, aws.ToString(input.SubnetId))
+	return &ec2.DeleteSubnetOutput{}, nil
+}
+func (t *trackingEC2) DeleteVpcEndpoints(_ context.Context, input *ec2.DeleteVpcEndpointsInput, _ ...func(*ec2.Options)) (*ec2.DeleteVpcEndpointsOutput, error) {
+	t.deletedVPCEs = append(t.deletedVPCEs, input.VpcEndpointIds...)
+	return &ec2.DeleteVpcEndpointsOutput{}, nil
+}
+func (t *trackingEC2) DeleteVpcEndpointServiceConfigurations(_ context.Context, input *ec2.DeleteVpcEndpointServiceConfigurationsInput, _ ...func(*ec2.Options)) (*ec2.DeleteVpcEndpointServiceConfigurationsOutput, error) {
+	t.deletedVPCESvcs = append(t.deletedVPCESvcs, input.ServiceIds...)
+	return &ec2.DeleteVpcEndpointServiceConfigurationsOutput{}, nil
+}
+func (t *trackingEC2) DetachInternetGateway(_ context.Context, _ *ec2.DetachInternetGatewayInput, _ ...func(*ec2.Options)) (*ec2.DetachInternetGatewayOutput, error) {
+	return &ec2.DetachInternetGatewayOutput{}, nil
+}
+func (t *trackingEC2) DeleteInternetGateway(_ context.Context, input *ec2.DeleteInternetGatewayInput, _ ...func(*ec2.Options)) (*ec2.DeleteInternetGatewayOutput, error) {
+	t.deletedIGWs = append(t.deletedIGWs, aws.ToString(input.InternetGatewayId))
+	return &ec2.DeleteInternetGatewayOutput{}, nil
+}
+func (t *trackingEC2) DisassociateRouteTable(_ context.Context, _ *ec2.DisassociateRouteTableInput, _ ...func(*ec2.Options)) (*ec2.DisassociateRouteTableOutput, error) {
+	return &ec2.DisassociateRouteTableOutput{}, nil
+}
+func (t *trackingEC2) DeleteRouteTable(_ context.Context, input *ec2.DeleteRouteTableInput, _ ...func(*ec2.Options)) (*ec2.DeleteRouteTableOutput, error) {
+	t.deletedRTBs = append(t.deletedRTBs, aws.ToString(input.RouteTableId))
+	return &ec2.DeleteRouteTableOutput{}, nil
+}
+func (t *trackingEC2) DetachNetworkInterface(_ context.Context, _ *ec2.DetachNetworkInterfaceInput, _ ...func(*ec2.Options)) (*ec2.DetachNetworkInterfaceOutput, error) {
+	return &ec2.DetachNetworkInterfaceOutput{}, nil
+}
+func (t *trackingEC2) DeleteNetworkInterface(_ context.Context, input *ec2.DeleteNetworkInterfaceInput, _ ...func(*ec2.Options)) (*ec2.DeleteNetworkInterfaceOutput, error) {
+	t.deletedENIs = append(t.deletedENIs, aws.ToString(input.NetworkInterfaceId))
+	return &ec2.DeleteNetworkInterfaceOutput{}, nil
+}
+func (t *trackingEC2) DeleteVpc(_ context.Context, input *ec2.DeleteVpcInput, _ ...func(*ec2.Options)) (*ec2.DeleteVpcOutput, error) {
+	t.deletedVPCs = append(t.deletedVPCs, aws.ToString(input.VpcId))
+	return &ec2.DeleteVpcOutput{}, nil
+}
+func (t *trackingEC2) RevokeSecurityGroupIngress(_ context.Context, _ *ec2.RevokeSecurityGroupIngressInput, _ ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	return &ec2.RevokeSecurityGroupIngressOutput{}, nil
+}
+func (t *trackingEC2) RevokeSecurityGroupEgress(_ context.Context, _ *ec2.RevokeSecurityGroupEgressInput, _ ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+	return &ec2.RevokeSecurityGroupEgressOutput{}, nil
+}
+
+// trackingELBv2 records deleted load balancers.
+type trackingELBv2 struct {
+	loadBalancers []elbv2types.LoadBalancer
+	deletedLBs    []string
+}
+
+func (t *trackingELBv2) DescribeLoadBalancers(_ context.Context, _ *elbv2.DescribeLoadBalancersInput, _ ...func(*elbv2.Options)) (*elbv2.DescribeLoadBalancersOutput, error) {
+	return &elbv2.DescribeLoadBalancersOutput{LoadBalancers: t.loadBalancers}, nil
+}
+func (t *trackingELBv2) DeleteLoadBalancer(_ context.Context, input *elbv2.DeleteLoadBalancerInput, _ ...func(*elbv2.Options)) (*elbv2.DeleteLoadBalancerOutput, error) {
+	t.deletedLBs = append(t.deletedLBs, aws.ToString(input.LoadBalancerArn))
+	return &elbv2.DeleteLoadBalancerOutput{}, nil
+}
+
+// trackingRoute53 records deleted zones.
+type trackingRoute53 struct {
+	deletedZones []string
+}
+
+func (t *trackingRoute53) ListHostedZones(_ context.Context, _ *route53.ListHostedZonesInput, _ ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error) {
+	return &route53.ListHostedZonesOutput{}, nil
+}
+func (t *trackingRoute53) GetHostedZone(_ context.Context, _ *route53.GetHostedZoneInput, _ ...func(*route53.Options)) (*route53.GetHostedZoneOutput, error) {
+	return &route53.GetHostedZoneOutput{}, nil
+}
+func (t *trackingRoute53) ListResourceRecordSets(_ context.Context, _ *route53.ListResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
+	return &route53.ListResourceRecordSetsOutput{}, nil
+}
+func (t *trackingRoute53) ChangeResourceRecordSets(_ context.Context, _ *route53.ChangeResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error) {
+	return &route53.ChangeResourceRecordSetsOutput{}, nil
+}
+func (t *trackingRoute53) DeleteHostedZone(_ context.Context, input *route53.DeleteHostedZoneInput, _ ...func(*route53.Options)) (*route53.DeleteHostedZoneOutput, error) {
+	t.deletedZones = append(t.deletedZones, aws.ToString(input.Id))
+	return &route53.DeleteHostedZoneOutput{}, nil
+}
+
+// trackingIAM records deleted OIDC providers.
+type trackingIAM struct {
+	deletedOIDC []string
+}
+
+func (t *trackingIAM) ListOpenIDConnectProviders(_ context.Context, _ *iam.ListOpenIDConnectProvidersInput, _ ...func(*iam.Options)) (*iam.ListOpenIDConnectProvidersOutput, error) {
+	return &iam.ListOpenIDConnectProvidersOutput{}, nil
+}
+func (t *trackingIAM) GetOpenIDConnectProvider(_ context.Context, _ *iam.GetOpenIDConnectProviderInput, _ ...func(*iam.Options)) (*iam.GetOpenIDConnectProviderOutput, error) {
+	return &iam.GetOpenIDConnectProviderOutput{}, nil
+}
+func (t *trackingIAM) ListRoles(_ context.Context, _ *iam.ListRolesInput, _ ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
+	return &iam.ListRolesOutput{}, nil
+}
+func (t *trackingIAM) DeleteOpenIDConnectProvider(_ context.Context, input *iam.DeleteOpenIDConnectProviderInput, _ ...func(*iam.Options)) (*iam.DeleteOpenIDConnectProviderOutput, error) {
+	t.deletedOIDC = append(t.deletedOIDC, aws.ToString(input.OpenIDConnectProviderArn))
+	return &iam.DeleteOpenIDConnectProviderOutput{}, nil
+}
+func (t *trackingIAM) ListAttachedRolePolicies(_ context.Context, _ *iam.ListAttachedRolePoliciesInput, _ ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error) {
+	return &iam.ListAttachedRolePoliciesOutput{}, nil
+}
+func (t *trackingIAM) DetachRolePolicy(_ context.Context, _ *iam.DetachRolePolicyInput, _ ...func(*iam.Options)) (*iam.DetachRolePolicyOutput, error) {
+	return &iam.DetachRolePolicyOutput{}, nil
+}
+func (t *trackingIAM) ListRolePolicies(_ context.Context, _ *iam.ListRolePoliciesInput, _ ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error) {
+	return &iam.ListRolePoliciesOutput{}, nil
+}
+func (t *trackingIAM) DeleteRolePolicy(_ context.Context, _ *iam.DeleteRolePolicyInput, _ ...func(*iam.Options)) (*iam.DeleteRolePolicyOutput, error) {
+	return &iam.DeleteRolePolicyOutput{}, nil
+}
+func (t *trackingIAM) ListInstanceProfilesForRole(_ context.Context, _ *iam.ListInstanceProfilesForRoleInput, _ ...func(*iam.Options)) (*iam.ListInstanceProfilesForRoleOutput, error) {
+	return &iam.ListInstanceProfilesForRoleOutput{}, nil
+}
+func (t *trackingIAM) RemoveRoleFromInstanceProfile(_ context.Context, _ *iam.RemoveRoleFromInstanceProfileInput, _ ...func(*iam.Options)) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
+	return &iam.RemoveRoleFromInstanceProfileOutput{}, nil
+}
+func (t *trackingIAM) DeleteInstanceProfile(_ context.Context, _ *iam.DeleteInstanceProfileInput, _ ...func(*iam.Options)) (*iam.DeleteInstanceProfileOutput, error) {
+	return &iam.DeleteInstanceProfileOutput{}, nil
+}
+func (t *trackingIAM) DeleteRole(_ context.Context, _ *iam.DeleteRoleInput, _ ...func(*iam.Options)) (*iam.DeleteRoleOutput, error) {
+	return &iam.DeleteRoleOutput{}, nil
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDeleter_EIPRelease(t *testing.T) {
+	tests := []struct {
+		name            string
+		natGateways     []ec2types.NatGateway
+		allEIPs         []ec2types.Address
+		wantReleased    []string
+		wantNotReleased []string
+	}{
+		{
+			name: "When VPC has a NAT with EIP and account has other orphaned EIPs, it should only release the NAT EIP",
+			natGateways: []ec2types.NatGateway{
+				{
+					NatGatewayId: aws.String("nat-leaked"),
+					VpcId:        aws.String("vpc-leaked"),
+					NatGatewayAddresses: []ec2types.NatGatewayAddress{
+						{AllocationId: aws.String("eip-nat-leaked"), PublicIp: aws.String("1.2.3.4")},
+					},
+				},
+			},
+			allEIPs: []ec2types.Address{
+				{AllocationId: aws.String("eip-nat-leaked"), PublicIp: aws.String("1.2.3.4")},
+				{AllocationId: aws.String("eip-ci2-nat"), PublicIp: aws.String("18.233.217.161")},
+				{AllocationId: aws.String("eip-ci3-nat"), PublicIp: aws.String("100.25.75.227")},
+				{AllocationId: aws.String("eip-orphan-1"), PublicIp: aws.String("100.27.126.159")},
+				{AllocationId: aws.String("eip-orphan-2"), PublicIp: aws.String("100.29.246.172")},
+			},
+			wantReleased:    []string{"eip-nat-leaked"},
+			wantNotReleased: []string{"eip-ci2-nat", "eip-ci3-nat", "eip-orphan-1", "eip-orphan-2"},
+		},
+		{
+			name:        "When VPC has no NAT gateways, it should release zero EIPs regardless of orphaned EIPs in account",
+			natGateways: []ec2types.NatGateway{},
+			allEIPs: []ec2types.Address{
+				{AllocationId: aws.String("eip-orphan-1"), PublicIp: aws.String("100.27.126.159")},
+				{AllocationId: aws.String("eip-orphan-2"), PublicIp: aws.String("100.29.246.172")},
+				{AllocationId: aws.String("eip-ci2"), PublicIp: aws.String("18.233.217.161")},
+			},
+			wantReleased:    nil,
+			wantNotReleased: []string{"eip-orphan-1", "eip-orphan-2", "eip-ci2"},
+		},
+		{
+			name: "When VPC has multiple NATs with EIPs, it should release only those EIPs",
+			natGateways: []ec2types.NatGateway{
+				{
+					NatGatewayId: aws.String("nat-1"),
+					VpcId:        aws.String("vpc-leaked"),
+					NatGatewayAddresses: []ec2types.NatGatewayAddress{
+						{AllocationId: aws.String("eip-nat-1"), PublicIp: aws.String("1.1.1.1")},
+					},
+				},
+				{
+					NatGatewayId: aws.String("nat-2"),
+					VpcId:        aws.String("vpc-leaked"),
+					NatGatewayAddresses: []ec2types.NatGatewayAddress{
+						{AllocationId: aws.String("eip-nat-2"), PublicIp: aws.String("2.2.2.2")},
+					},
+				},
+			},
+			allEIPs: []ec2types.Address{
+				{AllocationId: aws.String("eip-nat-1"), PublicIp: aws.String("1.1.1.1")},
+				{AllocationId: aws.String("eip-nat-2"), PublicIp: aws.String("2.2.2.2")},
+				{AllocationId: aws.String("eip-other"), PublicIp: aws.String("3.3.3.3")},
+			},
+			wantReleased:    []string{"eip-nat-1", "eip-nat-2"},
+			wantNotReleased: []string{"eip-other"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ec2Client := &trackingEC2{
+				natGateways: tt.natGateways,
+				addresses:   tt.allEIPs,
+			}
+
+			deleter := &Deleter{
+				EC2:     ec2Client,
+				ELBv2:   &trackingELBv2{},
+				Route53: &trackingRoute53{},
+				IAM:     &trackingIAM{},
+			}
+
+			eips := deleter.collectNATGatewayEIPs(context.Background(), "vpc-leaked")
+			deleter.releaseEIPs(context.Background(), eips)
+
+			for _, want := range tt.wantReleased {
+				if !contains(ec2Client.releasedEIPs, want) {
+					t.Errorf("expected EIP %s to be released, but it was not", want)
+				}
+			}
+			for _, notWant := range tt.wantNotReleased {
+				if contains(ec2Client.releasedEIPs, notWant) {
+					t.Errorf("EIP %s should NOT have been released, but it was", notWant)
+				}
+			}
+		})
+	}
+}
+
+func TestDeleter_DefaultSGNeverDeleted(t *testing.T) {
+	tests := []struct {
+		name       string
+		sgs        []ec2types.SecurityGroup
+		wantDelete []string
+		wantSkip   []string
+	}{
+		{
+			name: "When VPC has default and custom SGs, it should only delete the custom ones",
+			sgs: []ec2types.SecurityGroup{
+				{GroupId: aws.String("sg-default"), GroupName: aws.String("default")},
+				{GroupId: aws.String("sg-custom-1"), GroupName: aws.String("my-cluster-sg")},
+				{GroupId: aws.String("sg-custom-2"), GroupName: aws.String("my-cluster-vpce-sg")},
+			},
+			wantDelete: []string{"sg-custom-1", "sg-custom-2"},
+			wantSkip:   []string{"sg-default"},
+		},
+		{
+			name: "When VPC only has default SG, it should delete nothing",
+			sgs: []ec2types.SecurityGroup{
+				{GroupId: aws.String("sg-default"), GroupName: aws.String("default")},
+			},
+			wantDelete: nil,
+			wantSkip:   []string{"sg-default"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ec2Client := &trackingEC2{sgGroups: tt.sgs}
+			deleter := &Deleter{
+				EC2:     ec2Client,
+				ELBv2:   &trackingELBv2{},
+				Route53: &trackingRoute53{},
+				IAM:     &trackingIAM{},
+			}
+
+			deleter.deleteSecurityGroups(context.Background(), "vpc-test")
+
+			for _, want := range tt.wantDelete {
+				if !contains(ec2Client.deletedSGs, want) {
+					t.Errorf("expected SG %s to be deleted, but it was not", want)
+				}
+			}
+			for _, notWant := range tt.wantSkip {
+				if contains(ec2Client.deletedSGs, notWant) {
+					t.Errorf("default SG %s should NEVER be deleted, but it was", notWant)
+				}
+			}
+		})
+	}
+}
+
+func TestDeleter_ELBOnlyDeletesTargetVPC(t *testing.T) {
+	t.Run("When account has ELBs in multiple VPCs, it should only delete ELBs in the target VPC", func(t *testing.T) {
+		elbClient := &trackingELBv2{
+			loadBalancers: []elbv2types.LoadBalancer{
+				{LoadBalancerArn: aws.String("arn:elb:leaked-1"), LoadBalancerName: aws.String("leaked-elb"), VpcId: aws.String("vpc-leaked")},
+				{LoadBalancerArn: aws.String("arn:elb:ci2-1"), LoadBalancerName: aws.String("ci2-elb"), VpcId: aws.String("vpc-ci2")},
+				{LoadBalancerArn: aws.String("arn:elb:ci3-1"), LoadBalancerName: aws.String("ci3-elb"), VpcId: aws.String("vpc-ci3")},
+			},
+		}
+
+		deleter := &Deleter{
+			EC2:     &trackingEC2{},
+			ELBv2:   elbClient,
+			Route53: &trackingRoute53{},
+			IAM:     &trackingIAM{},
+		}
+
+		deleter.deleteLoadBalancers(context.Background(), "vpc-leaked")
+
+		if !contains(elbClient.deletedLBs, "arn:elb:leaked-1") {
+			t.Error("expected leaked-elb to be deleted")
+		}
+		if contains(elbClient.deletedLBs, "arn:elb:ci2-1") {
+			t.Error("ci2-elb should NOT have been deleted")
+		}
+		if contains(elbClient.deletedLBs, "arn:elb:ci3-1") {
+			t.Error("ci3-elb should NOT have been deleted")
+		}
+	})
+}
+
+func TestDeleter_MainRTBNeverDeleted(t *testing.T) {
+	t.Run("When VPC has main and non-main route tables, it should only delete non-main ones", func(t *testing.T) {
+		ec2Client := &trackingEC2{
+			rtbs: []ec2types.RouteTable{
+				{
+					RouteTableId: aws.String("rtb-main"),
+					Associations: []ec2types.RouteTableAssociation{
+						{Main: aws.Bool(true), RouteTableAssociationId: aws.String("rtbassoc-main")},
+					},
+				},
+				{
+					RouteTableId: aws.String("rtb-custom"),
+					Associations: []ec2types.RouteTableAssociation{
+						{Main: aws.Bool(false), RouteTableAssociationId: aws.String("rtbassoc-custom")},
+					},
+				},
+			},
+		}
+
+		deleter := &Deleter{EC2: ec2Client, ELBv2: &trackingELBv2{}, Route53: &trackingRoute53{}, IAM: &trackingIAM{}}
+		deleter.deleteRouteTables(context.Background(), "vpc-test")
+
+		if contains(ec2Client.deletedRTBs, "rtb-main") {
+			t.Error("main route table should NEVER be deleted")
+		}
+		if !contains(ec2Client.deletedRTBs, "rtb-custom") {
+			t.Error("expected custom route table to be deleted")
+		}
+	})
+}
+
+func TestDeleter_FullCascadeOnlyTargetsOwnResources(t *testing.T) {
+	t.Run("When deleting a leaked VPC, it should not touch resources from other VPCs", func(t *testing.T) {
+		ec2Client := &trackingEC2{
+			natGateways: []ec2types.NatGateway{
+				{NatGatewayId: aws.String("nat-leaked"), VpcId: aws.String("vpc-leaked"),
+					NatGatewayAddresses: []ec2types.NatGatewayAddress{
+						{AllocationId: aws.String("eip-leaked"), PublicIp: aws.String("1.2.3.4")},
+					}},
+			},
+			addresses: []ec2types.Address{
+				{AllocationId: aws.String("eip-leaked"), PublicIp: aws.String("1.2.3.4")},
+				{AllocationId: aws.String("eip-ci2"), PublicIp: aws.String("18.233.217.161")},
+			},
+			sgGroups: []ec2types.SecurityGroup{
+				{GroupId: aws.String("sg-default"), GroupName: aws.String("default")},
+				{GroupId: aws.String("sg-leaked"), GroupName: aws.String("leaked-sg")},
+			},
+			subnets: []ec2types.Subnet{
+				{SubnetId: aws.String("subnet-leaked")},
+			},
+		}
+
+		elbClient := &trackingELBv2{
+			loadBalancers: []elbv2types.LoadBalancer{
+				{LoadBalancerArn: aws.String("arn:elb:leaked"), LoadBalancerName: aws.String("leaked-elb"), VpcId: aws.String("vpc-leaked")},
+				{LoadBalancerArn: aws.String("arn:elb:ci2"), LoadBalancerName: aws.String("ci2-elb"), VpcId: aws.String("vpc-ci2")},
+			},
+		}
+
+		r53Client := &trackingRoute53{}
+		iamClient := &trackingIAM{}
+
+		deleter := &Deleter{EC2: ec2Client, ELBv2: elbClient, Route53: r53Client, IAM: iamClient}
+
+		leaked := []InfraSet{{
+			InfraID: "leaked-infra",
+			Verdict: VerdictLeaked,
+			VPCs:    []VPCInfo{{VPCID: "vpc-leaked", Name: "leaked-infra-vpc"}},
+		}}
+
+		if err := deleter.DeleteAll(context.Background(), leaked, ConfirmAll); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !contains(ec2Client.deletedVPCs, "vpc-leaked") {
+			t.Error("expected vpc-leaked to be deleted")
+		}
+		if !contains(ec2Client.releasedEIPs, "eip-leaked") {
+			t.Error("expected eip-leaked to be released")
+		}
+		if contains(ec2Client.releasedEIPs, "eip-ci2") {
+			t.Error("eip-ci2 should NOT have been released")
+		}
+		if contains(elbClient.deletedLBs, "arn:elb:ci2") {
+			t.Error("ci2 ELB should NOT have been deleted")
+		}
+		if contains(ec2Client.deletedSGs, "sg-default") {
+			t.Error("default SG should NEVER be deleted")
+		}
+		if !contains(ec2Client.deletedSGs, "sg-leaked") {
+			t.Error("expected sg-leaked to be deleted")
+		}
+		if !contains(ec2Client.deletedSubnets, "subnet-leaked") {
+			t.Error("expected subnet-leaked to be deleted")
+		}
+	})
+}
+
+func TestDeleter_ProtectedInfraSetNeverDeleted(t *testing.T) {
+	t.Run("When DeleteAll receives a PROTECTED infra set, it should skip it entirely", func(t *testing.T) {
+		ec2Client := &trackingEC2{}
+		deleter := &Deleter{EC2: ec2Client, ELBv2: &trackingELBv2{}, Route53: &trackingRoute53{}, IAM: &trackingIAM{}}
+
+		sets := []InfraSet{
+			{InfraID: "ci2", Verdict: VerdictProtected, VPCs: []VPCInfo{{VPCID: "vpc-ci2"}}},
+			{InfraID: "ci3", Verdict: VerdictProtected, VPCs: []VPCInfo{{VPCID: "vpc-ci3"}}},
+			{InfraID: "leaked", Verdict: VerdictLeaked, VPCs: []VPCInfo{{VPCID: "vpc-leaked"}}},
+		}
+
+		if err := deleter.DeleteAll(context.Background(), sets, ConfirmAll); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if contains(ec2Client.deletedVPCs, "vpc-ci2") {
+			t.Error("PROTECTED vpc-ci2 should NEVER be deleted")
+		}
+		if contains(ec2Client.deletedVPCs, "vpc-ci3") {
+			t.Error("PROTECTED vpc-ci3 should NEVER be deleted")
+		}
+		if !contains(ec2Client.deletedVPCs, "vpc-leaked") {
+			t.Error("expected vpc-leaked to be deleted")
+		}
+	})
+}
+
+func TestDeleter_CollectNATGatewayEIPsReturnsCorrectIDs(t *testing.T) {
+	tests := []struct {
+		name     string
+		nats     []ec2types.NatGateway
+		wantEIPs []string
+	}{
+		{
+			name: "When NAT has one EIP, it should return that AllocationID",
+			nats: []ec2types.NatGateway{
+				{NatGatewayId: aws.String("nat-1"), NatGatewayAddresses: []ec2types.NatGatewayAddress{
+					{AllocationId: aws.String("eip-1")},
+				}},
+			},
+			wantEIPs: []string{"eip-1"},
+		},
+		{
+			name: "When multiple NATs have EIPs, it should return all AllocationIDs",
+			nats: []ec2types.NatGateway{
+				{NatGatewayId: aws.String("nat-1"), NatGatewayAddresses: []ec2types.NatGatewayAddress{{AllocationId: aws.String("eip-1")}}},
+				{NatGatewayId: aws.String("nat-2"), NatGatewayAddresses: []ec2types.NatGatewayAddress{{AllocationId: aws.String("eip-2")}}},
+			},
+			wantEIPs: []string{"eip-1", "eip-2"},
+		},
+		{
+			name:     "When no NATs exist, it should return empty",
+			nats:     nil,
+			wantEIPs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ec2Client := &trackingEC2{natGateways: tt.nats}
+			deleter := &Deleter{EC2: ec2Client}
+
+			got := deleter.collectNATGatewayEIPs(context.Background(), "vpc-test")
+
+			if len(got) != len(tt.wantEIPs) {
+				t.Fatalf("got %d EIPs, want %d", len(got), len(tt.wantEIPs))
+			}
+			for i, want := range tt.wantEIPs {
+				if got[i] != want {
+					t.Errorf("EIP[%d] = %q, want %q", i, got[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestDeleter_ActiveInfraSetNeverDeleted(t *testing.T) {
+	t.Run("When DeleteAll receives ACTIVE and TOO_YOUNG infra sets mixed with LEAKED, it should only delete LEAKED", func(t *testing.T) {
+		ec2Client := &trackingEC2{}
+		deleter := &Deleter{EC2: ec2Client, ELBv2: &trackingELBv2{}, Route53: &trackingRoute53{}, IAM: &trackingIAM{}}
+
+		sets := []InfraSet{
+			{InfraID: "active", Verdict: VerdictActive, VPCs: []VPCInfo{{VPCID: "vpc-active"}}},
+			{InfraID: "young", Verdict: VerdictTooYoung, VPCs: []VPCInfo{{VPCID: "vpc-young"}}},
+			{InfraID: "leaked", Verdict: VerdictLeaked, VPCs: []VPCInfo{{VPCID: "vpc-leaked"}}},
+		}
+
+		if err := deleter.DeleteAll(context.Background(), sets, ConfirmAll); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		for _, v := range []string{"vpc-active", "vpc-young"} {
+			if contains(ec2Client.deletedVPCs, v) {
+				t.Errorf("%s should NOT have been deleted", v)
+			}
+		}
+		if !contains(ec2Client.deletedVPCs, "vpc-leaked") {
+			t.Error("expected vpc-leaked to be deleted")
+		}
+	})
+}
+
+func TestDeleter_RealWorldScenario_CI2EIPSurvives(t *testing.T) {
+	t.Run("When deleting leaked VPC while ci-2 NAT has an orphaned EIP in account, ci-2 EIP should not be touched", func(t *testing.T) {
+		ec2Client := &trackingEC2{
+			natGateways: []ec2types.NatGateway{},
+			addresses: []ec2types.Address{
+				{AllocationId: aws.String("eip-ci2-nat"), PublicIp: aws.String("18.233.217.161")},
+				{AllocationId: aws.String("eip-ci3-nat"), PublicIp: aws.String("100.25.75.227")},
+				{AllocationId: aws.String("eip-orphan"), PublicIp: aws.String("100.27.126.159")},
+			},
+		}
+
+		deleter := &Deleter{EC2: ec2Client, ELBv2: &trackingELBv2{}, Route53: &trackingRoute53{}, IAM: &trackingIAM{}}
+
+		leaked := []InfraSet{{
+			InfraID: "leaked-no-nat",
+			Verdict: VerdictLeaked,
+			VPCs:    []VPCInfo{{VPCID: "vpc-leaked-no-nat", Name: "leaked-vpc"}},
+		}}
+
+		if err := deleter.DeleteAll(context.Background(), leaked, ConfirmAll); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(ec2Client.releasedEIPs) != 0 {
+			t.Errorf("expected 0 EIPs released, got %d: %v", len(ec2Client.releasedEIPs), ec2Client.releasedEIPs)
+		}
+
+		for _, protected := range []string{"eip-ci2-nat", "eip-ci3-nat", "eip-orphan"} {
+			if contains(ec2Client.releasedEIPs, protected) {
+				t.Errorf("EIP %s should NEVER have been released — this is the bug that hit production", protected)
+			}
+		}
+	})
+
+	t.Run("When deleting leaked VPC that has its own NAT EIP while ci-2 NAT EIP exists, only the leaked NAT EIP should be released", func(t *testing.T) {
+		ec2Client := &trackingEC2{
+			natGateways: []ec2types.NatGateway{
+				{
+					NatGatewayId: aws.String("nat-leaked"),
+					VpcId:        aws.String("vpc-leaked"),
+					NatGatewayAddresses: []ec2types.NatGatewayAddress{
+						{AllocationId: aws.String("eip-leaked-nat"), PublicIp: aws.String("5.5.5.5")},
+					},
+				},
+			},
+			addresses: []ec2types.Address{
+				{AllocationId: aws.String("eip-leaked-nat"), PublicIp: aws.String("5.5.5.5")},
+				{AllocationId: aws.String("eip-ci2-nat"), PublicIp: aws.String("18.233.217.161")},
+				{AllocationId: aws.String("eip-ci3-nat"), PublicIp: aws.String("100.25.75.227")},
+			},
+		}
+
+		deleter := &Deleter{EC2: ec2Client, ELBv2: &trackingELBv2{}, Route53: &trackingRoute53{}, IAM: &trackingIAM{}}
+
+		leaked := []InfraSet{{
+			InfraID: "leaked-with-nat",
+			Verdict: VerdictLeaked,
+			VPCs:    []VPCInfo{{VPCID: "vpc-leaked", Name: "leaked-vpc"}},
+		}}
+
+		if err := deleter.DeleteAll(context.Background(), leaked, ConfirmAll); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !contains(ec2Client.releasedEIPs, "eip-leaked-nat") {
+			t.Error("expected eip-leaked-nat to be released")
+		}
+		if contains(ec2Client.releasedEIPs, "eip-ci2-nat") {
+			t.Error("ci-2 NAT EIP should NEVER be released — this would break the management cluster")
+		}
+		if contains(ec2Client.releasedEIPs, "eip-ci3-nat") {
+			t.Error("ci-3 NAT EIP should NEVER be released — this would break the management cluster")
+		}
+	})
+}
+
+func TestDeleter_DeleteIAMRole(t *testing.T) {
+	t.Run("When IAM role has attached policies, inline policies, and instance profiles, it should clean all before deleting", func(t *testing.T) {
+		iamClient := &trackingIAM{
+			deletedOIDC: nil,
+		}
+
+		deleter := &Deleter{
+			EC2:     &trackingEC2{},
+			ELBv2:   &trackingELBv2{},
+			Route53: &trackingRoute53{},
+			IAM:     iamClient,
+		}
+
+		err := deleter.deleteIAMRole(context.Background(), "test-infra-cloud-controller")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestDeleter_DeleteHostedZone(t *testing.T) {
+	t.Run("When hosted zone has NS, SOA, and A records, it should only delete the A record before deleting the zone", func(t *testing.T) {
+		r53Client := &trackingRoute53WithRecords{
+			records: []route53types.ResourceRecordSet{
+				{Name: aws.String("zone.example.com."), Type: route53types.RRTypeNs},
+				{Name: aws.String("zone.example.com."), Type: route53types.RRTypeSoa},
+				{Name: aws.String("*.apps.zone.example.com."), Type: route53types.RRTypeA, ResourceRecords: []route53types.ResourceRecord{{Value: aws.String("1.2.3.4")}}},
+			},
+		}
+
+		deleter := &Deleter{
+			EC2:     &trackingEC2{},
+			ELBv2:   &trackingELBv2{},
+			Route53: r53Client,
+			IAM:     &trackingIAM{},
+		}
+
+		err := deleter.deleteHostedZone(context.Background(), "Z1234", "zone.example.com")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !contains(r53Client.deletedZones, "Z1234") {
+			t.Error("expected zone to be deleted")
+		}
+		if r53Client.changedRecordCount != 1 {
+			t.Errorf("expected 1 record change (the A record), got %d", r53Client.changedRecordCount)
+		}
+	})
+}
+
+type trackingRoute53WithRecords struct {
+	records            []route53types.ResourceRecordSet
+	deletedZones       []string
+	changedRecordCount int
+}
+
+func (t *trackingRoute53WithRecords) ListHostedZones(_ context.Context, _ *route53.ListHostedZonesInput, _ ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error) {
+	return &route53.ListHostedZonesOutput{}, nil
+}
+func (t *trackingRoute53WithRecords) GetHostedZone(_ context.Context, _ *route53.GetHostedZoneInput, _ ...func(*route53.Options)) (*route53.GetHostedZoneOutput, error) {
+	return &route53.GetHostedZoneOutput{}, nil
+}
+func (t *trackingRoute53WithRecords) ListResourceRecordSets(_ context.Context, _ *route53.ListResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
+	return &route53.ListResourceRecordSetsOutput{ResourceRecordSets: t.records}, nil
+}
+func (t *trackingRoute53WithRecords) ChangeResourceRecordSets(_ context.Context, input *route53.ChangeResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error) {
+	t.changedRecordCount = len(input.ChangeBatch.Changes)
+	return &route53.ChangeResourceRecordSetsOutput{}, nil
+}
+func (t *trackingRoute53WithRecords) DeleteHostedZone(_ context.Context, input *route53.DeleteHostedZoneInput, _ ...func(*route53.Options)) (*route53.DeleteHostedZoneOutput, error) {
+	t.deletedZones = append(t.deletedZones, aws.ToString(input.Id))
+	return &route53.DeleteHostedZoneOutput{}, nil
+}
+
+func TestDeleter_VPCEndpointServicesOnlyDeletesMatchingInfraID(t *testing.T) {
+	t.Run("When account has VPCE services from multiple infra sets, it should only delete services tagged with the target infraID", func(t *testing.T) {
+		ec2Client := &trackingEC2WithVPCESvcs{
+			trackingEC2: trackingEC2{},
+			svcConfigs: []ec2types.ServiceConfiguration{
+				{
+					ServiceId: aws.String("vpce-svc-leaked"),
+					Tags: []ec2types.Tag{
+						{Key: aws.String("kubernetes.io/cluster/leaked-infra"), Value: aws.String("owned")},
+					},
+				},
+				{
+					ServiceId: aws.String("vpce-svc-ci2"),
+					Tags: []ec2types.Tag{
+						{Key: aws.String("kubernetes.io/cluster/ci2-infra"), Value: aws.String("owned")},
+					},
+				},
+				{
+					ServiceId: aws.String("vpce-svc-notag"),
+					Tags:      []ec2types.Tag{},
+				},
+			},
+		}
+
+		deleter := &Deleter{EC2: ec2Client, ELBv2: &trackingELBv2{}, Route53: &trackingRoute53{}, IAM: &trackingIAM{}}
+		deleter.deleteVPCEndpointServices(context.Background(), "leaked-infra")
+
+		if !contains(ec2Client.deletedVPCESvcs, "vpce-svc-leaked") {
+			t.Error("expected vpce-svc-leaked to be deleted")
+		}
+		if contains(ec2Client.deletedVPCESvcs, "vpce-svc-ci2") {
+			t.Error("vpce-svc-ci2 should NOT have been deleted")
+		}
+		if contains(ec2Client.deletedVPCESvcs, "vpce-svc-notag") {
+			t.Error("vpce-svc-notag should NOT have been deleted")
+		}
+	})
+}
+
+type trackingEC2WithVPCESvcs struct {
+	trackingEC2
+	svcConfigs []ec2types.ServiceConfiguration
+}
+
+func (t *trackingEC2WithVPCESvcs) DescribeVpcEndpointServiceConfigurations(_ context.Context, _ *ec2.DescribeVpcEndpointServiceConfigurationsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error) {
+	return &ec2.DescribeVpcEndpointServiceConfigurationsOutput{ServiceConfigurations: t.svcConfigs}, nil
+}

--- a/contrib/aws-leaked-resources/main.go
+++ b/contrib/aws-leaked-resources/main.go
@@ -1,0 +1,316 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	cfg := DefaultConfig()
+
+	rootCmd := &cobra.Command{
+		Use:   "cleanleaked",
+		Short: "Detect and clean leaked AWS resources from HyperShift CI",
+		Long: `cleanleaked scans AWS for orphaned VPCs and associated resources left behind
+by failed HyperShift CI test runs, classifies them by safety, and optionally
+deletes them.
+
+Each VPC is classified through a series of gates:
+  PROTECTED  - Management cluster or developer resource (never touched)
+  TOO_YOUNG  - Created less than --min-age ago (skipped)
+  ACTIVE     - OIDC S3 doc or EC2 instances still exist (live cluster)
+  UNCERTAIN  - No CI pattern match; may belong to a developer
+  LEAKED     - No OIDC, no instances, matches CI pattern (safe to delete)
+
+Examples:
+  # Scan and report all VPCs
+  cleanleaked scan
+
+  # Scan with JSON output
+  cleanleaked scan --output json
+
+  # Preview what would be deleted (no actual deletion)
+  cleanleaked delete --dry-run
+
+  # Delete first 5 leaked infra sets, prompting for each one
+  cleanleaked delete --limit 5 --interactive
+
+  # Delete all leaked infra sets without prompts (CI-safe)
+  cleanleaked delete --confirm
+
+  # Delete with a 48h age threshold
+  cleanleaked delete --min-age 48h --confirm
+
+  # Scan a single VPC by ID
+  cleanleaked scan --target vpc-066231b8dc5a4400f
+
+  # Scan a single infra set by infraID
+  cleanleaked scan --target node-pool-78vcg
+
+  # Delete a specific infra set interactively
+  cleanleaked delete --target 00ab3695c5f73d4354b9 --interactive`,
+	}
+
+	scanCmd := &cobra.Command{
+		Use:   "scan",
+		Short: "Scan for leaked VPCs and associated resources",
+		Long: `Scan all VPCs in the region and classify each by safety verdict.
+
+The report includes sub-resource inventory, Route53 zones, OIDC providers,
+IAM roles, Prow job correlation, and creation timestamps.
+
+Examples:
+  cleanleaked scan
+  cleanleaked scan --output json
+  cleanleaked scan --min-age 48h
+  cleanleaked scan --target vpc-066231b8dc5a4400f
+  cleanleaked scan --target node-pool-78vcg`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runScan(cmd.Context(), cfg)
+		},
+	}
+
+	deleteCmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete leaked VPCs and associated resources",
+		Long: `Delete leaked VPCs and all their dependent resources in cascade order:
+  ELBs → VPCE Services → VPCE → NAT → EIPs → IGW → RTB → ENI → Subnets → SG → VPC
+  Then: Route53 zones, OIDC providers, IAM roles.
+
+Three modes:
+  delete                Prompt once at the start, then delete all
+  delete --confirm      No prompts, delete all immediately (CI-safe)
+  delete --interactive  Show full inventory per infra set, prompt for each
+
+Safety: resources with do-not-delete=true, protected VPC names, protected
+usernames, running instances, or unexpired expirationDate are NEVER deleted.
+
+Examples:
+  cleanleaked delete --dry-run
+  cleanleaked delete --limit 10 --interactive
+  cleanleaked delete --confirm --min-age 48h
+  cleanleaked delete --target node-pool-78vcg --interactive
+  cleanleaked delete --target vpc-0abc123 --confirm`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg.Delete = true
+			return runDelete(cmd.Context(), cfg)
+		},
+	}
+
+	scanCmd.Flags().StringVar(&cfg.Region, "region", cfg.Region, "AWS region")
+	scanCmd.Flags().DurationVar(&cfg.MinAge, "min-age", cfg.MinAge, "Minimum VPC age to consider for deletion")
+	scanCmd.Flags().StringVar(&cfg.Target, "target", cfg.Target, "Scan a single infraID or VPC ID instead of all VPCs")
+	scanCmd.Flags().StringVar(&cfg.OutputFormat, "output", cfg.OutputFormat, "Output format: table or json")
+	scanCmd.Flags().StringVar(&cfg.OutputDir, "output-dir", cfg.OutputDir, "Directory for report files (empty to disable)")
+
+	deleteCmd.Flags().StringVar(&cfg.Region, "region", cfg.Region, "AWS region")
+	deleteCmd.Flags().DurationVar(&cfg.MinAge, "min-age", cfg.MinAge, "Minimum VPC age to consider for deletion")
+	deleteCmd.Flags().StringVar(&cfg.Target, "target", cfg.Target, "Delete a single infraID or VPC ID instead of all leaked")
+	deleteCmd.Flags().BoolVar(&cfg.DryRun, "dry-run", cfg.DryRun, "Show what would be deleted without deleting")
+	deleteCmd.Flags().BoolVar(&cfg.Confirm, "confirm", cfg.Confirm, "No prompts, delete all leaked resources immediately")
+	deleteCmd.Flags().BoolVarP(&cfg.Interactive, "interactive", "i", cfg.Interactive, "Prompt before each individual resource deletion")
+	deleteCmd.Flags().IntVar(&cfg.Limit, "limit", cfg.Limit, "Max number of infra sets to delete (0 = no limit)")
+	deleteCmd.Flags().StringVar(&cfg.OutputFormat, "output", cfg.OutputFormat, "Output format: table or json")
+	deleteCmd.Flags().StringVar(&cfg.OutputDir, "output-dir", cfg.OutputDir, "Directory for report files (empty to disable)")
+
+	rootCmd.AddCommand(scanCmd, deleteCmd)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		cancel()
+	}()
+
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newScanner(ctx context.Context, cfg Config) (*Scanner, error) {
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(cfg.Region))
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+
+	return &Scanner{
+		EC2:     ec2.NewFromConfig(awsCfg),
+		ELBv2:   elbv2.NewFromConfig(awsCfg),
+		Route53: route53.NewFromConfig(awsCfg),
+		IAM:     iam.NewFromConfig(awsCfg),
+		S3:      s3.NewFromConfig(awsCfg),
+		Config:  cfg,
+		Now:     time.Now,
+	}, nil
+}
+
+func openReportFile(outputDir, prefix string) (io.Writer, func(), error) {
+	if outputDir == "" {
+		return io.Discard, func() {}, nil
+	}
+
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return nil, nil, fmt.Errorf("creating output dir: %w", err)
+	}
+
+	ts := time.Now().Format("2006-01-02T15-04-05")
+	filename := filepath.Join(outputDir, fmt.Sprintf("%s-%s.txt", prefix, ts))
+
+	f, err := os.Create(filename)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating report file: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Report file: %s\n", filename)
+	return f, func() { f.Close() }, nil
+}
+
+func tee(a, b io.Writer) io.Writer {
+	return io.MultiWriter(a, b)
+}
+
+// promptYN asks a yes/no question on stderr and reads from stdin.
+func promptYN(question string) bool {
+	fmt.Fprintf(os.Stderr, "%s [y/N] ", question)
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	return strings.HasPrefix(strings.TrimSpace(strings.ToLower(answer)), "y")
+}
+
+func runScan(ctx context.Context, cfg Config) error {
+	scanner, err := newScanner(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	fileW, closeFile, err := openReportFile(cfg.OutputDir, "scan")
+	if err != nil {
+		return err
+	}
+	defer closeFile()
+
+	fmt.Fprintf(os.Stderr, "Scanning VPCs in %s (min-age: %s)...\n", cfg.Region, cfg.MinAge)
+
+	results, err := scanner.Scan(ctx)
+	if err != nil {
+		return fmt.Errorf("scan failed: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Correlating with Prow data...\n")
+	CorrelateWithProw(ctx, scanner.Route53, results)
+
+	out := tee(os.Stdout, fileW)
+
+	switch cfg.OutputFormat {
+	case "json":
+		if err := PrintJSON(out, results); err != nil {
+			return err
+		}
+	default:
+		PrintTable(out, results)
+		PrintSummary(out, results)
+	}
+
+	return nil
+}
+
+func runDelete(ctx context.Context, cfg Config) error {
+	scanner, err := newScanner(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	prefix := "delete"
+	if cfg.DryRun {
+		prefix = "dry-run"
+	} else if cfg.Interactive {
+		prefix = "interactive-delete"
+	}
+	fileW, closeFile, err := openReportFile(cfg.OutputDir, prefix)
+	if err != nil {
+		return err
+	}
+	defer closeFile()
+
+	fmt.Fprintf(os.Stderr, "Scanning VPCs in %s (min-age: %s)...\n", cfg.Region, cfg.MinAge)
+
+	results, err := scanner.Scan(ctx)
+	if err != nil {
+		return fmt.Errorf("scan failed: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Correlating with Prow data...\n")
+	CorrelateWithProw(ctx, scanner.Route53, results)
+
+	out := tee(os.Stdout, fileW)
+
+	PrintTable(out, results)
+	PrintSummary(out, results)
+
+	leaked := FilterLeaked(results)
+	if len(leaked) == 0 {
+		fmt.Fprintln(out, "\nNo leaked resources to delete.")
+		return nil
+	}
+
+	if cfg.Limit > 0 && len(leaked) > cfg.Limit {
+		fmt.Fprintf(out, "\nLimiting to %d of %d leaked infra sets (--limit %d).\n", cfg.Limit, len(leaked), cfg.Limit)
+		leaked = leaked[:cfg.Limit]
+	}
+
+	totalVPCs := 0
+	totalZones := 0
+	for _, s := range leaked {
+		totalVPCs += len(s.VPCs)
+		totalZones += len(s.HostedZones)
+	}
+
+	if cfg.DryRun {
+		fmt.Fprintf(out, "\n[DRY RUN] Would delete %d infra sets (%d VPCs, %d zones).\n", len(leaked), totalVPCs, totalZones)
+		return nil
+	}
+
+	deleter := &Deleter{
+		EC2:     scanner.EC2,
+		ELBv2:   scanner.ELBv2,
+		Route53: scanner.Route53,
+		IAM:     scanner.IAM,
+	}
+
+	// Mode 1: --confirm → no prompts, delete everything
+	if cfg.Confirm {
+		return deleter.DeleteAll(ctx, leaked, ConfirmAll)
+	}
+
+	// Mode 2: --interactive → prompt per resource
+	if cfg.Interactive {
+		return deleter.DeleteAll(ctx, leaked, ConfirmEach)
+	}
+
+	// Mode 3: no flags → prompt once at the start
+	fmt.Fprintf(os.Stderr, "\nWARNING: This will delete %d infra sets (%d VPCs, %d zones) and ALL their sub-resources.\n", len(leaked), totalVPCs, totalZones)
+	if !promptYN("Proceed with deletion?") {
+		fmt.Fprintln(os.Stderr, "Aborted.")
+		return nil
+	}
+
+	return deleter.DeleteAll(ctx, leaked, ConfirmAll)
+}

--- a/contrib/aws-leaked-resources/prow.go
+++ b/contrib/aws-leaked-resources/prow.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+)
+
+const (
+	prowDeckURL   = "https://prow.ci.openshift.org"
+	serviceCIZone = "service.ci.hypershift.devcluster.openshift.com"
+)
+
+var (
+	knownTestPrefixes = []string{
+		"control-plane-upgrade",
+		"karpenter-upgrade-control-plane",
+		"request-serving-isolation",
+		"scale-from-zero",
+		"create-cluster",
+		"node-pool",
+		"autoscaling",
+		"karpenter",
+		"kms-verify",
+		"ha-break-glass-creds",
+		"custom-config",
+		"ho-upgrade",
+		"multi-hop-upgrade",
+		"spot-demo",
+		"private",
+		"proxy",
+	}
+
+	namespaceFromRouteRe = regexp.MustCompile(`resource=route/([^/]+)/`)
+)
+
+func init() {
+	sort.Slice(knownTestPrefixes, func(i, j int) bool {
+		return len(knownTestPrefixes[i]) > len(knownTestPrefixes[j])
+	})
+}
+
+// InferTestType extracts the e2e test type from a cluster name (VPC Name without -vpc suffix).
+// Returns the test type and the cluster-specific suffix.
+// Examples:
+//
+//	"create-cluster-hg78d" → ("create-cluster", "hg78d")
+//	"node-pool-78vcg"      → ("node-pool", "78vcg")
+//	"00ab3695c5f73d4354b9" → ("", "")  (hex infraID, no test type)
+func InferTestType(infraID string) (testType, suffix string) {
+	for _, prefix := range knownTestPrefixes {
+		if strings.HasPrefix(infraID, prefix+"-") {
+			suffix = strings.TrimPrefix(infraID, prefix+"-")
+			return prefix, suffix
+		}
+	}
+
+	if isHexInfraID(infraID) {
+		return "e2e-generic", ""
+	}
+
+	return "", ""
+}
+
+var hexPattern = regexp.MustCompile(`^[0-9a-f]{16,}$`)
+
+func isHexInfraID(s string) bool {
+	return hexPattern.MatchString(s)
+}
+
+// ProwJobURL returns a direct Prow link when we have the job name and build ID,
+// or a search URL as fallback.
+func ProwJobURL(testType, prowJobID string) string {
+	if prowJobID != "" {
+		return fmt.Sprintf("%s/view/gs/test-platform-results/logs/%s", prowDeckURL, prowJobID)
+	}
+
+	if testType == "" || testType == "e2e-generic" {
+		return ""
+	}
+	query := fmt.Sprintf("hypershift e2e %s", testType)
+	return fmt.Sprintf("%s/?query=%s&type=periodic", prowDeckURL, url.QueryEscape(query))
+}
+
+// LookupNamespaceFromServiceZone searches the service.ci zone TXT records for a
+// given cluster name and returns the HC namespace (e2e-clusters-XXXXX-<cluster>).
+func LookupNamespaceFromServiceZone(ctx context.Context, r53 Route53API, serviceCIZoneID, clusterName string) string {
+	if serviceCIZoneID == "" || clusterName == "" {
+		return ""
+	}
+
+	target := clusterName + "/"
+	input := &route53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(serviceCIZoneID),
+	}
+
+	for {
+		out, err := r53.ListResourceRecordSets(ctx, input)
+		if err != nil {
+			return ""
+		}
+
+		for _, rr := range out.ResourceRecordSets {
+			if rr.Type != "TXT" {
+				continue
+			}
+			for _, r := range rr.ResourceRecords {
+				val := aws.ToString(r.Value)
+				if strings.Contains(val, target) {
+					if ns := extractNamespace(val); ns != "" {
+						return ns
+					}
+				}
+			}
+		}
+
+		if !out.IsTruncated {
+			break
+		}
+		input.StartRecordName = out.NextRecordName
+		input.StartRecordType = out.NextRecordType
+		input.StartRecordIdentifier = out.NextRecordIdentifier
+	}
+
+	return ""
+}
+
+// extractNamespace extracts the namespace from an external-dns TXT record value.
+// Input:  "heritage=external-dns,...,external-dns/resource=route/e2e-clusters-7c84g-node-pool-78vcg/kube-apiserver"
+// Output: "e2e-clusters-7c84g-node-pool-78vcg"
+func extractNamespace(txtValue string) string {
+	m := namespaceFromRouteRe.FindStringSubmatch(txtValue)
+	if m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// FindServiceCIZoneID finds the zone ID for service.ci.hypershift.devcluster.openshift.com
+func FindServiceCIZoneID(ctx context.Context, r53 Route53API) string {
+	var nextMarker *string
+	for {
+		out, err := r53.ListHostedZones(ctx, &route53.ListHostedZonesInput{
+			Marker: nextMarker,
+		})
+		if err != nil {
+			return ""
+		}
+
+		for _, z := range out.HostedZones {
+			name := strings.TrimSuffix(aws.ToString(z.Name), ".")
+			if name == serviceCIZone {
+				return strings.TrimPrefix(aws.ToString(z.Id), "/hostedzone/")
+			}
+		}
+
+		if !out.IsTruncated {
+			break
+		}
+		nextMarker = out.NextMarker
+	}
+	return ""
+}
+
+// CorrelateWithProw enriches leaked InfraSets with test type, namespace, and Prow link.
+func CorrelateWithProw(ctx context.Context, r53 Route53API, sets []InfraSet) {
+	serviceCIZoneID := FindServiceCIZoneID(ctx, r53)
+
+	for i, infra := range sets {
+		if infra.Verdict != VerdictLeaked && infra.Verdict != VerdictUncertain {
+			continue
+		}
+
+		testType, _ := InferTestType(infra.InfraID)
+		sets[i].TestType = testType
+
+		// Use the prow-job-id tag from any VPC if available (PR #8909)
+		prowJobID := ""
+		for _, vpc := range infra.VPCs {
+			if vpc.ProwJobID != "" {
+				prowJobID = vpc.ProwJobID
+				break
+			}
+		}
+		sets[i].ProwLink = ProwJobURL(testType, prowJobID)
+
+		if serviceCIZoneID != "" && testType != "" && testType != "e2e-generic" {
+			ns := LookupNamespaceFromServiceZone(ctx, r53, serviceCIZoneID, infra.InfraID)
+			sets[i].Namespace = ns
+		}
+	}
+}

--- a/contrib/aws-leaked-resources/prow_test.go
+++ b/contrib/aws-leaked-resources/prow_test.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+func TestInferTestType(t *testing.T) {
+	tests := []struct {
+		name       string
+		infraID    string
+		wantType   string
+		wantSuffix string
+	}{
+		{
+			name:       "When infraID is a create-cluster job, it should return create-cluster",
+			infraID:    "create-cluster-hg78d",
+			wantType:   "create-cluster",
+			wantSuffix: "hg78d",
+		},
+		{
+			name:       "When infraID is a node-pool job, it should return node-pool",
+			infraID:    "node-pool-78vcg",
+			wantType:   "node-pool",
+			wantSuffix: "78vcg",
+		},
+		{
+			name:       "When infraID is a control-plane-upgrade job, it should return control-plane-upgrade",
+			infraID:    "control-plane-upgrade-6tnx2",
+			wantType:   "control-plane-upgrade",
+			wantSuffix: "6tnx2",
+		},
+		{
+			name:       "When infraID is a karpenter-upgrade-control-plane job, it should return karpenter-upgrade-control-plane",
+			infraID:    "karpenter-upgrade-control-plane-s6tnb",
+			wantType:   "karpenter-upgrade-control-plane",
+			wantSuffix: "s6tnb",
+		},
+		{
+			name:       "When infraID is a hex string, it should return e2e-generic",
+			infraID:    "00ab3695c5f73d4354b9",
+			wantType:   "e2e-generic",
+			wantSuffix: "",
+		},
+		{
+			name:       "When infraID is a scale-from-zero job, it should return scale-from-zero",
+			infraID:    "scale-from-zero-tw2b6",
+			wantType:   "scale-from-zero",
+			wantSuffix: "tw2b6",
+		},
+		{
+			name:       "When infraID is a developer cluster name, it should return empty",
+			infraID:    "brcox-mgmt-4tw4x",
+			wantType:   "",
+			wantSuffix: "",
+		},
+		{
+			name:       "When infraID is a proxy test, it should return proxy",
+			infraID:    "proxy-dp6cv",
+			wantType:   "proxy",
+			wantSuffix: "dp6cv",
+		},
+		{
+			name:       "When infraID is an autoscaling test, it should return autoscaling",
+			infraID:    "autoscaling-p9dsn",
+			wantType:   "autoscaling",
+			wantSuffix: "p9dsn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotSuffix := InferTestType(tt.infraID)
+			if gotType != tt.wantType {
+				t.Errorf("InferTestType(%q) type = %q, want %q", tt.infraID, gotType, tt.wantType)
+			}
+			if gotSuffix != tt.wantSuffix {
+				t.Errorf("InferTestType(%q) suffix = %q, want %q", tt.infraID, gotSuffix, tt.wantSuffix)
+			}
+		})
+	}
+}
+
+func TestExtractNamespace(t *testing.T) {
+	tests := []struct {
+		name     string
+		txtValue string
+		want     string
+	}{
+		{
+			name:     "When TXT has resource=route with namespace, it should extract the namespace",
+			txtValue: `"heritage=external-dns,external-dns/owner=4f2bbcda-debd-4d01-84f2-d68db8b6ea97,external-dns/resource=route/e2e-clusters-7c84g-node-pool-78vcg/kube-apiserver"`,
+			want:     "e2e-clusters-7c84g-node-pool-78vcg",
+		},
+		{
+			name:     "When TXT has oauth resource, it should extract the namespace",
+			txtValue: `"heritage=external-dns,external-dns/owner=xxx,external-dns/resource=route/e2e-clusters-27ddr-node-pool-58vw7/oauth"`,
+			want:     "e2e-clusters-27ddr-node-pool-58vw7",
+		},
+		{
+			name:     "When TXT has no resource field, it should return empty",
+			txtValue: `"heritage=external-dns,external-dns/owner=xxx"`,
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractNamespace(tt.txtValue)
+			if got != tt.want {
+				t.Errorf("extractNamespace() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProwJobURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		testType   string
+		prowJobID  string
+		wantDirect bool
+		wantSearch bool
+		wantEmpty  bool
+	}{
+		{
+			name:       "When prow-job-id tag is present, it should return a direct job URL",
+			testType:   "node-pool",
+			prowJobID:  "2074787416719233024",
+			wantDirect: true,
+		},
+		{
+			name:       "When no prow-job-id but test type is known, it should return a search URL",
+			testType:   "node-pool",
+			prowJobID:  "",
+			wantSearch: true,
+		},
+		{
+			name:      "When test type is e2e-generic and no prow-job-id, it should return empty",
+			testType:  "e2e-generic",
+			prowJobID: "",
+			wantEmpty: true,
+		},
+		{
+			name:      "When test type is empty and no prow-job-id, it should return empty",
+			testType:  "",
+			prowJobID: "",
+			wantEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := ProwJobURL(tt.testType, tt.prowJobID)
+			if tt.wantDirect {
+				if !strings.Contains(url, "/view/gs/") {
+					t.Errorf("expected direct job URL, got %q", url)
+				}
+				if !strings.Contains(url, tt.prowJobID) {
+					t.Errorf("expected URL to contain job ID %q, got %q", tt.prowJobID, url)
+				}
+			}
+			if tt.wantSearch {
+				if !strings.Contains(url, "query=") {
+					t.Errorf("expected search URL, got %q", url)
+				}
+			}
+			if tt.wantEmpty && url != "" {
+				t.Errorf("expected empty, got %q", url)
+			}
+		})
+	}
+}
+
+// paginatingRoute53 is a mock that splits records across two pages to test pagination.
+type paginatingRoute53 struct {
+	zones     []route53types.HostedZone
+	page1     []route53types.ResourceRecordSet
+	page2     []route53types.ResourceRecordSet
+	nextName  *string
+	nextType  route53types.RRType
+	callCount int
+}
+
+func (m *paginatingRoute53) ListHostedZones(_ context.Context, _ *route53.ListHostedZonesInput, _ ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error) {
+	return &route53.ListHostedZonesOutput{HostedZones: m.zones}, nil
+}
+func (m *paginatingRoute53) GetHostedZone(_ context.Context, _ *route53.GetHostedZoneInput, _ ...func(*route53.Options)) (*route53.GetHostedZoneOutput, error) {
+	return &route53.GetHostedZoneOutput{}, nil
+}
+func (m *paginatingRoute53) ListResourceRecordSets(_ context.Context, input *route53.ListResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
+	m.callCount++
+	if input.StartRecordName == nil {
+		return &route53.ListResourceRecordSetsOutput{
+			ResourceRecordSets: m.page1,
+			IsTruncated:        true,
+			NextRecordName:     m.nextName,
+			NextRecordType:     m.nextType,
+		}, nil
+	}
+	return &route53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: m.page2,
+		IsTruncated:        false,
+	}, nil
+}
+func (m *paginatingRoute53) ChangeResourceRecordSets(_ context.Context, _ *route53.ChangeResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error) {
+	return &route53.ChangeResourceRecordSetsOutput{}, nil
+}
+func (m *paginatingRoute53) DeleteHostedZone(_ context.Context, _ *route53.DeleteHostedZoneInput, _ ...func(*route53.Options)) (*route53.DeleteHostedZoneOutput, error) {
+	return &route53.DeleteHostedZoneOutput{}, nil
+}
+
+func TestLookupNamespaceFromServiceZone(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		page1       []route53types.ResourceRecordSet
+		page2       []route53types.ResourceRecordSet
+		wantNS      string
+		wantPages   int
+	}{
+		{
+			name:        "When matching TXT is on page 1, it should return the namespace without fetching page 2",
+			clusterName: "node-pool-78vcg",
+			page1: []route53types.ResourceRecordSet{
+				{Type: "A", Name: aws.String("api.node-pool-78vcg.ci.hypershift.devcluster.openshift.com.")},
+				{Type: "TXT", ResourceRecords: []route53types.ResourceRecord{
+					{Value: aws.String(`"heritage=external-dns,external-dns/owner=xxx,external-dns/resource=route/e2e-clusters-7c84g-node-pool-78vcg/kube-apiserver"`)},
+				}},
+			},
+			wantNS:    "e2e-clusters-7c84g-node-pool-78vcg",
+			wantPages: 1,
+		},
+		{
+			name:        "When matching TXT is on page 2, it should paginate and find it",
+			clusterName: "node-pool-99abc",
+			page1: []route53types.ResourceRecordSet{
+				{Type: "A", Name: aws.String("unrelated.ci.hypershift.devcluster.openshift.com.")},
+				{Type: "TXT", ResourceRecords: []route53types.ResourceRecord{
+					{Value: aws.String(`"heritage=external-dns,external-dns/owner=xxx,external-dns/resource=route/e2e-clusters-other/kube-apiserver"`)},
+				}},
+			},
+			page2: []route53types.ResourceRecordSet{
+				{Type: "TXT", ResourceRecords: []route53types.ResourceRecord{
+					{Value: aws.String(`"heritage=external-dns,external-dns/owner=yyy,external-dns/resource=route/e2e-clusters-abc12-node-pool-99abc/kube-apiserver"`)},
+				}},
+			},
+			wantNS:    "e2e-clusters-abc12-node-pool-99abc",
+			wantPages: 2,
+		},
+		{
+			name:        "When no matching TXT exists on any page, it should return empty",
+			clusterName: "nonexistent-cluster",
+			page1: []route53types.ResourceRecordSet{
+				{Type: "TXT", ResourceRecords: []route53types.ResourceRecord{
+					{Value: aws.String(`"heritage=external-dns,external-dns/owner=xxx,external-dns/resource=route/e2e-clusters-other/kube-apiserver"`)},
+				}},
+			},
+			page2:     []route53types.ResourceRecordSet{},
+			wantNS:    "",
+			wantPages: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &paginatingRoute53{
+				page1:    tt.page1,
+				page2:    tt.page2,
+				nextName: aws.String("next.record.com."),
+				nextType: "TXT",
+			}
+
+			ns := LookupNamespaceFromServiceZone(context.Background(), mock, "Z12345", tt.clusterName)
+			if ns != tt.wantNS {
+				t.Errorf("LookupNamespaceFromServiceZone() = %q, want %q", ns, tt.wantNS)
+			}
+			if mock.callCount != tt.wantPages {
+				t.Errorf("expected %d API calls, got %d", tt.wantPages, mock.callCount)
+			}
+		})
+	}
+}

--- a/contrib/aws-leaked-resources/report.go
+++ b/contrib/aws-leaked-resources/report.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+)
+
+func PrintTable(w io.Writer, sets []InfraSet) {
+	sort.Slice(sets, func(i, j int) bool {
+		order := map[Verdict]int{
+			VerdictProtected: 0,
+			VerdictActive:    1,
+			VerdictTooYoung:  2,
+			VerdictUncertain: 3,
+			VerdictLeaked:    4,
+		}
+		if order[sets[i].Verdict] != order[sets[j].Verdict] {
+			return order[sets[i].Verdict] < order[sets[j].Verdict]
+		}
+		return sets[i].InfraID < sets[j].InfraID
+	})
+
+	fmt.Fprintf(w, "%-24s %-12s %-4s %-42s %s\n", "VERDICT", "AGE", "VPCs", "INFRA-ID", "REASON")
+	fmt.Fprintf(w, "%s\n", strings.Repeat("-", 120))
+
+	for _, s := range sets {
+		age := ""
+		if s.Age > 0 {
+			age = formatDuration(s.Age)
+		}
+
+		vpcCount := len(s.VPCs)
+		fmt.Fprintf(w, "%-24s %-12s %-4d %-42s %s\n",
+			s.Verdict, age, vpcCount, s.InfraID, s.VerdictReason)
+
+		if s.Verdict == VerdictLeaked || s.Verdict == VerdictUncertain {
+			if s.TestType != "" {
+				prowInfo := fmt.Sprintf("test=%s", s.TestType)
+				if s.Namespace != "" {
+					prowInfo += fmt.Sprintf("  ns=%s", s.Namespace)
+				}
+				if s.ProwLink != "" {
+					prowInfo += fmt.Sprintf("  prow=%s", s.ProwLink)
+				}
+				fmt.Fprintf(w, "  %-22s %s\n", "", prowInfo)
+			}
+			for _, vpc := range s.VPCs {
+				subRes := formatSubResources(vpc)
+				provenance := formatProvenance(vpc)
+				fmt.Fprintf(w, "  %-22s vpc: %-25s name: %-30s %s%s\n", "", vpc.VPCID, vpc.Name, subRes, provenance)
+			}
+			for _, z := range s.HostedZones {
+				zType := "public"
+				if z.Private {
+					zType = "private"
+				}
+				fmt.Fprintf(w, "  %-22s zone: %-25s %s (%s, %d records)\n", "", z.ZoneID, z.Name, zType, z.Records)
+			}
+			for _, oidc := range s.OIDCProviders {
+				fmt.Fprintf(w, "  %-22s oidc: %s\n", "", oidc)
+			}
+			for _, role := range s.IAMRoles {
+				fmt.Fprintf(w, "  %-22s role: %s\n", "", role)
+			}
+		}
+	}
+}
+
+func PrintSummary(w io.Writer, sets []InfraSet) {
+	counts := CountByVerdict(sets)
+	totalVPCs := 0
+	for _, s := range sets {
+		totalVPCs += len(s.VPCs)
+	}
+
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "==============================\n")
+	fmt.Fprintf(w, "  Summary\n")
+	fmt.Fprintf(w, "==============================\n")
+	fmt.Fprintf(w, "  Protected:   %d (%d VPCs)\n", counts[VerdictProtected], countVPCs(sets, VerdictProtected))
+	fmt.Fprintf(w, "  Active:      %d (%d VPCs)\n", counts[VerdictActive], countVPCs(sets, VerdictActive))
+	fmt.Fprintf(w, "  Too young:   %d (%d VPCs)\n", counts[VerdictTooYoung], countVPCs(sets, VerdictTooYoung))
+	fmt.Fprintf(w, "  Uncertain:   %d (%d VPCs)\n", counts[VerdictUncertain], countVPCs(sets, VerdictUncertain))
+	fmt.Fprintf(w, "  Leaked:      %d (%d VPCs)\n", counts[VerdictLeaked], countVPCs(sets, VerdictLeaked))
+	fmt.Fprintf(w, "  Total:       %d infra sets (%d VPCs)\n", len(sets), totalVPCs)
+	fmt.Fprintf(w, "==============================\n")
+}
+
+func PrintJSON(w io.Writer, sets []InfraSet) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(sets)
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	hours := int(d.Hours())
+	if hours < 48 {
+		return fmt.Sprintf("%dh", hours)
+	}
+	return fmt.Sprintf("%dd%dh", hours/24, hours%24)
+}
+
+func formatSubResources(vpc VPCInfo) string {
+	parts := []string{}
+	if vpc.Endpoints > 0 {
+		parts = append(parts, fmt.Sprintf("endpoints=%d", vpc.Endpoints))
+	}
+	if vpc.NATGateways > 0 {
+		parts = append(parts, fmt.Sprintf("nats=%d", vpc.NATGateways))
+	}
+	if vpc.IGWs > 0 {
+		parts = append(parts, fmt.Sprintf("igws=%d", vpc.IGWs))
+	}
+	if vpc.Subnets > 0 {
+		parts = append(parts, fmt.Sprintf("subnets=%d", vpc.Subnets))
+	}
+	if vpc.SecurityGroups > 0 {
+		parts = append(parts, fmt.Sprintf("sgs=%d", vpc.SecurityGroups))
+	}
+	if vpc.RouteTables > 0 {
+		parts = append(parts, fmt.Sprintf("rtbs=%d", vpc.RouteTables))
+	}
+	if vpc.ENIs > 0 {
+		parts = append(parts, fmt.Sprintf("enis=%d", vpc.ENIs))
+	}
+	if vpc.ELBs > 0 {
+		parts = append(parts, fmt.Sprintf("elbs=%d", vpc.ELBs))
+	}
+	if vpc.EIPs > 0 {
+		parts = append(parts, fmt.Sprintf("eips=%d", vpc.EIPs))
+	}
+	if vpc.EndpointServices > 0 {
+		parts = append(parts, fmt.Sprintf("vpce-svcs=%d", vpc.EndpointServices))
+	}
+	if len(parts) == 0 {
+		return "(empty VPC)"
+	}
+	return strings.Join(parts, " ")
+}
+
+func formatProvenance(vpc VPCInfo) string {
+	if vpc.Source == "" && vpc.ProwJobID == "" {
+		return ""
+	}
+	parts := []string{}
+	if vpc.Source != "" {
+		parts = append(parts, "source="+vpc.Source)
+	}
+	if vpc.ProwJobID != "" {
+		parts = append(parts, "prow="+vpc.ProwJobID)
+	}
+	if vpc.ClusterName != "" {
+		parts = append(parts, "cluster="+vpc.ClusterName)
+	}
+	return " [" + strings.Join(parts, " ") + "]"
+}

--- a/contrib/aws-leaked-resources/scan.go
+++ b/contrib/aws-leaked-resources/scan.go
@@ -1,0 +1,703 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type Scanner struct {
+	EC2     EC2API
+	ELBv2   ELBv2API
+	Route53 Route53API
+	IAM     IAMAPI
+	S3      S3API
+	Config  Config
+	Now     func() time.Time
+
+	lbCache  []lbCacheEntry
+	lbCached bool
+}
+
+type lbCacheEntry struct {
+	VpcID string
+	Name  string
+}
+
+func (s *Scanner) now() time.Time {
+	if s.Now != nil {
+		return s.Now()
+	}
+	return time.Now()
+}
+
+func (s *Scanner) Scan(ctx context.Context) ([]InfraSet, error) {
+	var vpcs []ec2types.Vpc
+	var err error
+
+	if s.Config.Target != "" {
+		fmt.Fprintf(os.Stderr, "  Fetching target: %s\n", s.Config.Target)
+		vpcs, err = s.fetchTargetVPCs(ctx, s.Config.Target)
+	} else {
+		fmt.Fprintf(os.Stderr, "  Fetching VPCs...\n")
+		vpcs, err = s.fetchAllVPCs(ctx)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("fetching VPCs: %w", err)
+	}
+
+	grouped := s.groupByInfraID(vpcs)
+	fmt.Fprintf(os.Stderr, "  Found %d VPCs, %d infra sets\n", len(vpcs), len(grouped))
+
+	fmt.Fprintf(os.Stderr, "  Fetching OIDC providers...\n")
+	oidcMap, err := s.fetchOIDCProviders(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetching OIDC providers: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "  Found %d OIDC providers\n", len(oidcMap))
+
+	fmt.Fprintf(os.Stderr, "  Classifying %d infra sets...\n", len(grouped))
+	progress := 0
+	leakedFound := 0
+	var results []InfraSet
+	for infraID, vpcInfos := range grouped {
+		progress++
+		if progress%10 == 0 {
+			fmt.Fprintf(os.Stderr, "    %d/%d ...\n", progress, len(grouped))
+		}
+
+		limitReached := s.Config.Limit > 0 && leakedFound >= s.Config.Limit
+
+		infraSet := InfraSet{
+			InfraID: infraID,
+			VPCs:    vpcInfos,
+		}
+
+		if verdict, reason := s.checkProtection(infraID, vpcInfos); verdict != "" {
+			infraSet.Verdict = verdict
+			infraSet.VerdictReason = reason
+			results = append(results, infraSet)
+			continue
+		}
+
+		s.resolveVPCCreationTime(ctx, &infraSet)
+
+		if verdict, reason := s.checkAge(infraSet.VPCs, s.Config.MinAge); verdict != "" {
+			infraSet.Verdict = verdict
+			infraSet.VerdictReason = reason
+			results = append(results, infraSet)
+			continue
+		}
+
+		if limitReached {
+			continue
+		}
+
+		if verdict, reason := s.checkOIDC(ctx, infraID, oidcMap); verdict != "" {
+			infraSet.Verdict = verdict
+			infraSet.VerdictReason = reason
+			results = append(results, infraSet)
+			continue
+		}
+
+		if verdict, reason, count := s.checkEC2Instances(ctx, infraID); verdict != "" {
+			infraSet.Instances = count
+			infraSet.Verdict = verdict
+			infraSet.VerdictReason = reason
+			results = append(results, infraSet)
+			continue
+		}
+
+		// If the infraID doesn't match any known CI pattern (hex ID or test name),
+		// mark as UNCERTAIN — it could be a developer cluster or unknown origin.
+		testType, _ := InferTestType(infraID)
+		if testType == "" {
+			infraSet.Verdict = VerdictUncertain
+			infraSet.VerdictReason = fmt.Sprintf("no OIDC, no instances, but infraID %q does not match CI patterns — may belong to a developer", infraID)
+			results = append(results, infraSet)
+			continue
+		}
+
+		infraSet.Verdict = VerdictLeaked
+		infraSet.VerdictReason = "no OIDC, no S3 doc, no EC2 instances"
+
+		if info, ok := oidcMap[infraID]; ok {
+			infraSet.OIDCProviders = append(infraSet.OIDCProviders, info.ARN)
+			infraSet.VerdictReason += " (OIDC provider still exists)"
+		}
+
+		leakedFound++
+		if s.Config.Limit > 0 {
+			fmt.Fprintf(os.Stderr, "    LEAKED [%d/%d]: %s — inventorying sub-resources...\n", leakedFound, s.Config.Limit, infraID)
+		} else {
+			fmt.Fprintf(os.Stderr, "    LEAKED: %s — inventorying sub-resources...\n", infraID)
+		}
+		s.inventorySubResources(ctx, &infraSet)
+		s.inventoryHostedZones(ctx, &infraSet)
+		s.inventoryIAMRoles(ctx, &infraSet)
+
+		if oldest := oldestVPC(infraSet.VPCs); !oldest.IsZero() {
+			infraSet.Age = s.now().Sub(oldest)
+		}
+
+		results = append(results, infraSet)
+	}
+
+	return results, nil
+}
+
+// fetchTargetVPCs resolves a --target (VPC ID or infraID) to VPCs.
+func (s *Scanner) fetchTargetVPCs(ctx context.Context, target string) ([]ec2types.Vpc, error) {
+	if strings.HasPrefix(target, "vpc-") {
+		out, err := s.EC2.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
+			VpcIds: []string{target},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("VPC %s not found: %w", target, err)
+		}
+		return out.Vpcs, nil
+	}
+
+	infraID := strings.TrimSuffix(target, "-vpc")
+	out, err := s.EC2.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("tag:Name"), Values: []string{infraID + "-vpc"}},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("searching for infraID %s: %w", infraID, err)
+	}
+	if len(out.Vpcs) == 0 {
+		return nil, fmt.Errorf("no VPC found for infraID %s (searched for Name tag '%s-vpc')", infraID, infraID)
+	}
+	return out.Vpcs, nil
+}
+
+func (s *Scanner) fetchAllVPCs(ctx context.Context) ([]ec2types.Vpc, error) {
+	var all []ec2types.Vpc
+	var nextToken *string
+	for {
+		out, err := s.EC2.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, out.Vpcs...)
+		if out.NextToken == nil {
+			break
+		}
+		nextToken = out.NextToken
+	}
+	return all, nil
+}
+
+func (s *Scanner) groupByInfraID(vpcs []ec2types.Vpc) map[string][]VPCInfo {
+	groups := make(map[string][]VPCInfo)
+	for _, vpc := range vpcs {
+		if aws.ToBool(vpc.IsDefault) {
+			continue
+		}
+
+		vpcName := getTagValue(vpc.Tags, "Name")
+		infraID := extractInfraID(vpc.Tags)
+
+		doNotDelete := getTagValue(vpc.Tags, TagDoNotDelete) == "true"
+
+		// VPCs without a k8s cluster tag are normally skipped, but protected
+		// VPCs must ALWAYS appear so the protection gate can catch them.
+		if infraID == "" {
+			if !IsProtectedVPC(vpcName, s.Config.ProtectedVPCs) && !doNotDelete {
+				continue
+			}
+			infraID = strings.TrimSuffix(vpcName, "-vpc")
+		}
+
+		info := VPCInfo{
+			VPCID:          aws.ToString(vpc.VpcId),
+			Name:           vpcName,
+			CIDR:           aws.ToString(vpc.CidrBlock),
+			State:          string(vpc.State),
+			CreatedAt:      VPCCreateTime(vpc),
+			ExpirationDate: parseExpirationDate(getTagValue(vpc.Tags, "expirationDate")),
+			DoNotDelete:    getTagValue(vpc.Tags, TagDoNotDelete) == "true",
+			CICluster:      getTagValue(vpc.Tags, TagCICluster),
+			Source:         getTagValue(vpc.Tags, TagHypershiftSource),
+			ClusterName:    getTagValue(vpc.Tags, TagHypershiftClusterName),
+			ProwJobID:      getTagValue(vpc.Tags, TagHypershiftProwJobID),
+		}
+
+		groups[infraID] = append(groups[infraID], info)
+	}
+	return groups
+}
+
+func (s *Scanner) checkProtection(infraID string, vpcs []VPCInfo) (Verdict, string) {
+	// Highest priority: do-not-delete tag is a hard block
+	for _, vpc := range vpcs {
+		if vpc.DoNotDelete {
+			ciCluster := vpc.CICluster
+			if ciCluster == "" {
+				ciCluster = "unknown"
+			}
+			return VerdictProtected, fmt.Sprintf("do-not-delete=true (ci-cluster=%s)", ciCluster)
+		}
+	}
+
+	// Protected VPC names
+	for _, vpc := range vpcs {
+		for _, protected := range s.Config.ProtectedVPCs {
+			if vpc.Name == protected {
+				return VerdictProtected, fmt.Sprintf("VPC name %q matches protected VPC", vpc.Name)
+			}
+		}
+	}
+
+	// Protected users
+	for _, user := range s.Config.ProtectedUsers {
+		if strings.Contains(infraID, user) {
+			return VerdictProtected, fmt.Sprintf("infraID contains protected user %q", user)
+		}
+		for _, vpc := range vpcs {
+			if strings.Contains(vpc.Name, user) {
+				return VerdictProtected, fmt.Sprintf("VPC name %q contains protected user %q", vpc.Name, user)
+			}
+		}
+	}
+
+	return "", ""
+}
+
+func (s *Scanner) checkAge(vpcs []VPCInfo, minAge time.Duration) (Verdict, string) {
+	// If any VPC has an expirationDate tag and it hasn't expired yet, it's too young
+	for _, vpc := range vpcs {
+		if !vpc.ExpirationDate.IsZero() && s.now().Before(vpc.ExpirationDate) {
+			return VerdictTooYoung, fmt.Sprintf("expirationDate %s not reached yet", vpc.ExpirationDate.Format("2006-01-02 15:04"))
+		}
+	}
+
+	oldest := oldestVPC(vpcs)
+	if oldest.IsZero() {
+		return VerdictUncertain, "could not determine VPC creation time from tags or resource timestamps"
+	}
+
+	age := s.now().Sub(oldest)
+	if age < minAge {
+		return VerdictTooYoung, fmt.Sprintf("VPC is %s old (min: %s)", age.Round(time.Minute), minAge)
+	}
+
+	return "", ""
+}
+
+type oidcProviderInfo struct {
+	ARN    string
+	Bucket string
+	Region string
+}
+
+func (s *Scanner) fetchOIDCProviders(ctx context.Context) (map[string]oidcProviderInfo, error) {
+	result := make(map[string]oidcProviderInfo)
+
+	out, err := s.IAM.ListOpenIDConnectProviders(ctx, &iam.ListOpenIDConnectProvidersInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	re := regexp.MustCompile(`([^.]+)\.s3\.([^.]+)\.amazonaws\.com/(.+)`)
+	for _, p := range out.OpenIDConnectProviderList {
+		arn := aws.ToString(p.Arn)
+		parts := strings.SplitN(arn, "oidc-provider/", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		m := re.FindStringSubmatch(parts[1])
+		if m == nil {
+			continue
+		}
+		infraID := m[3]
+		result[infraID] = oidcProviderInfo{
+			ARN:    arn,
+			Bucket: m[1],
+			Region: m[2],
+		}
+	}
+
+	return result, nil
+}
+
+func (s *Scanner) checkOIDC(ctx context.Context, infraID string, oidcMap map[string]oidcProviderInfo) (Verdict, string) {
+	if info, ok := oidcMap[infraID]; ok {
+		isAllowed := false
+		for _, bucket := range s.Config.AllowedBuckets {
+			if strings.HasPrefix(info.Bucket, bucket) {
+				isAllowed = true
+				break
+			}
+		}
+		if !isAllowed {
+			return "", ""
+		}
+
+		if s.s3DocExists(ctx, info.Bucket, infraID) {
+			return VerdictActive, fmt.Sprintf("S3 OIDC doc exists (bucket=%s)", info.Bucket)
+		}
+		return "", ""
+	}
+
+	for _, bucket := range s.Config.AllowedBuckets {
+		if s.s3DocExists(ctx, bucket, infraID) {
+			return VerdictActive, fmt.Sprintf("S3 OIDC doc found in bucket %s", bucket)
+		}
+	}
+
+	return "", ""
+}
+
+func (s *Scanner) s3DocExists(ctx context.Context, bucket, infraID string) bool {
+	_, err := s.S3.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(infraID + "/.well-known/openid-configuration"),
+	})
+	return err == nil
+}
+
+func (s *Scanner) checkEC2Instances(ctx context.Context, infraID string) (Verdict, string, int) {
+	out, err := s.EC2.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   aws.String("tag:kubernetes.io/cluster/" + infraID),
+				Values: []string{"owned"},
+			},
+			{
+				Name:   aws.String("instance-state-name"),
+				Values: []string{"pending", "running", "stopping", "stopped", "shutting-down"},
+			},
+		},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "    WARN: DescribeInstances failed for %s: %v\n", infraID, err)
+		return VerdictUncertain, fmt.Sprintf("could not verify EC2 instances: %v", err), 0
+	}
+
+	count := 0
+	for _, r := range out.Reservations {
+		count += len(r.Instances)
+	}
+
+	if count > 0 {
+		return VerdictActive, fmt.Sprintf("%d EC2 instances still running", count), count
+	}
+
+	return "", "", 0
+}
+
+// resolveVPCCreationTime fetches the earliest VPCE CreationTimestamp or ENI AttachTime
+// for each VPC to determine when the infra was created. This is cheap (1 API call per VPC)
+// and must run before the age gate.
+func (s *Scanner) resolveVPCCreationTime(ctx context.Context, infra *InfraSet) {
+	for i, vpc := range infra.VPCs {
+		if !vpc.CreatedAt.IsZero() {
+			continue
+		}
+		if out, err := s.EC2.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpc.VPCID}}},
+		}); err == nil {
+			for _, ep := range out.VpcEndpoints {
+				if ep.CreationTimestamp != nil && (infra.VPCs[i].CreatedAt.IsZero() || ep.CreationTimestamp.Before(infra.VPCs[i].CreatedAt)) {
+					infra.VPCs[i].CreatedAt = *ep.CreationTimestamp
+				}
+			}
+		}
+		if infra.VPCs[i].CreatedAt.IsZero() {
+			if out, err := s.EC2.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+				Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpc.VPCID}}},
+			}); err == nil {
+				for _, eni := range out.NetworkInterfaces {
+					if eni.Attachment != nil && eni.Attachment.AttachTime != nil {
+						if infra.VPCs[i].CreatedAt.IsZero() || eni.Attachment.AttachTime.Before(infra.VPCs[i].CreatedAt) {
+							infra.VPCs[i].CreatedAt = *eni.Attachment.AttachTime
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+//nolint:gocyclo // sequential AWS inventory queries
+func (s *Scanner) inventorySubResources(ctx context.Context, infra *InfraSet) {
+	for i, vpc := range infra.VPCs {
+		vpcID := vpc.VPCID
+
+		if out, err := s.EC2.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+		}); err == nil {
+			infra.VPCs[i].Endpoints = len(out.VpcEndpoints)
+			for _, ep := range out.VpcEndpoints {
+				if ep.CreationTimestamp != nil && (infra.VPCs[i].CreatedAt.IsZero() || ep.CreationTimestamp.Before(infra.VPCs[i].CreatedAt)) {
+					infra.VPCs[i].CreatedAt = *ep.CreationTimestamp
+				}
+			}
+		}
+
+		if out, err := s.EC2.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+			Filter: []ec2types.Filter{
+				{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+				{Name: aws.String("state"), Values: []string{"available", "pending", "failed"}},
+			},
+		}); err == nil {
+			infra.VPCs[i].NATGateways = len(out.NatGateways)
+		}
+
+		if out, err := s.EC2.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{
+			Filters: []ec2types.Filter{{Name: aws.String("attachment.vpc-id"), Values: []string{vpcID}}},
+		}); err == nil {
+			infra.VPCs[i].IGWs = len(out.InternetGateways)
+		}
+
+		if out, err := s.EC2.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+		}); err == nil {
+			infra.VPCs[i].Subnets = len(out.Subnets)
+		}
+
+		if out, err := s.EC2.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+		}); err == nil {
+			nonDefault := 0
+			for _, sg := range out.SecurityGroups {
+				if aws.ToString(sg.GroupName) != "default" {
+					nonDefault++
+				}
+			}
+			infra.VPCs[i].SecurityGroups = nonDefault
+		}
+
+		if out, err := s.EC2.DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{
+			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+		}); err == nil {
+			nonMain := 0
+			for _, rt := range out.RouteTables {
+				isMain := false
+				for _, a := range rt.Associations {
+					if aws.ToBool(a.Main) {
+						isMain = true
+						break
+					}
+				}
+				if !isMain {
+					nonMain++
+				}
+			}
+			infra.VPCs[i].RouteTables = nonMain
+		}
+
+		if out, err := s.EC2.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+		}); err == nil {
+			infra.VPCs[i].ENIs = len(out.NetworkInterfaces)
+			if infra.VPCs[i].CreatedAt.IsZero() {
+				for _, eni := range out.NetworkInterfaces {
+					if eni.Attachment != nil && eni.Attachment.AttachTime != nil {
+						if infra.VPCs[i].CreatedAt.IsZero() || eni.Attachment.AttachTime.Before(infra.VPCs[i].CreatedAt) {
+							infra.VPCs[i].CreatedAt = *eni.Attachment.AttachTime
+						}
+					}
+				}
+			}
+		}
+
+		infra.VPCs[i].ELBs = s.countLBsForVPC(ctx, vpcID)
+
+		if out, err := s.EC2.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{
+			Filters: []ec2types.Filter{{Name: aws.String("domain"), Values: []string{"vpc"}}},
+		}); err == nil {
+			for _, addr := range out.Addresses {
+				if s.eipBelongsToVPC(ctx, addr, vpcID) {
+					infra.VPCs[i].EIPs++
+				}
+			}
+		}
+	}
+
+	var nextToken *string
+	for {
+		out, err := s.EC2.DescribeVpcEndpointServiceConfigurations(ctx, &ec2.DescribeVpcEndpointServiceConfigurationsInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			break
+		}
+		for _, svc := range out.ServiceConfigurations {
+			svcInfraID := ""
+			for _, tag := range svc.Tags {
+				key := aws.ToString(tag.Key)
+				if strings.HasPrefix(key, "kubernetes.io/cluster/") {
+					svcInfraID = strings.TrimPrefix(key, "kubernetes.io/cluster/")
+					break
+				}
+			}
+			if svcInfraID == infra.InfraID {
+				for i := range infra.VPCs {
+					infra.VPCs[i].EndpointServices++
+				}
+			}
+		}
+		if out.NextToken == nil {
+			break
+		}
+		nextToken = out.NextToken
+	}
+}
+
+func (s *Scanner) eipBelongsToVPC(ctx context.Context, addr ec2types.Address, vpcID string) bool {
+	eniID := aws.ToString(addr.NetworkInterfaceId)
+	if eniID == "" {
+		return false
+	}
+	out, err := s.EC2.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: []string{eniID},
+	})
+	if err != nil || len(out.NetworkInterfaces) == 0 {
+		return false
+	}
+	return aws.ToString(out.NetworkInterfaces[0].VpcId) == vpcID
+}
+
+func (s *Scanner) inventoryHostedZones(ctx context.Context, infra *InfraSet) {
+	var nextMarker *string
+	for {
+		out, err := s.Route53.ListHostedZones(ctx, &route53.ListHostedZonesInput{
+			Marker: nextMarker,
+		})
+		if err != nil {
+			return
+		}
+
+		for _, z := range out.HostedZones {
+			name := strings.TrimSuffix(aws.ToString(z.Name), ".")
+			zoneID := strings.TrimPrefix(aws.ToString(z.Id), "/hostedzone/")
+
+			if ZoneMatchesInfra(name, infra.InfraID) {
+				isPrivate := false
+				if z.Config != nil {
+					isPrivate = z.Config.PrivateZone
+				}
+				infra.HostedZones = append(infra.HostedZones, ZoneInfo{
+					ZoneID:  zoneID,
+					Name:    name,
+					Private: isPrivate,
+					Records: int(aws.ToInt64(z.ResourceRecordSetCount)),
+				})
+			}
+		}
+
+		if !out.IsTruncated {
+			break
+		}
+		nextMarker = out.NextMarker
+	}
+}
+
+var iamRoleSuffixes = []string{
+	"-cloud-network-config-controller",
+	"-aws-ebs-csi-driver-controller",
+	"-openshift-image-registry",
+	"-control-plane-operator",
+	"-shared-vpc-control-plane",
+	"-openshift-ingress",
+	"-shared-vpc-ingress",
+	"-cloud-controller",
+	"-kms-provider",
+	"-shared-role",
+	"-karpenter",
+	"-node-pool",
+	"-worker-ROSA-Worker-Role",
+	"-worker-role",
+}
+
+func (s *Scanner) inventoryIAMRoles(ctx context.Context, infra *InfraSet) {
+	var nextMarker *string
+	for {
+		input := &iam.ListRolesInput{}
+		if nextMarker != nil {
+			input.Marker = nextMarker
+		}
+		out, err := s.IAM.ListRoles(ctx, input)
+		if err != nil {
+			return
+		}
+
+		for _, role := range out.Roles {
+			roleName := aws.ToString(role.RoleName)
+			for _, suffix := range iamRoleSuffixes {
+				if strings.HasSuffix(roleName, suffix) {
+					prefix := strings.TrimSuffix(roleName, suffix)
+					if prefix == infra.InfraID {
+						infra.IAMRoles = append(infra.IAMRoles, roleName)
+					}
+				}
+			}
+			if roleName == infra.InfraID {
+				infra.IAMRoles = append(infra.IAMRoles, roleName)
+			}
+		}
+
+		if !out.IsTruncated {
+			break
+		}
+		nextMarker = out.Marker
+	}
+}
+
+func (s *Scanner) fetchAllLoadBalancers(ctx context.Context) []lbCacheEntry {
+	if s.lbCached {
+		return s.lbCache
+	}
+	s.lbCached = true
+	if s.ELBv2 == nil {
+		return nil
+	}
+	var marker *string
+	for {
+		out, err := s.ELBv2.DescribeLoadBalancers(ctx, &elbv2.DescribeLoadBalancersInput{Marker: marker})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "    WARN: list ELBs: %v\n", err)
+			return nil
+		}
+		for _, lb := range out.LoadBalancers {
+			s.lbCache = append(s.lbCache, lbCacheEntry{
+				VpcID: aws.ToString(lb.VpcId),
+				Name:  aws.ToString(lb.LoadBalancerName),
+			})
+		}
+		if out.NextMarker == nil {
+			break
+		}
+		marker = out.NextMarker
+	}
+	return s.lbCache
+}
+
+func (s *Scanner) countLBsForVPC(ctx context.Context, vpcID string) int {
+	count := 0
+	for _, lb := range s.fetchAllLoadBalancers(ctx) {
+		if lb.VpcID == vpcID {
+			count++
+		}
+	}
+	return count
+}
+
+// Tag constants, helpers, and utility functions are in tags.go

--- a/contrib/aws-leaked-resources/scan_test.go
+++ b/contrib/aws-leaked-resources/scan_test.go
@@ -1,0 +1,1227 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// mockEC2 implements EC2API for testing.
+type mockEC2 struct {
+	vpcs      []ec2types.Vpc
+	instances []ec2types.Reservation
+
+	vpcEndpoints     []ec2types.VpcEndpoint
+	natGateways      []ec2types.NatGateway
+	internetGateways []ec2types.InternetGateway
+	subnets          []ec2types.Subnet
+	securityGroups   []ec2types.SecurityGroup
+	routeTables      []ec2types.RouteTable
+	networkIfaces    []ec2types.NetworkInterface
+}
+
+func (m *mockEC2) DescribeVpcs(_ context.Context, _ *ec2.DescribeVpcsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+	return &ec2.DescribeVpcsOutput{Vpcs: m.vpcs}, nil
+}
+
+func (m *mockEC2) DescribeInstances(_ context.Context, input *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	return &ec2.DescribeInstancesOutput{Reservations: m.instances}, nil
+}
+
+func (m *mockEC2) DescribeVpcEndpoints(_ context.Context, _ *ec2.DescribeVpcEndpointsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointsOutput, error) {
+	return &ec2.DescribeVpcEndpointsOutput{VpcEndpoints: m.vpcEndpoints}, nil
+}
+
+func (m *mockEC2) DescribeNatGateways(_ context.Context, _ *ec2.DescribeNatGatewaysInput, _ ...func(*ec2.Options)) (*ec2.DescribeNatGatewaysOutput, error) {
+	return &ec2.DescribeNatGatewaysOutput{NatGateways: m.natGateways}, nil
+}
+
+func (m *mockEC2) DescribeInternetGateways(_ context.Context, _ *ec2.DescribeInternetGatewaysInput, _ ...func(*ec2.Options)) (*ec2.DescribeInternetGatewaysOutput, error) {
+	return &ec2.DescribeInternetGatewaysOutput{InternetGateways: m.internetGateways}, nil
+}
+
+func (m *mockEC2) DescribeSubnets(_ context.Context, _ *ec2.DescribeSubnetsInput, _ ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+	return &ec2.DescribeSubnetsOutput{Subnets: m.subnets}, nil
+}
+
+func (m *mockEC2) DescribeSecurityGroups(_ context.Context, _ *ec2.DescribeSecurityGroupsInput, _ ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+	return &ec2.DescribeSecurityGroupsOutput{SecurityGroups: m.securityGroups}, nil
+}
+
+func (m *mockEC2) DescribeRouteTables(_ context.Context, _ *ec2.DescribeRouteTablesInput, _ ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error) {
+	return &ec2.DescribeRouteTablesOutput{RouteTables: m.routeTables}, nil
+}
+
+func (m *mockEC2) DescribeNetworkInterfaces(_ context.Context, _ *ec2.DescribeNetworkInterfacesInput, _ ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	return &ec2.DescribeNetworkInterfacesOutput{NetworkInterfaces: m.networkIfaces}, nil
+}
+
+func (m *mockEC2) DeleteVpcEndpoints(_ context.Context, _ *ec2.DeleteVpcEndpointsInput, _ ...func(*ec2.Options)) (*ec2.DeleteVpcEndpointsOutput, error) {
+	return &ec2.DeleteVpcEndpointsOutput{}, nil
+}
+func (m *mockEC2) DeleteNatGateway(_ context.Context, _ *ec2.DeleteNatGatewayInput, _ ...func(*ec2.Options)) (*ec2.DeleteNatGatewayOutput, error) {
+	return &ec2.DeleteNatGatewayOutput{}, nil
+}
+func (m *mockEC2) DetachInternetGateway(_ context.Context, _ *ec2.DetachInternetGatewayInput, _ ...func(*ec2.Options)) (*ec2.DetachInternetGatewayOutput, error) {
+	return &ec2.DetachInternetGatewayOutput{}, nil
+}
+func (m *mockEC2) DeleteInternetGateway(_ context.Context, _ *ec2.DeleteInternetGatewayInput, _ ...func(*ec2.Options)) (*ec2.DeleteInternetGatewayOutput, error) {
+	return &ec2.DeleteInternetGatewayOutput{}, nil
+}
+func (m *mockEC2) DeleteSubnet(_ context.Context, _ *ec2.DeleteSubnetInput, _ ...func(*ec2.Options)) (*ec2.DeleteSubnetOutput, error) {
+	return &ec2.DeleteSubnetOutput{}, nil
+}
+func (m *mockEC2) DeleteSecurityGroup(_ context.Context, _ *ec2.DeleteSecurityGroupInput, _ ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error) {
+	return &ec2.DeleteSecurityGroupOutput{}, nil
+}
+func (m *mockEC2) RevokeSecurityGroupIngress(_ context.Context, _ *ec2.RevokeSecurityGroupIngressInput, _ ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	return &ec2.RevokeSecurityGroupIngressOutput{}, nil
+}
+func (m *mockEC2) RevokeSecurityGroupEgress(_ context.Context, _ *ec2.RevokeSecurityGroupEgressInput, _ ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+	return &ec2.RevokeSecurityGroupEgressOutput{}, nil
+}
+func (m *mockEC2) DisassociateRouteTable(_ context.Context, _ *ec2.DisassociateRouteTableInput, _ ...func(*ec2.Options)) (*ec2.DisassociateRouteTableOutput, error) {
+	return &ec2.DisassociateRouteTableOutput{}, nil
+}
+func (m *mockEC2) DeleteRouteTable(_ context.Context, _ *ec2.DeleteRouteTableInput, _ ...func(*ec2.Options)) (*ec2.DeleteRouteTableOutput, error) {
+	return &ec2.DeleteRouteTableOutput{}, nil
+}
+func (m *mockEC2) DetachNetworkInterface(_ context.Context, _ *ec2.DetachNetworkInterfaceInput, _ ...func(*ec2.Options)) (*ec2.DetachNetworkInterfaceOutput, error) {
+	return &ec2.DetachNetworkInterfaceOutput{}, nil
+}
+func (m *mockEC2) DeleteNetworkInterface(_ context.Context, _ *ec2.DeleteNetworkInterfaceInput, _ ...func(*ec2.Options)) (*ec2.DeleteNetworkInterfaceOutput, error) {
+	return &ec2.DeleteNetworkInterfaceOutput{}, nil
+}
+func (m *mockEC2) DeleteVpc(_ context.Context, _ *ec2.DeleteVpcInput, _ ...func(*ec2.Options)) (*ec2.DeleteVpcOutput, error) {
+	return &ec2.DeleteVpcOutput{}, nil
+}
+func (m *mockEC2) DescribeVpcEndpointServiceConfigurations(_ context.Context, _ *ec2.DescribeVpcEndpointServiceConfigurationsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error) {
+	return &ec2.DescribeVpcEndpointServiceConfigurationsOutput{}, nil
+}
+func (m *mockEC2) DeleteVpcEndpointServiceConfigurations(_ context.Context, _ *ec2.DeleteVpcEndpointServiceConfigurationsInput, _ ...func(*ec2.Options)) (*ec2.DeleteVpcEndpointServiceConfigurationsOutput, error) {
+	return &ec2.DeleteVpcEndpointServiceConfigurationsOutput{}, nil
+}
+func (m *mockEC2) DescribeAddresses(_ context.Context, _ *ec2.DescribeAddressesInput, _ ...func(*ec2.Options)) (*ec2.DescribeAddressesOutput, error) {
+	return &ec2.DescribeAddressesOutput{}, nil
+}
+func (m *mockEC2) ReleaseAddress(_ context.Context, _ *ec2.ReleaseAddressInput, _ ...func(*ec2.Options)) (*ec2.ReleaseAddressOutput, error) {
+	return &ec2.ReleaseAddressOutput{}, nil
+}
+
+// mockELBv2 implements ELBv2API for testing.
+type mockELBv2 struct{}
+
+func (m *mockELBv2) DescribeLoadBalancers(_ context.Context, _ *elbv2.DescribeLoadBalancersInput, _ ...func(*elbv2.Options)) (*elbv2.DescribeLoadBalancersOutput, error) {
+	return &elbv2.DescribeLoadBalancersOutput{}, nil
+}
+func (m *mockELBv2) DeleteLoadBalancer(_ context.Context, _ *elbv2.DeleteLoadBalancerInput, _ ...func(*elbv2.Options)) (*elbv2.DeleteLoadBalancerOutput, error) {
+	return &elbv2.DeleteLoadBalancerOutput{}, nil
+}
+
+// mockRoute53 implements Route53API for testing.
+type mockRoute53 struct {
+	zones []route53types.HostedZone
+}
+
+func (m *mockRoute53) ListHostedZones(_ context.Context, _ *route53.ListHostedZonesInput, _ ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error) {
+	return &route53.ListHostedZonesOutput{HostedZones: m.zones}, nil
+}
+func (m *mockRoute53) GetHostedZone(_ context.Context, _ *route53.GetHostedZoneInput, _ ...func(*route53.Options)) (*route53.GetHostedZoneOutput, error) {
+	return &route53.GetHostedZoneOutput{}, nil
+}
+func (m *mockRoute53) ListResourceRecordSets(_ context.Context, _ *route53.ListResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
+	return &route53.ListResourceRecordSetsOutput{}, nil
+}
+func (m *mockRoute53) ChangeResourceRecordSets(_ context.Context, _ *route53.ChangeResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error) {
+	return &route53.ChangeResourceRecordSetsOutput{}, nil
+}
+func (m *mockRoute53) DeleteHostedZone(_ context.Context, _ *route53.DeleteHostedZoneInput, _ ...func(*route53.Options)) (*route53.DeleteHostedZoneOutput, error) {
+	return &route53.DeleteHostedZoneOutput{}, nil
+}
+
+// mockIAM implements IAMAPI for testing.
+type mockIAM struct {
+	providers []iamtypes.OpenIDConnectProviderListEntry
+}
+
+func (m *mockIAM) ListOpenIDConnectProviders(_ context.Context, _ *iam.ListOpenIDConnectProvidersInput, _ ...func(*iam.Options)) (*iam.ListOpenIDConnectProvidersOutput, error) {
+	return &iam.ListOpenIDConnectProvidersOutput{OpenIDConnectProviderList: m.providers}, nil
+}
+func (m *mockIAM) GetOpenIDConnectProvider(_ context.Context, _ *iam.GetOpenIDConnectProviderInput, _ ...func(*iam.Options)) (*iam.GetOpenIDConnectProviderOutput, error) {
+	return &iam.GetOpenIDConnectProviderOutput{}, nil
+}
+func (m *mockIAM) ListRoles(_ context.Context, _ *iam.ListRolesInput, _ ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
+	return &iam.ListRolesOutput{}, nil
+}
+func (m *mockIAM) DeleteOpenIDConnectProvider(_ context.Context, _ *iam.DeleteOpenIDConnectProviderInput, _ ...func(*iam.Options)) (*iam.DeleteOpenIDConnectProviderOutput, error) {
+	return &iam.DeleteOpenIDConnectProviderOutput{}, nil
+}
+func (m *mockIAM) ListAttachedRolePolicies(_ context.Context, _ *iam.ListAttachedRolePoliciesInput, _ ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error) {
+	return &iam.ListAttachedRolePoliciesOutput{}, nil
+}
+func (m *mockIAM) DetachRolePolicy(_ context.Context, _ *iam.DetachRolePolicyInput, _ ...func(*iam.Options)) (*iam.DetachRolePolicyOutput, error) {
+	return &iam.DetachRolePolicyOutput{}, nil
+}
+func (m *mockIAM) ListRolePolicies(_ context.Context, _ *iam.ListRolePoliciesInput, _ ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error) {
+	return &iam.ListRolePoliciesOutput{}, nil
+}
+func (m *mockIAM) DeleteRolePolicy(_ context.Context, _ *iam.DeleteRolePolicyInput, _ ...func(*iam.Options)) (*iam.DeleteRolePolicyOutput, error) {
+	return &iam.DeleteRolePolicyOutput{}, nil
+}
+func (m *mockIAM) ListInstanceProfilesForRole(_ context.Context, _ *iam.ListInstanceProfilesForRoleInput, _ ...func(*iam.Options)) (*iam.ListInstanceProfilesForRoleOutput, error) {
+	return &iam.ListInstanceProfilesForRoleOutput{}, nil
+}
+func (m *mockIAM) RemoveRoleFromInstanceProfile(_ context.Context, _ *iam.RemoveRoleFromInstanceProfileInput, _ ...func(*iam.Options)) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
+	return &iam.RemoveRoleFromInstanceProfileOutput{}, nil
+}
+func (m *mockIAM) DeleteInstanceProfile(_ context.Context, _ *iam.DeleteInstanceProfileInput, _ ...func(*iam.Options)) (*iam.DeleteInstanceProfileOutput, error) {
+	return &iam.DeleteInstanceProfileOutput{}, nil
+}
+func (m *mockIAM) DeleteRole(_ context.Context, _ *iam.DeleteRoleInput, _ ...func(*iam.Options)) (*iam.DeleteRoleOutput, error) {
+	return &iam.DeleteRoleOutput{}, nil
+}
+
+// mockS3 implements S3API for testing.
+type mockS3 struct {
+	existingKeys map[string]bool // "bucket/key" → exists
+}
+
+func (m *mockS3) HeadObject(_ context.Context, input *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	key := aws.ToString(input.Bucket) + "/" + aws.ToString(input.Key)
+	if m.existingKeys != nil && m.existingKeys[key] {
+		return &s3.HeadObjectOutput{}, nil
+	}
+	return nil, fmt.Errorf("NoSuchKey")
+}
+
+func makeVPC(vpcID, name, infraID string, isDefault bool) ec2types.Vpc {
+	tags := []ec2types.Tag{
+		{Key: aws.String("Name"), Value: aws.String(name)},
+	}
+	if infraID != "" {
+		tags = append(tags, ec2types.Tag{
+			Key:   aws.String("kubernetes.io/cluster/" + infraID),
+			Value: aws.String("owned"),
+		})
+	}
+	return ec2types.Vpc{
+		VpcId:     aws.String(vpcID),
+		CidrBlock: aws.String("10.0.0.0/16"),
+		State:     ec2types.VpcStateAvailable,
+		IsDefault: aws.Bool(isDefault),
+		Tags:      tags,
+	}
+}
+
+func makeVPCWithDoNotDelete(vpcID, name, infraID, ciCluster string) ec2types.Vpc {
+	tags := []ec2types.Tag{
+		{Key: aws.String("Name"), Value: aws.String(name)},
+		{Key: aws.String("hypershift.openshift.io/do-not-delete"), Value: aws.String("true")},
+		{Key: aws.String("hypershift.openshift.io/ci-cluster"), Value: aws.String(ciCluster)},
+	}
+	if infraID != "" {
+		tags = append(tags, ec2types.Tag{
+			Key:   aws.String("kubernetes.io/cluster/" + infraID),
+			Value: aws.String("owned"),
+		})
+	}
+	return ec2types.Vpc{
+		VpcId:     aws.String(vpcID),
+		CidrBlock: aws.String("10.0.0.0/16"),
+		State:     ec2types.VpcStateAvailable,
+		IsDefault: aws.Bool(false),
+		Tags:      tags,
+	}
+}
+
+func makeVPCWithExpiration(vpcID, name, infraID string, createdAt, expirationDate time.Time) ec2types.Vpc {
+	tags := []ec2types.Tag{
+		{Key: aws.String("Name"), Value: aws.String(name)},
+		{Key: aws.String("creation_date"), Value: aws.String(createdAt.Format(time.RFC3339))},
+	}
+	if !expirationDate.IsZero() {
+		tags = append(tags, ec2types.Tag{
+			Key:   aws.String("expirationDate"),
+			Value: aws.String(expirationDate.Format("2006-01-02T15:04+00:00")),
+		})
+	}
+	if infraID != "" {
+		tags = append(tags, ec2types.Tag{
+			Key:   aws.String("kubernetes.io/cluster/" + infraID),
+			Value: aws.String("owned"),
+		})
+	}
+	return ec2types.Vpc{
+		VpcId:     aws.String(vpcID),
+		CidrBlock: aws.String("10.0.0.0/16"),
+		State:     ec2types.VpcStateAvailable,
+		IsDefault: aws.Bool(false),
+		Tags:      tags,
+	}
+}
+
+func makeVPCWithAge(vpcID, name, infraID string, createdAt time.Time) ec2types.Vpc {
+	tags := []ec2types.Tag{
+		{Key: aws.String("Name"), Value: aws.String(name)},
+		{Key: aws.String("creation_date"), Value: aws.String(createdAt.Format(time.RFC3339))},
+	}
+	if infraID != "" {
+		tags = append(tags, ec2types.Tag{
+			Key:   aws.String("kubernetes.io/cluster/" + infraID),
+			Value: aws.String("owned"),
+		})
+	}
+	return ec2types.Vpc{
+		VpcId:     aws.String(vpcID),
+		CidrBlock: aws.String("10.0.0.0/16"),
+		State:     ec2types.VpcStateAvailable,
+		IsDefault: aws.Bool(false),
+		Tags:      tags,
+	}
+}
+
+func newTestScanner(ec2Client *mockEC2, s3Client *mockS3) *Scanner {
+	return &Scanner{
+		EC2:     ec2Client,
+		ELBv2:   &mockELBv2{},
+		Route53: &mockRoute53{},
+		IAM:     &mockIAM{},
+		S3:      s3Client,
+		Config:  DefaultConfig(),
+		Now:     func() time.Time { return time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC) },
+	}
+}
+
+func TestGate0_ProtectedVPCs(t *testing.T) {
+	tests := []struct {
+		name    string
+		vpcName string
+		infraID string
+		want    Verdict
+	}{
+		{
+			name:    "When VPC belongs to ci-2, it should be classified as PROTECTED",
+			vpcName: "hypershift-ci-2-vpc",
+			infraID: "298afphbsd2sqa34kjfuo87as2hjhbrn",
+			want:    VerdictProtected,
+		},
+		{
+			name:    "When VPC belongs to ci-3, it should be classified as PROTECTED",
+			vpcName: "hypershift-ci-3-vpc",
+			infraID: "some-ci3-infra-id",
+			want:    VerdictProtected,
+		},
+		{
+			name:    "When VPC belongs to ci-metrics, it should be classified as PROTECTED",
+			vpcName: "hypershift-ci-metrics-vpc",
+			infraID: "metrics-infra-id",
+			want:    VerdictProtected,
+		},
+		{
+			name:    "When VPC name is a random CI job, it should NOT be protected by VPC name",
+			vpcName: "00ab3695c5f73d4354b9-vpc",
+			infraID: "00ab3695c5f73d4354b9",
+			want:    VerdictLeaked,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+			created := now.Add(-48 * time.Hour)
+
+			scanner := newTestScanner(
+				&mockEC2{
+					vpcs: []ec2types.Vpc{
+						makeVPCWithAge("vpc-test", tt.vpcName, tt.infraID, created),
+					},
+				},
+				&mockS3{existingKeys: map[string]bool{}},
+			)
+
+			results, err := scanner.Scan(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(results))
+			}
+			if results[0].Verdict != tt.want {
+				t.Errorf("got verdict %q, want %q (reason: %s)", results[0].Verdict, tt.want, results[0].VerdictReason)
+			}
+		})
+	}
+}
+
+func TestGate0_ProtectedUsers(t *testing.T) {
+	tests := []struct {
+		name    string
+		infraID string
+		want    Verdict
+	}{
+		{
+			name:    "When infraID contains a protected user name, it should be PROTECTED",
+			infraID: "brcox-mgmt-4tw4x",
+			want:    VerdictProtected,
+		},
+		{
+			name:    "When infraID contains 'sjenning', it should be PROTECTED",
+			infraID: "sjenning-mgmt-2",
+			want:    VerdictProtected,
+		},
+		{
+			name:    "When infraID is a hex string with no user match, it should NOT be protected by user",
+			infraID: "00ab3695c5f73d4354b9",
+			want:    VerdictLeaked,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+			created := now.Add(-48 * time.Hour)
+
+			scanner := newTestScanner(
+				&mockEC2{
+					vpcs: []ec2types.Vpc{
+						makeVPCWithAge("vpc-test", tt.infraID+"-vpc", tt.infraID, created),
+					},
+				},
+				&mockS3{existingKeys: map[string]bool{}},
+			)
+
+			results, err := scanner.Scan(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(results))
+			}
+			if results[0].Verdict != tt.want {
+				t.Errorf("got verdict %q, want %q (reason: %s)", results[0].Verdict, tt.want, results[0].VerdictReason)
+			}
+		})
+	}
+}
+
+func TestGate1_Age(t *testing.T) {
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		createdAt time.Time
+		want      Verdict
+	}{
+		{
+			name:      "When VPC was created 2 hours ago, it should be TOO_YOUNG",
+			createdAt: now.Add(-2 * time.Hour),
+			want:      VerdictTooYoung,
+		},
+		{
+			name:      "When VPC was created 48 hours ago, it should pass age check",
+			createdAt: now.Add(-48 * time.Hour),
+			want:      VerdictLeaked,
+		},
+		{
+			name:      "When VPC was created exactly 24 hours ago, it should pass age check",
+			createdAt: now.Add(-24 * time.Hour),
+			want:      VerdictLeaked,
+		},
+		{
+			name:      "When VPC was created 23h59m ago, it should be TOO_YOUNG",
+			createdAt: now.Add(-23*time.Hour - 59*time.Minute),
+			want:      VerdictTooYoung,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := newTestScanner(
+				&mockEC2{
+					vpcs: []ec2types.Vpc{
+						makeVPCWithAge("vpc-test", "abcdef1234567890abcd-vpc", "abcdef1234567890abcd", tt.createdAt),
+					},
+				},
+				&mockS3{existingKeys: map[string]bool{}},
+			)
+
+			results, err := scanner.Scan(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(results))
+			}
+			if results[0].Verdict != tt.want {
+				t.Errorf("got verdict %q, want %q (reason: %s)", results[0].Verdict, tt.want, results[0].VerdictReason)
+			}
+		})
+	}
+}
+
+func TestGate1_AgeUnknown(t *testing.T) {
+	t.Run("When VPC has no creation_date tag and no sub-resources to infer age, it should be classified as UNCERTAIN", func(t *testing.T) {
+		scanner := newTestScanner(
+			&mockEC2{
+				vpcs: []ec2types.Vpc{
+					makeVPC("vpc-test", "abcdef1234567890abcd-vpc", "abcdef1234567890abcd", false),
+				},
+			},
+			&mockS3{existingKeys: map[string]bool{}},
+		)
+
+		results, err := scanner.Scan(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		if results[0].Verdict != VerdictUncertain {
+			t.Errorf("got verdict %q, want UNCERTAIN when age is undetermined (reason: %s)", results[0].Verdict, results[0].VerdictReason)
+		}
+	})
+}
+
+func TestGate3_OIDC(t *testing.T) {
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	created := now.Add(-48 * time.Hour)
+
+	tests := []struct {
+		name    string
+		infraID string
+		s3Keys  map[string]bool
+		want    Verdict
+	}{
+		{
+			name:    "When S3 OIDC doc exists, it should be ACTIVE",
+			infraID: "abcdef1234567890abcd",
+			s3Keys: map[string]bool{
+				"hypershift-ci-2-oidc/abcdef1234567890abcd/.well-known/openid-configuration": true,
+			},
+			want: VerdictActive,
+		},
+		{
+			name:    "When S3 OIDC doc does not exist, it should pass OIDC check",
+			infraID: "abcdef1234567890abcd",
+			s3Keys:  map[string]bool{},
+			want:    VerdictLeaked,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := newTestScanner(
+				&mockEC2{
+					vpcs: []ec2types.Vpc{
+						makeVPCWithAge("vpc-test", tt.infraID+"-vpc", tt.infraID, created),
+					},
+				},
+				&mockS3{existingKeys: tt.s3Keys},
+			)
+
+			results, err := scanner.Scan(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(results))
+			}
+			if results[0].Verdict != tt.want {
+				t.Errorf("got verdict %q, want %q (reason: %s)", results[0].Verdict, tt.want, results[0].VerdictReason)
+			}
+		})
+	}
+}
+
+func TestGate4_EC2Instances(t *testing.T) {
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	created := now.Add(-48 * time.Hour)
+
+	tests := []struct {
+		name      string
+		infraID   string
+		instances []ec2types.Reservation
+		want      Verdict
+	}{
+		{
+			name:    "When EC2 instances are running, it should be ACTIVE",
+			infraID: "abcdef1234567890abcd",
+			instances: []ec2types.Reservation{
+				{Instances: []ec2types.Instance{{InstanceId: aws.String("i-123")}}},
+			},
+			want: VerdictActive,
+		},
+		{
+			name:      "When no EC2 instances are running, it should be LEAKED",
+			infraID:   "abcdef1234567890abcd",
+			instances: []ec2types.Reservation{},
+			want:      VerdictLeaked,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := newTestScanner(
+				&mockEC2{
+					vpcs: []ec2types.Vpc{
+						makeVPCWithAge("vpc-test", tt.infraID+"-vpc", tt.infraID, created),
+					},
+					instances: tt.instances,
+				},
+				&mockS3{existingKeys: map[string]bool{}},
+			)
+
+			results, err := scanner.Scan(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(results))
+			}
+			if results[0].Verdict != tt.want {
+				t.Errorf("got verdict %q, want %q (reason: %s)", results[0].Verdict, tt.want, results[0].VerdictReason)
+			}
+		})
+	}
+}
+
+func TestFullScan_MixedVPCs(t *testing.T) {
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-48 * time.Hour)
+	young := now.Add(-2 * time.Hour)
+
+	ec2Client := &mockEC2{
+		vpcs: []ec2types.Vpc{
+			makeVPC("vpc-default", "", "", true),
+			makeVPCWithAge("vpc-ci2", "hypershift-ci-2-vpc", "ci2-infra", old),
+			makeVPCWithAge("vpc-ci3", "hypershift-ci-3-vpc", "ci3-infra", old),
+			makeVPCWithAge("vpc-leaked", "abcdef1234567890abcd-vpc", "abcdef1234567890abcd", old),
+			makeVPCWithAge("vpc-young", "fedcba0987654321fedc-vpc", "fedcba0987654321fedc", young),
+			makeVPCWithAge("vpc-brcox", "brcox-mgmt-4tw4x-vpc", "brcox-mgmt-4tw4x", old),
+			makeVPC("vpc-notag", "some-random-vpc", "", false),
+		},
+	}
+
+	scanner := newTestScanner(ec2Client, &mockS3{existingKeys: map[string]bool{}})
+
+	results, err := scanner.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	verdicts := make(map[string]Verdict)
+	for _, r := range results {
+		verdicts[r.InfraID] = r.Verdict
+	}
+
+	// ci-2 and ci-3 should be PROTECTED
+	if v, ok := verdicts["ci2-infra"]; !ok || v != VerdictProtected {
+		t.Errorf("ci2-infra: got %v, want PROTECTED", v)
+	}
+	if v, ok := verdicts["ci3-infra"]; !ok || v != VerdictProtected {
+		t.Errorf("ci3-infra: got %v, want PROTECTED", v)
+	}
+
+	// Leaked hex VPC should be LEAKED
+	if v, ok := verdicts["abcdef1234567890abcd"]; !ok || v != VerdictLeaked {
+		t.Errorf("abcdef1234567890abcd: got %v, want LEAKED", v)
+	}
+
+	// Young VPC should be TOO_YOUNG
+	if v, ok := verdicts["fedcba0987654321fedc"]; !ok || v != VerdictTooYoung {
+		t.Errorf("fedcba0987654321fedc: got %v, want TOO_YOUNG", v)
+	}
+
+	// brcox should be PROTECTED (protected user)
+	if v, ok := verdicts["brcox-mgmt-4tw4x"]; !ok || v != VerdictProtected {
+		t.Errorf("brcox-mgmt-4tw4x: got %v, want PROTECTED", v)
+	}
+
+	// Untagged VPC should not appear (no infraID → filtered out during grouping)
+	if _, ok := verdicts[""]; ok {
+		t.Error("untagged VPC should not appear in results")
+	}
+}
+
+func TestZoneMatchesInfra(t *testing.T) {
+	tests := []struct {
+		name     string
+		zoneName string
+		infraID  string
+		want     bool
+	}{
+		{
+			name:     "When zone is CI zone for infraID, it should match",
+			zoneName: "abc123.ci.hypershift.devcluster.openshift.com.",
+			infraID:  "abc123",
+			want:     true,
+		},
+		{
+			name:     "When zone is hypershift.local for infraID, it should match",
+			zoneName: "abc123.hypershift.local.",
+			infraID:  "abc123",
+			want:     true,
+		},
+		{
+			name:     "When zone belongs to different infraID, it should NOT match",
+			zoneName: "xyz999.ci.hypershift.devcluster.openshift.com.",
+			infraID:  "abc123",
+			want:     false,
+		},
+		{
+			name:     "When zone is a dev user zone, it should NOT match CI infraID",
+			zoneName: "brcox.hypershift.devcluster.openshift.com.",
+			infraID:  "abc123",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ZoneMatchesInfra(tt.zoneName, tt.infraID)
+			if got != tt.want {
+				t.Errorf("ZoneMatchesInfra(%q, %q) = %v, want %v", tt.zoneName, tt.infraID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsProtectedVPC(t *testing.T) {
+	protected := []string{"hypershift-ci-2-vpc", "hypershift-ci-3-vpc", "hypershift-ci-metrics-vpc"}
+
+	tests := []struct {
+		name    string
+		vpcName string
+		want    bool
+	}{
+		{"ci-2 is protected", "hypershift-ci-2-vpc", true},
+		{"ci-3 is protected", "hypershift-ci-3-vpc", true},
+		{"ci-metrics is protected", "hypershift-ci-metrics-vpc", true},
+		{"random VPC is not protected", "abc123-vpc", false},
+		{"partial match is not protected", "hypershift-ci-2", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsProtectedVPC(tt.vpcName, protected)
+			if got != tt.want {
+				t.Errorf("IsProtectedVPC(%q) = %v, want %v", tt.vpcName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsProtectedUser(t *testing.T) {
+	users := DefaultConfig().ProtectedUsers
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"brcox in infraID", "brcox-mgmt-4tw4x", true},
+		{"sjenning in infraID", "sjenning-mgmt-2", true},
+		{"hex ID has no user", "00ab3695c5f73d4354b9", false},
+		{"partial user name that does not match", "brc-something", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := IsProtectedUser(tt.value, users)
+			if got != tt.want {
+				t.Errorf("IsProtectedUser(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterLeaked(t *testing.T) {
+	sets := []InfraSet{
+		{InfraID: "a", Verdict: VerdictProtected},
+		{InfraID: "b", Verdict: VerdictLeaked},
+		{InfraID: "c", Verdict: VerdictActive},
+		{InfraID: "d", Verdict: VerdictLeaked},
+	}
+
+	leaked := FilterLeaked(sets)
+	if len(leaked) != 2 {
+		t.Fatalf("expected 2 leaked, got %d", len(leaked))
+	}
+	if leaked[0].InfraID != "b" || leaked[1].InfraID != "d" {
+		t.Errorf("unexpected leaked IDs: %v, %v", leaked[0].InfraID, leaked[1].InfraID)
+	}
+}
+
+func TestCountByVerdict(t *testing.T) {
+	sets := []InfraSet{
+		{Verdict: VerdictProtected},
+		{Verdict: VerdictLeaked},
+		{Verdict: VerdictLeaked},
+		{Verdict: VerdictActive},
+		{Verdict: VerdictTooYoung},
+	}
+
+	counts := CountByVerdict(sets)
+	if counts[VerdictProtected] != 1 {
+		t.Errorf("expected 1 PROTECTED, got %d", counts[VerdictProtected])
+	}
+	if counts[VerdictLeaked] != 2 {
+		t.Errorf("expected 2 LEAKED, got %d", counts[VerdictLeaked])
+	}
+	if counts[VerdictActive] != 1 {
+		t.Errorf("expected 1 ACTIVE, got %d", counts[VerdictActive])
+	}
+}
+
+func TestGate0_DoNotDeleteTag(t *testing.T) {
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-72 * time.Hour)
+
+	oldVPC := func(vpcID, name, infraID, ciCluster string) ec2types.Vpc {
+		vpc := makeVPCWithDoNotDelete(vpcID, name, infraID, ciCluster)
+		vpc.Tags = append(vpc.Tags, ec2types.Tag{
+			Key:   aws.String("creation_date"),
+			Value: aws.String(old.Format(time.RFC3339)),
+		})
+		return vpc
+	}
+
+	tests := []struct {
+		name        string
+		vpcs        []ec2types.Vpc
+		wantVerdict map[string]Verdict
+	}{
+		{
+			name: "When VPC has do-not-delete tag with k8s cluster tag, it should be classified as PROTECTED",
+			vpcs: []ec2types.Vpc{
+				makeVPCWithDoNotDelete("vpc-ci2", "hypershift-ci-2-vpc", "298afphbsd2sqa34kjfuo87as2hjhbrn", "hypershift-ci-2"),
+			},
+			wantVerdict: map[string]Verdict{"vpc-ci2": VerdictProtected},
+		},
+		{
+			name: "When VPC has do-not-delete tag without k8s cluster tag, it should be classified as PROTECTED",
+			vpcs: []ec2types.Vpc{
+				makeVPCWithDoNotDelete("vpc-ci3", "hypershift-ci-3-vpc", "", "hypershift-ci-3"),
+			},
+			wantVerdict: map[string]Verdict{"vpc-ci3": VerdictProtected},
+		},
+		{
+			name: "When VPC has do-not-delete tag for metrics server, it should be classified as PROTECTED",
+			vpcs: []ec2types.Vpc{
+				makeVPCWithDoNotDelete("vpc-met", "hypershift-ci-metrics-vpc", "", "hypershift-ci-metrics"),
+			},
+			wantVerdict: map[string]Verdict{"vpc-met": VerdictProtected},
+		},
+		{
+			name: "When VPC has do-not-delete tag and is old with no OIDC and no instances, it should still be classified as PROTECTED",
+			vpcs: []ec2types.Vpc{
+				oldVPC("vpc-ci2", "hypershift-ci-2-vpc", "some-infra", "hypershift-ci-2"),
+			},
+			wantVerdict: map[string]Verdict{"vpc-ci2": VerdictProtected},
+		},
+		{
+			name: "When scanning a mix of do-not-delete and leaked VPCs, it should classify each correctly",
+			vpcs: []ec2types.Vpc{
+				makeVPCWithDoNotDelete("vpc-ci2", "hypershift-ci-2-vpc", "ci2-infra", "hypershift-ci-2"),
+				makeVPCWithDoNotDelete("vpc-ci3", "hypershift-ci-3-vpc", "", "hypershift-ci-3"),
+				makeVPCWithDoNotDelete("vpc-met", "hypershift-ci-metrics-vpc", "", "hypershift-ci-metrics"),
+				makeVPCWithAge("vpc-leaked", "abcdef1234567890abcd-vpc", "abcdef1234567890abcd", old),
+			},
+			wantVerdict: map[string]Verdict{
+				"vpc-ci2":    VerdictProtected,
+				"vpc-ci3":    VerdictProtected,
+				"vpc-met":    VerdictProtected,
+				"vpc-leaked": VerdictLeaked,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := newTestScanner(
+				&mockEC2{vpcs: tt.vpcs},
+				&mockS3{existingKeys: map[string]bool{}},
+			)
+
+			results, err := scanner.Scan(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotVerdicts := make(map[string]Verdict)
+			for _, r := range results {
+				for _, vpc := range r.VPCs {
+					gotVerdicts[vpc.VPCID] = r.Verdict
+				}
+			}
+
+			for vpcID, wantV := range tt.wantVerdict {
+				gotV, ok := gotVerdicts[vpcID]
+				if !ok {
+					t.Errorf("VPC %s not found in results", vpcID)
+					continue
+				}
+				if gotV != wantV {
+					t.Errorf("VPC %s: got verdict %q, want %q", vpcID, gotV, wantV)
+				}
+			}
+		})
+	}
+}
+
+func TestGate1_ExpirationDate(t *testing.T) {
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-48 * time.Hour)
+
+	tests := []struct {
+		name           string
+		createdAt      time.Time
+		expirationDate time.Time
+		want           Verdict
+	}{
+		{
+			name:           "When VPC has expirationDate in the future, it should be classified as TOO_YOUNG",
+			createdAt:      now.Add(-2 * time.Hour),
+			expirationDate: now.Add(4 * time.Hour),
+			want:           VerdictTooYoung,
+		},
+		{
+			name:           "When VPC has expirationDate in the past, it should pass the age gate",
+			createdAt:      old,
+			expirationDate: now.Add(-5 * 24 * time.Hour),
+			want:           VerdictLeaked,
+		},
+		{
+			name:           "When VPC has expirationDate exactly now, it should pass the age gate",
+			createdAt:      old,
+			expirationDate: now,
+			want:           VerdictLeaked,
+		},
+		{
+			name:           "When VPC has no expirationDate but is old enough, it should pass the age gate",
+			createdAt:      old,
+			expirationDate: time.Time{},
+			want:           VerdictLeaked,
+		},
+		{
+			name:           "When VPC has no expirationDate and is too young, it should be classified as TOO_YOUNG",
+			createdAt:      now.Add(-2 * time.Hour),
+			expirationDate: time.Time{},
+			want:           VerdictTooYoung,
+		},
+		{
+			name:           "When VPC was created 48h ago but expirationDate is still in the future, it should be classified as TOO_YOUNG",
+			createdAt:      old,
+			expirationDate: now.Add(1 * time.Hour),
+			want:           VerdictTooYoung,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := newTestScanner(
+				&mockEC2{
+					vpcs: []ec2types.Vpc{
+						makeVPCWithExpiration("vpc-test", "create-cluster-abc12-vpc", "create-cluster-abc12", tt.createdAt, tt.expirationDate),
+					},
+				},
+				&mockS3{existingKeys: map[string]bool{}},
+			)
+
+			results, err := scanner.Scan(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(results))
+			}
+			if results[0].Verdict != tt.want {
+				t.Errorf("got verdict %q, want %q (reason: %s)", results[0].Verdict, tt.want, results[0].VerdictReason)
+			}
+		})
+	}
+}
+
+func TestParseExpirationDate(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"When format is RFC3339, it should parse", "2026-07-03T17:01:00Z", true},
+		{"When format is short ISO with offset, it should parse", "2026-07-03T17:01+00:00", true},
+		{"When format is date only, it should parse", "2026-07-03", true},
+		{"When input is empty, it should return zero", "", false},
+		{"When input is garbage, it should return zero", "not-a-date", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseExpirationDate(tt.input)
+			if tt.want && got.IsZero() {
+				t.Errorf("parseExpirationDate(%q) returned zero, expected a valid time", tt.input)
+			}
+			if !tt.want && !got.IsZero() {
+				t.Errorf("parseExpirationDate(%q) returned %v, expected zero", tt.input, got)
+			}
+		})
+	}
+}
+
+func TestUncertainVerdict(t *testing.T) {
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-48 * time.Hour)
+
+	tests := []struct {
+		name    string
+		infraID string
+		vpcName string
+		want    Verdict
+	}{
+		{
+			name:    "When infraID is a dev cluster name like hc1-xxxxx, it should be classified as UNCERTAIN",
+			infraID: "hc1-nbh66",
+			vpcName: "hc1-nbh66-vpc",
+			want:    VerdictUncertain,
+		},
+		{
+			name:    "When infraID is a dev cluster name like clust-xxxxx, it should be classified as UNCERTAIN",
+			infraID: "clust-dms2d",
+			vpcName: "clust-dms2d-vpc",
+			want:    VerdictUncertain,
+		},
+		{
+			name:    "When infraID is a dev cluster name like dev-cluster-1-xxxxx, it should be classified as UNCERTAIN",
+			infraID: "dev-cluster-1-wwfbv",
+			vpcName: "dev-cluster-1-wwfbv-vpc",
+			want:    VerdictUncertain,
+		},
+		{
+			name:    "When infraID is a hex CI infra ID, it should be classified as LEAKED",
+			infraID: "00ab3695c5f73d4354b9",
+			vpcName: "00ab3695c5f73d4354b9-vpc",
+			want:    VerdictLeaked,
+		},
+		{
+			name:    "When infraID is a CI test pattern like node-pool-xxxxx, it should be classified as LEAKED",
+			infraID: "node-pool-78vcg",
+			vpcName: "node-pool-78vcg-vpc",
+			want:    VerdictLeaked,
+		},
+		{
+			name:    "When infraID is a CI test pattern like create-cluster-xxxxx, it should be classified as LEAKED",
+			infraID: "create-cluster-hg78d",
+			vpcName: "create-cluster-hg78d-vpc",
+			want:    VerdictLeaked,
+		},
+		{
+			name:    "When infraID is a QE test like qe-cpv-test-xxxxx, it should be classified as UNCERTAIN",
+			infraID: "qe-cpv-test-jxk7s",
+			vpcName: "qe-cpv-test-jxk7s-vpc",
+			want:    VerdictUncertain,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := newTestScanner(
+				&mockEC2{
+					vpcs: []ec2types.Vpc{
+						makeVPCWithAge("vpc-test", tt.vpcName, tt.infraID, old),
+					},
+				},
+				&mockS3{existingKeys: map[string]bool{}},
+			)
+
+			results, err := scanner.Scan(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(results))
+			}
+			if results[0].Verdict != tt.want {
+				t.Errorf("got verdict %q, want %q (reason: %s)", results[0].Verdict, tt.want, results[0].VerdictReason)
+			}
+		})
+	}
+}
+
+func TestCheckEC2Instances_APIError(t *testing.T) {
+	t.Run("When DescribeInstances returns an error, it should classify as UNCERTAIN not LEAKED", func(t *testing.T) {
+		now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+		old := now.Add(-48 * time.Hour)
+
+		ec2Client := &mockEC2ErrorInstances{
+			mockEC2: mockEC2{
+				vpcs: []ec2types.Vpc{
+					makeVPCWithAge("vpc-test", "abcdef1234567890abcd-vpc", "abcdef1234567890abcd", old),
+				},
+			},
+		}
+
+		scanner := &Scanner{
+			EC2:     ec2Client,
+			ELBv2:   &mockELBv2{},
+			Route53: &mockRoute53{},
+			IAM:     &mockIAM{},
+			S3:      &mockS3{existingKeys: map[string]bool{}},
+			Config:  DefaultConfig(),
+			Now:     func() time.Time { return now },
+		}
+
+		results, err := scanner.Scan(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		if results[0].Verdict != VerdictUncertain {
+			t.Errorf("got verdict %q, want UNCERTAIN when API fails (reason: %s)", results[0].Verdict, results[0].VerdictReason)
+		}
+	})
+}
+
+type mockEC2ErrorInstances struct {
+	mockEC2
+}
+
+func (m *mockEC2ErrorInstances) DescribeInstances(_ context.Context, _ *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	return nil, fmt.Errorf("ThrottlingException: Rate exceeded")
+}
+
+func TestExtractInfraID(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []ec2types.Tag
+		want string
+	}{
+		{
+			name: "When VPC has hypershift.openshift.io/infra-id tag, it should prefer that over k8s tag",
+			tags: []ec2types.Tag{
+				{Key: aws.String("hypershift.openshift.io/infra-id"), Value: aws.String("explicit-infra")},
+				{Key: aws.String("kubernetes.io/cluster/k8s-infra"), Value: aws.String("owned")},
+			},
+			want: "explicit-infra",
+		},
+		{
+			name: "When VPC has only k8s cluster tag, it should extract infraID from the key",
+			tags: []ec2types.Tag{
+				{Key: aws.String("kubernetes.io/cluster/my-cluster-abc"), Value: aws.String("owned")},
+			},
+			want: "my-cluster-abc",
+		},
+		{
+			name: "When VPC has no cluster tags, it should return empty",
+			tags: []ec2types.Tag{
+				{Key: aws.String("Name"), Value: aws.String("some-vpc")},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractInfraID(tt.tags)
+			if got != tt.want {
+				t.Errorf("extractInfraID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOldestVPC(t *testing.T) {
+	tests := []struct {
+		name     string
+		vpcs     []VPCInfo
+		wantZero bool
+	}{
+		{
+			name:     "When VPC list is empty, it should return zero time",
+			vpcs:     nil,
+			wantZero: true,
+		},
+		{
+			name:     "When all VPCs have zero CreatedAt, it should return zero time",
+			vpcs:     []VPCInfo{{VPCID: "vpc-1"}, {VPCID: "vpc-2"}},
+			wantZero: true,
+		},
+		{
+			name: "When VPCs have mixed zero and non-zero CreatedAt, it should return the earliest non-zero",
+			vpcs: []VPCInfo{
+				{VPCID: "vpc-1"},
+				{VPCID: "vpc-2", CreatedAt: time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC)},
+				{VPCID: "vpc-3", CreatedAt: time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)},
+			},
+			wantZero: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := oldestVPC(tt.vpcs)
+			if tt.wantZero && !got.IsZero() {
+				t.Errorf("expected zero time, got %v", got)
+			}
+			if !tt.wantZero && got.IsZero() {
+				t.Error("expected non-zero time, got zero")
+			}
+			if !tt.wantZero {
+				expected := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
+				if !got.Equal(expected) {
+					t.Errorf("expected earliest %v, got %v", expected, got)
+				}
+			}
+		})
+	}
+}
+
+func TestVPCCreateTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     []ec2types.Tag
+		wantZero bool
+	}{
+		{
+			name:     "When VPC has creation_date tag in RFC3339, it should parse",
+			tags:     []ec2types.Tag{{Key: aws.String("creation_date"), Value: aws.String("2026-07-03T14:30:00Z")}},
+			wantZero: false,
+		},
+		{
+			name:     "When VPC has no creation_date tag, it should return zero",
+			tags:     []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test")}},
+			wantZero: true,
+		},
+		{
+			name:     "When VPC has malformed creation_date tag, it should return zero",
+			tags:     []ec2types.Tag{{Key: aws.String("creation_date"), Value: aws.String("not-a-date")}},
+			wantZero: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vpc := ec2types.Vpc{Tags: tt.tags}
+			got := VPCCreateTime(vpc)
+			if tt.wantZero && !got.IsZero() {
+				t.Errorf("expected zero time, got %v", got)
+			}
+			if !tt.wantZero && got.IsZero() {
+				t.Error("expected non-zero time")
+			}
+		})
+	}
+}

--- a/contrib/aws-leaked-resources/tags.go
+++ b/contrib/aws-leaked-resources/tags.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// HyperShift resource tag keys (from support/awsutil/tags.go in PR #8909).
+const (
+	TagHypershiftInfraID     = "hypershift.openshift.io/infra-id"
+	TagHypershiftClusterName = "hypershift.openshift.io/cluster-name"
+	TagHypershiftSource      = "hypershift.openshift.io/source"
+	TagHypershiftProwJobID   = "hypershift.openshift.io/prow-job-id"
+
+	TagDoNotDelete = "hypershift.openshift.io/do-not-delete"
+	TagCICluster   = "hypershift.openshift.io/ci-cluster"
+)
+
+func extractInfraID(tags []ec2types.Tag) string {
+	if v := getTagValue(tags, TagHypershiftInfraID); v != "" {
+		return v
+	}
+	for _, tag := range tags {
+		key := aws.ToString(tag.Key)
+		if strings.HasPrefix(key, "kubernetes.io/cluster/") {
+			return strings.TrimPrefix(key, "kubernetes.io/cluster/")
+		}
+	}
+	return ""
+}
+
+func getTagValue(tags []ec2types.Tag, key string) string {
+	for _, tag := range tags {
+		if aws.ToString(tag.Key) == key {
+			return aws.ToString(tag.Value)
+		}
+	}
+	return ""
+}
+
+func oldestVPC(vpcs []VPCInfo) time.Time {
+	var oldest time.Time
+	for _, vpc := range vpcs {
+		if vpc.CreatedAt.IsZero() {
+			continue
+		}
+		if oldest.IsZero() || vpc.CreatedAt.Before(oldest) {
+			oldest = vpc.CreatedAt
+		}
+	}
+	return oldest
+}
+
+func parseExpirationDate(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	formats := []string{
+		time.RFC3339,
+		"2006-01-02T15:04-07:00",
+		"2006-01-02",
+	}
+	for _, f := range formats {
+		if t, err := time.Parse(f, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+// VPCCreateTime extracts the creation time from a VPC's tags.
+func VPCCreateTime(vpc ec2types.Vpc) time.Time {
+	for _, tag := range vpc.Tags {
+		if aws.ToString(tag.Key) == "creation_date" {
+			if t, err := time.Parse(time.RFC3339, aws.ToString(tag.Value)); err == nil {
+				return t
+			}
+		}
+	}
+	return time.Time{}
+}
+
+// ZoneMatchesInfra determines if a Route53 zone belongs to a given infra set.
+func ZoneMatchesInfra(zoneName string, infraID string) bool {
+	name := strings.TrimSuffix(zoneName, ".")
+
+	if strings.HasPrefix(name, infraID+".") {
+		return true
+	}
+	if name == infraID+".hypershift.local" {
+		return true
+	}
+
+	ciSuffix := ".ci.hypershift.devcluster.openshift.com"
+	if strings.HasSuffix(name, ciSuffix) {
+		prefix := strings.TrimSuffix(name, ciSuffix)
+		parts := strings.SplitN(prefix, ".", 2)
+		if len(parts) > 0 && parts[0] == infraID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func IsProtectedVPC(vpcName string, protectedVPCs []string) bool {
+	for _, p := range protectedVPCs {
+		if vpcName == p {
+			return true
+		}
+	}
+	return false
+}
+
+func IsProtectedUser(value string, protectedUsers []string) (bool, string) {
+	for _, user := range protectedUsers {
+		if strings.Contains(value, user) {
+			return true, user
+		}
+	}
+	return false, ""
+}
+
+func FilterLeaked(sets []InfraSet) []InfraSet {
+	var leaked []InfraSet
+	for _, s := range sets {
+		if s.Verdict == VerdictLeaked {
+			leaked = append(leaked, s)
+		}
+	}
+	return leaked
+}
+
+func CountByVerdict(sets []InfraSet) map[Verdict]int {
+	counts := make(map[Verdict]int)
+	for _, s := range sets {
+		counts[s.Verdict]++
+	}
+	return counts
+}
+
+func countVPCs(sets []InfraSet, v Verdict) int {
+	total := 0
+	for _, s := range sets {
+		if s.Verdict == v {
+			total += len(s.VPCs)
+		}
+	}
+	return total
+}

--- a/contrib/aws-leaked-resources/types.go
+++ b/contrib/aws-leaked-resources/types.go
@@ -1,0 +1,114 @@
+package main
+
+import "time"
+
+type Verdict string
+
+const (
+	VerdictProtected Verdict = "PROTECTED"
+	VerdictTooYoung  Verdict = "TOO_YOUNG"
+	VerdictActive    Verdict = "ACTIVE"
+	VerdictLeaked    Verdict = "LEAKED"
+	VerdictUncertain Verdict = "UNCERTAIN"
+)
+
+type InfraSet struct {
+	InfraID       string
+	VPCs          []VPCInfo
+	Verdict       Verdict
+	VerdictReason string
+
+	HostedZones   []ZoneInfo
+	IAMRoles      []string
+	OIDCProviders []string
+	Instances     int
+	Age           time.Duration
+
+	// Prow correlation
+	TestType  string // "node-pool", "create-cluster", "control-plane-upgrade", etc.
+	Namespace string // "e2e-clusters-XXXXX-<cluster>" from service.ci TXT records
+	ProwLink  string // URL to Prow deck search for this test type
+}
+
+type VPCInfo struct {
+	VPCID     string
+	Name      string
+	CIDR      string
+	State     string
+	CreatedAt time.Time
+
+	// Protection tags
+	DoNotDelete    bool
+	CICluster      string
+	ExpirationDate time.Time
+
+	// Provenance tags (PR #8909: hypershift.openshift.io/*)
+	Source      string // "cli", "e2e", or ""
+	ClusterName string
+	ProwJobID   string
+
+	Endpoints        int
+	EndpointServices int
+	ENIs             int
+	NATGateways      int
+	IGWs             int
+	Subnets          int
+	SecurityGroups   int
+	RouteTables      int
+	ELBs             int
+	EIPs             int
+}
+
+type ZoneInfo struct {
+	ZoneID  string
+	Name    string
+	Private bool
+	Records int
+}
+
+type Config struct {
+	Region         string
+	MinAge         time.Duration
+	ProtectedVPCs  []string
+	ProtectedUsers []string
+	AllowedBuckets []string
+	DryRun         bool
+	Delete         bool
+	Confirm        bool
+	Interactive    bool
+	Limit          int
+	Target         string
+	OutputFormat   string
+	OutputDir      string
+}
+
+func DefaultConfig() Config {
+	return Config{
+		Region: "us-east-1",
+		MinAge: 24 * time.Hour,
+		ProtectedVPCs: []string{
+			"hypershift-ci-2-vpc",
+			"hypershift-ci-3-vpc",
+			"hypershift-ci-metrics-vpc",
+		},
+		ProtectedUsers: []string{
+			"aabdelre", "agarcial", "ahmed", "alamela", "alesross",
+			"bclement", "brcox", "celebdor", "cewong",
+			"dario", "dari2o", "dmace",
+			"glipceanu",
+			"jiezhao", "jparrill",
+			"mbhalodi", "mbrown", "meha", "mgencur", "mulham", "mraee",
+			"rkshirsa",
+			"sdminonne", "sjenning",
+			"tsegura",
+			"vismishr",
+		},
+		AllowedBuckets: []string{
+			"hypershift-ci-oidc",
+			"hypershift-ci-2-oidc",
+			"hypershift-ci-3-oidc",
+		},
+		OutputFormat: "table",
+		OutputDir:    "output",
+	}
+}


### PR DESCRIPTION
## Summary

- Go tool (`contrib/aws-leaked-resources/cleanleaked`) that scans AWS VPCs, classifies them through safety gates, and deletes leaked CI resources with full cascade support
- Claude Code skill (`triage-leaked-infra`) for interactive assessment of individual infra sets
- Protection tags applied to all root CI resources (ci-2, ci-3, ci-metrics)

## Context

On 2026-07-06, ad-hoc bash cleanup scripts accidentally deleted NAT gateways belonging to ci-2/ci-3 management clusters due to a bash `IFS` field-parsing bug, causing a multi-hour CI outage. This tool addresses the root causes with testable classification logic, protection tags, and safety invariants verified by unit tests.

## Classification Gates

| Gate | Check | Verdict |
|------|-------|---------|
| 0 | `do-not-delete` tag, protected VPC name, protected username | PROTECTED |
| 1 | `expirationDate` tag or VPCE/ENI timestamp < min-age | TOO_YOUNG |
| 2 | S3 OIDC discovery document exists | ACTIVE |
| 3 | EC2 instances tagged with infraID | ACTIVE |
| 4 | infraID does not match CI patterns | UNCERTAIN |
| 5 | All gates pass | LEAKED |

## Features

- 3 delete modes: prompt-once, `--confirm` (CI-safe), `--interactive` (per infra set with full inventory)
- Full cascade: ELBs → VPCE Services → VPCE → NAT → EIPs → IGW → RTB → ENI → Subnets → SG → VPC → Zones → OIDC → IAM roles
- Retries 0/10 with 2s delay, Ctrl+C support (context propagation)
- EIPs scoped to NAT gateways of target VPC only
- Default SG never deleted, main RTB never deleted
- `--target` for single infra set operations, `--limit` for batch control, `--dry-run`
- Prow correlation: test type inference, HC namespace from service.ci zone, Prow deck link
- Output: table/JSON, timestamped file reports

## Cleanup Results (2026-07-08)

| Metric | Value |
|--------|-------|
| VPCs | 150 → 90 |
| VPCs deleted by cleanleaked | 48 |
| HostedZones | 339 → 210 |
| Zones deleted by cleanleaked | 87 |
| IAM roles deleted | 11 |
| EIPs released | 18 |
| LEAKED remaining | 0 |
| Quota errors resolved | VPCLimitExceeded, TooManyHostedZones |

## Test plan

- [x] `go build ./contrib/aws-leaked-resources/` compiles
- [x] `go test ./contrib/aws-leaked-resources/...` — all unit tests pass
- [x] `go vet ./contrib/aws-leaked-resources/...` — no issues
- [x] Protected VPCs (ci-2, ci-3, ci-metrics) classified as PROTECTED in all scenarios
- [x] `do-not-delete=true` tag always results in PROTECTED verdict
- [x] Default SG never deleted (tested)
- [x] EIPs scoped to NAT gateways only — never releases unrelated EIPs (tested with real-world ci-2 scenario)
- [x] API errors in DescribeInstances result in UNCERTAIN, not false LEAKED (tested)
- [x] Ctrl+C interrupts immediately during retries and NAT wait
- [x] `--dry-run` verified against real AWS — no resources modified
- [x] `--interactive` mode shows full resource inventory before prompting
- [x] Ran 3 delete sessions against real AWS: 48 infra sets cleaned, 0 incidents

Fixes [CNTRLPLANE-3820](https://redhat.atlassian.net/browse/CNTRLPLANE-3820)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the `cleanleaked` workflow to scan and safely delete leaked AWS HyperShift CI infrastructure with verdict-based gating and dry-run/confirmation modes.
  * Added enriched scan reporting (table and JSON) plus Prow and namespace correlation, with per-infra-set resource inventories.
  * Added an AWS CI triage guide to help determine safe-to-delete infra sets.
* **Bug Fixes**
  * Improved deletion safety with dependency-aware, VPC-scoped cleanup and context-cancel-aware retry behavior.
* **Documentation**
  * Added comprehensive `cleanleaked` documentation covering scan/delete modes, flags, and safety constraints.
* **Tests**
  * Added unit tests covering scanning, Prow correlation, and deletion/protection behavior.
* **Chores**
  * Added build/test automation (Makefile), updated gitignore for outputs, and expanded Codecov coverage ignores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->