### PR TITLE
CNTRLPLANE-3761: fix(ci): make race detection opt-out for pre-push hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,8 +55,8 @@ repos:
         require_serial: true
       - id: make-test
         name: Run make test
-        description: Runs `make test`.
-        entry: make test
+        description: Runs `make test` without race detection for faster hook feedback.
+        entry: make test GO_TEST_FLAGS=
         language: system
         stages: [ pre-push ]
 exclude: '^vendor/|^hack/tools/vendor/|^api/vendor/'

--- a/Makefile
+++ b/Makefile
@@ -372,10 +372,11 @@ setup-envtest: $(SETUP_ENVTEST) ## Setup envtest binaries (etcd, kube-apiserver)
 
 # Determine the number of CPU cores
 NUM_CORES := $(shell getconf _NPROCESSORS_ONLN || echo 1)
+GO_TEST_FLAGS ?= -race
 
 test: generate
 	@echo "Running tests with $(NUM_CORES) parallel jobs..."
-	$(GO) test -race -parallel=$(NUM_CORES) -count=1 -timeout=30m ./... -coverprofile cover.out
+	$(GO) test $(GO_TEST_FLAGS) -parallel=$(NUM_CORES) -count=1 -timeout=30m ./... -coverprofile cover.out
 
 # Run a subset of unit tests (used by CI sharding).
 # Usage: make test-shard TEST_PACKAGES="./cmd/... ./support/..." COVER_PROFILE="cover-shard.out"
@@ -384,7 +385,7 @@ COVER_PROFILE ?= cover.out
 .PHONY: test-shard
 test-shard: generate
 	@echo "Running shard tests for packages: $(TEST_PACKAGES)"
-	$(GO) test -race -parallel=$(NUM_CORES) -count=1 -timeout=30m $(TEST_PACKAGES) -coverprofile $(COVER_PROFILE)
+	$(GO) test $(GO_TEST_FLAGS) -parallel=$(NUM_CORES) -count=1 -timeout=30m $(TEST_PACKAGES) -coverprofile $(COVER_PROFILE)
 
 # OCP envtest index for downstream kubebuilder assets
 ENVTEST_OCP_INDEX := https://raw.githubusercontent.com/openshift/api/master/envtest-releases.yaml


### PR DESCRIPTION
## Summary

- Add `GO_TEST_FLAGS` variable to the Makefile (defaults to `-race`) so callers can opt out
- Pre-push hook now passes `GO_TEST_FLAGS=` to skip race detection

## Why

The race detector adds 2-10x overhead to test execution. On CI agent pods (currently 500m CPU, being bumped in openshift/release#81875), `make test -race` across 374 packages takes 30+ minutes and hits the 20-minute Bash tool timeout, causing pre-push hooks to fail with exit 143. This blocks all pushes from agent sessions.

Direct `make test` and CI sharded jobs keep `-race` by default — only the pre-push hook opts out for faster feedback.

## Related

- openshift/release#81875 — bumps agent pod CPU from 500m to 4 cores
- openshift-eng/ai-helpers#620 — removes duplicate inline verification from solve command
- [CNTRLPLANE-3761](https://redhat.atlassian.net/browse/CNTRLPLANE-3761) — platform and harness reliability epic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test command flexibility by allowing test flags to be configured.
  * Updated pre-push test checks to run faster without race detection by default.
  * Preserved race detection for standard test and CI workflows unless explicitly overridden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->