### PR TITLE
OCPBUGS-97942: fix(cli): add --service-publishing-strategy flag to hcp create cluster agent

### DIFF
--- a/cmd/cluster/agent/create.go
+++ b/cmd/cluster/agent/create.go
@@ -16,14 +16,22 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const (
+	NodePortServicePublishingStrategy     = "NodePort"
+	LoadBalancerServicePublishingStrategy = "LoadBalancer"
+)
+
 func DefaultOptions() *RawCreateOptions {
-	return &RawCreateOptions{}
+	return &RawCreateOptions{
+		ServicePublishingStrategy: NodePortServicePublishingStrategy,
+	}
 }
 
 type RawCreateOptions struct {
-	APIServerAddress   string
-	AgentNamespace     string
-	AgentLabelSelector string
+	ServicePublishingStrategy string
+	APIServerAddress          string
+	AgentNamespace            string
+	AgentLabelSelector        string
 }
 
 // validatedCreateOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
@@ -37,6 +45,19 @@ type ValidatedCreateOptions struct {
 }
 
 func (o *RawCreateOptions) Validate(ctx context.Context, opts *core.CreateOptions) (core.PlatformCompleter, error) {
+	if o.ServicePublishingStrategy != NodePortServicePublishingStrategy && o.ServicePublishingStrategy != LoadBalancerServicePublishingStrategy {
+		return nil, fmt.Errorf("service publishing strategy %s is not supported, supported options: %s, %s", o.ServicePublishingStrategy, NodePortServicePublishingStrategy, LoadBalancerServicePublishingStrategy)
+	}
+	if o.ServicePublishingStrategy != NodePortServicePublishingStrategy && o.APIServerAddress != "" {
+		return nil, fmt.Errorf("--api-server-address is supported only for NodePort service publishing strategy, service publishing strategy %s is used", o.ServicePublishingStrategy)
+	}
+	if o.APIServerAddress == "" && o.ServicePublishingStrategy == NodePortServicePublishingStrategy && !opts.Render {
+		var err error
+		if o.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx, opts.Log, opts.Kubeconfig); err != nil {
+			return nil, err
+		}
+	}
+
 	return &ValidatedCreateOptions{
 		validatedCreateOptions: &validatedCreateOptions{
 			RawCreateOptions: o,
@@ -47,6 +68,8 @@ func (o *RawCreateOptions) Validate(ctx context.Context, opts *core.CreateOption
 // completedCreateOptions is a private wrapper that enforces a call of Complete() before cluster creation can be invoked.
 type completedCreateOptions struct {
 	*ValidatedCreateOptions
+
+	externalDNSDomain string
 }
 
 type CreateOptions struct {
@@ -55,10 +78,6 @@ type CreateOptions struct {
 }
 
 func (o *ValidatedCreateOptions) Complete(ctx context.Context, opts *core.CreateOptions) (core.Platform, error) {
-	var err error
-	if o.APIServerAddress == "" {
-		o.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx, opts.Log, opts.Kubeconfig)
-	}
 	if opts.DefaultDual {
 		// Using this AgentNamespace field because I cannot infer the Provider we are using at this point
 		// TODO (jparrill): Refactor this to use a 'forward' instead of a 'backward' logic flow
@@ -71,8 +90,9 @@ func (o *ValidatedCreateOptions) Complete(ctx context.Context, opts *core.Create
 	return &CreateOptions{
 		completedCreateOptions: &completedCreateOptions{
 			ValidatedCreateOptions: o,
+			externalDNSDomain:      opts.ExternalDNSDomain,
 		},
-	}, err
+	}, nil
 }
 
 func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) error {
@@ -85,7 +105,16 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 			AgentNamespace: o.AgentNamespace,
 		},
 	}
-	cluster.Spec.Services = core.GetServicePublishingStrategyMappingByAPIServerAddress(o.APIServerAddress, cluster.Spec.Networking.NetworkType)
+
+	switch o.ServicePublishingStrategy {
+	case NodePortServicePublishingStrategy:
+		cluster.Spec.Services = core.GetServicePublishingStrategyMappingByAPIServerAddress(o.APIServerAddress, cluster.Spec.Networking.NetworkType)
+	case LoadBalancerServicePublishingStrategy:
+		cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, o.externalDNSDomain != "")
+	default:
+		return fmt.Errorf("service publishing strategy %s is not supported", o.ServicePublishingStrategy)
+	}
+
 	return nil
 }
 
@@ -112,7 +141,8 @@ func (o *CreateOptions) GenerateResources() ([]crclient.Object, error) {
 var _ core.Platform = (*CreateOptions)(nil)
 
 func BindOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
-	flags.StringVar(&opts.APIServerAddress, "api-server-address", opts.APIServerAddress, "The IP address to be used for the hosted cluster's Kubernetes API communication. Requires management cluster connectivity if left unset.")
+	flags.StringVar(&opts.ServicePublishingStrategy, "service-publishing-strategy", opts.ServicePublishingStrategy, fmt.Sprintf("Define how to expose the cluster services. Supported options: %s (Use LoadBalancer and Route to expose services), %s (Select a random node to expose service access through NodePort)", LoadBalancerServicePublishingStrategy, NodePortServicePublishingStrategy))
+	flags.StringVar(&opts.APIServerAddress, "api-server-address", opts.APIServerAddress, "The IP address to be used for the hosted cluster's Kubernetes API communication. Only used with NodePort service publishing strategy. Requires management cluster connectivity if left unset.")
 	flags.StringVar(&opts.AgentNamespace, "agent-namespace", opts.AgentNamespace, "The namespace in which to search for Agents")
 	flags.StringVar(&opts.AgentLabelSelector, "agentLabelSelector", opts.AgentLabelSelector, "A LabelSelector for selecting Agents according to their labels, e.g., 'size=large,zone notin (az1,az2)'")
 }

--- a/cmd/cluster/agent/create.go
+++ b/cmd/cluster/agent/create.go
@@ -110,7 +110,7 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 	case NodePortServicePublishingStrategy:
 		cluster.Spec.Services = core.GetServicePublishingStrategyMappingByAPIServerAddress(o.APIServerAddress, cluster.Spec.Networking.NetworkType)
 	case LoadBalancerServicePublishingStrategy:
-		cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, o.externalDNSDomain != "")
+		cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, o.externalDNSDomain != "", false)
 	default:
 		return fmt.Errorf("service publishing strategy %s is not supported", o.ServicePublishingStrategy)
 	}

--- a/cmd/cluster/agent/create_test.go
+++ b/cmd/cluster/agent/create_test.go
@@ -12,12 +12,58 @@ import (
 
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
 )
 
+func TestRawCreateOptions_Validate(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		input         RawCreateOptions
+		expectedError string
+	}{
+		{
+			name: "When service-publishing-strategy is unsupported, it should return an error",
+			input: RawCreateOptions{
+				ServicePublishingStrategy: "whatever",
+			},
+			expectedError: "service publishing strategy whatever is not supported, supported options: NodePort, LoadBalancer",
+		},
+		{
+			name: "When api-server-address is set with LoadBalancer strategy, it should return an error",
+			input: RawCreateOptions{
+				ServicePublishingStrategy: LoadBalancerServicePublishingStrategy,
+				APIServerAddress:          "1.2.3.4",
+			},
+			expectedError: "--api-server-address is supported only for NodePort service publishing strategy, service publishing strategy LoadBalancer is used",
+		},
+		{
+			name: "When service-publishing-strategy is NodePort, it should pass validation",
+			input: RawCreateOptions{
+				ServicePublishingStrategy: NodePortServicePublishingStrategy,
+				APIServerAddress:          "1.2.3.4",
+			},
+		},
+		{
+			name: "When service-publishing-strategy is LoadBalancer, it should pass validation",
+			input: RawCreateOptions{
+				ServicePublishingStrategy: LoadBalancerServicePublishingStrategy,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var errString string
+			if _, err := test.input.Validate(t.Context(), nil); err != nil {
+				errString = err.Error()
+			}
+			if diff := cmp.Diff(test.expectedError, errString); diff != "" {
+				t.Errorf("got incorrect error: %v", diff)
+			}
+		})
+	}
+}
+
 func TestCreateCluster(t *testing.T) {
-	utilrand.Seed(1234567890)
-	certs.UnsafeSeed(1234567890)
 	ctx := framework.InterruptableContext(t.Context())
 
 	tempDir := t.TempDir()
@@ -41,8 +87,20 @@ func TestCreateCluster(t *testing.T) {
 				"--pull-secret=" + pullSecretFile,
 			},
 		},
+		{
+			name: "When service-publishing-strategy is LoadBalancer, it should render LoadBalancer services",
+			args: []string{
+				"--service-publishing-strategy=LoadBalancer",
+				"--render-sensitive",
+				"--name=example",
+				"--pull-secret=" + pullSecretFile,
+			},
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
+			utilrand.Seed(1234567890)
+			certs.UnsafeSeed(1234567890)
+
 			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
 			coreOpts := core.DefaultOptions()
 			core.BindDeveloperOptions(coreOpts, flags)

--- a/cmd/cluster/agent/create_test.go
+++ b/cmd/cluster/agent/create_test.go
@@ -23,6 +23,13 @@ func TestRawCreateOptions_Validate(t *testing.T) {
 		expectedError string
 	}{
 		{
+			name: "When service-publishing-strategy is not provided, it should return an error",
+			input: RawCreateOptions{
+				ServicePublishingStrategy: "",
+			},
+			expectedError: "service publishing strategy  is not supported, supported options: NodePort, LoadBalancer",
+		},
+		{
 			name: "When service-publishing-strategy is unsupported, it should return an error",
 			input: RawCreateOptions{
 				ServicePublishingStrategy: "whatever",
@@ -64,6 +71,8 @@ func TestRawCreateOptions_Validate(t *testing.T) {
 }
 
 func TestCreateCluster(t *testing.T) {
+	utilrand.Seed(1234567890)
+	certs.UnsafeSeed(1234567890)
 	ctx := framework.InterruptableContext(t.Context())
 
 	tempDir := t.TempDir()
@@ -98,9 +107,6 @@ func TestCreateCluster(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			utilrand.Seed(1234567890)
-			certs.UnsafeSeed(1234567890)
-
 			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
 			coreOpts := core.DefaultOptions()
 			core.BindDeveloperOptions(coreOpts, flags)

--- a/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_When_service_publishing_strategy_is_LoadBalancer__it_should_render_LoadBalancer_services.yaml
+++ b/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_When_service_publishing_strategy_is_LoadBalancer__it_should_render_LoadBalancer_services.yaml
@@ -1,0 +1,122 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clusters
+spec: {}
+status: {}
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: ZmFrZQ==
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-pull-secret
+  namespace: clusters
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: capi-provider-role
+rules:
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - agents
+  verbs:
+  - '*'
+---
+apiVersion: v1
+data:
+  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  autoscaling: {}
+  capabilities: {}
+  configuration: {}
+  controllerAvailabilityPolicy: SingleReplica
+  dns:
+    baseDomain: example.com
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: 8Gi
+        type: PersistentVolume
+    managementType: Managed
+  fips: false
+  infraID: example-sffhb
+  networking:
+    clusterNetwork:
+    - cidr: 10.132.0.0/14
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - cidr: 172.31.0.0/16
+  olmCatalogPlacement: management
+  platform:
+    agent:
+      agentNamespace: ""
+    type: Agent
+  pullSecret:
+    name: example-pull-secret
+  release:
+    image: ""
+  secretEncryption:
+    aescbc:
+      activeKey:
+        name: example-etcd-encryption-key
+    type: aescbc
+  services:
+  - service: APIServer
+    servicePublishingStrategy:
+      type: LoadBalancer
+  - service: Ignition
+    servicePublishingStrategy:
+      type: Route
+  - service: Konnectivity
+    servicePublishingStrategy:
+      type: Route
+  - service: OAuthServer
+    servicePublishingStrategy:
+      type: Route
+  sshKey: {}
+status:
+  controlPlaneEndpoint:
+    host: ""
+    port: 0
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  arch: amd64
+  clusterName: example
+  management:
+    autoRepair: false
+    upgradeType: InPlace
+  nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
+  platform:
+    agent: {}
+    type: Agent
+  release:
+    image: ""
+  replicas: 0
+status:
+  replicas: 0
+---

--- a/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_When_service_publishing_strategy_is_LoadBalancer__it_should_render_LoadBalancer_services.yaml
+++ b/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_When_service_publishing_strategy_is_LoadBalancer__it_should_render_LoadBalancer_services.yaml
@@ -15,21 +15,9 @@ metadata:
   name: example-pull-secret
   namespace: clusters
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: capi-provider-role
-rules:
-- apiGroups:
-  - agent-install.openshift.io
-  resources:
-  - agents
-  verbs:
-  - '*'
----
 apiVersion: v1
 data:
-  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
+  key: FYHY8RFxHaJUPFFWuo2z9iWCO01hcj3fqHMMWMeEHHw=
 kind: Secret
 metadata:
   labels:
@@ -58,7 +46,7 @@ spec:
         type: PersistentVolume
     managementType: Managed
   fips: false
-  infraID: example-sffhb
+  infraID: example-f9nvz
   networking:
     clusterNetwork:
     - cidr: 10.132.0.0/14


### PR DESCRIPTION
## Summary

- Adds a `--service-publishing-strategy` flag to `hcp create cluster agent` supporting `NodePort` (default, backward-compatible) and `LoadBalancer` options
- When `LoadBalancer` is selected, APIServer uses LoadBalancer and OAuthServer/Konnectivity/Ignition use Route, matching the documented preferred method for bare metal
- Adds validation: rejects unsupported strategies, rejects `--api-server-address` with LoadBalancer strategy, auto-detects address only for NodePort

Fixes [OCPBUGS-97942](https://redhat.atlassian.net/browse/OCPBUGS-97942)

## Test plan

- [x] New `TestRawCreateOptions_Validate` with 4 cases covering validation logic
- [x] New `TestCreateCluster` case for LoadBalancer strategy rendering with fixture
- [x] Existing NodePort test continues to pass unchanged
- [x] `make lint-fix` passes with 0 issues
- [ ] CI e2e tests


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for choosing how cluster services are published: NodePort or LoadBalancer.
  * Added the `--service-publishing-strategy` command-line option, defaulting to NodePort.
  * LoadBalancer publishing now supports optional external DNS configuration.
  * API server address configuration is validated according to the selected publishing strategy.

* **Bug Fixes**
  * Improved conditional handling of API server address discovery and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->