### PR TITLE
OCPBUGS-98571: Exclude ARO HCP from internal LB scope for PublicAndPrivate topology

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/globalconfig"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -47,7 +48,12 @@ func NewIngressParams(hcp *hyperv1.HostedControlPlane) *IngressParams {
 			loadBalancerScope = v1.InternalLoadBalancer
 		}
 	}
+	// For self-managed Azure clusters, set internal LB scope when topology
+	// requires private connectivity. ARO HCP clusters are excluded because
+	// they use shared ingress — the guest cluster's ingress operator should
+	// not create a per-cluster internal LB that bypasses the shared router.
 	if hcp.Spec.Platform.Type == hyperv1.AzurePlatform && hcp.Spec.Platform.Azure != nil &&
+		!azureutil.IsAroHCPByHCP(hcp) &&
 		(hcp.Spec.Platform.Azure.Topology == hyperv1.AzureTopologyPrivate ||
 			hcp.Spec.Platform.Azure.Topology == hyperv1.AzureTopologyPublicAndPrivate) {
 		loadBalancerScope = v1.InternalLoadBalancer


### PR DESCRIPTION
## Summary

Adds an `IsAroHCPByHCP` guard to the HCCO's `params.go` to prevent setting `loadBalancerScope=InternalLoadBalancer` on ARO HCP clusters with `PublicAndPrivate` topology. This matches the existing guard pattern in `router.go`.

## Problem

When CS sets `topology=PublicAndPrivate` on Swift-enabled HostedClusters (as required by the enhancement openshift/enhancements#1985), the HCCO creates the guest cluster's IngressController with `loadBalancerScope=Internal`. This causes the ingress operator to create a per-cluster internal Azure LB (`<infraID>-internal`), bypassing the shared ingress router that ARO HCP uses. The `*.apps` DNS record points to the internal LB private IP (10.0.0.5) instead of the shared ingress public IP, making application routes unreachable externally.

## Validation

- Validated on OCP 4.22.3 with `topology=PublicAndPrivate` on a personal dev environment
- Baseline cluster (no fix): `-internal` LB created at 10.0.0.5, IngressController `scope: Internal`
- Fix cluster: after overriding the **HCCO image** (not just the CPO image) with this fix and deleting the IngressController, the HCCO recreated it with `scope: External`
- Note: initial testing only overrode the CPO image which did not work — the HCCO is a separate deployment pulled from the release image, so the fix must be applied to the HCCO image specifically

## Bug

https://redhat.atlassian.net/browse/OCPBUGS-98571

## References

- Enhancement: https://github.com/openshift/enhancements/pull/1985
- PR #7821 (added the params.go code): https://github.com/openshift/hypershift/pull/7821
- `router.go` (existing ARO HCP guard): `control-plane-operator/controllers/hostedcontrolplane/ingress/router.go` line 48