### PR TITLE
CNTRLPLANE-3843: feat: ho,cpo,hcco: expose console URL

### DIFF
--- a/api/hypershift/v1beta1/hosted_controlplane.go
+++ b/api/hypershift/v1beta1/hosted_controlplane.go
@@ -360,6 +360,15 @@ type HostedControlPlaneStatus struct {
 	// +kubebuilder:validation:MaxLength=255
 	OAuthCallbackURLTemplate string `json:"oauthCallbackURLTemplate,omitempty"`
 
+	// consoleURL is the URL of the OpenShift web console for this hosted cluster.
+	// This is populated from the console.config.openshift.io/cluster resource
+	// in the guest cluster once the console operator has reconciled.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=4096
+	// +kubebuilder:validation:XValidation:rule="isURL(self)",message="consoleURL must be a valid URL"
+	ConsoleURL string `json:"consoleURL,omitempty"`
+
 	// controlPlaneVersion tracks the rollout status of the control plane
 	// components running on the management cluster, independently from
 	// the data-plane version reported in the version field.

--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -208,6 +208,14 @@ const (
 	// connectivity issues between the control plane and the hosted cluster.
 	ConfigOperatorReconciliationSucceeded ConditionType = "ConfigOperatorReconciliationSucceeded"
 
+	// DataPlaneStatusSynced indicates whether status information propagated
+	// from the hosted cluster (e.g. ConsoleURL from the console operator) has
+	// been successfully synced to the control plane. A False value means the
+	// hosted cluster reported data that could not be propagated — for example,
+	// a ConsoleURL that exceeds the maximum allowed length. This condition is
+	// set by HCCO and bubbled up to the HostedCluster.
+	DataPlaneStatusSynced ConditionType = "DataPlaneStatusSynced"
+
 	// EtcdRecoveryActive indicates that the Etcd cluster is failing and the
 	// recovery job was triggered.
 	EtcdRecoveryActive ConditionType = "EtcdRecoveryActive"
@@ -357,6 +365,8 @@ const (
 	ControlPlaneConnectionConfigMapNotFoundReason = "ConfigMapNotFound"
 
 	ControlPlaneConnectionNoWorkerNodesAvailableReason = "NoWorkerNodesAvailable"
+
+	DataPlaneStatusSyncFailedReason = "DataPlaneStatusSyncFailed"
 
 	ControlPlaneComponentsNotAvailable = "ComponentsNotAvailable"
 

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -2672,6 +2672,15 @@ type HostedClusterStatus struct {
 	// +kubebuilder:validation:MaxLength=1024
 	OAuthCallbackURLTemplate string `json:"oauthCallbackURLTemplate,omitempty"`
 
+	// consoleURL is the URL of the OpenShift web console for this hosted cluster.
+	// This is populated from the console.config.openshift.io/cluster resource
+	// in the guest cluster once the console operator has reconciled.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=4096
+	// +kubebuilder:validation:XValidation:rule="isURL(self)",message="consoleURL must be a valid URL"
+	ConsoleURL string `json:"consoleURL,omitempty"`
+
 	// payloadArch represents the CPU architecture type of the HostedCluster.Spec.Release.Image. The valid values are:
 	// Multi, ARM64, AMD64, S390X, or PPC64LE.
 	// +kubebuilder:validation:Enum=Multi;ARM64;AMD64;PPC64LE;S390X

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -7005,6 +7005,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -7099,6 +7099,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -6988,6 +6988,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -7082,6 +7082,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -7008,6 +7008,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -7102,6 +7102,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
@@ -7459,6 +7459,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
@@ -7553,6 +7553,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -7485,6 +7485,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -7579,6 +7579,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
@@ -7836,6 +7836,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -7625,6 +7625,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -7719,6 +7719,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -7451,6 +7451,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -7545,6 +7545,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -7434,6 +7434,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -7528,6 +7528,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -7053,6 +7053,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -7147,6 +7147,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -7010,6 +7010,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -7104,6 +7104,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -7006,6 +7006,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -7100,6 +7100,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/IngressComponentRouteLabels.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/IngressComponentRouteLabels.yaml
@@ -7138,6 +7138,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryption.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryption.yaml
@@ -7395,6 +7395,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -7064,6 +7064,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkObservabilityInstall.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkObservabilityInstall.yaml
@@ -7104,6 +7104,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -7539,6 +7539,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -7633,6 +7633,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
@@ -7028,6 +7028,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
@@ -7122,6 +7122,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSGroupPreferences.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSGroupPreferences.yaml
@@ -7122,6 +7122,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -6805,6 +6805,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -6899,6 +6899,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -6788,6 +6788,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -6882,6 +6882,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -6808,6 +6808,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -6902,6 +6902,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
@@ -7259,6 +7259,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
@@ -7353,6 +7353,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -7285,6 +7285,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -7379,6 +7379,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
@@ -7636,6 +7636,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -7425,6 +7425,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -7519,6 +7519,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -7251,6 +7251,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -7345,6 +7345,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -7234,6 +7234,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -7328,6 +7328,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -6853,6 +6853,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -6947,6 +6947,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -6810,6 +6810,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -6904,6 +6904,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -6806,6 +6806,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -6900,6 +6900,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/IngressComponentRouteLabels.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/IngressComponentRouteLabels.yaml
@@ -6938,6 +6938,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryption.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryption.yaml
@@ -7195,6 +7195,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -6864,6 +6864,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkObservabilityInstall.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkObservabilityInstall.yaml
@@ -6904,6 +6904,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -7339,6 +7339,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -7433,6 +7433,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
@@ -6828,6 +6828,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
@@ -6922,6 +6922,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSGroupPreferences.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSGroupPreferences.yaml
@@ -6922,6 +6922,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/client/applyconfiguration/hypershift/v1beta1/hostedclusterstatus.go
+++ b/client/applyconfiguration/hypershift/v1beta1/hostedclusterstatus.go
@@ -35,6 +35,7 @@ type HostedClusterStatusApplyConfiguration struct {
 	IgnitionEndpoint            *string                                      `json:"ignitionEndpoint,omitempty"`
 	ControlPlaneEndpoint        *APIEndpointApplyConfiguration               `json:"controlPlaneEndpoint,omitempty"`
 	OAuthCallbackURLTemplate    *string                                      `json:"oauthCallbackURLTemplate,omitempty"`
+	ConsoleURL                  *string                                      `json:"consoleURL,omitempty"`
 	PayloadArch                 *hypershiftv1beta1.PayloadArchType           `json:"payloadArch,omitempty"`
 	Platform                    *PlatformStatusApplyConfiguration            `json:"platform,omitempty"`
 	AutoNode                    *AutoNodeStatusApplyConfiguration            `json:"autoNode,omitempty"`
@@ -123,6 +124,14 @@ func (b *HostedClusterStatusApplyConfiguration) WithControlPlaneEndpoint(value *
 // If called multiple times, the OAuthCallbackURLTemplate field is set to the value of the last call.
 func (b *HostedClusterStatusApplyConfiguration) WithOAuthCallbackURLTemplate(value string) *HostedClusterStatusApplyConfiguration {
 	b.OAuthCallbackURLTemplate = &value
+	return b
+}
+
+// WithConsoleURL sets the ConsoleURL field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ConsoleURL field is set to the value of the last call.
+func (b *HostedClusterStatusApplyConfiguration) WithConsoleURL(value string) *HostedClusterStatusApplyConfiguration {
+	b.ConsoleURL = &value
 	return b
 }
 

--- a/client/applyconfiguration/hypershift/v1beta1/hostedcontrolplanestatus.go
+++ b/client/applyconfiguration/hypershift/v1beta1/hostedcontrolplanestatus.go
@@ -32,6 +32,7 @@ type HostedControlPlaneStatusApplyConfiguration struct {
 	ExternalManagedControlPlane    *bool                                        `json:"externalManagedControlPlane,omitempty"`
 	ControlPlaneEndpoint           *APIEndpointApplyConfiguration               `json:"controlPlaneEndpoint,omitempty"`
 	OAuthCallbackURLTemplate       *string                                      `json:"oauthCallbackURLTemplate,omitempty"`
+	ConsoleURL                     *string                                      `json:"consoleURL,omitempty"`
 	ControlPlaneVersion            *ControlPlaneVersionStatusApplyConfiguration `json:"controlPlaneVersion,omitempty"`
 	VersionStatus                  *ClusterVersionStatusApplyConfiguration      `json:"versionStatus,omitempty"`
 	Version                        *string                                      `json:"version,omitempty"`
@@ -103,6 +104,14 @@ func (b *HostedControlPlaneStatusApplyConfiguration) WithControlPlaneEndpoint(va
 // If called multiple times, the OAuthCallbackURLTemplate field is set to the value of the last call.
 func (b *HostedControlPlaneStatusApplyConfiguration) WithOAuthCallbackURLTemplate(value string) *HostedControlPlaneStatusApplyConfiguration {
 	b.OAuthCallbackURLTemplate = &value
+	return b
+}
+
+// WithConsoleURL sets the ConsoleURL field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ConsoleURL field is set to the value of the last call.
+func (b *HostedControlPlaneStatusApplyConfiguration) WithConsoleURL(value string) *HostedControlPlaneStatusApplyConfiguration {
+	b.ConsoleURL = &value
 	return b
 }
 

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -9462,6 +9462,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -10345,6 +10345,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -7662,6 +7662,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -7892,6 +7892,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -9333,6 +9333,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -9467,6 +9467,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -9262,6 +9262,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -10145,6 +10145,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
@@ -7462,6 +7462,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
@@ -7692,6 +7692,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -9133,6 +9133,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -9267,6 +9267,17 @@ spec:
                         x-kubernetes-list-type: map
                     type: object
                 type: object
+              consoleURL:
+                description: |-
+                  consoleURL is the URL of the OpenShift web console for this hosted cluster.
+                  This is populated from the console.config.openshift.io/cluster resource
+                  in the guest cluster once the console operator has reconciled.
+                maxLength: 4096
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: consoleURL must be a valid URL
+                  rule: isURL(self)
               controlPlaneEndpoint:
                 description: |-
                   controlPlaneEndpoint contains the endpoint information by which

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -71,9 +71,9 @@ var controllerFuncs = map[string]operator.ControllerSetupFunc{
 	nodecount.ControllerName:       nodecount.Setup,
 	"machine":                      machine.Setup,
 	"drainer":                      drainer.Setup,
-	hcpstatus.ControllerName:       hcpstatus.Setup,
 	spotremediation.ControllerName: spotremediation.Setup,
 	reencryption.ControllerName:    reencryption.Setup,
+	hcpstatus.ControllerName:       hcpstatus.Setup,
 }
 
 type HostedClusterConfigOperator struct {
@@ -240,6 +240,10 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 	}
 
 	mgr := operator.Mgr(ctx, cfg, cpConfig, o.Namespace, o.HostedControlPlaneName)
+	hcpCapabilities, err := operator.GetHCPCapabilities(ctx, cpConfig, o.Namespace, o.HostedControlPlaneName)
+	if err != nil {
+		return fmt.Errorf("failed to get HCP capabilities: %w", err)
+	}
 	mgr.GetLogger().Info("Starting hosted-cluster-config-operator", "version", supportedversion.String())
 	cpCluster, err := cluster.New(cpConfig, func(opt *cluster.Options) {
 		opt.Cache = cache.Options{
@@ -341,6 +345,7 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 		EnableCIDebugOutput:           o.enableCIDebugOutput,
 		ImageMetaDataProvider:         imageMetaDataProvider,
 		ManagementClusterCapabilities: mgmtClusterCaps,
+		HCPCapabilities:               hcpCapabilities,
 	}
 	configmetrics.Register(mgr.GetCache())
 	return operatorConfig.Start(ctx)

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -242,6 +242,10 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 	}
 
 	mgr := operator.Mgr(ctx, cfg, cpConfig, o.Namespace, o.HostedControlPlaneName)
+	hcpCapabilities, err := operator.GetHCPCapabilities(ctx, cpConfig, o.Namespace, o.HostedControlPlaneName)
+	if err != nil {
+		return fmt.Errorf("failed to get HCP capabilities: %w", err)
+	}
 	mgr.GetLogger().Info("Starting hosted-cluster-config-operator", "version", supportedversion.String())
 	cpCluster, err := cluster.New(cpConfig, func(opt *cluster.Options) {
 		opt.Cache = cache.Options{
@@ -343,6 +347,7 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 		EnableCIDebugOutput:           o.enableCIDebugOutput,
 		ImageMetaDataProvider:         imageMetaDataProvider,
 		ManagementClusterCapabilities: mgmtClusterCaps,
+		HCPCapabilities:               hcpCapabilities,
 	}
 	configmetrics.Register(mgr.GetCache())
 	return operatorConfig.Start(ctx)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
@@ -8,11 +8,13 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
+	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/releaseinfo"
 
 	configv1 "github.com/openshift/api/config/v1"
 
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -54,6 +56,15 @@ func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig
 
 	if err := c.Watch(source.Kind[crclient.Object](opts.Manager.GetCache(), &configv1.Authentication{}, handler.EnqueueRequestsFromMapFunc(clusterAuthenticationMapper))); err != nil {
 		return fmt.Errorf("failed to watch authentication: %w", err)
+	}
+
+	if capabilities.IsConsoleCapabilityEnabled(opts.HCPCapabilities) {
+		consoleMapper := func(context.Context, crclient.Object) []reconcile.Request {
+			return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: opts.Namespace, Name: opts.HCPName}}}
+		}
+		if err := c.Watch(source.Kind[crclient.Object](opts.Manager.GetCache(), &configv1.Console{}, handler.EnqueueRequestsFromMapFunc(consoleMapper))); err != nil {
+			return fmt.Errorf("failed to watch console: %w", err)
+		}
 	}
 
 	return nil
@@ -232,6 +243,54 @@ func (h *hcpStatusReconciler) reconcile(ctx context.Context, hcp *hyperv1.Hosted
 		}
 
 		meta.SetStatusCondition(&hcp.Status.Conditions, hcpCVOCondition)
+	}
+
+	if !capabilities.IsConsoleCapabilityEnabled(hcp.Spec.Capabilities) {
+		meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
+			Type:               string(hyperv1.DataPlaneStatusSynced),
+			Status:             metav1.ConditionTrue,
+			Reason:             hyperv1.AsExpectedReason,
+			ObservedGeneration: hcp.Generation,
+		})
+	} else {
+		var console configv1.Console
+		if err := h.hostedClusterClient.Get(ctx, crclient.ObjectKey{Name: "cluster"}, &console); err != nil {
+			if apierrors.IsNotFound(err) {
+				hcp.Status.ConsoleURL = ""
+				meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
+					Type:               string(hyperv1.DataPlaneStatusSynced),
+					Status:             metav1.ConditionFalse,
+					Reason:             hyperv1.DataPlaneStatusSyncFailedReason,
+					Message:            "Console resource not found in the hosted cluster",
+					ObservedGeneration: hcp.Generation,
+				})
+			} else {
+				// Log and continue — a transient Console fetch failure should not
+				// block Authentication and ConfigurationStatus updates below.
+				// ConsoleURL stays unchanged until the next successful reconcile.
+				log.Error(err, "Failed to get Console resource, skipping ConsoleURL update")
+			}
+		} else {
+			const maxConsoleURLLength = 4096
+			if len(console.Status.ConsoleURL) > maxConsoleURLLength {
+				log.Info("Ignoring oversized ConsoleURL from hosted cluster", "length", len(console.Status.ConsoleURL), "max", maxConsoleURLLength)
+				meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
+					Type:               string(hyperv1.DataPlaneStatusSynced),
+					Status:             metav1.ConditionFalse,
+					Reason:             hyperv1.DataPlaneStatusSyncFailedReason,
+					Message:            fmt.Sprintf("ConsoleURL from hosted cluster exceeds maximum length (%d > %d); value was not propagated", len(console.Status.ConsoleURL), maxConsoleURLLength),
+					ObservedGeneration: hcp.Generation,
+				})
+			} else {
+				hcp.Status.ConsoleURL = console.Status.ConsoleURL
+				meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
+					Type:               string(hyperv1.DataPlaneStatusSynced),
+					Status:             metav1.ConditionTrue,
+					Reason:             hyperv1.AsExpectedReason,
+					ObservedGeneration: hcp.Generation,
+				})
+			}
+		}
 	}
 
 	var authentication configv1.Authentication

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus_test.go
@@ -1,7 +1,10 @@
 package hcpstatus
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"reflect"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -209,6 +212,175 @@ func TestHCPStatusReconciler(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcileConsoleURL(t *testing.T) {
+	t.Parallel()
+
+	baseObjects := func(extra ...crclient.Object) []crclient.Object {
+		objs := []crclient.Object{
+			&configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}},
+			&configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			},
+		}
+		return append(objs, extra...)
+	}
+
+	t.Run("When Console resource exists, it should set ConsoleURL on HCP status", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-hcp", Namespace: "test-ns"},
+			Spec:       hyperv1.HostedControlPlaneSpec{Capabilities: &hyperv1.Capabilities{}},
+		}
+
+		hostedClusterClient := fake.NewClientBuilder().
+			WithScheme(api.Scheme).
+			WithObjects(baseObjects(&configv1.Console{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status:     configv1.ConsoleStatus{ConsoleURL: "https://console.example.com"},
+			})...).
+			Build()
+
+		reconciler := &hcpStatusReconciler{
+			hostedClusterClient: hostedClusterClient,
+		}
+
+		err := reconciler.reconcile(t.Context(), hcp)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(hcp.Status.ConsoleURL).To(Equal("https://console.example.com"))
+
+		statusCond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.DataPlaneStatusSynced))
+		g.Expect(statusCond).NotTo(BeNil(), "DataPlaneStatusSynced condition should be set")
+		g.Expect(statusCond.Status).To(Equal(metav1.ConditionTrue))
+		g.Expect(statusCond.Reason).To(Equal(hyperv1.AsExpectedReason))
+	})
+
+	t.Run("When Console resource is not found, it should clear ConsoleURL without error", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-hcp", Namespace: "test-ns"},
+			Spec:       hyperv1.HostedControlPlaneSpec{Capabilities: &hyperv1.Capabilities{}},
+			Status:     hyperv1.HostedControlPlaneStatus{ConsoleURL: "https://old.example.com"},
+		}
+
+		hostedClusterClient := fake.NewClientBuilder().
+			WithScheme(api.Scheme).
+			WithObjects(baseObjects()...).
+			Build()
+
+		reconciler := &hcpStatusReconciler{
+			hostedClusterClient: hostedClusterClient,
+		}
+
+		err := reconciler.reconcile(t.Context(), hcp)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(hcp.Status.ConsoleURL).To(BeEmpty())
+		statusCond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.DataPlaneStatusSynced))
+		g.Expect(statusCond).NotTo(BeNil(), "DataPlaneStatusSynced condition should be set even when Console is not found")
+		g.Expect(statusCond.Status).To(Equal(metav1.ConditionFalse))
+		g.Expect(statusCond.Message).To(ContainSubstring("Console resource not found"))
+	})
+
+	t.Run("When Console resource fetch returns a generic error, it should log and continue without blocking other updates", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-hcp", Namespace: "test-ns"},
+			Spec:       hyperv1.HostedControlPlaneSpec{Capabilities: &hyperv1.Capabilities{}},
+			Status:     hyperv1.HostedControlPlaneStatus{ConsoleURL: "https://previous.example.com"},
+		}
+
+		hostedClusterClient := &erroringClient{
+			Client:    fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(baseObjects()...).Build(),
+			errorOn:   "Console",
+			returnErr: fmt.Errorf("connection refused"),
+		}
+
+		reconciler := &hcpStatusReconciler{
+			hostedClusterClient: hostedClusterClient,
+		}
+
+		err := reconciler.reconcile(t.Context(), hcp)
+		g.Expect(err).NotTo(HaveOccurred(), "transient Console error should not fail the reconcile")
+		g.Expect(hcp.Status.ConsoleURL).To(Equal("https://previous.example.com"),
+			"ConsoleURL should remain unchanged when Console fetch fails")
+		g.Expect(hcp.Status.Configuration).NotTo(BeNil(),
+			"Authentication/Configuration should still be populated despite Console error")
+	})
+
+	t.Run("When Console capability is disabled, it should not update ConsoleURL even if Console resource exists", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-hcp", Namespace: "test-ns"},
+			Spec: hyperv1.HostedControlPlaneSpec{Capabilities: &hyperv1.Capabilities{
+				Disabled: []hyperv1.OptionalCapability{hyperv1.ConsoleCapability},
+			}},
+			Status: hyperv1.HostedControlPlaneStatus{ConsoleURL: "https://existing.example.com"},
+		}
+
+		hostedClusterClient := fake.NewClientBuilder().
+			WithScheme(api.Scheme).
+			WithObjects(baseObjects(&configv1.Console{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status:     configv1.ConsoleStatus{ConsoleURL: "https://different.example.com"},
+			})...).
+			Build()
+
+		reconciler := &hcpStatusReconciler{
+			hostedClusterClient: hostedClusterClient,
+		}
+
+		err := reconciler.reconcile(t.Context(), hcp)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(hcp.Status.ConsoleURL).To(Equal("https://existing.example.com"),
+			"ConsoleURL should remain unchanged when Console capability is disabled")
+		statusCond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.DataPlaneStatusSynced))
+		g.Expect(statusCond).NotTo(BeNil(), "DataPlaneStatusSynced condition should be set even when Console capability is disabled")
+		g.Expect(statusCond.Status).To(Equal(metav1.ConditionTrue))
+	})
+
+	t.Run("When ConsoleURL exceeds MaxLength, it should not update ConsoleURL", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-hcp", Namespace: "test-ns"},
+			Spec:       hyperv1.HostedControlPlaneSpec{Capabilities: &hyperv1.Capabilities{}},
+			Status:     hyperv1.HostedControlPlaneStatus{ConsoleURL: "https://previous.example.com"},
+		}
+
+		longURL := "https://console." + string(make([]byte, 4097))
+		hostedClusterClient := fake.NewClientBuilder().
+			WithScheme(api.Scheme).
+			WithObjects(baseObjects(&configv1.Console{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status:     configv1.ConsoleStatus{ConsoleURL: longURL},
+			})...).
+			Build()
+
+		reconciler := &hcpStatusReconciler{
+			hostedClusterClient: hostedClusterClient,
+		}
+
+		err := reconciler.reconcile(t.Context(), hcp)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(hcp.Status.ConsoleURL).To(Equal("https://previous.example.com"),
+			"ConsoleURL should remain unchanged when value exceeds MaxLength")
+
+		statusCond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.DataPlaneStatusSynced))
+		g.Expect(statusCond).NotTo(BeNil(), "DataPlaneStatusSynced condition should be set")
+		g.Expect(statusCond.Status).To(Equal(metav1.ConditionFalse))
+		g.Expect(statusCond.Reason).To(Equal(hyperv1.DataPlaneStatusSyncFailedReason))
+		g.Expect(statusCond.Message).To(ContainSubstring("ConsoleURL"))
+	})
 }
 
 func TestBuildStatusPatch(t *testing.T) {
@@ -538,4 +710,19 @@ func TestBuildStatusPatch(t *testing.T) {
 			"/status/releaseImage",
 		))
 	})
+}
+
+// erroringClient wraps a crclient.Client and returns a specific error when
+// Get is called for an object whose kind name contains the errorOn string.
+type erroringClient struct {
+	crclient.Client
+	errorOn   string
+	returnErr error
+}
+
+func (e *erroringClient) Get(ctx context.Context, key crclient.ObjectKey, obj crclient.Object, opts ...crclient.GetOption) error {
+	if reflect.TypeOf(obj).Elem().Name() == e.errorOn {
+		return e.returnErr
+	}
+	return e.Client.Get(ctx, key, obj, opts...)
 }

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -80,6 +80,7 @@ type HostedClusterConfigOperatorConfig struct {
 	EnableCIDebugOutput           bool
 	ImageMetaDataProvider         util.ImageMetadataProvider
 	ManagementClusterCapabilities capabilities.CapabiltyChecker
+	HCPCapabilities               *hyperv1.Capabilities
 
 	kubeClient kubeclient.Interface
 }
@@ -146,6 +147,10 @@ func Mgr(ctx context.Context, cfg, cpConfig *rest.Config, namespace string, hcpN
 		byObject[&operatorv1.IngressController{}] = allSelector
 	}
 
+	if capabilities.IsConsoleCapabilityEnabled(hcp.Spec.Capabilities) {
+		byObject[&configv1.Console{}] = allSelector
+	}
+
 	leaseDuration := time.Second * 60
 	renewDeadline := time.Second * 40
 	retryPeriod := time.Second * 15
@@ -192,6 +197,19 @@ func Mgr(ctx context.Context, cfg, cpConfig *rest.Config, namespace string, hcpN
 	}
 
 	return mgr
+}
+
+// GetHCPCapabilities reads the HostedControlPlane and returns its capabilities.
+func GetHCPCapabilities(ctx context.Context, cpConfig *rest.Config, namespace, hcpName string) (*hyperv1.Capabilities, error) {
+	ct, err := client.New(cpConfig, client.Options{Scheme: hyperapi.Scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+	hcp := resourcemanifests.HostedControlPlane(namespace, hcpName)
+	if err := ct.Get(ctx, client.ObjectKeyFromObject(hcp), hcp); err != nil {
+		return nil, fmt.Errorf("failed to get HCP: %w", err)
+	}
+	return hcp.Spec.Capabilities, nil
 }
 
 func CfgFromFile(path string) *rest.Config {

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -43899,6 +43899,14 @@ firewall rules, missing data plane nodes, or problems with infrastructure
 components like the konnectivity-agent workload.
 <strong>Unknown</strong> means the status cannot be determined (e.g., no worker nodes available or unable to inspect).</p>
 </td>
+</tr><tr><td><p>&#34;DataPlaneStatusSynced&#34;</p></td>
+<td><p>DataPlaneStatusSynced indicates whether status information propagated
+from the hosted cluster (e.g. ConsoleURL from the console operator) has
+been successfully synced to the control plane. A False value means the
+hosted cluster reported data that could not be propagated — for example,
+a ConsoleURL that exceeds the maximum allowed length. This condition is
+set by HCCO and bubbled up to the HostedCluster.</p>
+</td>
 </tr><tr><td><p>&#34;EtcdAvailable&#34;</p></td>
 <td><p>EtcdAvailable bubbles up the same condition from HCP. It signals if etcd is available.
 A failure here often means a software bug or a non-stable cluster.</p>
@@ -47819,6 +47827,20 @@ This is populated after the infrastructure is ready.</p>
 </tr>
 <tr>
 <td>
+<code>consoleURL</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>consoleURL is the URL of the OpenShift web console for this hosted cluster.
+This is populated from the console.config.openshift.io/cluster resource
+in the guest cluster once the console operator has reconciled.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>payloadArch</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1beta1.PayloadArchType">
@@ -48527,6 +48549,20 @@ string
 for identity providers. The [identity-provider-name] placeholder must be replaced
 with the name of an identity provider defined on the HostedCluster.
 This is populated after the infrastructure is ready.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>consoleURL</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>consoleURL is the URL of the OpenShift web console for this hosted cluster.
+This is populated from the console.config.openshift.io/cluster resource
+in the guest cluster once the console operator has reconciled.</p>
 </td>
 </tr>
 <tr>

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -45260,6 +45260,14 @@ firewall rules, missing data plane nodes, or problems with infrastructure
 components like the konnectivity-agent workload.
 <strong>Unknown</strong> means the status cannot be determined (e.g., no worker nodes available or unable to inspect).</p>
 </td>
+</tr><tr><td><p>&#34;DataPlaneStatusSynced&#34;</p></td>
+<td><p>DataPlaneStatusSynced indicates whether status information propagated
+from the hosted cluster (e.g. ConsoleURL from the console operator) has
+been successfully synced to the control plane. A False value means the
+hosted cluster reported data that could not be propagated — for example,
+a ConsoleURL that exceeds the maximum allowed length. This condition is
+set by HCCO and bubbled up to the HostedCluster.</p>
+</td>
 </tr><tr><td><p>&#34;EtcdAvailable&#34;</p></td>
 <td><p>EtcdAvailable bubbles up the same condition from HCP. It signals if etcd is available.
 A failure here often means a software bug or a non-stable cluster.</p>
@@ -49180,6 +49188,20 @@ This is populated after the infrastructure is ready.</p>
 </tr>
 <tr>
 <td>
+<code>consoleURL</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>consoleURL is the URL of the OpenShift web console for this hosted cluster.
+This is populated from the console.config.openshift.io/cluster resource
+in the guest cluster once the console operator has reconciled.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>payloadArch</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1beta1.PayloadArchType">
@@ -49888,6 +49910,20 @@ string
 for identity providers. The [identity-provider-name] placeholder must be replaced
 with the name of an identity provider defined on the HostedCluster.
 This is populated after the infrastructure is ready.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>consoleURL</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>consoleURL is the URL of the OpenShift web console for this hosted cluster.
+This is populated from the console.config.openshift.io/cluster resource
+in the guest cluster once the console operator has reconciled.</p>
 </td>
 </tr>
 <tr>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -6156,6 +6156,14 @@ firewall rules, missing data plane nodes, or problems with infrastructure
 components like the konnectivity-agent workload.
 <strong>Unknown</strong> means the status cannot be determined (e.g., no worker nodes available or unable to inspect).</p>
 </td>
+</tr><tr><td><p>&#34;DataPlaneStatusSynced&#34;</p></td>
+<td><p>DataPlaneStatusSynced indicates whether status information propagated
+from the hosted cluster (e.g. ConsoleURL from the console operator) has
+been successfully synced to the control plane. A False value means the
+hosted cluster reported data that could not be propagated — for example,
+a ConsoleURL that exceeds the maximum allowed length. This condition is
+set by HCCO and bubbled up to the HostedCluster.</p>
+</td>
 </tr><tr><td><p>&#34;EtcdAvailable&#34;</p></td>
 <td><p>EtcdAvailable bubbles up the same condition from HCP. It signals if etcd is available.
 A failure here often means a software bug or a non-stable cluster.</p>
@@ -10076,6 +10084,20 @@ This is populated after the infrastructure is ready.</p>
 </tr>
 <tr>
 <td>
+<code>consoleURL</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>consoleURL is the URL of the OpenShift web console for this hosted cluster.
+This is populated from the console.config.openshift.io/cluster resource
+in the guest cluster once the console operator has reconciled.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>payloadArch</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1beta1.PayloadArchType">
@@ -10784,6 +10806,20 @@ string
 for identity providers. The [identity-provider-name] placeholder must be replaced
 with the name of an identity provider defined on the HostedCluster.
 This is populated after the infrastructure is ready.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>consoleURL</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>consoleURL is the URL of the OpenShift web console for this hosted cluster.
+This is populated from the console.config.openshift.io/cluster resource
+in the guest cluster once the console operator has reconciled.</p>
 </td>
 </tr>
 <tr>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -824,6 +824,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			hyperv1.ControlPlaneConnectionAvailable,
 			hyperv1.EtcdBackupSucceeded,
 			hyperv1.ConfigOperatorReconciliationSucceeded,
+			hyperv1.DataPlaneStatusSynced,
 		}
 
 		for _, conditionType := range hcpConditions {
@@ -1136,6 +1137,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 				hcluster.Status.ControlPlaneEndpoint.Port = 443
 			}
 			hcluster.Status.OAuthCallbackURLTemplate = hcp.Status.OAuthCallbackURLTemplate
+			hcluster.Status.ConsoleURL = hcp.Status.ConsoleURL
 		}
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -817,6 +817,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			hyperv1.ControlPlaneConnectionAvailable,
 			hyperv1.EtcdBackupSucceeded,
 			hyperv1.ConfigOperatorReconciliationSucceeded,
+			hyperv1.DataPlaneStatusSynced,
 		}
 
 		for _, conditionType := range hcpConditions {
@@ -1129,6 +1130,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 				hcluster.Status.ControlPlaneEndpoint.Port = 443
 			}
 			hcluster.Status.OAuthCallbackURLTemplate = hcp.Status.OAuthCallbackURLTemplate
+			hcluster.Status.ConsoleURL = hcp.Status.ConsoleURL
 		}
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/reconcile_legacy.go
+++ b/hypershift-operator/controllers/hostedcluster/reconcile_legacy.go
@@ -504,6 +504,7 @@ func (r *HostedClusterReconciler) reconcileLegacy(ctx context.Context, req ctrl.
 			hyperv1.DataPlaneConnectionAvailable,
 			hyperv1.ControlPlaneConnectionAvailable,
 			hyperv1.EtcdBackupSucceeded,
+			hyperv1.DataPlaneStatusSynced,
 		}
 
 		for _, conditionType := range hcpConditions {
@@ -816,6 +817,7 @@ func (r *HostedClusterReconciler) reconcileLegacy(ctx context.Context, req ctrl.
 				hcluster.Status.ControlPlaneEndpoint.Port = 443
 			}
 			hcluster.Status.OAuthCallbackURLTemplate = hcp.Status.OAuthCallbackURLTemplate
+			hcluster.Status.ConsoleURL = hcp.Status.ConsoleURL
 		}
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/reconcile_legacy.go
+++ b/hypershift-operator/controllers/hostedcluster/reconcile_legacy.go
@@ -498,6 +498,7 @@ func (r *HostedClusterReconciler) reconcileLegacy(ctx context.Context, req ctrl.
 			hyperv1.DataPlaneConnectionAvailable,
 			hyperv1.ControlPlaneConnectionAvailable,
 			hyperv1.EtcdBackupSucceeded,
+			hyperv1.DataPlaneStatusSynced,
 		}
 
 		for _, conditionType := range hcpConditions {
@@ -810,6 +811,7 @@ func (r *HostedClusterReconciler) reconcileLegacy(ctx context.Context, req ctrl.
 				hcluster.Status.ControlPlaneEndpoint.Port = 443
 			}
 			hcluster.Status.OAuthCallbackURLTemplate = hcp.Status.OAuthCallbackURLTemplate
+			hcluster.Status.ConsoleURL = hcp.Status.ConsoleURL
 		}
 	}
 

--- a/support/capabilities/hosted_control_plane_capabilities.go
+++ b/support/capabilities/hosted_control_plane_capabilities.go
@@ -37,6 +37,19 @@ func IsIngressCapabilityEnabled(capabilities *hyperv1.Capabilities) bool {
 	return true
 }
 
+// IsConsoleCapabilityEnabled returns true if the Console capability is enabled, or false if disabled.
+func IsConsoleCapabilityEnabled(capabilities *hyperv1.Capabilities) bool {
+	if capabilities == nil {
+		return true
+	}
+	for _, disabledCap := range capabilities.Disabled {
+		if disabledCap == hyperv1.ConsoleCapability {
+			return false
+		}
+	}
+	return true
+}
+
 // HasDisabledCapabilities returns true if any capabilities are disabled; otherwise, it returns false.
 func HasDisabledCapabilities(capabilities *hyperv1.Capabilities) bool {
 	if capabilities == nil {

--- a/support/capabilities/hosted_control_plane_capabilities_test.go
+++ b/support/capabilities/hosted_control_plane_capabilities_test.go
@@ -148,6 +148,53 @@ func TestCalculateEnabledCapabilities(t *testing.T) {
 	}
 }
 
+func TestIsConsoleCapabilityEnabled(t *testing.T) {
+	tests := []struct {
+		name         string
+		capabilities *hyperv1.Capabilities
+		expectResult bool
+	}{
+		{
+			name:         "When capabilities is nil, it should return true",
+			capabilities: nil,
+			expectResult: true,
+		},
+		{
+			name: "When Console is not in the disabled list, it should return true",
+			capabilities: &hyperv1.Capabilities{
+				Disabled: []hyperv1.OptionalCapability{hyperv1.NodeTuningCapability},
+			},
+			expectResult: true,
+		},
+		{
+			name: "When Console is explicitly disabled, it should return false",
+			capabilities: &hyperv1.Capabilities{
+				Disabled: []hyperv1.OptionalCapability{hyperv1.ConsoleCapability},
+			},
+			expectResult: false,
+		},
+		{
+			name: "When Console is enabled and not disabled, it should return true",
+			capabilities: &hyperv1.Capabilities{
+				Enabled: []hyperv1.OptionalCapability{hyperv1.ConsoleCapability},
+			},
+			expectResult: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := IsConsoleCapabilityEnabled(test.capabilities)
+			if test.expectResult && !result {
+				t.Fatal("expected Console capability to be enabled, but it wasn't")
+			}
+			if !test.expectResult && result {
+				t.Fatal("expected Console capability to be disabled, but it wasn't")
+			}
+		})
+	}
+}
+
 func TestHasDisabledCapabilities(t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/support/capabilities/hosted_control_plane_capabilities_test.go
+++ b/support/capabilities/hosted_control_plane_capabilities_test.go
@@ -226,6 +226,53 @@ func TestFilterByKnownCapabilities(t *testing.T) {
 	}
 }
 
+func TestIsConsoleCapabilityEnabled(t *testing.T) {
+	tests := []struct {
+		name         string
+		capabilities *hyperv1.Capabilities
+		expectResult bool
+	}{
+		{
+			name:         "When capabilities is nil, it should return true",
+			capabilities: nil,
+			expectResult: true,
+		},
+		{
+			name: "When Console is not in the disabled list, it should return true",
+			capabilities: &hyperv1.Capabilities{
+				Disabled: []hyperv1.OptionalCapability{hyperv1.NodeTuningCapability},
+			},
+			expectResult: true,
+		},
+		{
+			name: "When Console is explicitly disabled, it should return false",
+			capabilities: &hyperv1.Capabilities{
+				Disabled: []hyperv1.OptionalCapability{hyperv1.ConsoleCapability},
+			},
+			expectResult: false,
+		},
+		{
+			name: "When Console is enabled and not disabled, it should return true",
+			capabilities: &hyperv1.Capabilities{
+				Enabled: []hyperv1.OptionalCapability{hyperv1.ConsoleCapability},
+			},
+			expectResult: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := IsConsoleCapabilityEnabled(test.capabilities)
+			if test.expectResult && !result {
+				t.Fatal("expected Console capability to be enabled, but it wasn't")
+			}
+			if !test.expectResult && result {
+				t.Fatal("expected Console capability to be disabled, but it wasn't")
+			}
+		})
+	}
+}
+
 func TestHasDisabledCapabilities(t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -26,6 +26,7 @@ func ExpectedHCConditions(hostedCluster *hyperv1.HostedCluster) map[hyperv1.Cond
 		hyperv1.ReconciliationSucceeded:               metav1.ConditionTrue,
 		hyperv1.ConfigOperatorReconciliationSucceeded: metav1.ConditionTrue,
 		hyperv1.ValidHostedControlPlaneConfiguration:  metav1.ConditionTrue,
+		hyperv1.DataPlaneStatusSynced:                 metav1.ConditionTrue,
 		hyperv1.ValidReleaseImage:                     metav1.ConditionTrue,
 		hyperv1.PlatformCredentialsFound:              metav1.ConditionTrue,
 		hyperv1.DataPlaneConnectionAvailable:          metav1.ConditionTrue,

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -3161,6 +3161,15 @@ func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 		delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
 	}
 
+	if IsLessThan(Version424) {
+		delete(expectedConditions, hyperv1.DataPlaneStatusSynced)
+	}
+	// Exclude DataPlaneStatusSynced during upgrade tests as the old HCCO
+	// won't set this condition, causing the HC controller to synthesize Unknown.
+	if upgradeContext != nil {
+		delete(expectedConditions, hyperv1.DataPlaneStatusSynced)
+	}
+
 	var predicates []Predicate[*hyperv1.HostedCluster]
 	for conditionType, conditionStatus := range expectedConditions {
 		predicates = append(predicates, ConditionPredicate[*hyperv1.HostedCluster](Condition{

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -3185,6 +3185,15 @@ func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 		delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
 	}
 
+	if IsLessThan(Version424) {
+		delete(expectedConditions, hyperv1.DataPlaneStatusSynced)
+	}
+	// Exclude DataPlaneStatusSynced during upgrade tests as the old HCCO
+	// won't set this condition, causing the HC controller to synthesize Unknown.
+	if upgradeContext != nil {
+		delete(expectedConditions, hyperv1.DataPlaneStatusSynced)
+	}
+
 	var predicates []Predicate[*hyperv1.HostedCluster]
 	for conditionType, conditionStatus := range expectedConditions {
 		predicates = append(predicates, ConditionPredicate[*hyperv1.HostedCluster](Condition{

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -16,6 +16,7 @@ import (
 var (
 	// y-stream versions supported by e2e in main
 	Version50  = semver.MustParse("5.0.0")
+	Version424 = semver.MustParse("4.24.0")
 	Version423 = semver.MustParse("4.23.0")
 	Version422 = semver.MustParse("4.22.0")
 	Version421 = semver.MustParse("4.21.0")
@@ -35,6 +36,7 @@ func init() {
 	// This is a compile-time check to ensure that the versions are valid
 	// semver versions.
 	_ = Version50
+	_ = Version424
 	_ = Version423
 	_ = Version422
 	_ = Version421

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -16,6 +16,7 @@ var (
 	// y-stream versions supported by e2e in main
 	Version51  = semver.MustParse("5.1.0")
 	Version50  = semver.MustParse("5.0.0")
+	Version424 = semver.MustParse("4.24.0")
 	Version423 = semver.MustParse("4.23.0")
 	Version422 = semver.MustParse("4.22.0")
 	Version421 = semver.MustParse("4.21.0")
@@ -36,6 +37,7 @@ func init() {
 	// semver versions.
 	_ = Version51
 	_ = Version50
+	_ = Version424
 	_ = Version423
 	_ = Version422
 	_ = Version421

--- a/test/e2e/v2/tests/hosted_cluster_health_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_health_test.go
@@ -24,6 +24,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hcc "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster"
+	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/conditions"
 	hyperutil "github.com/openshift/hypershift/support/util"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
@@ -45,6 +46,7 @@ func RegisterHostedClusterHealthTests(getTestCtx internal.TestContextGetter) {
 	EnsureFeatureGateStatusTest(getTestCtx)
 	EnsurePayloadArchSetCorrectlyTest(getTestCtx)
 	ValidateConfigurationStatusTest(getTestCtx)
+	ValidateConsoleURLTest(getTestCtx)
 }
 
 func ValidateHostedClusterConditionsTest(getTestCtx internal.TestContextGetter) {
@@ -62,9 +64,12 @@ func ValidateHostedClusterConditionsTest(getTestCtx internal.TestContextGetter) 
 				delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
 				delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkPolicyRBAC)
 			}
-			if e2eutil.IsLessThan(e2eutil.Version423) {
-				delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
-			}
+		if e2eutil.IsLessThan(e2eutil.Version423) {
+			delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
+		}
+		if e2eutil.IsLessThan(e2eutil.Version424) {
+			delete(expectedConditions, hyperv1.DataPlaneStatusSynced)
+		}
 
 			Eventually(func(g Gomega) {
 				hc := &hyperv1.HostedCluster{}
@@ -184,6 +189,45 @@ func ValidateConfigurationStatusTest(getTestCtx internal.TestContextGetter) {
 					"HC authentication status should match hosted cluster Authentication resource")
 				g.Expect(hcp.Status.Configuration.Authentication).To(Equal(hc.Status.Configuration.Authentication),
 					"HCP and HC authentication status should be consistent")
+			}, 10*time.Minute, 10*time.Second).Should(Succeed())
+		})
+	})
+}
+
+func ValidateConsoleURLTest(getTestCtx internal.TestContextGetter) {
+	When("hosted cluster console is enabled", func() {
+		It("should propagate console URL to HCP and HC status", func() {
+			tc := getTestCtx()
+			hostedCluster := tc.GetHostedCluster()
+			if !capabilities.IsConsoleCapabilityEnabled(hostedCluster.Spec.Capabilities) {
+				Skip("Console capability is disabled")
+			}
+			tc.ValidateHostedClusterClient()
+			hcClient := tc.GetHostedClusterClient()
+
+			Eventually(func(g Gomega) {
+				var hostedClusterConsole configv1.Console
+				g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, &hostedClusterConsole)).To(Succeed())
+				g.Expect(hostedClusterConsole.Status.ConsoleURL).NotTo(BeEmpty(), "hosted cluster Console resource should have a URL")
+
+				var hcp hyperv1.HostedControlPlane
+				g.Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+					Name:      hostedCluster.Name,
+					Namespace: tc.ControlPlaneNamespace,
+				}, &hcp)).To(Succeed(), "failed to get HostedControlPlane %s/%s", tc.ControlPlaneNamespace, hostedCluster.Name)
+				g.Expect(hcp.Status.ConsoleURL).NotTo(BeEmpty(), "HCP console URL should be set")
+
+				var hc hyperv1.HostedCluster
+				g.Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKeyFromObject(hostedCluster), &hc)).To(Succeed(),
+					"failed to get HostedCluster %s/%s", hostedCluster.Namespace, hostedCluster.Name)
+				g.Expect(hc.Status.ConsoleURL).NotTo(BeEmpty(), "HC console URL should be set")
+
+				g.Expect(hcp.Status.ConsoleURL).To(Equal(hostedClusterConsole.Status.ConsoleURL),
+					"HCP console URL should match hosted cluster Console resource")
+				g.Expect(hc.Status.ConsoleURL).To(Equal(hostedClusterConsole.Status.ConsoleURL),
+					"HC console URL should match hosted cluster Console resource")
+				g.Expect(hc.Status.ConsoleURL).To(Equal(hcp.Status.ConsoleURL),
+					"HC and HCP console URL should be consistent")
 			}, 10*time.Minute, 10*time.Second).Should(Succeed())
 		})
 	})

--- a/test/e2e/v2/tests/hosted_cluster_health_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_health_test.go
@@ -24,6 +24,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hcc "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster"
+	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/conditions"
 	hyperutil "github.com/openshift/hypershift/support/util"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
@@ -45,6 +46,7 @@ func RegisterHostedClusterHealthTests(getTestCtx internal.TestContextGetter) {
 	EnsureFeatureGateStatusTest(getTestCtx)
 	EnsurePayloadArchSetCorrectlyTest(getTestCtx)
 	ValidateConfigurationStatusTest(getTestCtx)
+	ValidateConsoleURLTest(getTestCtx)
 }
 
 func ValidateHostedClusterConditionsTest(getTestCtx internal.TestContextGetter) {
@@ -65,6 +67,9 @@ func ValidateHostedClusterConditionsTest(getTestCtx internal.TestContextGetter) 
 			}
 			if !tc.VersionAtLeast(e2eutil.Version423) {
 				delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
+			}
+			if !tc.VersionAtLeast(e2eutil.Version424) {
+				delete(expectedConditions, hyperv1.DataPlaneStatusSynced)
 			}
 
 			Eventually(func(g Gomega) {
@@ -186,6 +191,46 @@ func ValidateConfigurationStatusTest(getTestCtx internal.TestContextGetter) {
 					"HC authentication status should match hosted cluster Authentication resource")
 				g.Expect(hcp.Status.Configuration.Authentication).To(Equal(hc.Status.Configuration.Authentication),
 					"HCP and HC authentication status should be consistent")
+			}, 10*time.Minute, 10*time.Second).Should(Succeed())
+		})
+	})
+}
+
+func ValidateConsoleURLTest(getTestCtx internal.TestContextGetter) {
+	When("hosted cluster console is enabled", func() {
+		It("should propagate console URL to HCP and HC status", func() {
+			tc := getTestCtx()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			if !capabilities.IsConsoleCapabilityEnabled(hostedCluster.Spec.Capabilities) {
+				Skip("Console capability is disabled")
+			}
+			hcClient, err := tc.GetHostedClusterClient(hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				var hostedClusterConsole configv1.Console
+				g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, &hostedClusterConsole)).To(Succeed())
+				g.Expect(hostedClusterConsole.Status.ConsoleURL).NotTo(BeEmpty(), "hosted cluster Console resource should have a URL")
+
+				var hcp hyperv1.HostedControlPlane
+				g.Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+					Name:      hostedCluster.Name,
+					Namespace: tc.ControlPlaneNamespace,
+				}, &hcp)).To(Succeed(), "failed to get HostedControlPlane %s/%s", tc.ControlPlaneNamespace, hostedCluster.Name)
+				g.Expect(hcp.Status.ConsoleURL).NotTo(BeEmpty(), "HCP console URL should be set")
+
+				var hc hyperv1.HostedCluster
+				g.Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKeyFromObject(hostedCluster), &hc)).To(Succeed(),
+					"failed to get HostedCluster %s/%s", hostedCluster.Namespace, hostedCluster.Name)
+				g.Expect(hc.Status.ConsoleURL).NotTo(BeEmpty(), "HC console URL should be set")
+
+				g.Expect(hcp.Status.ConsoleURL).To(Equal(hostedClusterConsole.Status.ConsoleURL),
+					"HCP console URL should match hosted cluster Console resource")
+				g.Expect(hc.Status.ConsoleURL).To(Equal(hostedClusterConsole.Status.ConsoleURL),
+					"HC console URL should match hosted cluster Console resource")
+				g.Expect(hc.Status.ConsoleURL).To(Equal(hcp.Status.ConsoleURL),
+					"HC and HCP console URL should be consistent")
 			}, 10*time.Minute, 10*time.Second).Should(Succeed())
 		})
 	})

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hosted_controlplane.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hosted_controlplane.go
@@ -360,6 +360,15 @@ type HostedControlPlaneStatus struct {
 	// +kubebuilder:validation:MaxLength=255
 	OAuthCallbackURLTemplate string `json:"oauthCallbackURLTemplate,omitempty"`
 
+	// consoleURL is the URL of the OpenShift web console for this hosted cluster.
+	// This is populated from the console.config.openshift.io/cluster resource
+	// in the guest cluster once the console operator has reconciled.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=4096
+	// +kubebuilder:validation:XValidation:rule="isURL(self)",message="consoleURL must be a valid URL"
+	ConsoleURL string `json:"consoleURL,omitempty"`
+
 	// controlPlaneVersion tracks the rollout status of the control plane
 	// components running on the management cluster, independently from
 	// the data-plane version reported in the version field.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -208,6 +208,14 @@ const (
 	// connectivity issues between the control plane and the hosted cluster.
 	ConfigOperatorReconciliationSucceeded ConditionType = "ConfigOperatorReconciliationSucceeded"
 
+	// DataPlaneStatusSynced indicates whether status information propagated
+	// from the hosted cluster (e.g. ConsoleURL from the console operator) has
+	// been successfully synced to the control plane. A False value means the
+	// hosted cluster reported data that could not be propagated — for example,
+	// a ConsoleURL that exceeds the maximum allowed length. This condition is
+	// set by HCCO and bubbled up to the HostedCluster.
+	DataPlaneStatusSynced ConditionType = "DataPlaneStatusSynced"
+
 	// EtcdRecoveryActive indicates that the Etcd cluster is failing and the
 	// recovery job was triggered.
 	EtcdRecoveryActive ConditionType = "EtcdRecoveryActive"
@@ -357,6 +365,8 @@ const (
 	ControlPlaneConnectionConfigMapNotFoundReason = "ConfigMapNotFound"
 
 	ControlPlaneConnectionNoWorkerNodesAvailableReason = "NoWorkerNodesAvailable"
+
+	DataPlaneStatusSyncFailedReason = "DataPlaneStatusSyncFailed"
 
 	ControlPlaneComponentsNotAvailable = "ComponentsNotAvailable"
 

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -2672,6 +2672,15 @@ type HostedClusterStatus struct {
 	// +kubebuilder:validation:MaxLength=1024
 	OAuthCallbackURLTemplate string `json:"oauthCallbackURLTemplate,omitempty"`
 
+	// consoleURL is the URL of the OpenShift web console for this hosted cluster.
+	// This is populated from the console.config.openshift.io/cluster resource
+	// in the guest cluster once the console operator has reconciled.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=4096
+	// +kubebuilder:validation:XValidation:rule="isURL(self)",message="consoleURL must be a valid URL"
+	ConsoleURL string `json:"consoleURL,omitempty"`
+
 	// payloadArch represents the CPU architecture type of the HostedCluster.Spec.Release.Image. The valid values are:
 	// Multi, ARM64, AMD64, S390X, or PPC64LE.
 	// +kubebuilder:validation:Enum=Multi;ARM64;AMD64;PPC64LE;S390X


### PR DESCRIPTION
Service operators would like to expose the console URL to users, and users control how the console URL actually gets routed by changing config in the cluster, so we need to read it from the cluster for the correct source of truth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hosted cluster status now includes an optional OpenShift web console URL (with validated length) and populates it from the guest console configuration when available.
  * HostedCluster now mirrors the HostedControlPlane console URL.
  * Console URL updates are capability-gated: it clears when the console resource is missing and otherwise leaves the current value unchanged on fetch errors.

* **Tests**
  * Added an end-to-end health check to verify both statuses publish a non-empty console URL and that they match.
  * Added unit coverage for console URL reconciliation behavior and capability gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->