### PR TITLE
CNTRLPLANE-3831: skip UpstreamParity OIDC tests on releases before 4.23

### DIFF
--- a/test/e2e/external_oidc_test.go
+++ b/test/e2e/external_oidc_test.go
@@ -249,7 +249,11 @@ func TestExternalOIDC(t *testing.T) {
 		// Auth config adds: CEL expressions for username/groups (NO prefixes)
 		// Auth config adds: Claim validation rules (email exists, email_verified)
 		// Auth config adds: User validation rules (no system: prefix, no 'forbidden' word)
+		// KAS in releases before 4.23 does not support CEL-based OIDC claim mapping;
+		// patching the auth config has no effect and the legacy prefix-based mapping persists,
+		// causing these subtests to timeout waiting for a config reload that never happens.
 		if featuregates.Gate().Enabled(featuregates.ExternalOIDCWithUpstreamParity) {
+			e2eutil.AtLeast(t, e2eutil.Version423)
 			upstreamParityOpts := clusterOpts
 			upstreamParityOpts.FeatureSet = string(configv1.TechPreviewNoUpgrade)
 			upstreamParityOpts.ExtOIDCConfig.CustomizeAuthSpec = func(spec *configv1.AuthenticationSpec) {


### PR DESCRIPTION
## Summary

- Skip `[OCPFeatureGate:ExternalOIDCWithUpstreamParity]` subtests when the release image is < 4.23

Fixes: https://issues.redhat.com/browse/CNTRLPLANE-3831

## Root Cause

The `ExternalOIDCWithUpstreamParity` subtests rely on CEL-based OIDC claim mapping in KAS, which is not functional before 4.23. On 4.22 and 4.21, patching the HostedCluster auth config has no effect — KAS keeps the legacy prefix-based mapping, causing:

1. **Timeout** (5min) waiting for CEL username mapping to take effect
2. **401 Unauthorized** cascade when creating Keycloak groups
3. **Panic** (`rand.Intn(0)`) from empty available-users list

The `e2e-aws-external-oidc-techpreview` periodic has been at **0% pass rate** on 4.22 and 4.21 since the subtests were added (April 2026). The same tests pass consistently on 5.0 and 4.23.

| Release | Pass rate | UpstreamParity subtests |
|---------|-----------|------------------------|
| 5.0 | 69.2% (last 3: 100%) | PASS |
| 4.23 | passes when infra cooperates | PASS |
| 4.22 | 0% (13 runs) | FAIL — KAS ignores CEL config |
| 4.21 | 0% (13 runs) | FAIL — KAS ignores CEL config |

## Changes

One `AtLeast(t, Version423)` guard before the `ExternalOIDCWithUpstreamParity` block. The base `ExternalOIDC` and `ExternalOIDCWithUIDAndExtraClaimMappings` subtests are unaffected and continue running on all versions.

## Test plan

- [ ] `go vet ./test/e2e/...` passes
- [ ] On 4.22/4.21 periodics: `UpstreamParity` subtests are skipped, remaining OIDC tests still run
- [ ] On 5.0/4.23 periodics: all subtests continue to run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated external OIDC end-to-end coverage to run upstream parity validation only on Kubernetes Authentication Service versions that support CEL-based OIDC claim mapping (4.23+).
  * Avoided running parity-related checks on older versions where the configuration would have no effect, reducing the risk of timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->