### PR TITLE
OCPBUGS-98575: feat: inject hosted cluster TLS security profile into packageserver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -88,6 +88,8 @@ spec:
         - /etc/openshift/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/openshift/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/package-server
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -88,6 +88,8 @@ spec:
         - /etc/openshift/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/openshift/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/package-server
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -88,6 +88,8 @@ spec:
         - /etc/openshift/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/openshift/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/package-server
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -88,6 +88,8 @@ spec:
         - /etc/openshift/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/openshift/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/package-server
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -88,6 +88,8 @@ spec:
         - /etc/openshift/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/openshift/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - /bin/package-server
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/deployment.go
@@ -1,10 +1,12 @@
 package packageserver
 
 import (
+	"fmt"
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
+	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 
@@ -21,11 +23,18 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		noProxy = append(noProxy, "certified-operators", "community-operators", "redhat-operators", "redhat-marketplace")
 	}
 
+	tlsProfile := hcp.Spec.Configuration.GetTLSSecurityProfile()
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		podspec.UpsertEnvVars(c, []corev1.EnvVar{
 			{Name: "RELEASE_VERSION", Value: cpContext.UserReleaseImageProvider.Version()},
 			{Name: "NO_PROXY", Value: strings.Join(noProxy, ",")},
 		})
+		if minTLSVersion := config.MinTLSVersion(tlsProfile); minTLSVersion != "" {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", minTLSVersion))
+		}
+		if cipherSuites := config.CipherSuites(tlsProfile); len(cipherSuites) != 0 {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
 	})
 
 	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform && hcp.Spec.ControllerAvailabilityPolicy == hyperv1.HighlyAvailable {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/deployment_test.go
@@ -1,6 +1,7 @@
 package packageserver
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -11,6 +12,8 @@ import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/testutil"
+
+	configv1 "github.com/openshift/api/config/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,10 +27,13 @@ func TestAdaptDeployment(t *testing.T) {
 		platformType                 hyperv1.PlatformType
 		olmCatalogPlacement          hyperv1.OLMCatalogPlacement
 		controllerAvailabilityPolicy hyperv1.AvailabilityPolicy
+		tlsSecurityProfile           *configv1.TLSSecurityProfile
 		expectedNoProxyHosts         []string
 		expectedReleaseVersion       string
 		expectedReplicas             *int32
 		expectedKASReadinessCheck    bool
+		expectedTLSMinVersion        string
+		expectedTLSCipherSuites      string
 	}{
 		{
 			name:                         "When OLMCatalogPlacement is Management, it should set NO_PROXY with catalog services",
@@ -69,6 +75,42 @@ func TestAdaptDeployment(t *testing.T) {
 			expectedReplicas:             nil,
 			expectedKASReadinessCheck:    true,
 		},
+		{
+			name:                      "When TLS security profile is Modern, it should set --tls-min-version=VersionTLS13",
+			platformType:              hyperv1.AWSPlatform,
+			olmCatalogPlacement:       hyperv1.GuestOLMCatalogPlacement,
+			expectedNoProxyHosts:      []string{"kube-apiserver"},
+			expectedReleaseVersion:    "4.15.0",
+			expectedKASReadinessCheck: true,
+			tlsSecurityProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectedTLSMinVersion: "VersionTLS13",
+		},
+		{
+			name:                      "When TLS security profile is Intermediate, it should set --tls-min-version=VersionTLS12 with cipher suites",
+			platformType:              hyperv1.AWSPlatform,
+			olmCatalogPlacement:       hyperv1.GuestOLMCatalogPlacement,
+			expectedNoProxyHosts:      []string{"kube-apiserver"},
+			expectedReleaseVersion:    "4.15.0",
+			expectedKASReadinessCheck: true,
+			tlsSecurityProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectedTLSMinVersion:   "VersionTLS12",
+			expectedTLSCipherSuites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+		},
+		{
+			name:                      "When TLS security profile is nil, it should default to Intermediate and set VersionTLS12 with cipher suites",
+			platformType:              hyperv1.AWSPlatform,
+			olmCatalogPlacement:       hyperv1.GuestOLMCatalogPlacement,
+			expectedNoProxyHosts:      []string{"kube-apiserver"},
+			expectedReleaseVersion:    "4.15.0",
+			expectedKASReadinessCheck: true,
+			tlsSecurityProfile:        nil,
+			expectedTLSMinVersion:     "VersionTLS12",
+			expectedTLSCipherSuites:   "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -87,6 +129,11 @@ func TestAdaptDeployment(t *testing.T) {
 					},
 					OLMCatalogPlacement:          tc.olmCatalogPlacement,
 					ControllerAvailabilityPolicy: tc.controllerAvailabilityPolicy,
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: tc.tlsSecurityProfile,
+						},
+					},
 				},
 			}
 
@@ -144,6 +191,18 @@ func TestAdaptDeployment(t *testing.T) {
 			if tc.expectedKASReadinessCheck {
 				kasReadinessContainer := podspec.FindContainer("kas-readiness-check", deployment.Spec.Template.Spec.Containers)
 				g.Expect(kasReadinessContainer).ToNot(BeNil(), "KAS readiness check container should be present")
+			}
+
+			// Verify TLS flags when expected
+			if tc.expectedTLSMinVersion != "" {
+				g.Expect(packageServerContainer.Args).To(ContainElement(
+					fmt.Sprintf("--tls-min-version=%s", tc.expectedTLSMinVersion),
+				), "expected --tls-min-version flag")
+			}
+			if tc.expectedTLSCipherSuites != "" {
+				g.Expect(packageServerContainer.Args).To(ContainElement(
+					fmt.Sprintf("--tls-cipher-suites=%s", tc.expectedTLSCipherSuites),
+				), "expected --tls-cipher-suites flag")
 			}
 		})
 	}


### PR DESCRIPTION
Inject --tls-min-version and --tls-cipher-suites flags from the HostedCluster's TLS security profile (spec.configuration.apiServer. tlsSecurityProfile) into the packageserver deployment. This ensures the packageserver honours the hosted cluster's TLS policy rather than using Go defaults, consistent with how other control plane components (KCM, kube-scheduler, machine-approver, CVO, oauth-apiserver) handle TLS.

When no profile is configured the Intermediate profile defaults apply.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Package server deployments now honor the configured TLS security profile.
  * Applies the appropriate minimum TLS version and cipher suites (when applicable) to improve secure communication.

* **Bug Fixes**
  * Ensures TLS settings are consistently propagated to package server containers.
  * Adds test coverage to verify the correct TLS-related flags are included for different TLS profile inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->