### PR TITLE
NOJIRA: docs: fix stale N-2 version skew references to N-3

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -540,7 +540,7 @@ type HostedClusterSpec struct {
 	// This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
 	// The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
 	// Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-	// Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+	// Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
 	// Changing this field will trigger a rollout of the control plane components.
 	// The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
 	// +required

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -543,7 +543,7 @@ type HostedClusterSpec struct {
 	// This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
 	// The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
 	// Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-	// Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+	// Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
 	// Changing this field will trigger a rollout of the control plane components.
 	// The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
 	// +required

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -123,9 +123,9 @@ type NodePoolSpec struct {
 	// the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 	//
 	// Version-skew rules and effects:
-	//   - The minor-version skew relative to the control-plane release must be <= N-2.
-	//     This is not currently enforced, but exceeding this limit is unsupported and
-	//     may lead to unpredictable behavior.
+	//   - The minor-version skew relative to the control-plane release must be <= N-3.
+	//     Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+	//     condition to report False.
 	//   - If the specified release is higher than the HostedCluster's release, the
 	//     NodePool will be degraded and the ValidReleaseImage condition will be false.
 	//   - If the specified release is lower than the NodePool's current y-stream,

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -6097,7 +6097,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -6292,7 +6292,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -6080,7 +6080,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -6275,7 +6275,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -6100,7 +6100,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -6294,7 +6294,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
@@ -6746,7 +6746,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -6412,7 +6412,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -6607,7 +6607,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
@@ -7029,7 +7029,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -6552,7 +6552,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -6747,7 +6747,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -6543,7 +6543,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -6738,7 +6738,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -6526,7 +6526,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -6722,7 +6722,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -6145,7 +6145,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -6341,7 +6341,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPUserFacingOperatorLogs.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPUserFacingOperatorLogs.yaml
@@ -6522,7 +6522,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -6102,7 +6102,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -6297,7 +6297,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -6098,7 +6098,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -6293,7 +6293,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/IngressComponentRouteLabels.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/IngressComponentRouteLabels.yaml
@@ -6331,7 +6331,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryption.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryption.yaml
@@ -6588,7 +6588,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -6156,7 +6156,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkObservabilityInstall.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkObservabilityInstall.yaml
@@ -6297,7 +6297,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -6631,7 +6631,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -6826,7 +6826,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
@@ -6120,7 +6120,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
@@ -6315,7 +6315,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSGroupPreferences.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSGroupPreferences.yaml
@@ -6315,7 +6315,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -1389,9 +1389,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -1411,9 +1411,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -1658,9 +1658,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -1681,9 +1681,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
@@ -1414,9 +1414,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
@@ -1436,9 +1436,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -1576,9 +1576,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -1598,9 +1598,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -7918,7 +7918,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -9621,7 +9621,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -6589,7 +6589,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -6920,7 +6920,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -7789,7 +7789,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -8743,7 +8743,7 @@ spec:
                   This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
                   The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
                   Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-                  Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+                  Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
                   Changing this field will trigger a rollout of the control plane components.
                   The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
                 properties:

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -1879,9 +1879,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -1902,9 +1902,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -1392,9 +1392,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -1447,9 +1447,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -1879,9 +1879,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -1902,9 +1902,9 @@ spec:
                   the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 
                   Version-skew rules and effects:
-                    - The minor-version skew relative to the control-plane release must be <= N-2.
-                      This is not currently enforced, but exceeding this limit is unsupported and
-                      may lead to unpredictable behavior.
+                    - The minor-version skew relative to the control-plane release must be <= N-3.
+                      Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+                      condition to report False.
                     - If the specified release is higher than the HostedCluster's release, the
                       NodePool will be degraded and the ValidReleaseImage condition will be false.
                     - If the specified release is lower than the NodePool's current y-stream,

--- a/docs/content/getting-started/onboarding/lifecycle.md
+++ b/docs/content/getting-started/onboarding/lifecycle.md
@@ -83,7 +83,7 @@ graph LR
 ```
 
 - `controlPlaneRelease`: allows patching management-side components without touching the data plane
-- NodePool releases can be updated independently (within N-2 y-stream skew)
+- NodePool releases can be updated independently (within N-3 y-stream skew)
 
 ### Deletion
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -2532,7 +2532,7 @@ graph LR
 ```
 
 - `controlPlaneRelease`: allows patching management-side components without touching the data plane
-- NodePool releases can be updated independently (within N-2 y-stream skew)
+- NodePool releases can be updated independently (within N-3 y-stream skew)
 
 ### Deletion
 
@@ -37607,7 +37607,7 @@ Release
 This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
 The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
 Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
 Changing this field will trigger a rollout of the control plane components.
 The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.</p>
 </td>
@@ -38270,9 +38270,9 @@ Release
 <p>release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
 the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).</p>
 <p>Version-skew rules and effects:
-- The minor-version skew relative to the control-plane release must be &lt;= N-2.
-This is not currently enforced, but exceeding this limit is unsupported and
-may lead to unpredictable behavior.
+- The minor-version skew relative to the control-plane release must be &lt;= N-3.
+Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+condition to report False.
 - If the specified release is higher than the HostedCluster&rsquo;s release, the
 NodePool will be degraded and the ValidReleaseImage condition will be false.
 - If the specified release is lower than the NodePool&rsquo;s current y-stream,
@@ -46394,7 +46394,7 @@ Release
 This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
 The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
 Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
 Changing this field will trigger a rollout of the control plane components.
 The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.</p>
 </td>
@@ -50998,9 +50998,9 @@ Release
 <p>release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
 the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).</p>
 <p>Version-skew rules and effects:
-- The minor-version skew relative to the control-plane release must be &lt;= N-2.
-This is not currently enforced, but exceeding this limit is unsupported and
-may lead to unpredictable behavior.
+- The minor-version skew relative to the control-plane release must be &lt;= N-3.
+Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+condition to report False.
 - If the specified release is higher than the HostedCluster&rsquo;s release, the
 NodePool will be degraded and the ValidReleaseImage condition will be false.
 - If the specified release is lower than the NodePool&rsquo;s current y-stream,

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -2564,7 +2564,7 @@ graph LR
 ```
 
 - `controlPlaneRelease`: allows patching management-side components without touching the data plane
-- NodePool releases can be updated independently (within N-2 y-stream skew)
+- NodePool releases can be updated independently (within N-3 y-stream skew)
 
 ### Deletion
 
@@ -40308,7 +40308,7 @@ Release
 This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
 The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
 Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
 Changing this field will trigger a rollout of the control plane components.
 The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.</p>
 </td>
@@ -40972,9 +40972,9 @@ Release
 <p>release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
 the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).</p>
 <p>Version-skew rules and effects:
-- The minor-version skew relative to the control-plane release must be &lt;= N-2.
-This is not currently enforced, but exceeding this limit is unsupported and
-may lead to unpredictable behavior.
+- The minor-version skew relative to the control-plane release must be &lt;= N-3.
+Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+condition to report False.
 - If the specified release is higher than the HostedCluster&rsquo;s release, the
 NodePool will be degraded and the ValidReleaseImage condition will be false.
 - If the specified release is lower than the NodePool&rsquo;s current y-stream,
@@ -49516,7 +49516,7 @@ Release
 This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
 The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
 Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
 Changing this field will trigger a rollout of the control plane components.
 The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.</p>
 </td>
@@ -54525,9 +54525,9 @@ Release
 <p>release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
 the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).</p>
 <p>Version-skew rules and effects:
-- The minor-version skew relative to the control-plane release must be &lt;= N-2.
-This is not currently enforced, but exceeding this limit is unsupported and
-may lead to unpredictable behavior.
+- The minor-version skew relative to the control-plane release must be &lt;= N-3.
+Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+condition to report False.
 - If the specified release is higher than the HostedCluster&rsquo;s release, the
 NodePool will be degraded and the ValidReleaseImage condition will be false.
 - If the specified release is lower than the NodePool&rsquo;s current y-stream,

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -465,7 +465,7 @@ Release
 This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
 The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
 Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
 Changing this field will trigger a rollout of the control plane components.
 The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.</p>
 </td>
@@ -1128,9 +1128,9 @@ Release
 <p>release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
 the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).</p>
 <p>Version-skew rules and effects:
-- The minor-version skew relative to the control-plane release must be &lt;= N-2.
-This is not currently enforced, but exceeding this limit is unsupported and
-may lead to unpredictable behavior.
+- The minor-version skew relative to the control-plane release must be &lt;= N-3.
+Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+condition to report False.
 - If the specified release is higher than the HostedCluster&rsquo;s release, the
 NodePool will be degraded and the ValidReleaseImage condition will be false.
 - If the specified release is lower than the NodePool&rsquo;s current y-stream,
@@ -9252,7 +9252,7 @@ Release
 This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
 The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
 Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
 Changing this field will trigger a rollout of the control plane components.
 The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.</p>
 </td>
@@ -13856,9 +13856,9 @@ Release
 <p>release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
 the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).</p>
 <p>Version-skew rules and effects:
-- The minor-version skew relative to the control-plane release must be &lt;= N-2.
-This is not currently enforced, but exceeding this limit is unsupported and
-may lead to unpredictable behavior.
+- The minor-version skew relative to the control-plane release must be &lt;= N-3.
+Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+condition to report False.
 - If the specified release is higher than the HostedCluster&rsquo;s release, the
 NodePool will be degraded and the ValidReleaseImage condition will be false.
 - If the specified release is lower than the NodePool&rsquo;s current y-stream,

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -465,7 +465,7 @@ Release
 This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
 The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
 Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
 Changing this field will trigger a rollout of the control plane components.
 The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.</p>
 </td>
@@ -1129,9 +1129,9 @@ Release
 <p>release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
 the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).</p>
 <p>Version-skew rules and effects:
-- The minor-version skew relative to the control-plane release must be &lt;= N-2.
-This is not currently enforced, but exceeding this limit is unsupported and
-may lead to unpredictable behavior.
+- The minor-version skew relative to the control-plane release must be &lt;= N-3.
+Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+condition to report False.
 - If the specified release is higher than the HostedCluster&rsquo;s release, the
 NodePool will be degraded and the ValidReleaseImage condition will be false.
 - If the specified release is lower than the NodePool&rsquo;s current y-stream,
@@ -9673,7 +9673,7 @@ Release
 This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
 The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
 Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
 Changing this field will trigger a rollout of the control plane components.
 The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.</p>
 </td>
@@ -14682,9 +14682,9 @@ Release
 <p>release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
 the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).</p>
 <p>Version-skew rules and effects:
-- The minor-version skew relative to the control-plane release must be &lt;= N-2.
-This is not currently enforced, but exceeding this limit is unsupported and
-may lead to unpredictable behavior.
+- The minor-version skew relative to the control-plane release must be &lt;= N-3.
+Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+condition to report False.
 - If the specified release is higher than the HostedCluster&rsquo;s release, the
 NodePool will be degraded and the ValidReleaseImage condition will be false.
 - If the specified release is lower than the NodePool&rsquo;s current y-stream,

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -540,7 +540,7 @@ type HostedClusterSpec struct {
 	// This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
 	// The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
 	// Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-	// Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+	// Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
 	// Changing this field will trigger a rollout of the control plane components.
 	// The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
 	// +required

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -543,7 +543,7 @@ type HostedClusterSpec struct {
 	// This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
 	// The maximum and minimum supported release versions are determined by the running Hypersfhit Operator.
 	// Attempting to use an unsupported version will result in the HostedCluster being degraded and the validateReleaseImage condition being false.
-	// Attempting to use a release with a skew against a NodePool release bigger than N-2 for the y-stream will result in leaving the NodePool in an unsupported state.
+	// Attempting to use a release with a skew against a NodePool release bigger than N-3 for the y-stream will result in leaving the NodePool in an unsupported state.
 	// Changing this field will trigger a rollout of the control plane components.
 	// The behavior of the rollout will be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy for PDBs and maxUnavailable and surce policies.
 	// +required

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -123,9 +123,9 @@ type NodePoolSpec struct {
 	// the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
 	//
 	// Version-skew rules and effects:
-	//   - The minor-version skew relative to the control-plane release must be <= N-2.
-	//     This is not currently enforced, but exceeding this limit is unsupported and
-	//     may lead to unpredictable behavior.
+	//   - The minor-version skew relative to the control-plane release must be <= N-3.
+	//     Exceeding this limit is unsupported and will cause the SupportedVersionSkew
+	//     condition to report False.
 	//   - If the specified release is higher than the HostedCluster's release, the
 	//     NodePool will be degraded and the ValidReleaseImage condition will be false.
 	//   - If the specified release is lower than the NodePool's current y-stream,


### PR DESCRIPTION
The code enforces a maximum N-3 minor version skew between NodePools and HostedClusters (maxAllowedDiff := 3), but several API godoc comments and lifecycle docs still referenced the older N-2 policy. Update all source references to N-3 and regenerate CRDs and docs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated HostedCluster and NodePool release-version compatibility guidance from N-2 to N-3.
  * Clarified that exceeding the supported NodePool version skew is reported through the `SupportedVersionSkew` condition.
  * Updated lifecycle upgrade guidance to reflect the revised version-skew tolerance and supported release relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->