### PR TITLE
OCPBUGS-98695: add AWS CPO overrides for 4.22

### DIFF
--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
@@ -388,6 +388,24 @@ platforms:
       cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-cert-hotfix-416-multi:2d2e6071841bb12ff1f41c457889bb44b6fb1cf7
     # End of OCPBUGS-58837 overrides 4.15 section
     # End of OCPBUGS-58837 overrides
+    # Beginning of OCPBUGS-98627/OCPBUGS-98220 overrides 4.22 section
+    - version: 4.22.0
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+    - version: 4.22.1
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+    - version: 4.22.2
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+    - version: 4.22.3
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+    - version: 4.22.4
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+    - version: 4.22.5
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+    - version: 4.22.6
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+    # 4.22.7 does not need an override: both PRs (#8972, #8998) merged before the
+    # 4.22.7 development cutoff (2026-07-22).
+    # End of OCPBUGS-98627/OCPBUGS-98220 overrides 4.22 section
     testing:
     # Update the image refs below to indicate which images should be used for CPO override
     # testing. Currently, we only test one latest/previous combination. In the future, we

--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
@@ -411,6 +411,6 @@ platforms:
     # testing. Currently, we only test one latest/previous combination. In the future, we
     # may be able to test multiple combinations at a time. To test more than one, update
     # the referenced images before each e2e test run.
-      latest: quay.io/openshift-release-dev/ocp-release:4.17.43-x86_64
-      previous: quay.io/openshift-release-dev/ocp-release:4.17.20-x86_64
+      latest: quay.io/openshift-release-dev/ocp-release:4.22.5-x86_64
+      previous: quay.io/openshift-release-dev/ocp-release:4.21.24-x86_64
       runTests: true


### PR DESCRIPTION
## Summary

- Add AWS CPO image overrides for 4.22.0-4.22.6 to fix KMS key rotation and related issues
- 4.22.7 does not need an override: both PRs merged before the development cutoff (2026-07-22)
- Image source: Konflux push build (commit fb3b1a355476)

branch: 4.22 wants: https://github.com/openshift/hypershift/pull/8972, https://github.com/openshift/hypershift/pull/8998

## Test plan

- [ ] Unit tests pass (`go test ./hypershift-operator/controlplaneoperator-overrides/...`)
- [ ] `/validate-pr-override-images` passes against this PR
- [ ] Override image is publicly pullable from quay.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Azure platform overrides for OpenShift 4.22 to use explicit control-plane-operator image digests for versions 4.22.0–4.22.6, with no override required for 4.22.7.
  * Refreshed the Azure testing image references used for control-plane-operator override validation (latest and previous) to align with the 4.22 release stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->