### PR TITLE
OCPBUGS-98571: Skip Azure topology LB scope override for ARO HCP IngressController

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/globalconfig"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -47,7 +48,12 @@ func NewIngressParams(hcp *hyperv1.HostedControlPlane) *IngressParams {
 			loadBalancerScope = v1.InternalLoadBalancer
 		}
 	}
+	// For self-managed Azure clusters, set internal LB scope when topology
+	// requires private connectivity. ARO HCP clusters are excluded because
+	// they use shared ingress — the guest cluster's ingress operator should
+	// not create a per-cluster internal LB that bypasses the shared router.
 	if hcp.Spec.Platform.Type == hyperv1.AzurePlatform && hcp.Spec.Platform.Azure != nil &&
+		!azureutil.IsAroHCPByHCP(hcp) &&
 		(hcp.Spec.Platform.Azure.Topology == hyperv1.AzureTopologyPrivate ||
 			hcp.Spec.Platform.Azure.Topology == hyperv1.AzureTopologyPublicAndPrivate) {
 		loadBalancerScope = v1.InternalLoadBalancer

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params_test.go
@@ -208,6 +208,92 @@ func TestNewIngressParams(t *testing.T) {
 			},
 		},
 		{
+			name: "When ARO HCP Azure topology is PublicAndPrivate it should set external load balancer scope",
+			args: args{
+				hcp: &hyperv1.HostedControlPlane{
+					Spec: hyperv1.HostedControlPlaneSpec{
+						Platform: hyperv1.PlatformSpec{
+							Type: hyperv1.AzurePlatform,
+							Azure: &hyperv1.AzurePlatformSpec{
+								Topology: hyperv1.AzureTopologyPublicAndPrivate,
+								AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+									AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeManagedIdentities,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &IngressParams{
+				IngressSubdomain:  "apps.",
+				Replicas:          1,
+				PlatformType:      hyperv1.AzurePlatform,
+				IsPrivate:         false,
+				IBMCloudUPI:       false,
+				AWSNLB:            false,
+				LoadBalancerScope: v1.ExternalLoadBalancer,
+			},
+		},
+		{
+			name: "When ARO HCP Azure topology is Private it should set external load balancer scope",
+			args: args{
+				hcp: &hyperv1.HostedControlPlane{
+					Spec: hyperv1.HostedControlPlaneSpec{
+						Platform: hyperv1.PlatformSpec{
+							Type: hyperv1.AzurePlatform,
+							Azure: &hyperv1.AzurePlatformSpec{
+								Topology: hyperv1.AzureTopologyPrivate,
+								AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+									AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeManagedIdentities,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &IngressParams{
+				IngressSubdomain:  "apps.",
+				Replicas:          1,
+				PlatformType:      hyperv1.AzurePlatform,
+				IsPrivate:         false,
+				IBMCloudUPI:       false,
+				AWSNLB:            false,
+				LoadBalancerScope: v1.ExternalLoadBalancer,
+			},
+		},
+		{
+			name: "When ARO HCP has IngressControllerLoadBalancerScope annotation set to Internal it should respect it",
+			args: args{
+				hcp: &hyperv1.HostedControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							hyperv1.IngressControllerLoadBalancerScope: string(v1.InternalLoadBalancer),
+						},
+					},
+					Spec: hyperv1.HostedControlPlaneSpec{
+						Platform: hyperv1.PlatformSpec{
+							Type: hyperv1.AzurePlatform,
+							Azure: &hyperv1.AzurePlatformSpec{
+								Topology: hyperv1.AzureTopologyPublicAndPrivate,
+								AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+									AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeManagedIdentities,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &IngressParams{
+				IngressSubdomain:  "apps.",
+				Replicas:          1,
+				PlatformType:      hyperv1.AzurePlatform,
+				IsPrivate:         false,
+				IBMCloudUPI:       false,
+				AWSNLB:            false,
+				LoadBalancerScope: v1.InternalLoadBalancer,
+			},
+		},
+		{
 			name: "When Azure endpoint access is Public it should set external load balancer scope",
 			args: args{
 				hcp: &hyperv1.HostedControlPlane{


### PR DESCRIPTION
## What this PR does / why we need it:

PR #7821 ([CNTRLPLANE-2172](https://redhat.atlassian.net/browse/CNTRLPLANE-2172)) added code in the HCCO's `NewIngressParams()` to force `InternalLoadBalancer` scope on the guest-cluster IngressController for Azure clusters with `Private` or `PublicAndPrivate` topology. This was correct for **self-managed Azure** but also affected **ARO HCP** clusters, which use shared ingress and should keep `ExternalLoadBalancer` scope (or defer to the annotation set by Cluster Service).

When CS sets `topology=PublicAndPrivate` on ARO HCP clusters (as required by the enhancement openshift/enhancements#1985), the HCCO creates the IngressController with `loadBalancerScope=Internal`. This causes:
- The ingress operator creates a per-cluster internal Azure LB (10.0.0.5)
- `*.apps` DNS points to this private IP instead of the shared ingress public IP
- Application routes are unreachable externally

This PR adds an `IsAroHCPByHCP` guard so the topology-based scope override only applies to self-managed Azure. ARO HCP clusters now respect the `IngressControllerLoadBalancerScope` annotation propagated from the HostedCluster, matching the pattern already used in `router.go`.

The fix commit is authored by @zgalor who identified the root cause and wrote the initial fix in #8993.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-98571

## Special notes for your reviewer:

### Root cause analysis

There is exactly **one code path** that sets the IngressController LB scope — `params.go:50-54`. The fix is a one-line guard addition.

### Empirical validation on a live ARO HCP cluster

The fix was validated on @zgalor's ARO HCP cluster (`zg-fix-ingress`):

1. **`azureAuthenticationConfigType = ManagedIdentities`** on the HCP — confirmed `IsAroHCPByHCP` returns `true`
2. **`MANAGED_SERVICE = ARO-HCP`** set on the HCCO deployment
3. After overriding the HCCO image with the fix and deleting the IngressController, it was recreated with `scope: External`

### Why the initial fix attempt appeared to fail

@zgalor's initial fix attempt (PR #8993) appeared not to work for two compounding reasons:

1. **Day-2 skip**: `ReconcileDefaultIngressController` in `reconcile.go:18-20` skips reconciliation when the IngressController already exists (`ResourceVersion != ""`). Deleting the IngressController is required.
2. **CPO ≠ HCCO image**: @zgalor built and deployed a custom CPO image, but the `params.go` code runs inside the **HCCO**, which is a separate Deployment. The CPO sets the HCCO image from `HOSTED_CLUSTER_CONFIG_OPERATOR_IMAGE` (set by the hypershift-operator to `cpo.Image`), not from its own container image. Patching the CPO container doesn't change the HCCO. Once the HCCO image was explicitly overridden, the fix worked.

### Why the guard is correct

- **Self-managed Azure** uses `AzureAuthenticationTypeWorkloadIdentities` → `IsAroHCPByHCP` returns `false` → topology override fires as before (no regression)
- **ARO HCP** uses `AzureAuthenticationTypeManagedIdentities` → `IsAroHCPByHCP` returns `true` → topology override is skipped → scope comes from annotation (lines 38-40) or defaults to `ExternalLoadBalancer`
- This matches the guard pattern used in `router.go:61`: `!azureutil.IsAroHCPByHCP(hcp)`

### Note on CodeRabbit review comment (PR #8993)

CodeRabbit suggested also gating the annotation path (`IngressControllerLoadBalancerScope`) on `!IsAroHCPByHCP`. This is **incorrect** — the annotation is the mechanism Cluster Service uses to control the scope. Blocking it for ARO HCP would break CS's ability to configure private ingress when needed. The unit test "When ARO HCP has annotation set to Internal it should respect it" explicitly validates this behavior.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Azure ingress load balancer behavior for ARO hosted control planes on **private** and **public-and-private** Azure topologies, ensuring they use an **external** load balancer.
* **Tests**
  * Expanded ingress parameter tests to cover ARO-specific load balancer scope selection for the affected Azure topologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->