### PR TITLE
NO-JIRA: chore: update core-reviewers membership

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -21,7 +21,6 @@ aliases:
   core-reviewers:
     - enxebre
     - csrwng
-    - sjenning
     - muraee
     - bryan-cox
     - cblecker
@@ -30,6 +29,7 @@ aliases:
     - sdminonne
     - clebs
     - Nirshal
+    - ironcladlou
   karpenter-approvers:
     - elmiko
     - enxebre


### PR DESCRIPTION
## What this PR does / why we need it:

Updates the `core-reviewers` alias in OWNERS_ALIASES:
- Adds Dan Mace (ironcladlou)
- Removes sjenning so he doesn't get pinged for reviews

## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

None

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reviewer alias settings for the core review group, adjusting the set of reviewers used for approvals (one reviewer was removed and another added).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->