### PR TITLE
OCPBUGS-98718: retry CreateVpcEndpoint on AWS throttle errors

### DIFF
--- a/cmd/infra/aws/ec2.go
+++ b/cmd/infra/aws/ec2.go
@@ -12,6 +12,7 @@ import (
 	supportawsutil "github.com/openshift/hypershift/support/awsutil"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
@@ -131,13 +132,7 @@ func (o *CreateInfraOptions) CreateVPCS3Endpoint(ctx context.Context, l logr.Log
 		l.Info("Found existing s3 VPC endpoint", "id", existingEndpoint)
 		return nil
 	}
-	isRetriable := func(err error) bool {
-		var apiErr smithy.APIError
-		if errors.As(err, &apiErr) {
-			return strings.EqualFold(apiErr.ErrorCode(), invalidRouteTableID)
-		}
-		return false
-	}
+	isRetriable := isRetriableVPCEndpointError
 	if err = retry.OnError(retryBackoff, isRetriable, func() error {
 		result, err := client.CreateVpcEndpoint(ctx, &ec2.CreateVpcEndpointInput{
 			VpcId:             aws.String(vpcID),
@@ -688,4 +683,17 @@ func ec2Tags(infraID, clusterName, name string) []ec2types.Tag {
 		})
 	}
 	return tags
+}
+
+func isRetriableVPCEndpointError(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		code := apiErr.ErrorCode()
+		if strings.EqualFold(code, invalidRouteTableID) {
+			return true
+		}
+		_, isThrottle := awsretry.DefaultThrottleErrorCodes[code]
+		return isThrottle
+	}
+	return false
 }

--- a/cmd/infra/aws/ec2_test.go
+++ b/cmd/infra/aws/ec2_test.go
@@ -1,0 +1,64 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/smithy-go"
+)
+
+type testAPIError struct {
+	code string
+}
+
+func (e *testAPIError) Error() string                 { return fmt.Sprintf("api error %s", e.code) }
+func (e *testAPIError) ErrorCode() string             { return e.code }
+func (e *testAPIError) ErrorMessage() string          { return e.code }
+func (e *testAPIError) ErrorFault() smithy.ErrorFault { return smithy.FaultUnknown }
+
+func TestIsRetriableVPCEndpointError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "When error is invalidRouteTableID it should be retriable",
+			err:      &testAPIError{code: invalidRouteTableID},
+			expected: true,
+		},
+		{
+			name:     "When error is RequestLimitExceeded it should be retriable",
+			err:      &testAPIError{code: "RequestLimitExceeded"},
+			expected: true,
+		},
+		{
+			name:     "When error is Throttling it should be retriable",
+			err:      &testAPIError{code: "Throttling"},
+			expected: true,
+		},
+		{
+			name:     "When error is EC2ThrottledException it should be retriable",
+			err:      &testAPIError{code: "EC2ThrottledException"},
+			expected: true,
+		},
+		{
+			name:     "When error is a non-retriable API error it should not be retriable",
+			err:      &testAPIError{code: "InvalidParameterValue"},
+			expected: false,
+		},
+		{
+			name:     "When error is not an API error it should not be retriable",
+			err:      fmt.Errorf("network timeout"),
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(isRetriableVPCEndpointError(tt.err)).To(Equal(tt.expected))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add AWS throttle error codes to the `isRetriable` predicate in `CreateVPCS3Endpoint` so rate-limited `ec2:CreateVpcEndpoint` calls are retried with the existing exponential backoff

## Fixes

- https://redhat.atlassian.net/browse/OCPBUGS-98718

## Root Cause

When 14+ HostedClusters are created in parallel (as in `e2e-aws-ovn`), AWS throttles `ec2:CreateVpcEndpoint` with `RequestLimitExceeded`. The `isRetriable` predicate only matched `invalidRouteTableID`, so the throttle error was treated as non-retriable and `retry.OnError` returned immediately.

Evidence from build [2077041517976883200](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/8996/pull-ci-openshift-hypershift-main-e2e-aws-4-22/2077041517976883200) (Jul 14, PR #8996 CI):
```
cannot create VPC S3 endpoint: operation error EC2: CreateVpcEndpoint,
exceeded maximum number of attempts, 11, api error RequestLimitExceeded:
Request limit exceeded. Account 820196288204 has been throttled on ec2:CreateVpcEndpoint
```

Same class of issue as OCPBUGS-98462 (Route53 throttle) but different AWS API.

## Changes

| Before | After |
|--------|-------|
| `isRetriable` matches only `invalidRouteTableID` | Also matches all `awsretry.DefaultThrottleErrorCodes` (14 standard AWS throttle codes including `RequestLimitExceeded`, `Throttling`, `EC2ThrottledException`, etc.) |

The existing `retryBackoff` (5 steps, 3s base, 3x factor, 0.1 jitter) already provides exponential backoff with jitter — only the predicate was missing.

## Test plan

- [x] `go build` passes
- [x] `make lint` — 0 issues
- [ ] `e2e-aws-4-22` presubmit should no longer fail on `RequestLimitExceeded` during VPC endpoint creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating Amazon VPC S3 endpoints by retrying transient AWS throttling and rate-limit errors.
  * Added retry handling for endpoint creation when the related route table is temporarily unavailable.

* **Tests**
  * Added coverage to ensure the retry logic correctly distinguishes retriable versus non-retriable AWS API errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->