### PR TITLE
GCP-896: chore: add gbarabasz to gcp-reviewers alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -71,6 +71,7 @@ aliases:
     - ckandag
     - cristianoveiga
     - floresroger
+    - gbarabasz
     - jimdaga
     - patjlm
   powervs-reviewers:


### PR DESCRIPTION
## Summary
- Add `gbarabasz` (Grzegorz Barabasz) to `gcp-reviewers` alias in OWNERS_ALIASES
- Part of onboarding tracked in [GCP-896](https://redhat.atlassian.net/browse/GCP-896)

## Test plan
- [ ] Verify `gbarabasz` appears in `gcp-reviewers` alias
- [ ] Verify alphabetical ordering preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an additional reviewer to the Google Cloud Platform review alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->