### PR TITLE
AUTOSCALE-870: add KarpenterOperator tech-preview FeatureGate

### DIFF
--- a/hypershift-operator/featuregate/feature.go
+++ b/hypershift-operator/featuregate/feature.go
@@ -34,6 +34,12 @@ const (
 	// alpha: v0.1.49
 	// beta: x.y.z
 	HCPEtcdBackup featuregate.Feature = "HCPEtcdBackup"
+
+	// KarpenterOperator gates deploying the karpenter-operator as a standalone component instead of using the embedded karpenter-operator code in HyperShift.
+	// owner: openshift-autoscaling
+	// alpha: v0.1.79
+	// beta: x.y.z
+	KarpenterOperator featuregate.Feature = "KarpenterOperator"
 )
 
 // Initialize new features here
@@ -44,6 +50,7 @@ var (
 	openStackFeature               = featuregates.NewFeature(OpenStack, featuregates.WithEnableForFeatureSets(configv1.TechPreviewNoUpgrade))
 	gcpHCPFeature                  = featuregates.NewFeature(GCPPlatform, featuregates.WithEnableForFeatureSets(configv1.TechPreviewNoUpgrade))
 	hcpEtcdBackupFeature           = featuregates.NewFeature(HCPEtcdBackup, featuregates.WithEnableForFeatureSets(configv1.TechPreviewNoUpgrade))
+	karpenterOperatorFeature       = featuregates.NewFeature(KarpenterOperator, featuregates.WithEnableForFeatureSets(configv1.TechPreviewNoUpgrade))
 )
 
 func init() {
@@ -52,6 +59,7 @@ func init() {
 	allFeatures.AddFeature(openStackFeature)
 	allFeatures.AddFeature(gcpHCPFeature)
 	allFeatures.AddFeature(hcpEtcdBackupFeature)
+	allFeatures.AddFeature(karpenterOperatorFeature)
 
 	// Default to configuring the Default featureset
 	ConfigureFeatureSet(string(configv1.Default))

--- a/hypershift-operator/featuregate/feature_test.go
+++ b/hypershift-operator/featuregate/feature_test.go
@@ -101,6 +101,7 @@ func TestAllHypershiftOperatorFeatureGates(t *testing.T) {
 				"OpenStack":               false,
 				"GCPPlatform":             false,
 				"HCPEtcdBackup":           false,
+				"KarpenterOperator":       false,
 			},
 		},
 		{
@@ -111,6 +112,7 @@ func TestAllHypershiftOperatorFeatureGates(t *testing.T) {
 				"OpenStack":               true,
 				"GCPPlatform":             true,
 				"HCPEtcdBackup":           true,
+				"KarpenterOperator":       true,
 			},
 		},
 		{
@@ -121,6 +123,7 @@ func TestAllHypershiftOperatorFeatureGates(t *testing.T) {
 				"OpenStack":               false,
 				"GCPPlatform":             false,
 				"HCPEtcdBackup":           false,
+				"KarpenterOperator":       false,
 			},
 		},
 	}
@@ -153,6 +156,12 @@ func TestAllHypershiftOperatorFeatureGates(t *testing.T) {
 			assert.Equal(t, tc.expected["HCPEtcdBackup"], actualHCPEtcdBackup,
 				"HCPEtcdBackup should be %v for feature set %s",
 				tc.expected["HCPEtcdBackup"], tc.featureSet)
+
+			// Test KarpenterOperator
+			actualKarpenterOperator := featuregate.Gate().Enabled(featuregate.KarpenterOperator)
+			assert.Equal(t, tc.expected["KarpenterOperator"], actualKarpenterOperator,
+				"KarpenterOperator should be %v for feature set %s",
+				tc.expected["KarpenterOperator"], tc.featureSet)
 		})
 	}
 }
@@ -163,4 +172,5 @@ func TestFeatureGateConstants(t *testing.T) {
 	assert.Equal(t, "OpenStack", string(featuregate.OpenStack))
 	assert.Equal(t, "GCPPlatform", string(featuregate.GCPPlatform))
 	assert.Equal(t, "HCPEtcdBackup", string(featuregate.HCPEtcdBackup))
+	assert.Equal(t, "KarpenterOperator", string(featuregate.KarpenterOperator))
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Adds KarpenterOperator as a FeatureGate to HyperShift, behind the TechPreview HCP featureset. For now, this feature gate is a no-op.

Refer to openshift/enhancements#2007 for more details on the function of this feature gate.

This is the first part of refactoring karpenter-operator out of HyperShift, and replacing it with the standalone component here: https://github.com/openshift/karpenter-operator

## Which issue(s) this PR fixes:
Fixes https://redhat.atlassian.net/browse/AUTOSCALE-870

## Special notes for your reviewer:

Since this will automatically be enabled anytime someone uses techpreview feature set for HO, we have to be careful that any features we add behind this feature gate to not break anyone's existing HO deployment and HCP clusters.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new feature gate for Karpenter Operator support.
  * Made the feature available for the Tech Preview No Upgrade feature set.

* **Tests**
  * Updated feature gate coverage to verify the new gate is disabled by default and enabled in the Tech Preview No Upgrade set.
  * Added validation for the new feature gate name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->