### PR TITLE
OCPBUGS-98384: fix bastion cleanup KeyPair leak by capturing infraID/region eagerly

### DIFF
--- a/test/e2e/util/dump/journals.go
+++ b/test/e2e/util/dump/journals.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	bastionaws "github.com/openshift/hypershift/cmd/bastion/aws"
@@ -161,13 +162,17 @@ func setupBastion(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluster, 
 	if err != nil {
 		return "", err
 	}
+	infraID := hc.Spec.InfraID
+	region := hc.Spec.Platform.AWS.Region
 	t.Cleanup(func() {
+		destroyCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
 		destroyBastion := bastionaws.DestroyBastionOpts{
-			Namespace:          hc.Namespace,
-			Name:               hc.Name,
+			InfraID:            infraID,
+			Region:             region,
 			AWSCredentialsFile: awsCreds,
 		}
-		if err := destroyBastion.Run(ctx, zapr.NewLoggerWithOptions(destroyLogger)); err != nil {
+		if err := destroyBastion.Run(destroyCtx, zapr.NewLoggerWithOptions(destroyLogger)); err != nil {
 			t.Logf("error destroying bastion: %v", err)
 		}
 	})


### PR DESCRIPTION
## What this PR does / why we need it:

PR #8309 (merged May 11, 2026) refactored `test/e2e/util/dump/journals.go` to reduce cyclomatic complexity, changing bastion cleanup from `defer` to `t.Cleanup()`. This changed the execution order so that bastion destroy now runs **after** the HostedCluster is already deleted from Kubernetes.

Since `DestroyBastionOpts` was constructed with `Name`/`Namespace`, the destroy code tried to look up the already-deleted HC to resolve `infraID` and `region`, failed with a "not found" error, and the error was silently swallowed by `t.Logf`. This left EC2 bastion instances, security groups, and KeyPairs orphaned in AWS on every e2e test run. The AWS KeyPair limit (5000) was hit on June 17, 2026.

**Fix:** Capture `hc.Spec.InfraID` and `hc.Spec.Platform.AWS.Region` at bastion creation time and pass them directly to `DestroyBastionOpts`, bypassing the HC lookup path entirely. Also use `context.Background()` in the cleanup closure to avoid the parent context being cancelled before cleanup runs.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-98384

## Special notes for your reviewer:

`DestroyBastionOpts.Run()` (`cmd/bastion/aws/destroy.go:87-112`) supports two ways to resolve infraID/region: by looking up the HC via `Name`/`Namespace`, or by accepting `InfraID`/`Region` directly. The old test code used the lookup path, which fails when the HC is already deleted. This fix switches to passing `InfraID`/`Region` directly so no Kubernetes call is needed during cleanup.

Reported by Dan Mace.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of temporary bastion infrastructure during end-to-end test runs.
  - Cleanup now uses the correct infrastructure and region details and allows additional time for destruction to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->