### PR TITLE
OCPBUGS-98466: retry Prometheus query exec on transient konnectivity 502

### DIFF
--- a/test/e2e/util/util_metrics_proxy.go
+++ b/test/e2e/util/util_metrics_proxy.go
@@ -117,15 +117,36 @@ func EnsureMetricsForwarderWorking(t *testing.T, ctx context.Context, mgtClient 
 		g.Expect(err).NotTo(HaveOccurred(), "kube-apiserver target via metrics-forwarder should be UP in guest cluster Prometheus")
 
 		// 7. Query Prometheus for actual kube-apiserver metrics to confirm data was scraped.
+		// Retry because the exec goes through the konnectivity proxy, which can
+		// return transient 502 Bad Gateway errors (OCPBUGS-98466).
 		t.Log("Querying Prometheus for kube-apiserver metrics scraped via the metrics-forwarder")
-		output, err := execInGuestPod(ctx, guestRestConfig, monitoringNamespace, promPodName, "prometheus",
-			[]string{"curl", "-gs", "http://localhost:9090/api/v1/query?query=apiserver_request_total{job=\"apiserver\"}"})
-		g.Expect(err).NotTo(HaveOccurred(), "failed to query Prometheus for apiserver_request_total")
-
 		var queryResp queryAPIResponse
-		g.Expect(json.Unmarshal([]byte(output), &queryResp)).To(Succeed(), "failed to parse Prometheus query response")
-		g.Expect(queryResp.Status).To(Equal("success"), "Prometheus query should succeed")
-		g.Expect(queryResp.Data.Result).NotTo(BeEmpty(), "should have apiserver_request_total metrics from kube-apiserver")
+		err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			output, execErr := execInGuestPod(ctx, guestRestConfig, monitoringNamespace, promPodName, "prometheus",
+				[]string{"curl", "-gs", "http://localhost:9090/api/v1/query?query=apiserver_request_total{job=\"apiserver\"}"})
+			if execErr != nil {
+				t.Logf("failed to query Prometheus (will retry): %v", execErr)
+				return false, nil
+			}
+
+			if err := json.Unmarshal([]byte(output), &queryResp); err != nil {
+				t.Logf("failed to parse Prometheus query response (will retry): %v", err)
+				return false, nil
+			}
+
+			if queryResp.Status != "success" {
+				t.Logf("Prometheus query returned status %q (will retry)", queryResp.Status)
+				return false, nil
+			}
+
+			if len(queryResp.Data.Result) == 0 {
+				t.Log("no apiserver_request_total metrics yet (will retry)")
+				return false, nil
+			}
+
+			return true, nil
+		})
+		g.Expect(err).NotTo(HaveOccurred(), "should have apiserver_request_total metrics from kube-apiserver")
 
 		t.Logf("Found %d apiserver_request_total time series in guest cluster Prometheus", len(queryResp.Data.Result))
 	})


### PR DESCRIPTION
## Summary

- Add retry logic to the Prometheus `apiserver_request_total` query exec in `EnsureMetricsForwarderWorking` step 7, matching the existing retry pattern in step 6

## Fixes

- https://redhat.atlassian.net/browse/OCPBUGS-98466

## Root Cause

The test's step 6 (poll Prometheus targets API) already uses `PollUntilContextTimeout` with retry on exec errors. Step 7 (query `apiserver_request_total`) did a single exec with no retry — a transient konnectivity proxy 502 failed the test immediately.

Evidence from build [2075571849441316864](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-aws-ovn/2075571849441316864) (Jul 10):
- Step 6 passed: `kube-apiserver target via metrics-forwarder is UP`
- Step 7 failed: `exec in prometheus-k8s-0 failed: proxy error from konnectivity-server-local:8090 while dialing 10.0.27.44:10250, code 502: 502 Bad Gateway`

This was 1/29 failures across 40 builds — rare but preventable. The fix is consistent with step 6's existing retry pattern.

## Changes

Step 7 `execInGuestPod` + `g.Expect` → `PollUntilContextTimeout` (15s interval, 2min timeout) that retries on exec errors, JSON parse errors, non-success status, and empty results.

## Test plan

- [x] `go vet` passes
- [ ] `e2e-aws-ovn` periodic should no longer fail on transient konnectivity 502 during Prometheus query

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved metrics validation to retry until guest-cluster Prometheus successfully reports API server metrics.
  * Added tolerance for temporary connectivity and query failures, reducing premature test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->