### PR TITLE
OCPBUGS-97705: fix(azure): skip KMS validation for private Key Vaults on ARO HCP

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3148,6 +3148,21 @@ func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Contex
 	azureKmsSpec := hcp.Spec.SecretEncryption.KMS.Azure
 
 	if hyperazureutil.IsAroHCPByHCP(hcp) {
+		// CPO cannot reach private Key Vault endpoints; KAS pods access them
+		// through the private router (HAProxy TCP passthrough via hostAlias).
+		// Actual Key Vault access is not verified here, so the condition is
+		// Unknown rather than True until it is validated at runtime.
+		if hyperazureutil.IsPrivateKeyVault(hcp) {
+			meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
+				Type:               string(hyperv1.ValidAzureKMSConfig),
+				ObservedGeneration: hcp.Generation,
+				Status:             metav1.ConditionUnknown,
+				Reason:             hyperv1.StatusUnknownReason,
+				Message:            "Private Key Vault endpoint is not reachable from the management cluster",
+			})
+			return
+		}
+
 		key := hcp.Namespace + kmsAzureCredentials
 
 		// We need to only store the Azure credentials once and reuse them after that.

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3107,6 +3107,13 @@ func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Contex
 	azureKmsSpec := hcp.Spec.SecretEncryption.KMS.Azure
 
 	if hyperazureutil.IsAroHCPByHCP(hcp) {
+		// CPO cannot reach private Key Vault endpoints; KAS pods access them
+		// through the private router (HAProxy TCP passthrough via hostAlias).
+		if hyperazureutil.IsPrivateKeyVault(hcp) {
+			setValidKMSSkipCondition(hcp, "KMS configuration accepted; Key Vault access is validated at runtime through the private router")
+			return
+		}
+
 		key := hcp.Namespace + kmsAzureCredentials
 
 		// We need to only store the Azure credentials once and reuse them after that.
@@ -3142,14 +3149,7 @@ func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Contex
 		// minted inside the KAS pod. The CPO cannot validate Key Vault access directly because
 		// it does not have the KMS workload identity credentials. Key Vault access is validated
 		// at runtime by the azure-kms-provider container.
-		condition := metav1.Condition{
-			Type:               string(hyperv1.ValidAzureKMSConfig),
-			ObservedGeneration: hcp.Generation,
-			Status:             metav1.ConditionTrue,
-			Message:            "KMS configuration accepted; Key Vault access is validated at runtime by the KMS provider",
-			Reason:             hyperv1.AsExpectedReason,
-		}
-		meta.SetStatusCondition(&hcp.Status.Conditions, condition)
+		setValidKMSSkipCondition(hcp, "KMS configuration accepted; Key Vault access is validated at runtime by the KMS provider")
 		return
 	}
 
@@ -3205,6 +3205,18 @@ func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Contex
 	}
 
 	meta.SetStatusCondition(&hcp.Status.Conditions, condition)
+}
+
+// setValidKMSSkipCondition sets ValidAzureKMSConfig to True when CPO defers
+// Key Vault validation to runtime (private Key Vault or self-managed Azure).
+func setValidKMSSkipCondition(hcp *hyperv1.HostedControlPlane, message string) {
+	meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
+		Type:               string(hyperv1.ValidAzureKMSConfig),
+		ObservedGeneration: hcp.Generation,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+		Reason:             hyperv1.AsExpectedReason,
+	})
 }
 
 func (r *HostedControlPlaneReconciler) GetGuestClusterClient(ctx context.Context, hcp *hyperv1.HostedControlPlane) (*kubernetes.Clientset, error) {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -4626,6 +4626,100 @@ func TestRouterComponentComesAfterRouteCreatingComponents(t *testing.T) {
 	}
 }
 
+func TestValidateAzureKMSConfig(t *testing.T) {
+	tests := []struct {
+		name              string
+		keyVaultAccess    hyperv1.AzureKeyVaultAccessType
+		expectedStatus    metav1.ConditionStatus
+		expectedReason    string
+		expectMsgContains string
+		expectMsgExcludes string
+	}{
+		{
+			name:              "When KeyVaultAccess is Private, it should short-circuit to Unknown",
+			keyVaultAccess:    hyperv1.AzureKeyVaultPrivate,
+			expectedStatus:    metav1.ConditionUnknown,
+			expectedReason:    hyperv1.StatusUnknownReason,
+			expectMsgContains: "not reachable from the management cluster",
+		},
+		{
+			// Public falls through to credential validation, which fails because no client is configured.
+			name:              "When KeyVaultAccess is Public, it should proceed to credential validation",
+			keyVaultAccess:    hyperv1.AzureKeyVaultPublic,
+			expectedStatus:    metav1.ConditionFalse,
+			expectedReason:    hyperv1.InvalidAzureCredentialsReason,
+			expectMsgExcludes: "not reachable from the management cluster",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			azureutil.SetAsAroHCPTest(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "hcp",
+					Namespace:  "hcp-namespace",
+					Generation: 1,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							Cloud: "AzurePublicCloud",
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeManagedIdentities,
+								ManagedIdentities: &hyperv1.AzureResourceManagedIdentities{
+									ControlPlane: hyperv1.ControlPlaneManagedIdentities{
+										ManagedIdentitiesKeyVault: hyperv1.ManagedAzureKeyVault{
+											Name:     "test-keyvault",
+											TenantID: "00000000-0000-0000-0000-000000000000",
+										},
+									},
+								},
+							},
+						},
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						Type: hyperv1.KMS,
+						KMS: &hyperv1.KMSSpec{
+							Provider: hyperv1.AZURE,
+							Azure: &hyperv1.AzureKMSSpec{
+								ActiveKey: hyperv1.AzureKMSKey{
+									KeyVaultName: "test-kms-keyvault",
+									KeyName:      "test-key",
+									KeyVersion:   "1",
+								},
+								KMS: hyperv1.ManagedIdentity{
+									CredentialsSecretName: "test-kms-creds",
+								},
+								KeyVaultAccess: tc.keyVaultAccess,
+							},
+						},
+					},
+				},
+			}
+
+			r := &HostedControlPlaneReconciler{}
+			r.validateAzureKMSConfig(t.Context(), hcp)
+
+			g := NewWithT(t)
+			cond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ValidAzureKMSConfig))
+			g.Expect(cond).ToNot(BeNil(), "ValidAzureKMSConfig condition should be set")
+			g.Expect(cond.Status).To(Equal(tc.expectedStatus))
+			if tc.expectedReason != "" {
+				g.Expect(cond.Reason).To(Equal(tc.expectedReason))
+			}
+			if tc.expectMsgContains != "" {
+				g.Expect(cond.Message).To(ContainSubstring(tc.expectMsgContains))
+			}
+			if tc.expectMsgExcludes != "" {
+				g.Expect(cond.Message).ToNot(ContainSubstring(tc.expectMsgExcludes))
+			}
+		})
+	}
+}
+
 // Compile-time assertion that fakeVersionImageMetadataProvider satisfies the interface.
 var _ util.ImageMetadataProvider = &fakeVersionImageMetadataProvider{}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -4626,6 +4626,100 @@ func TestRouterComponentComesAfterRouteCreatingComponents(t *testing.T) {
 	}
 }
 
+func TestValidateAzureKMSConfig(t *testing.T) {
+	tests := []struct {
+		name              string
+		keyVaultAccess    hyperv1.AzureKeyVaultAccessType
+		expectedStatus    metav1.ConditionStatus
+		expectedReason    string
+		expectMsgContains string
+		expectMsgExcludes string
+	}{
+		{
+			name:              "When KeyVaultAccess is Private, it should short-circuit to True",
+			keyVaultAccess:    hyperv1.AzureKeyVaultPrivate,
+			expectedStatus:    metav1.ConditionTrue,
+			expectedReason:    hyperv1.AsExpectedReason,
+			expectMsgContains: "private router",
+		},
+		{
+			// Public falls through to credential validation, which fails because no client is configured.
+			name:              "When KeyVaultAccess is Public, it should proceed to credential validation",
+			keyVaultAccess:    hyperv1.AzureKeyVaultPublic,
+			expectedStatus:    metav1.ConditionFalse,
+			expectedReason:    hyperv1.InvalidAzureCredentialsReason,
+			expectMsgExcludes: "private router",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			azureutil.SetAsAroHCPTest(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "hcp",
+					Namespace:  "hcp-namespace",
+					Generation: 1,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							Cloud: "AzurePublicCloud",
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeManagedIdentities,
+								ManagedIdentities: &hyperv1.AzureResourceManagedIdentities{
+									ControlPlane: hyperv1.ControlPlaneManagedIdentities{
+										ManagedIdentitiesKeyVault: hyperv1.ManagedAzureKeyVault{
+											Name:     "test-keyvault",
+											TenantID: "00000000-0000-0000-0000-000000000000",
+										},
+									},
+								},
+							},
+						},
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						Type: hyperv1.KMS,
+						KMS: &hyperv1.KMSSpec{
+							Provider: hyperv1.AZURE,
+							Azure: &hyperv1.AzureKMSSpec{
+								ActiveKey: hyperv1.AzureKMSKey{
+									KeyVaultName: "test-kms-keyvault",
+									KeyName:      "test-key",
+									KeyVersion:   "1",
+								},
+								KMS: hyperv1.ManagedIdentity{
+									CredentialsSecretName: "test-kms-creds",
+								},
+								KeyVaultAccess: tc.keyVaultAccess,
+							},
+						},
+					},
+				},
+			}
+
+			r := &HostedControlPlaneReconciler{}
+			r.validateAzureKMSConfig(t.Context(), hcp)
+
+			g := NewWithT(t)
+			cond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ValidAzureKMSConfig))
+			g.Expect(cond).ToNot(BeNil(), "ValidAzureKMSConfig condition should be set")
+			g.Expect(cond.Status).To(Equal(tc.expectedStatus))
+			if tc.expectedReason != "" {
+				g.Expect(cond.Reason).To(Equal(tc.expectedReason))
+			}
+			if tc.expectMsgContains != "" {
+				g.Expect(cond.Message).To(ContainSubstring(tc.expectMsgContains))
+			}
+			if tc.expectMsgExcludes != "" {
+				g.Expect(cond.Message).ToNot(ContainSubstring(tc.expectMsgExcludes))
+			}
+		})
+	}
+}
+
 // Compile-time assertion that fakeVersionImageMetadataProvider satisfies the interface.
 var _ util.ImageMetadataProvider = &fakeVersionImageMetadataProvider{}
 

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -59,6 +59,10 @@ func ExpectedHCConditions(hostedCluster *hyperv1.HostedCluster) map[hyperv1.Cond
 		if hostedCluster.Spec.SecretEncryption == nil || hostedCluster.Spec.SecretEncryption.KMS == nil || hostedCluster.Spec.SecretEncryption.KMS.Azure == nil {
 			// Azure KMS is not configured
 			conditions[hyperv1.ValidAzureKMSConfig] = metav1.ConditionUnknown
+		} else if netutil.IsAroHCPByHC(hostedCluster) && hostedCluster.Spec.SecretEncryption.KMS.Azure.KeyVaultAccess == hyperv1.AzureKeyVaultPrivate {
+			// CPO cannot validate a private Key Vault from the management cluster;
+			// access is verified at runtime through the private router.
+			conditions[hyperv1.ValidAzureKMSConfig] = metav1.ConditionUnknown
 		} else {
 			conditions[hyperv1.ValidAzureKMSConfig] = metav1.ConditionTrue
 		}

--- a/support/conditions/conditions_test.go
+++ b/support/conditions/conditions_test.go
@@ -1,0 +1,89 @@
+package conditions
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExpectedHCConditions_ValidAzureKMSConfig(t *testing.T) {
+	newAzureHC := func(managedIdentities bool, kms *hyperv1.KMSSpec) *hyperv1.HostedCluster {
+		authType := hyperv1.AzureAuthenticationTypeWorkloadIdentities
+		if managedIdentities {
+			authType = hyperv1.AzureAuthenticationTypeManagedIdentities
+		}
+		hc := &hyperv1.HostedCluster{
+			Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.AzurePlatform,
+					Azure: &hyperv1.AzurePlatformSpec{
+						AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+							AzureAuthenticationConfigType: authType,
+						},
+					},
+				},
+			},
+		}
+		if kms != nil {
+			hc.Spec.SecretEncryption = &hyperv1.SecretEncryptionSpec{
+				Type: hyperv1.KMS,
+				KMS:  kms,
+			}
+		}
+		return hc
+	}
+
+	tests := []struct {
+		name           string
+		hc             *hyperv1.HostedCluster
+		expectedStatus metav1.ConditionStatus
+	}{
+		{
+			name:           "When Azure KMS is not configured, it should expect ValidAzureKMSConfig Unknown",
+			hc:             newAzureHC(true, nil),
+			expectedStatus: metav1.ConditionUnknown,
+		},
+		{
+			name: "When Azure KMS KeyVaultAccess is Private on ARO HCP, it should expect ValidAzureKMSConfig Unknown",
+			hc: newAzureHC(true, &hyperv1.KMSSpec{
+				Provider: hyperv1.AZURE,
+				Azure: &hyperv1.AzureKMSSpec{
+					KeyVaultAccess: hyperv1.AzureKeyVaultPrivate,
+				},
+			}),
+			expectedStatus: metav1.ConditionUnknown,
+		},
+		{
+			name: "When Azure KMS KeyVaultAccess is Public on ARO HCP, it should expect ValidAzureKMSConfig True",
+			hc: newAzureHC(true, &hyperv1.KMSSpec{
+				Provider: hyperv1.AZURE,
+				Azure: &hyperv1.AzureKMSSpec{
+					KeyVaultAccess: hyperv1.AzureKeyVaultPublic,
+				},
+			}),
+			expectedStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "When Azure KMS KeyVaultAccess is Private on self-managed Azure, it should expect ValidAzureKMSConfig True",
+			hc: newAzureHC(false, &hyperv1.KMSSpec{
+				Provider: hyperv1.AZURE,
+				Azure: &hyperv1.AzureKMSSpec{
+					KeyVaultAccess: hyperv1.AzureKeyVaultPrivate,
+				},
+			}),
+			expectedStatus: metav1.ConditionTrue,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := ExpectedHCConditions(tc.hc)
+			g.Expect(got[hyperv1.ValidAzureKMSConfig]).To(Equal(tc.expectedStatus))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Skip `ValidAzureKMSConfig` HTTPS validation for ARO HCP clusters with `KeyVaultAccess: Private`
- CPO cannot reach private Key Vault endpoints — KAS pods access them through the private router (HAProxy TCP passthrough via hostAlias)
- Short-circuit to `ValidAzureKMSConfig: True` with message deferring validation to runtime, matching the existing self-managed Azure pattern

## Bug

[OCPBUGS-97705](https://issues.redhat.com/browse/OCPBUGS-97705)

`validateAzureKMSConfig()` loads managed identity credentials and then attempts direct HTTPS validation against the Key Vault URL. For private Key Vaults, this fails with `403 ForbiddenByConnection` because CPO has no network path to the private endpoint.

## Verification

Tested on a live ARO HCP cluster on AKS (OCP `5.0.0-ec.3`) with custom CPO image containing the fix:

```
$ oc get hostedcontrolplane -n clusters-vsolanki-management-hc -o jsonpath='{.status.conditions[?(@.type=="ValidAzureKMSConfig")]}' | python3 -m json.tool
{
    "lastTransitionTime": "2026-07-09T06:12:33Z",
    "message": "KMS configuration accepted; Key Vault access is validated at runtime through the private router",
    "observedGeneration": 4,
    "reason": "AsExpected",
    "status": "True",
    "type": "ValidAzureKMSConfig"
}
```

## Test plan

- [x] Unit test `TestValidateAzureKMSConfig_PrivateKeyVault` added and passing
- [x] `make test` passes
- [x] `make verify` passes
- [x] Verified on live ARO HCP cluster with private Key Vault KMS config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure KMS validation now correctly succeeds for ARO using private Key Vault endpoints by validating Key Vault access at runtime through the private router.
* **Tests**
  * Added table-driven unit coverage for Azure KMS validation, asserting the condition outcome and message for both private and public Key Vault access cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->