### PR TITLE
OCPBUGS-98462: add jitter to AWS endpoint service requeue delay

### DIFF
--- a/hypershift-operator/controllers/platform/aws/controller.go
+++ b/hypershift-operator/controllers/platform/aws/controller.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -52,8 +53,13 @@ import (
 const (
 	finalizer                              = "hypershift.openshift.io/hypershift-operator-finalizer"
 	endpointServiceDeletionRequeueDuration = 5 * time.Second
-	lbNotActiveRequeueDuration             = 20 * time.Second
+	lbNotActiveRequeueBase                 = 15 * time.Second
+	lbNotActiveJitterMax                   = 10
 )
+
+func lbNotActiveRequeueDelay() time.Duration {
+	return lbNotActiveRequeueBase + time.Duration(rand.Intn(lbNotActiveJitterMax)+1)*time.Second
+}
 
 // AWSEndpointServiceReconciler watches HC/NodePools/awsEndpointService and reconcile the awsEndpointService
 // CRs existing for the KubeAPIServerPrivateService and the PrivateRouterService.
@@ -354,8 +360,9 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 		// Most likely cause of error here is the NLB is not yet active.  This can take ~2m so
 		// a longer requeue time is warranted.  This ratelimits AWS calls and updates to the CR.
-		log.Info("reconciliation failed, retrying in 20s", "err", err)
-		return ctrl.Result{RequeueAfter: lbNotActiveRequeueDuration}, nil
+		requeueAfter := lbNotActiveRequeueDelay()
+		log.Info("reconciliation failed, retrying with jitter", "err", err, "requeueAfter", requeueAfter)
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 
 	meta.SetStatusCondition(&awsEndpointService.Status.Conditions, metav1.Condition{

--- a/hypershift-operator/controllers/platform/aws/controller_test.go
+++ b/hypershift-operator/controllers/platform/aws/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -11,7 +12,9 @@ import (
 	hyperapi "github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/awsapi"
 	"github.com/openshift/hypershift/support/capabilities"
+	"github.com/openshift/hypershift/support/k8sutil"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
+	"github.com/openshift/hypershift/support/upsert"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -1260,4 +1263,89 @@ type fakeManager struct {
 
 func (m *fakeManager) GetLogger() logr.Logger {
 	return logr.Discard()
+}
+
+func TestLbNotActiveRequeueDelay(t *testing.T) {
+	g := NewWithT(t)
+	min := lbNotActiveRequeueBase + 1*time.Second
+	max := lbNotActiveRequeueBase + time.Duration(lbNotActiveJitterMax)*time.Second
+
+	for i := 0; i < 50; i++ {
+		d := lbNotActiveRequeueDelay()
+		g.Expect(d).To(And(
+			BeNumerically(">=", min),
+			BeNumerically("<=", max),
+		), "iteration %d returned %s", i, d)
+	}
+}
+
+func TestReconcileRequeuesWithJitter(t *testing.T) {
+	g := NewWithT(t)
+	min := lbNotActiveRequeueBase + 1*time.Second
+	max := lbNotActiveRequeueBase + time.Duration(lbNotActiveJitterMax)*time.Second
+
+	mockCtrl := gomock.NewController(t)
+	elbClient := awsapi.NewMockELBV2API(mockCtrl)
+	ec2Client := awsapi.NewMockEC2API(mockCtrl)
+
+	elbClient.EXPECT().DescribeLoadBalancers(gomock.Any(), gomock.Any()).Return(
+		&elasticloadbalancingv2.DescribeLoadBalancersOutput{LoadBalancers: []elbv2types.LoadBalancer{}}, nil,
+	).AnyTimes()
+
+	hcpNs := "test-ns-test-hc"
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-hc",
+			Namespace:   hcpNs,
+			Annotations: map[string]string{k8sutil.HostedClusterAnnotation: "test-ns/test-hc"},
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Platform: hyperv1.PlatformSpec{
+				AWS: &hyperv1.AWSPlatformSpec{
+					RolesRef: hyperv1.AWSRolesRef{ControlPlaneOperatorARN: "arn:aws:iam::role/fake"},
+				},
+			},
+		},
+	}
+	hc := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-hc", Namespace: "test-ns",
+		},
+		Spec: hyperv1.HostedClusterSpec{
+			Platform: hyperv1.PlatformSpec{
+				AWS: &hyperv1.AWSPlatformSpec{
+					RolesRef: hyperv1.AWSRolesRef{ControlPlaneOperatorARN: "arn:aws:iam::role/fake"},
+				},
+			},
+		},
+	}
+	awsES := &hyperv1.AWSEndpointService{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ep", Namespace: hcpNs},
+		Spec:       hyperv1.AWSEndpointServiceSpec{NetworkLoadBalancerName: "test-nlb"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(hyperapi.Scheme).
+		WithObjects(hcp, hc, awsES).
+		WithStatusSubresource(awsES).
+		Build()
+
+	r := &AWSEndpointServiceReconciler{
+		Client:                        fakeClient,
+		CreateOrUpdateProvider:        upsert.New(false),
+		ec2Client:                     ec2Client,
+		elbv2Client:                   elbClient,
+		ManagementClusterCapabilities: &capabilities.ManagementClusterCapabilities{},
+	}
+
+	ctx := log.IntoContext(context.Background(), testr.New(t))
+	result, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(awsES),
+	})
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(And(
+		BeNumerically(">=", min),
+		BeNumerically("<=", max),
+	))
 }


### PR DESCRIPTION
## Summary

- Replace fixed 20s requeue delay with 15s base + random 1-10s jitter in the AWS endpoint service controller

## Fixes

- https://redhat.atlassian.net/browse/OCPBUGS-98462

## Root Cause

When 14+ HostedClusters are created in parallel (as in `e2e-aws-ovn`), their AWS endpoint service controllers all call Route53 `ChangeResourceRecordSets` simultaneously. On failure (typically NLB not yet active), all controllers requeued after a fixed 20s — retrying at the exact same instant and sustaining Route53 API throttling (`Throttling: Rate exceeded`).

## Frequency

Searched 40 builds of `periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-aws-ovn` (29 failures total):
- **1/29 failures** (3.4%) had Route53 throttling as the root cause
- The single affected run ([2075226710403452928](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-aws-ovn/2075226710403452928), Jul 9) had 4 HCs stuck with `AWSEndpointAvailable=False` and 9 test failures
- Low frequency but the fix is safe, minimal, and consistent with AWS best practices for throttle mitigation

## Existing throttle handling

The CPO-side `awsprivatelink` controller already handles throttling with a 2min backoff (`throttleRequeueDelay`, line 61 of `control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go`). This fix targets the **HO-side** endpoint service controller where the fixed 20s delay caused synchronized retries across all HCs.

## Changes

| Before | After |
|--------|-------|
| `lbNotActiveRequeueDuration = 20s` (fixed, all controllers retry simultaneously) | `lbNotActiveRequeueBase = 15s` + `rand(1-10s)` jitter (16-25s range, desynchronized) |
| `log.Info("retrying in 20s")` | `log.Info("retrying with jitter", "requeueAfter", requeueAfter)` |

## Test plan

- [x] `go build` passes
- [ ] Observe `e2e-aws-ovn` periodic — Route53 throttling should no longer cascade across HCs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry timing when an AWS load balancer isn’t active yet by replacing the fixed requeue interval with a jittered, randomized backoff to avoid repeated retries at the same cadence.
  * Adjusted retry logs and scheduling to match the new randomized delay.
* **Tests**
  * Added unit coverage to verify the retry delay remains within the expected jitter-bounded range and that the reconciler uses that delay correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->