### PR TITLE
OCPBUGS-98464: handle stale DaemonSet in GlobalPullSecret test

### DIFF
--- a/test/e2e/util/globalps.go
+++ b/test/e2e/util/globalps.go
@@ -26,7 +26,8 @@ const (
 )
 
 // CreateKubeletConfigVerifierDaemonSet creates a DaemonSet that verifies the config.json file
-// on all nodes of the cluster, comparing it with the cluster's pull secret
+// on all nodes of the cluster, comparing it with the cluster's pull secret.
+// Stale resources from a previous failed run are cleaned up before creation.
 func CreateKubeletConfigVerifierDaemonSet(ctx context.Context, guestClient crclient.Client, dsImage string) error {
 	// Get the cluster's pull secret for comparison
 	pullSecret := &corev1.Secret{}
@@ -48,6 +49,17 @@ func CreateKubeletConfigVerifierDaemonSet(ctx context.Context, guestClient crcli
 		if !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create pull secret: %w", err)
 		}
+	}
+
+	// Clean up any stale DaemonSet left by a previous failed run
+	staleDS := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KubeletConfigVerifierDaemonSetName,
+			Namespace: KubeletConfigVerifierNamespace,
+		},
+	}
+	if err := guestClient.Delete(ctx, staleDS); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete stale DaemonSet: %w", err)
 	}
 
 	daemonSet := &appsv1.DaemonSet{
@@ -205,6 +217,29 @@ func CreateKubeletConfigVerifierDaemonSet(ctx context.Context, guestClient crcli
 func VerifyKubeletConfigWithDaemonSet(t *testing.T, ctx context.Context, guestClient crclient.Client, dsImage string, expectedNodeCount int32) {
 	g := NewWithT(t)
 
+	// Register cleanup first so it runs even if the test fails or times out
+	t.Cleanup(func() {
+		t.Log("Cleaning up kubelet config verifier resources")
+		ds := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      KubeletConfigVerifierDaemonSetName,
+				Namespace: KubeletConfigVerifierNamespace,
+			},
+		}
+		if err := guestClient.Delete(ctx, ds); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Warning: failed to clean up DaemonSet: %v", err)
+		}
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pull-secret",
+				Namespace: KubeletConfigVerifierNamespace,
+			},
+		}
+		if err := guestClient.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Warning: failed to clean up pull secret: %v", err)
+		}
+	})
+
 	// Create the DaemonSet
 	t.Log("Creating kubelet config verifier DaemonSet")
 	err := CreateKubeletConfigVerifierDaemonSet(ctx, guestClient, dsImage)
@@ -218,23 +253,4 @@ func VerifyKubeletConfigWithDaemonSet(t *testing.T, ctx context.Context, guestCl
 	konnectivityDS := hccomanifests.KonnectivityAgentDaemonSet()
 	g.Expect(waitForDaemonSetReady(t, ctx, guestClient, konnectivityDS.Name, konnectivityDS.Namespace, expectedNodeCount)).To(Succeed())
 	g.Expect(waitForDaemonSetReady(t, ctx, guestClient, KubeletConfigVerifierDaemonSetName, KubeletConfigVerifierNamespace, expectedNodeCount)).To(Succeed())
-
-	// Clean up the DaemonSet after verification
-	t.Log("Cleaning up kubelet config verifier DaemonSet")
-	daemonSet := &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      KubeletConfigVerifierDaemonSetName,
-			Namespace: KubeletConfigVerifierNamespace,
-		},
-	}
-	g.Expect(guestClient.Delete(ctx, daemonSet)).To(Succeed())
-
-	// Clean up pull-secret secret in kube-system namespace
-	pullSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pull-secret",
-			Namespace: KubeletConfigVerifierNamespace,
-		},
-	}
-	g.Expect(guestClient.Delete(ctx, pullSecret)).To(Succeed())
 }


### PR DESCRIPTION
## Summary

- Delete any stale `kubelet-config-verifier` DaemonSet before creating a new one in `CreateKubeletConfigVerifierDaemonSet`
- Move resource cleanup to `t.Cleanup()` in `VerifyKubeletConfigWithDaemonSet` so it runs even when the test fails or times out

## Fixes

- https://redhat.atlassian.net/browse/OCPBUGS-98464

## Root Cause

The `EnsureGlobalPullSecret` test creates a `kubelet-config-verifier` DaemonSet to verify pull secret propagation. Two issues caused intermittent 409 errors and cascading failures:

1. **No stale resource handling**: `CreateKubeletConfigVerifierDaemonSet` used a raw `client.Create()` with no `AlreadyExists` handling. If a previous test run left the DaemonSet behind (e.g., after a timeout), the next run got a 409 and failed.

2. **Cleanup dependent on test success**: Resource cleanup ran inline after the readiness wait using `g.Expect().To(Succeed())`. If the readiness wait timed out, cleanup never executed — leaving stale resources for the next run.

## Changes

| What | Before | After |
|------|--------|-------|
| Stale DS | 409 AlreadyExists → test fails | Delete stale DS (ignore NotFound) → create fresh |
| Cleanup | Inline after readiness wait (skipped on failure) | `t.Cleanup()` — always runs |
| Cleanup errors | `g.Expect` (fails the test on cleanup error) | `t.Logf` warning (non-fatal) |

## Test plan

- [x] Unit tested all scenarios locally (stale DS, no DS, stale pull secret, cleanup after failure)
- [ ] `e2e-aws-ovn` periodic should no longer hit 409 errors on the `kubelet-config-verifier` DaemonSet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kubelet configuration verification test cleanup, including automatic removal of temporary resources when tests fail or time out.
  * Prevented conflicts from stale verifier resources by removing existing resources before creating new ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->