### PR TITLE
OCPBUGS-98695: add Azure CPO overrides for 4.22

### DIFF
--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
@@ -103,25 +103,33 @@ platforms:
       # End of OCPBUGS-86416 overrides 4.21 section
       # 4.22 does not need an override: the fix (PR #8564) landed before rc.5
       # (SOURCE_GIT_COMMIT=d6c72d15350752e315c198f7a68558ae4086e3c7) and GA will include it.
-      # Beginning of CNTRLPLANE-3619/CNTRLPLANE-3656 overrides 4.22 section
+      # Beginning of CNTRLPLANE-3619/CNTRLPLANE-3656/OCPBUGS-98627/OCPBUGS-98220 overrides 4.22 section
+      # Supersedes the previous CNTRLPLANE-3619/3656 image: this build (commit fb3b1a355476)
+      # includes PRs #8721, #8790, #8972, and #8998.
       - version: 4.22.0
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9584e156f938121c050c2373583998ec78068013d1a94d97913bea3e6416c427
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
       - version: 4.22.1
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9584e156f938121c050c2373583998ec78068013d1a94d97913bea3e6416c427
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
       - version: 4.22.2
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9584e156f938121c050c2373583998ec78068013d1a94d97913bea3e6416c427
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
       - version: 4.22.3
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9584e156f938121c050c2373583998ec78068013d1a94d97913bea3e6416c427
-      # 4.22.4 does not need an override: both PRs (#8721, #8790) merged 2026-06-26,
-      # before the 4.22.4 development cutoff (2026-07-01).
-      # End of CNTRLPLANE-3619/CNTRLPLANE-3656 overrides 4.22 section
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+      - version: 4.22.4
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+      - version: 4.22.5
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+      - version: 4.22.6
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+      # 4.22.7 does not need an override: all four PRs (#8721, #8790, #8972, #8998)
+      # merged before the 4.22.7 development cutoff (2026-07-22).
+      # End of CNTRLPLANE-3619/CNTRLPLANE-3656/OCPBUGS-98627/OCPBUGS-98220 overrides 4.22 section
     testing:
       # Update the image refs below to indicate which images should be used for CPO override
       # testing. Currently, we only test one latest/previous combination. In the future, we
       # may be able to test multiple combinations at a time. To test more than one, update
       # the referenced images before each e2e test run.
-      latest: quay.io/openshift-release-dev/ocp-release:4.19.10-x86_64
-      previous: quay.io/openshift-release-dev/ocp-release:4.19.9-x86_64
+      latest: quay.io/openshift-release-dev/ocp-release:4.22.5-x86_64
+      previous: quay.io/openshift-release-dev/ocp-release:4.21.24-x86_64
       runTests: true
   aws:
     overrides:


### PR DESCRIPTION
## Summary

- Add Azure CPO image overrides for 4.22.0-4.22.6 to fix KMS key rotation (OCPBUGS-98220) and ARO HCP ingress LB scope (OCPBUGS-98627)
- Supersedes the previous CNTRLPLANE-3619/3656 overrides for 4.22.0-4.22.3: the new Konflux image (commit fb3b1a355476) includes all four PRs (#8721, #8790, #8972, #8998)
- 4.22.7 does not need an override: all PRs merged before the development cutoff (2026-07-22)
- Image source: Konflux push build (commit fb3b1a355476)
- Supersedes #9009 which incorrectly placed the overrides under the `aws` platform instead of `azure`

branch: 4.22 wants: https://github.com/openshift/hypershift/pull/8721, https://github.com/openshift/hypershift/pull/8790, https://github.com/openshift/hypershift/pull/8972, https://github.com/openshift/hypershift/pull/8998

## Test plan

- [x] Unit tests pass (`go test ./hypershift-operator/controlplaneoperator-overrides/...`)
- [x] All 4 PRs verified present in override image via `verify-pr-in-image.sh`
- [x] Override image is publicly pullable from quay.io
- [ ] `/validate-pr-override-images` passes against this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Azure control plane operator images for OpenShift 4.22.0–4.22.6.
  * Refreshed Azure testing image references to use OpenShift 4.22.5 and 4.21.24 releases.
  * Updated release annotations and override guidance for newer OpenShift 4.22 versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->