### PR TITLE
OCPBUGS-98217: fix(kubevirt): stop hardcoding evictionStrategy=External on KubeVirt VMs

### DIFF
--- a/api/hypershift/v1beta1/kubevirt.go
+++ b/api/hypershift/v1beta1/kubevirt.go
@@ -143,6 +143,22 @@ const (
 	MultiQueueDisable MultiQueueSetting = "Disable"
 )
 
+// KubevirtEvictionStrategy defines the eviction behavior for KubeVirt VMs.
+//
+// +kubebuilder:validation:Enum=LiveMigrate;LiveMigrateIfPossible;External;None
+type KubevirtEvictionStrategy string
+
+const (
+	// EvictionStrategyLiveMigrate live-migrates the VM to another node.
+	EvictionStrategyLiveMigrate KubevirtEvictionStrategy = "LiveMigrate"
+	// EvictionStrategyLiveMigrateIfPossible live-migrates if possible, otherwise kills the VMI.
+	EvictionStrategyLiveMigrateIfPossible KubevirtEvictionStrategy = "LiveMigrateIfPossible"
+	// EvictionStrategyExternal delegates eviction to CAPK for graceful guest drain.
+	EvictionStrategyExternal KubevirtEvictionStrategy = "External"
+	// EvictionStrategyNone kills the VM immediately with no migration or drain.
+	EvictionStrategyNone KubevirtEvictionStrategy = "None"
+)
+
 // KubevirtNodePoolPlatform specifies the configuration of a NodePool when operating
 // on KubeVirt platform.
 type KubevirtNodePoolPlatform struct {
@@ -191,6 +207,26 @@ type KubevirtNodePoolPlatform struct {
 	// +optional
 	// +kubebuilder:validation:MaxItems=10
 	KubevirtHostDevices []KubevirtHostDevice `json:"hostDevices,omitempty"`
+
+	// evictionStrategy defines the eviction behavior for KubeVirt VMs during
+	// infrastructure node drain. When not set and host devices are configured,
+	// the strategy defaults to External to ensure graceful guest node drain
+	// for non-migratable VMs. Otherwise, the cluster-level default from the
+	// KubeVirt configuration applies (typically LiveMigrate on HA clusters
+	// and None on single-node OpenShift, when managed by HCO).
+	//
+	// - LiveMigrate: KubeVirt live-migrates the VM to another node (zero guest
+	//   disruption). If the VM is not migratable, the node drain stalls.
+	// - LiveMigrateIfPossible: live-migrates if possible, otherwise allows the
+	//   VMI pod to be killed (no graceful guest drain).
+	// - External: delegates eviction handling to CAPK, which drains the guest
+	//   node before deleting the VMI. Use this for non-migratable VMs (e.g.,
+	//   with GPU passthrough or SR-IOV) that need graceful guest node drain.
+	// - None: the VM is killed immediately on eviction with no migration or
+	//   graceful guest drain. This is the HCO default on single-node OpenShift.
+	//
+	// +optional
+	EvictionStrategy KubevirtEvictionStrategy `json:"evictionStrategy,omitempty"`
 }
 
 // KubevirtNetwork specifies the configuration for a virtual machine

--- a/api/hypershift/v1beta1/nodepool_types_test.go
+++ b/api/hypershift/v1beta1/nodepool_types_test.go
@@ -2,6 +2,7 @@ package v1beta1
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"k8s.io/utils/ptr"
@@ -21,9 +22,9 @@ func TestNodePoolAutoScalingSerializationCompatibility(t *testing.T) {
 		name string
 		// current is the N (current) version of the struct
 		current NodePoolAutoScaling
-		// expectedJSON is the expected JSON output from marshalling current
+		// expectedJSON is the expected JSON output from marshaling current
 		expectedJSON string
-		// nMinus1Result is the expected result when unmarshalling into the N-1 struct
+		// nMinus1Result is the expected result when unmarshaling into the N-1 struct
 		nMinus1Result nodePoolAutoScalingNMinus1
 	}{
 		{
@@ -91,5 +92,132 @@ func TestNodePoolAutoScalingSerializationCompatibility(t *testing.T) {
 				t.Errorf("Min mismatch after N-1 round-trip: got %v, want %d", roundTripped.Min, tt.nMinus1Result.Min)
 			}
 		})
+	}
+}
+
+func TestKubevirtEvictionStrategySerializationCompatibility(t *testing.T) {
+	tests := []struct {
+		name         string
+		current      KubevirtNodePoolPlatform
+		expectedJSON string
+	}{
+		{
+			name: "When EvictionStrategy is not set it should be omitted from JSON",
+			current: KubevirtNodePoolPlatform{
+				RootVolume: &KubevirtRootVolume{},
+			},
+			expectedJSON: `{"rootVolume":{}}`,
+		},
+		{
+			name: "When EvictionStrategy is External it should be preserved",
+			current: KubevirtNodePoolPlatform{
+				RootVolume:       &KubevirtRootVolume{},
+				EvictionStrategy: EvictionStrategyExternal,
+			},
+			expectedJSON: `{"rootVolume":{},"evictionStrategy":"External"}`,
+		},
+		{
+			name: "When EvictionStrategy is LiveMigrate it should be preserved",
+			current: KubevirtNodePoolPlatform{
+				RootVolume:       &KubevirtRootVolume{},
+				EvictionStrategy: EvictionStrategyLiveMigrate,
+			},
+			expectedJSON: `{"rootVolume":{},"evictionStrategy":"LiveMigrate"}`,
+		},
+		{
+			name: "When EvictionStrategy is None it should be preserved",
+			current: KubevirtNodePoolPlatform{
+				RootVolume:       &KubevirtRootVolume{},
+				EvictionStrategy: EvictionStrategyNone,
+			},
+			expectedJSON: `{"rootVolume":{},"evictionStrategy":"None"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.current)
+			if err != nil {
+				t.Fatalf("failed to marshal current struct: %v", err)
+			}
+			if string(data) != tt.expectedJSON {
+				t.Errorf("unexpected JSON output: got %s, want %s", string(data), tt.expectedJSON)
+			}
+
+			// Round-trip: unmarshal back into current type
+			var roundTripped KubevirtNodePoolPlatform
+			if err := json.Unmarshal(data, &roundTripped); err != nil {
+				t.Fatalf("failed to round-trip unmarshal: %v", err)
+			}
+			if roundTripped.EvictionStrategy != tt.current.EvictionStrategy {
+				t.Errorf("EvictionStrategy mismatch after round-trip: got %q, want %q", roundTripped.EvictionStrategy, tt.current.EvictionStrategy)
+			}
+
+			// N-1 compatibility: verify current JSON can be parsed by code
+			// that doesn't know about evictionStrategy (unknown fields ignored)
+			var rawMap map[string]json.RawMessage
+			if err := json.Unmarshal(data, &rawMap); err != nil {
+				t.Fatalf("failed to unmarshal into raw map: %v", err)
+			}
+
+			// N-1 JSON (without evictionStrategy) deserializes into current struct
+			delete(rawMap, "evictionStrategy")
+			nMinus1Data, err := json.Marshal(rawMap)
+			if err != nil {
+				t.Fatalf("failed to marshal N-1 map: %v", err)
+			}
+			var fromNMinus1 KubevirtNodePoolPlatform
+			if err := json.Unmarshal(nMinus1Data, &fromNMinus1); err != nil {
+				t.Fatalf("N failed to unmarshal JSON from N-1: %v", err)
+			}
+			if fromNMinus1.EvictionStrategy != "" {
+				t.Errorf("EvictionStrategy should be zero value when deserialized from N-1, got %q", fromNMinus1.EvictionStrategy)
+			}
+		})
+	}
+}
+
+func TestKubevirtEvictionStrategyEnumValues(t *testing.T) {
+	expected := []KubevirtEvictionStrategy{
+		EvictionStrategyLiveMigrate,
+		EvictionStrategyLiveMigrateIfPossible,
+		EvictionStrategyExternal,
+		EvictionStrategyNone,
+	}
+
+	for _, strategy := range expected {
+		t.Run("When EvictionStrategy is "+string(strategy)+" it should round-trip through JSON", func(t *testing.T) {
+			src := KubevirtNodePoolPlatform{
+				RootVolume:       &KubevirtRootVolume{},
+				EvictionStrategy: strategy,
+			}
+			data, err := json.Marshal(src)
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+			var dst KubevirtNodePoolPlatform
+			if err := json.Unmarshal(data, &dst); err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+			if dst.EvictionStrategy != strategy {
+				t.Errorf("got %q, want %q", dst.EvictionStrategy, strategy)
+			}
+		})
+	}
+}
+
+func TestKubevirtNodePoolPlatformDeepCopyPreservesEvictionStrategy(t *testing.T) {
+	original := &KubevirtNodePoolPlatform{
+		RootVolume:       &KubevirtRootVolume{},
+		EvictionStrategy: EvictionStrategyExternal,
+	}
+	copied := original.DeepCopy()
+	if !reflect.DeepEqual(original, copied) {
+		t.Errorf("DeepCopy mismatch: got %+v, want %+v", copied, original)
+	}
+	// Mutate copy, verify original unchanged
+	copied.EvictionStrategy = EvictionStrategyNone
+	if original.EvictionStrategy != EvictionStrategyExternal {
+		t.Error("mutating DeepCopy affected original")
 	}
 }

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -1129,6 +1129,30 @@ spec:
                             - Guaranteed
                             type: string
                         type: object
+                      evictionStrategy:
+                        description: |-
+                          evictionStrategy defines the eviction behavior for KubeVirt VMs during
+                          infrastructure node drain. When not set and host devices are configured,
+                          the strategy defaults to External to ensure graceful guest node drain
+                          for non-migratable VMs. Otherwise, the cluster-level default from the
+                          KubeVirt configuration applies (typically LiveMigrate on HA clusters
+                          and None on single-node OpenShift, when managed by HCO).
+
+                          - LiveMigrate: KubeVirt live-migrates the VM to another node (zero guest
+                            disruption). If the VM is not migratable, the node drain stalls.
+                          - LiveMigrateIfPossible: live-migrates if possible, otherwise allows the
+                            VMI pod to be killed (no graceful guest drain).
+                          - External: delegates eviction handling to CAPK, which drains the guest
+                            node before deleting the VMI. Use this for non-migratable VMs (e.g.,
+                            with GPU passthrough or SR-IOV) that need graceful guest node drain.
+                          - None: the VM is killed immediately on eviction with no migration or
+                            graceful guest drain. This is the HCO default on single-node OpenShift.
+                        enum:
+                        - LiveMigrate
+                        - LiveMigrateIfPossible
+                        - External
+                        - None
+                        type: string
                       hostDevices:
                         description: |-
                           hostDevices specifies the host devices (e.g. GPU devices) to be passed

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -1396,6 +1396,30 @@ spec:
                             - Guaranteed
                             type: string
                         type: object
+                      evictionStrategy:
+                        description: |-
+                          evictionStrategy defines the eviction behavior for KubeVirt VMs during
+                          infrastructure node drain. When not set and host devices are configured,
+                          the strategy defaults to External to ensure graceful guest node drain
+                          for non-migratable VMs. Otherwise, the cluster-level default from the
+                          KubeVirt configuration applies (typically LiveMigrate on HA clusters
+                          and None on single-node OpenShift, when managed by HCO).
+
+                          - LiveMigrate: KubeVirt live-migrates the VM to another node (zero guest
+                            disruption). If the VM is not migratable, the node drain stalls.
+                          - LiveMigrateIfPossible: live-migrates if possible, otherwise allows the
+                            VMI pod to be killed (no graceful guest drain).
+                          - External: delegates eviction handling to CAPK, which drains the guest
+                            node before deleting the VMI. Use this for non-migratable VMs (e.g.,
+                            with GPU passthrough or SR-IOV) that need graceful guest node drain.
+                          - None: the VM is killed immediately on eviction with no migration or
+                            graceful guest drain. This is the HCO default on single-node OpenShift.
+                        enum:
+                        - LiveMigrate
+                        - LiveMigrateIfPossible
+                        - External
+                        - None
+                        type: string
                       hostDevices:
                         description: |-
                           hostDevices specifies the host devices (e.g. GPU devices) to be passed

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
@@ -1162,6 +1162,30 @@ spec:
                             - Guaranteed
                             type: string
                         type: object
+                      evictionStrategy:
+                        description: |-
+                          evictionStrategy defines the eviction behavior for KubeVirt VMs during
+                          infrastructure node drain. When not set and host devices are configured,
+                          the strategy defaults to External to ensure graceful guest node drain
+                          for non-migratable VMs. Otherwise, the cluster-level default from the
+                          KubeVirt configuration applies (typically LiveMigrate on HA clusters
+                          and None on single-node OpenShift, when managed by HCO).
+
+                          - LiveMigrate: KubeVirt live-migrates the VM to another node (zero guest
+                            disruption). If the VM is not migratable, the node drain stalls.
+                          - LiveMigrateIfPossible: live-migrates if possible, otherwise allows the
+                            VMI pod to be killed (no graceful guest drain).
+                          - External: delegates eviction handling to CAPK, which drains the guest
+                            node before deleting the VMI. Use this for non-migratable VMs (e.g.,
+                            with GPU passthrough or SR-IOV) that need graceful guest node drain.
+                          - None: the VM is killed immediately on eviction with no migration or
+                            graceful guest drain. This is the HCO default on single-node OpenShift.
+                        enum:
+                        - LiveMigrate
+                        - LiveMigrateIfPossible
+                        - External
+                        - None
+                        type: string
                       hostDevices:
                         description: |-
                           hostDevices specifies the host devices (e.g. GPU devices) to be passed

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -1129,6 +1129,30 @@ spec:
                             - Guaranteed
                             type: string
                         type: object
+                      evictionStrategy:
+                        description: |-
+                          evictionStrategy defines the eviction behavior for KubeVirt VMs during
+                          infrastructure node drain. When not set and host devices are configured,
+                          the strategy defaults to External to ensure graceful guest node drain
+                          for non-migratable VMs. Otherwise, the cluster-level default from the
+                          KubeVirt configuration applies (typically LiveMigrate on HA clusters
+                          and None on single-node OpenShift, when managed by HCO).
+
+                          - LiveMigrate: KubeVirt live-migrates the VM to another node (zero guest
+                            disruption). If the VM is not migratable, the node drain stalls.
+                          - LiveMigrateIfPossible: live-migrates if possible, otherwise allows the
+                            VMI pod to be killed (no graceful guest drain).
+                          - External: delegates eviction handling to CAPK, which drains the guest
+                            node before deleting the VMI. Use this for non-migratable VMs (e.g.,
+                            with GPU passthrough or SR-IOV) that need graceful guest node drain.
+                          - None: the VM is killed immediately on eviction with no migration or
+                            graceful guest drain. This is the HCO default on single-node OpenShift.
+                        enum:
+                        - LiveMigrate
+                        - LiveMigrateIfPossible
+                        - External
+                        - None
+                        type: string
                       hostDevices:
                         description: |-
                           hostDevices specifies the host devices (e.g. GPU devices) to be passed

--- a/client/applyconfiguration/hypershift/v1beta1/kubevirtnodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1beta1/kubevirtnodepoolplatform.go
@@ -24,13 +24,14 @@ import (
 // KubevirtNodePoolPlatformApplyConfiguration represents a declarative configuration of the KubevirtNodePoolPlatform type for use
 // with apply.
 type KubevirtNodePoolPlatformApplyConfiguration struct {
-	RootVolume                 *KubevirtRootVolumeApplyConfiguration  `json:"rootVolume,omitempty"`
-	Compute                    *KubevirtComputeApplyConfiguration     `json:"compute,omitempty"`
-	NetworkInterfaceMultiQueue *hypershiftv1beta1.MultiQueueSetting   `json:"networkInterfaceMultiqueue,omitempty"`
-	AdditionalNetworks         []KubevirtNetworkApplyConfiguration    `json:"additionalNetworks,omitempty"`
-	AttachDefaultNetwork       *bool                                  `json:"attachDefaultNetwork,omitempty"`
-	NodeSelector               map[string]string                      `json:"nodeSelector,omitempty"`
-	KubevirtHostDevices        []KubevirtHostDeviceApplyConfiguration `json:"hostDevices,omitempty"`
+	RootVolume                 *KubevirtRootVolumeApplyConfiguration       `json:"rootVolume,omitempty"`
+	Compute                    *KubevirtComputeApplyConfiguration          `json:"compute,omitempty"`
+	NetworkInterfaceMultiQueue *hypershiftv1beta1.MultiQueueSetting        `json:"networkInterfaceMultiqueue,omitempty"`
+	AdditionalNetworks         []KubevirtNetworkApplyConfiguration         `json:"additionalNetworks,omitempty"`
+	AttachDefaultNetwork       *bool                                       `json:"attachDefaultNetwork,omitempty"`
+	NodeSelector               map[string]string                           `json:"nodeSelector,omitempty"`
+	KubevirtHostDevices        []KubevirtHostDeviceApplyConfiguration      `json:"hostDevices,omitempty"`
+	EvictionStrategy           *hypershiftv1beta1.KubevirtEvictionStrategy `json:"evictionStrategy,omitempty"`
 }
 
 // KubevirtNodePoolPlatformApplyConfiguration constructs a declarative configuration of the KubevirtNodePoolPlatform type for use with
@@ -108,5 +109,13 @@ func (b *KubevirtNodePoolPlatformApplyConfiguration) WithKubevirtHostDevices(val
 		}
 		b.KubevirtHostDevices = append(b.KubevirtHostDevices, *values[i])
 	}
+	return b
+}
+
+// WithEvictionStrategy sets the EvictionStrategy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EvictionStrategy field is set to the value of the last call.
+func (b *KubevirtNodePoolPlatformApplyConfiguration) WithEvictionStrategy(value hypershiftv1beta1.KubevirtEvictionStrategy) *KubevirtNodePoolPlatformApplyConfiguration {
+	b.EvictionStrategy = &value
 	return b
 }

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -1432,6 +1432,30 @@ spec:
                             - Guaranteed
                             type: string
                         type: object
+                      evictionStrategy:
+                        description: |-
+                          evictionStrategy defines the eviction behavior for KubeVirt VMs during
+                          infrastructure node drain. When not set and host devices are configured,
+                          the strategy defaults to External to ensure graceful guest node drain
+                          for non-migratable VMs. Otherwise, the cluster-level default from the
+                          KubeVirt configuration applies (typically LiveMigrate on HA clusters
+                          and None on single-node OpenShift, when managed by HCO).
+
+                          - LiveMigrate: KubeVirt live-migrates the VM to another node (zero guest
+                            disruption). If the VM is not migratable, the node drain stalls.
+                          - LiveMigrateIfPossible: live-migrates if possible, otherwise allows the
+                            VMI pod to be killed (no graceful guest drain).
+                          - External: delegates eviction handling to CAPK, which drains the guest
+                            node before deleting the VMI. Use this for non-migratable VMs (e.g.,
+                            with GPU passthrough or SR-IOV) that need graceful guest node drain.
+                          - None: the VM is killed immediately on eviction with no migration or
+                            graceful guest drain. This is the HCO default on single-node OpenShift.
+                        enum:
+                        - LiveMigrate
+                        - LiveMigrateIfPossible
+                        - External
+                        - None
+                        type: string
                       hostDevices:
                         description: |-
                           hostDevices specifies the host devices (e.g. GPU devices) to be passed

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -1132,6 +1132,30 @@ spec:
                             - Guaranteed
                             type: string
                         type: object
+                      evictionStrategy:
+                        description: |-
+                          evictionStrategy defines the eviction behavior for KubeVirt VMs during
+                          infrastructure node drain. When not set and host devices are configured,
+                          the strategy defaults to External to ensure graceful guest node drain
+                          for non-migratable VMs. Otherwise, the cluster-level default from the
+                          KubeVirt configuration applies (typically LiveMigrate on HA clusters
+                          and None on single-node OpenShift, when managed by HCO).
+
+                          - LiveMigrate: KubeVirt live-migrates the VM to another node (zero guest
+                            disruption). If the VM is not migratable, the node drain stalls.
+                          - LiveMigrateIfPossible: live-migrates if possible, otherwise allows the
+                            VMI pod to be killed (no graceful guest drain).
+                          - External: delegates eviction handling to CAPK, which drains the guest
+                            node before deleting the VMI. Use this for non-migratable VMs (e.g.,
+                            with GPU passthrough or SR-IOV) that need graceful guest node drain.
+                          - None: the VM is killed immediately on eviction with no migration or
+                            graceful guest drain. This is the HCO default on single-node OpenShift.
+                        enum:
+                        - LiveMigrate
+                        - LiveMigrateIfPossible
+                        - External
+                        - None
+                        type: string
                       hostDevices:
                         description: |-
                           hostDevices specifies the host devices (e.g. GPU devices) to be passed

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -1432,6 +1432,30 @@ spec:
                             - Guaranteed
                             type: string
                         type: object
+                      evictionStrategy:
+                        description: |-
+                          evictionStrategy defines the eviction behavior for KubeVirt VMs during
+                          infrastructure node drain. When not set and host devices are configured,
+                          the strategy defaults to External to ensure graceful guest node drain
+                          for non-migratable VMs. Otherwise, the cluster-level default from the
+                          KubeVirt configuration applies (typically LiveMigrate on HA clusters
+                          and None on single-node OpenShift, when managed by HCO).
+
+                          - LiveMigrate: KubeVirt live-migrates the VM to another node (zero guest
+                            disruption). If the VM is not migratable, the node drain stalls.
+                          - LiveMigrateIfPossible: live-migrates if possible, otherwise allows the
+                            VMI pod to be killed (no graceful guest drain).
+                          - External: delegates eviction handling to CAPK, which drains the guest
+                            node before deleting the VMI. Use this for non-migratable VMs (e.g.,
+                            with GPU passthrough or SR-IOV) that need graceful guest node drain.
+                          - None: the VM is killed immediately on eviction with no migration or
+                            graceful guest drain. This is the HCO default on single-node OpenShift.
+                        enum:
+                        - LiveMigrate
+                        - LiveMigrateIfPossible
+                        - External
+                        - None
+                        type: string
                       hostDevices:
                         description: |-
                           hostDevices specifies the host devices (e.g. GPU devices) to be passed

--- a/docs/content/how-to/kubevirt/gpu-devices.md
+++ b/docs/content/how-to/kubevirt/gpu-devices.md
@@ -78,6 +78,7 @@ spec:
       hostDevices:
       - count: 2
         deviceName: nvidia-a100
+      evictionStrategy: External
       networkInterfaceMultiqueue: Enable
       rootVolume:
         persistent:
@@ -86,4 +87,35 @@ spec:
     type: KubeVirt
   replicas: 3
 ```
+
+## Eviction Strategy for GPU NodePools
+
+VMs with GPU passthrough devices are not live-migratable. When
+`hostDevices` are configured on a NodePool and no explicit
+`evictionStrategy` is set, HyperShift automatically defaults to
+`External`. This ensures that draining an infrastructure node does not
+stall waiting for a live migration that can never succeed.
+
+With `External`, the Cluster API Provider for KubeVirt (CAPK) gracefully
+drains the guest node inside the hosted cluster before deleting the VM.
+KubeVirt then recreates the VM on another available node.
+
+If an explicit `evictionStrategy` is set on a NodePool that has
+`hostDevices`, the explicit value takes precedence over the automatic
+default.
+
+For NodePools **without** `hostDevices`, when no `evictionStrategy` is
+set the cluster-level KubeVirt default applies (`LiveMigrate` on HA
+clusters managed by HCO, `None` on single-node OpenShift).
+
+The supported values for `evictionStrategy` are:
+
+| Value | Behavior |
+|-------|----------|
+| *(not set, no hostDevices)* | Uses the cluster-level KubeVirt default (`LiveMigrate` on HA clusters, `None` on single-node). Best for migratable VMs. |
+| *(not set, with hostDevices)* | Automatically defaults to `External` (see above). |
+| `LiveMigrate` | KubeVirt live-migrates the VM on node drain. If the VM is not migratable, the drain stalls. |
+| `LiveMigrateIfPossible` | Live-migrates if possible, otherwise allows the VM to be killed without graceful guest drain. |
+| `External` | CAPK drains the guest node, then deletes the VM. Recommended for non-migratable VMs (GPU, SR-IOV). |
+| `None` | The VM is killed immediately on eviction with no migration or graceful drain. |
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -26492,6 +26492,7 @@ spec:
       hostDevices:
       - count: 2
         deviceName: nvidia-a100
+      evictionStrategy: External
       networkInterfaceMultiqueue: Enable
       rootVolume:
         persistent:
@@ -26500,6 +26501,37 @@ spec:
     type: KubeVirt
   replicas: 3
 ```
+
+## Eviction Strategy for GPU NodePools
+
+VMs with GPU passthrough devices are not live-migratable. When
+`hostDevices` are configured on a NodePool and no explicit
+`evictionStrategy` is set, HyperShift automatically defaults to
+`External`. This ensures that draining an infrastructure node does not
+stall waiting for a live migration that can never succeed.
+
+With `External`, the Cluster API Provider for KubeVirt (CAPK) gracefully
+drains the guest node inside the hosted cluster before deleting the VM.
+KubeVirt then recreates the VM on another available node.
+
+If an explicit `evictionStrategy` is set on a NodePool that has
+`hostDevices`, the explicit value takes precedence over the automatic
+default.
+
+For NodePools **without** `hostDevices`, when no `evictionStrategy` is
+set the cluster-level KubeVirt default applies (`LiveMigrate` on HA
+clusters managed by HCO, `None` on single-node OpenShift).
+
+The supported values for `evictionStrategy` are:
+
+| Value | Behavior |
+|-------|----------|
+| *(not set, no hostDevices)* | Uses the cluster-level KubeVirt default (`LiveMigrate` on HA clusters, `None` on single-node). Best for migratable VMs. |
+| *(not set, with hostDevices)* | Automatically defaults to `External` (see above). |
+| `LiveMigrate` | KubeVirt live-migrates the VM on node drain. If the VM is not migratable, the drain stalls. |
+| `LiveMigrateIfPossible` | Live-migrates if possible, otherwise allows the VM to be killed without graceful guest drain. |
+| `External` | CAPK drains the guest node, then deletes the VM. Recommended for non-migratable VMs (GPU, SR-IOV). |
+| `None` | The VM is killed immediately on eviction with no migration or graceful drain. |
 
 
 
@@ -49937,6 +49969,35 @@ string
 </tr>
 </tbody>
 </table>
+###KubevirtEvictionStrategy { #hypershift.openshift.io/v1beta1.KubevirtEvictionStrategy }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1beta1.KubevirtNodePoolPlatform">KubevirtNodePoolPlatform</a>)
+</p>
+<p>
+<p>KubevirtEvictionStrategy defines the eviction behavior for KubeVirt VMs.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;External&#34;</p></td>
+<td><p>EvictionStrategyExternal delegates eviction to CAPK for graceful guest drain.</p>
+</td>
+</tr><tr><td><p>&#34;LiveMigrate&#34;</p></td>
+<td><p>EvictionStrategyLiveMigrate live-migrates the VM to another node.</p>
+</td>
+</tr><tr><td><p>&#34;LiveMigrateIfPossible&#34;</p></td>
+<td><p>EvictionStrategyLiveMigrateIfPossible live-migrates if possible, otherwise kills the VMI.</p>
+</td>
+</tr><tr><td><p>&#34;None&#34;</p></td>
+<td><p>EvictionStrategyNone kills the VM immediately with no migration or drain.</p>
+</td>
+</tr></tbody>
+</table>
 ###KubevirtHostDevice { #hypershift.openshift.io/v1beta1.KubevirtHostDevice }
 <p>
 (<em>Appears on:</em>
@@ -50176,6 +50237,36 @@ Selector which must match a node&rsquo;s labels for the VM to be scheduled on th
 <em>(Optional)</em>
 <p>hostDevices specifies the host devices (e.g. GPU devices) to be passed
 from the management cluster, to the nodepool nodes</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>evictionStrategy</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1beta1.KubevirtEvictionStrategy">
+KubevirtEvictionStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>evictionStrategy defines the eviction behavior for KubeVirt VMs during
+infrastructure node drain. When not set and host devices are configured,
+the strategy defaults to External to ensure graceful guest node drain
+for non-migratable VMs. Otherwise, the cluster-level default from the
+KubeVirt configuration applies (typically LiveMigrate on HA clusters
+and None on single-node OpenShift, when managed by HCO).</p>
+<ul>
+<li>LiveMigrate: KubeVirt live-migrates the VM to another node (zero guest
+disruption). If the VM is not migratable, the node drain stalls.</li>
+<li>LiveMigrateIfPossible: live-migrates if possible, otherwise allows the
+VMI pod to be killed (no graceful guest drain).</li>
+<li>External: delegates eviction handling to CAPK, which drains the guest
+node before deleting the VMI. Use this for non-migratable VMs (e.g.,
+with GPU passthrough or SR-IOV) that need graceful guest node drain.</li>
+<li>None: the VM is killed immediately on eviction with no migration or
+graceful guest drain. This is the HCO default on single-node OpenShift.</li>
+</ul>
 </td>
 </tr>
 </tbody>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -12030,6 +12030,35 @@ string
 </tr>
 </tbody>
 </table>
+###KubevirtEvictionStrategy { #hypershift.openshift.io/v1beta1.KubevirtEvictionStrategy }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1beta1.KubevirtNodePoolPlatform">KubevirtNodePoolPlatform</a>)
+</p>
+<p>
+<p>KubevirtEvictionStrategy defines the eviction behavior for KubeVirt VMs.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;External&#34;</p></td>
+<td><p>EvictionStrategyExternal delegates eviction to CAPK for graceful guest drain.</p>
+</td>
+</tr><tr><td><p>&#34;LiveMigrate&#34;</p></td>
+<td><p>EvictionStrategyLiveMigrate live-migrates the VM to another node.</p>
+</td>
+</tr><tr><td><p>&#34;LiveMigrateIfPossible&#34;</p></td>
+<td><p>EvictionStrategyLiveMigrateIfPossible live-migrates if possible, otherwise kills the VMI.</p>
+</td>
+</tr><tr><td><p>&#34;None&#34;</p></td>
+<td><p>EvictionStrategyNone kills the VM immediately with no migration or drain.</p>
+</td>
+</tr></tbody>
+</table>
 ###KubevirtHostDevice { #hypershift.openshift.io/v1beta1.KubevirtHostDevice }
 <p>
 (<em>Appears on:</em>
@@ -12269,6 +12298,36 @@ Selector which must match a node&rsquo;s labels for the VM to be scheduled on th
 <em>(Optional)</em>
 <p>hostDevices specifies the host devices (e.g. GPU devices) to be passed
 from the management cluster, to the nodepool nodes</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>evictionStrategy</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1beta1.KubevirtEvictionStrategy">
+KubevirtEvictionStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>evictionStrategy defines the eviction behavior for KubeVirt VMs during
+infrastructure node drain. When not set and host devices are configured,
+the strategy defaults to External to ensure graceful guest node drain
+for non-migratable VMs. Otherwise, the cluster-level default from the
+KubeVirt configuration applies (typically LiveMigrate on HA clusters
+and None on single-node OpenShift, when managed by HCO).</p>
+<ul>
+<li>LiveMigrate: KubeVirt live-migrates the VM to another node (zero guest
+disruption). If the VM is not migratable, the node drain stalls.</li>
+<li>LiveMigrateIfPossible: live-migrates if possible, otherwise allows the
+VMI pod to be killed (no graceful guest drain).</li>
+<li>External: delegates eviction handling to CAPK, which drains the guest
+node before deleting the VMI. Use this for non-migratable VMs (e.g.,
+with GPU passthrough or SR-IOV) that need graceful guest node drain.</li>
+<li>None: the VM is killed immediately on eviction with no migration or
+graceful guest drain. This is the HCO default on single-node OpenShift.</li>
+</ul>
 </td>
 </tr>
 </tbody>

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
@@ -180,8 +180,7 @@ func virtualMachineTemplateBase(nodePool *hyperv1.NodePool, bootImage BootImage)
 							Interfaces: virtualMachineInterfaces(kvPlatform),
 						},
 					},
-					EvictionStrategy: ptr.To(kubevirtv1.EvictionStrategyExternal),
-					Networks:         virtualMachineNetworks(kvPlatform),
+					Networks: virtualMachineNetworks(kvPlatform),
 				},
 			},
 		},
@@ -298,6 +297,13 @@ func virtualMachineTemplateBase(nodePool *hyperv1.NodePool, bootImage BootImage)
 			}
 		}
 		template.Spec.Template.Spec.Domain.Devices.HostDevices = hostDevices
+	}
+
+	if kvPlatform.EvictionStrategy != "" {
+		strategy := kubevirtv1.EvictionStrategy(kvPlatform.EvictionStrategy)
+		template.Spec.Template.Spec.EvictionStrategy = &strategy
+	} else if len(kvPlatform.KubevirtHostDevices) > 0 {
+		template.Spec.Template.Spec.EvictionStrategy = ptr.To(kubevirtv1.EvictionStrategyExternal)
 	}
 
 	return template, nil

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
@@ -532,6 +532,152 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 									DeviceName: "example.com/my-fast-gpu",
 								},
 							}),
+							evictionStrategyTmpltOpt(kubevirtv1.EvictionStrategyExternal),
+						),
+					},
+				},
+			},
+		},
+		{
+			name: "When host devices are configured with explicit eviction strategy, it should use the explicit strategy",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      poolName,
+					Namespace: namespace,
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: clusterName,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: generateKubevirtPlatform(
+							memoryNPOption("5Gi"),
+							coresNPOption(4),
+							imageNPOption("testimage"),
+							volumeNPOption("32Gi"),
+							hostDevicesOption([]hyperv1.KubevirtHostDevice{
+								{
+									DeviceName: "example.com/my-fast-gpu",
+									Count:      1,
+								},
+							}),
+							evictionStrategyNPOption(hyperv1.EvictionStrategyLiveMigrate),
+						),
+					},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-hostedcluster-gpu",
+					Namespace: "clusters",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					InfraID: "1234",
+				},
+			},
+
+			expected: &capikubevirt.KubevirtMachineTemplateSpec{
+				Template: capikubevirt.KubevirtMachineTemplateResource{
+					Spec: capikubevirt.KubevirtMachineSpec{
+						BootstrapCheckSpec: capikubevirt.VirtualMachineBootstrapCheckSpec{CheckStrategy: "none"},
+						VirtualMachineTemplate: *generateNodeTemplate(
+							memoryTmpltOpt("5Gi"),
+							cpuTmpltOpt(4),
+							storageTmpltOpt("32Gi"),
+							hostDevicesTmpltOpt([]kubevirtv1.HostDevice{
+								{
+									Name:       "hostdevice-1",
+									DeviceName: "example.com/my-fast-gpu",
+								},
+							}),
+							evictionStrategyTmpltOpt(kubevirtv1.EvictionStrategyLiveMigrate),
+						),
+					},
+				},
+			},
+		},
+		{
+			name: "When no eviction strategy is set and no host devices, it should leave EvictionStrategy nil",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      poolName,
+					Namespace: namespace,
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: clusterName,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: generateKubevirtPlatform(
+							memoryNPOption("5Gi"),
+							coresNPOption(4),
+							imageNPOption("testimage"),
+							volumeNPOption("32Gi"),
+						),
+					},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-hostedcluster",
+					Namespace: "clusters",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					InfraID: "1234",
+				},
+			},
+
+			expected: &capikubevirt.KubevirtMachineTemplateSpec{
+				Template: capikubevirt.KubevirtMachineTemplateResource{
+					Spec: capikubevirt.KubevirtMachineSpec{
+						BootstrapCheckSpec: capikubevirt.VirtualMachineBootstrapCheckSpec{CheckStrategy: "none"},
+						VirtualMachineTemplate: *generateNodeTemplate(
+							memoryTmpltOpt("5Gi"),
+							cpuTmpltOpt(4),
+							storageTmpltOpt("32Gi"),
+						),
+					},
+				},
+			},
+		},
+		{
+			name: "Eviction strategy is set explicitly",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      poolName,
+					Namespace: namespace,
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: clusterName,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: generateKubevirtPlatform(
+							memoryNPOption("5Gi"),
+							coresNPOption(4),
+							imageNPOption("testimage"),
+							volumeNPOption("32Gi"),
+							evictionStrategyNPOption(hyperv1.EvictionStrategyExternal),
+						),
+					},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-hostedcluster",
+					Namespace: "clusters",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					InfraID: "1234",
+				},
+			},
+
+			expected: &capikubevirt.KubevirtMachineTemplateSpec{
+				Template: capikubevirt.KubevirtMachineTemplateResource{
+					Spec: capikubevirt.KubevirtMachineSpec{
+						BootstrapCheckSpec: capikubevirt.VirtualMachineBootstrapCheckSpec{CheckStrategy: "none"},
+						VirtualMachineTemplate: *generateNodeTemplate(
+							memoryTmpltOpt("5Gi"),
+							cpuTmpltOpt(4),
+							storageTmpltOpt("32Gi"),
+							evictionStrategyTmpltOpt(kubevirtv1.EvictionStrategyExternal),
 						),
 					},
 				},
@@ -1290,6 +1436,12 @@ func hostDevicesOption(hostDevices []hyperv1.KubevirtHostDevice) nodePoolOption 
 	}
 }
 
+func evictionStrategyNPOption(strategy hyperv1.KubevirtEvictionStrategy) nodePoolOption {
+	return func(kvNodePool *hyperv1.KubevirtNodePoolPlatform) {
+		kvNodePool.EvictionStrategy = strategy
+	}
+}
+
 func generateKubevirtPlatform(options ...nodePoolOption) *hyperv1.KubevirtNodePoolPlatform {
 	exampleTemplate := &hyperv1.KubevirtNodePoolPlatform{}
 
@@ -1383,6 +1535,12 @@ func addNetworkOpt(nw kubevirtv1.Network) nodeTemplateOption {
 	}
 }
 
+func evictionStrategyTmpltOpt(strategy kubevirtv1.EvictionStrategy) nodeTemplateOption {
+	return func(template *capikubevirt.VirtualMachineTemplateSpec) {
+		template.Spec.Template.Spec.EvictionStrategy = &strategy
+	}
+}
+
 func annotationsTmpltOpt(annotations map[string]string) nodeTemplateOption {
 	return func(template *capikubevirt.VirtualMachineTemplateSpec) {
 		template.Spec.Template.ObjectMeta.Annotations = annotations
@@ -1453,8 +1611,6 @@ func generateNodeTemplate(options ...nodeTemplateOption) *capikubevirt.VirtualMa
 							},
 						},
 					},
-
-					EvictionStrategy: ptr.To(kubevirtv1.EvictionStrategyExternal),
 
 					Domain: kubevirtv1.DomainSpec{
 						Devices: kubevirtv1.Devices{

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/kubevirt.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/kubevirt.go
@@ -143,6 +143,22 @@ const (
 	MultiQueueDisable MultiQueueSetting = "Disable"
 )
 
+// KubevirtEvictionStrategy defines the eviction behavior for KubeVirt VMs.
+//
+// +kubebuilder:validation:Enum=LiveMigrate;LiveMigrateIfPossible;External;None
+type KubevirtEvictionStrategy string
+
+const (
+	// EvictionStrategyLiveMigrate live-migrates the VM to another node.
+	EvictionStrategyLiveMigrate KubevirtEvictionStrategy = "LiveMigrate"
+	// EvictionStrategyLiveMigrateIfPossible live-migrates if possible, otherwise kills the VMI.
+	EvictionStrategyLiveMigrateIfPossible KubevirtEvictionStrategy = "LiveMigrateIfPossible"
+	// EvictionStrategyExternal delegates eviction to CAPK for graceful guest drain.
+	EvictionStrategyExternal KubevirtEvictionStrategy = "External"
+	// EvictionStrategyNone kills the VM immediately with no migration or drain.
+	EvictionStrategyNone KubevirtEvictionStrategy = "None"
+)
+
 // KubevirtNodePoolPlatform specifies the configuration of a NodePool when operating
 // on KubeVirt platform.
 type KubevirtNodePoolPlatform struct {
@@ -191,6 +207,26 @@ type KubevirtNodePoolPlatform struct {
 	// +optional
 	// +kubebuilder:validation:MaxItems=10
 	KubevirtHostDevices []KubevirtHostDevice `json:"hostDevices,omitempty"`
+
+	// evictionStrategy defines the eviction behavior for KubeVirt VMs during
+	// infrastructure node drain. When not set and host devices are configured,
+	// the strategy defaults to External to ensure graceful guest node drain
+	// for non-migratable VMs. Otherwise, the cluster-level default from the
+	// KubeVirt configuration applies (typically LiveMigrate on HA clusters
+	// and None on single-node OpenShift, when managed by HCO).
+	//
+	// - LiveMigrate: KubeVirt live-migrates the VM to another node (zero guest
+	//   disruption). If the VM is not migratable, the node drain stalls.
+	// - LiveMigrateIfPossible: live-migrates if possible, otherwise allows the
+	//   VMI pod to be killed (no graceful guest drain).
+	// - External: delegates eviction handling to CAPK, which drains the guest
+	//   node before deleting the VMI. Use this for non-migratable VMs (e.g.,
+	//   with GPU passthrough or SR-IOV) that need graceful guest node drain.
+	// - None: the VM is killed immediately on eviction with no migration or
+	//   graceful guest drain. This is the HCO default on single-node OpenShift.
+	//
+	// +optional
+	EvictionStrategy KubevirtEvictionStrategy `json:"evictionStrategy,omitempty"`
 }
 
 // KubevirtNetwork specifies the configuration for a virtual machine


### PR DESCRIPTION
## What this PR does / why we need it:
PR https://github.com/openshift/hypershift/pull/6380 unconditionally set evictionStrategy=External on all KubeVirt
VMs created for HCP NodePools. This overrides the cluster-level default set by HCO (LiveMigrate on HA clusters), forcing CAPK to drain the guest node and delete the VMI on every infra node drain, even when the VM is live-migratable and KubeVirt could transparently migrate it with zero guest disruption.

With External strategy, KubeVirt's evacuation controller skips the VM entirely (VMIMigratableOnEviction returns false for External), so no live migration is ever attempted. Instead, CAPK cordons and drains the guest node, deletes the VMI, and KubeVirt recreates it on another host. This is a full disruption to all workloads on the guest node.

The External strategy is only appropriate for non-migratable VMs (e.g., with GPU passthrough or SR-IOV) where live migration is impossible and CAPK's drain-then-delete is the only graceful option. For the majority of VMs that are migratable, it is strictly worse than letting KubeVirt handle migration automatically via the cluster default.

This commit removes the hardcoded External strategy and adds an optional EvictionStrategy field to KubevirtNodePoolPlatform. When not set, the cluster-level KubeVirt default applies. For NodePools with hostDevices (GPU passthrough, SR-IOV), when no explicit evictionStrategy is set, HyperShift automatically defaults to External to prevent infra node drains from stalling on non-migratable VMs. An explicit evictionStrategy
always takes precedence.

## Which issue(s) this PR fixes:
Fixes https://redhat.atlassian.net/browse/OCPBUGS-98217

## Special notes for your reviewer:
Exposing this to the user is probably not the smartest or more automated solution. On the other side trying to automate it would require changes on:
- kubevirt
- CAPK
- here

Coordinating three releases.
So in terms of effectiveness this is definitively the low hanging fruit solution.

## Checklist:
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [X] This change includes docs. 
- [X] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a KubeVirt node pool `evictionStrategy` option with values: `LiveMigrate`, `LiveMigrateIfPossible`, `External`, and `None`.
* **Bug Fixes**
  * Node templates no longer apply an eviction strategy unless it is explicitly set.
* **Documentation**
  * Updated GPU passthrough node pool examples and added guidance on how each `evictionStrategy` affects VM eviction (including `External` vs `None`).
* **Tests**
  * Added coverage for eviction strategy propagation and JSON serialization/deep-copy compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->