### PR TITLE
OCPBUGS-98461: requeue CRR on transiently unavailable resources

### DIFF
--- a/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller.go
+++ b/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller.go
@@ -687,7 +687,7 @@ func (c *CertificateRevocationController) ensureNewSignerCertificatePropagated(c
 	signer, ok := secretForSignerClass(namespace, certificates.SignerClass(crr.Spec.SignerClass))
 	if !ok {
 		// we should never reach this case as we validate the class before transitioning states, and it's immutable
-		return true, nil, false, nil
+		return true, nil, true, nil
 	}
 
 	signerSecert, signers, err := c.loadCertificateSecret(signer.Namespace, signer.Name)
@@ -695,7 +695,7 @@ func (c *CertificateRevocationController) ensureNewSignerCertificatePropagated(c
 		return true, nil, false, err
 	}
 	if signers == nil {
-		return true, nil, false, nil
+		return true, nil, true, nil
 	}
 
 	currentCertPEM, ok := signerSecert.Data[corev1.TLSCertKey]
@@ -714,7 +714,7 @@ func (c *CertificateRevocationController) ensureNewSignerCertificatePropagated(c
 		return true, nil, false, err
 	}
 	if totalClientTrustBundle == nil {
-		return true, nil, false, nil
+		return true, nil, true, nil
 	}
 
 	var recorded bool
@@ -1008,14 +1008,14 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 	// Load the current (new) signer cert/key for cross-checking during per-pod verification.
 	signer, ok := secretForSignerClass(namespace, certificates.SignerClass(crr.Spec.SignerClass))
 	if !ok {
-		return true, nil, false, nil
+		return true, nil, true, nil
 	}
 	signerSecret, _, err := c.loadCertificateSecret(signer.Namespace, signer.Name)
 	if err != nil {
 		return true, nil, false, err
 	}
 	if signerSecret == nil {
-		return true, nil, false, nil
+		return true, nil, true, nil
 	}
 	currentCertPEM := signerSecret.Data[corev1.TLSCertKey]
 	currentKeyPEM := signerSecret.Data[corev1.TLSPrivateKeyKey]
@@ -1026,7 +1026,7 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 		return true, nil, false, err
 	}
 	if totalClientTrustBundle == nil {
-		return true, nil, false, nil
+		return true, nil, true, nil
 	}
 	// the real gate for this phase is that KAS has loaded the updated trust bundle and no longer
 	// authorizes clients using certificates signed by the revoked signer - it is difficult to unit-test

--- a/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller_test.go
+++ b/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller_test.go
@@ -2025,4 +2025,89 @@ func TestEnsureOldSignerCertificateRevoked_KASVerification(t *testing.T) {
 		}
 		g.Expect(foundRevoked).To(BeTrue(), "should have set PreviousCertificatesRevokedType condition to True")
 	})
+
+	t.Run("When trust bundle ConfigMap is transiently unavailable during revocation it should requeue", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		kubeconfigData := makeKubeconfig(t)
+		crr := newRevokedCRR()
+		secrets := newRevokedSecrets(kubeconfigData)
+		// No ConfigMaps — trust bundle not yet available
+		c := newRevokedController(crr, secrets, nil)
+
+		_, requeue, err := c.processCertificateRevocationRequest(t.Context(), "crr-ns", "crr-name", postRevocationClock.Now)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(requeue).To(BeTrue(), "should requeue when trust bundle ConfigMap is transiently unavailable")
+	})
+
+	// Direct function tests for transient nil resource paths that cannot be
+	// reached via processCertificateRevocationRequest because earlier state
+	// machine steps panic on missing resources.
+	propagationCRR := &certificatesv1alpha1.CertificateRevocationRequest{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "crr-name"},
+		Spec:       certificatesv1alpha1.CertificateRevocationRequestSpec{SignerClass: string(certificates.CustomerBreakGlassSigner)},
+		Status: certificatesv1alpha1.CertificateRevocationRequestStatus{
+			RevocationTimestamp: ptr.To(metav1.NewTime(revocationTime)),
+			PreviousSigner:      &corev1.LocalObjectReference{Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+			Conditions: []metav1.Condition{{
+				Type:               certificatesv1alpha1.RootCertificatesRegeneratedType,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+				Reason:             hypershiftv1beta1.AsExpectedReason,
+				Message:            `Signer certificate crr-ns/customer-system-admin-signer regenerated.`,
+			}},
+		},
+	}
+
+	for _, tt := range []struct {
+		name    string
+		fn      func(c *CertificateRevocationController) (bool, *actions, bool, error)
+		secrets []*corev1.Secret
+		cms     []*corev1.ConfigMap
+		crr     *certificatesv1alpha1.CertificateRevocationRequest
+	}{
+		{
+			name: "When signer secret is transiently unavailable during revocation it should requeue",
+			crr:  newRevokedCRR(),
+			secrets: []*corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+				Data:       map[string][]byte{corev1.TLSCertKey: data.original.raw.signerCert, corev1.TLSPrivateKeyKey: data.original.raw.signerKey},
+			}},
+			cms: newRevokedCMs(),
+			fn: func(c *CertificateRevocationController) (bool, *actions, bool, error) {
+				return c.ensureOldSignerCertificateRevoked(context.Background(), "crr-ns", "crr-name", postRevocationClock.Now, newRevokedCRR())
+			},
+		},
+		{
+			name: "When signer secret is transiently unavailable during propagation it should requeue",
+			crr:  propagationCRR,
+			fn: func(c *CertificateRevocationController) (bool, *actions, bool, error) {
+				return c.ensureNewSignerCertificatePropagated(context.Background(), "crr-ns", "crr-name", postRevocationClock.Now, propagationCRR)
+			},
+		},
+		{
+			name: "When trust bundle ConfigMap is transiently unavailable during propagation it should requeue",
+			crr:  propagationCRR,
+			secrets: []*corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: manifests.CustomerSystemAdminSigner("").Name},
+				Data:       map[string][]byte{corev1.TLSCertKey: data.future.raw.signerCert, corev1.TLSPrivateKeyKey: data.future.raw.signerKey},
+			}},
+			fn: func(c *CertificateRevocationController) (bool, *actions, bool, error) {
+				return c.ensureNewSignerCertificatePropagated(context.Background(), "crr-ns", "crr-name", postRevocationClock.Now, propagationCRR)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			c := newRevokedController(tt.crr, tt.secrets, tt.cms)
+
+			done, _, requeue, err := tt.fn(c)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(done).To(BeTrue())
+			g.Expect(requeue).To(BeTrue())
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Change `requeueSoon` from `false` to `true` in 6 return paths across `ensureOldSignerCertificateRevoked` and `ensureNewSignerCertificatePropagated` where a resource is transiently nil

## Fixes

- https://redhat.atlassian.net/browse/OCPBUGS-98461

## Root Cause

CertificateRevocationRequest operations stall at `PreviousCertificatesRevoked=False` for 10+ minutes (3/8 runs, Jul 8-10, most frequent CI failure). #8563 fixed one instance of this class of bug (stale trust bundle cache returning `requeueSoon=false`), but three other return paths in each function have the same issue:

| Line | Condition | Before | After |
|------|-----------|--------|-------|
| `:690`, `:1011` | `secretForSignerClass` not found | `requeueSoon=false` | `requeueSoon=true` |
| `:698`, `:1018` | signer secret nil | `requeueSoon=false` | `requeueSoon=true` |
| `:717`, `:1029` | trust bundle ConfigMap nil | `requeueSoon=false` | `requeueSoon=true` |

When any of these resources is transiently unavailable (being re-created, not yet propagated), the controller returned `needsWork=true, requeueSoon=false` — waiting for a watch event that might never come. With `requeueSoon=true`, it retries on the next synthetic requeue.

## Frequency

3/8 runs in Jul 8-10 window. Most frequent issue in `e2e-aws-ovn`. One CRR completed in 2min while a parallel one in the same run stalled for 10min+ — consistent with a transient resource availability race.

## Test plan

- [x] Unit test: "When trust bundle ConfigMap is transiently unavailable during revocation it should requeue"
- [x] `go test ./control-plane-pki-operator/certificaterevocationcontroller/` — all pass
- [x] `make lint` — 0 issues
- [x] `make verify` — clean (except expected uncommitted files)

/cc @csrwng

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated certificate revocation reconciliation to automatically retry when signer certificate secrets or aggregated trust-bundle data aren’t available yet.
  * Ensures reconciliation requeues (instead of prematurely completing) while prerequisites are still being propagated.

* **Tests**
  * Added additional coverage for scenarios where the trust-bundle ConfigMap is temporarily missing, validating that the controller requeues without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->