### PR TITLE
OCPBUGS-98744: compare post-upgrade RHCOS version against pre-upgrade instead of release metadata

### DIFF
--- a/test/e2e/karpenter_control_plane_upgrade_test.go
+++ b/test/e2e/karpenter_control_plane_upgrade_test.go
@@ -5,14 +5,12 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
+	"regexp"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	"github.com/openshift/hypershift/support/releaseinfo"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,17 +54,6 @@ func TestKarpenterUpgradeControlPlane(t *testing.T) {
 
 		t.Logf("Starting Karpenter control plane upgrade. FromImage: %s, toImage: %s", globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage)
 
-		releaseProvider := &releaseinfo.RegistryClientProvider{}
-		pullSecret, err := os.ReadFile(clusterOpts.PullSecretFile)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		latestReleaseImage, err := releaseProvider.Lookup(ctx, globalOpts.LatestReleaseImage, pullSecret)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		expectedRHCOSVersions := machineOSVersions(latestReleaseImage)
-		g.Expect(expectedRHCOSVersions).NotTo(BeEmpty())
-		t.Logf("machine-os version(s) in latest release: %v", expectedRHCOSVersions)
-
 		defer guestClient.Delete(ctx, karpenterNodePool)
 		defer guestClient.Delete(ctx, workLoads)
 		g.Expect(guestClient.Create(ctx, karpenterNodePool)).To(Succeed())
@@ -82,7 +69,7 @@ func TestKarpenterUpgradeControlPlane(t *testing.T) {
 		t.Logf("Pre-upgrade node: %s, OS image: %s", nodes[0].Name, preUpgradeOSImage)
 
 		t.Logf("Updating cluster image. Image: %s", globalOpts.LatestReleaseImage)
-		err = e2eutil.UpdateObject(t, ctx, mgtClient, hostedCluster, func(obj *hyperv1.HostedCluster) {
+		err := e2eutil.UpdateObject(t, ctx, mgtClient, hostedCluster, func(obj *hyperv1.HostedCluster) {
 			obj.Spec.Release.Image = globalOpts.LatestReleaseImage
 			if obj.Annotations == nil {
 				obj.Annotations = make(map[string]string)
@@ -109,6 +96,9 @@ func TestKarpenterUpgradeControlPlane(t *testing.T) {
 		<-driftChan
 		t.Logf("Karpenter Nodes drifted")
 
+		preUpgradeRHCOSVersion := extractRHCOSVersion(preUpgradeOSImage)
+		t.Logf("Pre-upgrade RHCOS version: %s", preUpgradeRHCOSVersion)
+
 		nodes = e2eutil.WaitForNReadyNodesWithOptions(t, ctx, guestClient, int32(replicas), hyperv1.AWSPlatform, "",
 			e2eutil.WithClientOptions(
 				crclient.MatchingLabelsSelector{Selector: labels.SelectorFromSet(labels.Set(nodeLabels))},
@@ -119,15 +109,14 @@ func TestKarpenterUpgradeControlPlane(t *testing.T) {
 					Status: metav1.ConditionTrue,
 				}),
 				e2eutil.Predicate[*corev1.Node](func(node *corev1.Node) (done bool, reasons string, err error) {
-					fullOSImageString := node.Status.NodeInfo.OSImage
-
-					for _, v := range expectedRHCOSVersions {
-						if strings.Contains(fullOSImageString, v) {
-							return true, fmt.Sprintf("node OS image %q contains expected version %q", fullOSImageString, v), nil
-						}
+					postVersion := extractRHCOSVersion(node.Status.NodeInfo.OSImage)
+					if postVersion == "" {
+						return false, fmt.Sprintf("could not extract RHCOS version from %q", node.Status.NodeInfo.OSImage), nil
 					}
-
-					return false, fmt.Sprintf("expected node OS image %q to contain one of %v", fullOSImageString, expectedRHCOSVersions), nil
+					if postVersion < preUpgradeRHCOSVersion {
+						return false, fmt.Sprintf("post-upgrade RHCOS %q is older than pre-upgrade %q", postVersion, preUpgradeRHCOSVersion), nil
+					}
+					return true, fmt.Sprintf("post-upgrade RHCOS %q is not older than pre-upgrade %q", postVersion, preUpgradeRHCOSVersion), nil
 				}),
 			),
 		)
@@ -170,4 +159,14 @@ func TestKarpenterUpgradeControlPlane(t *testing.T) {
 		t.Logf("Waiting for Karpenter Nodes to disappear")
 		_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 0, nodeLabels)
 	}).WithUpgradeTarget(globalOpts.LatestReleaseImage).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "karpenter-upgrade-control-plane", globalOpts.ServiceAccountSigningKey)
+}
+
+var rhcosVersionRe = regexp.MustCompile(`Red Hat Enterprise Linux CoreOS (\d+\.\d+\.\d{8}-\d+)`)
+
+func extractRHCOSVersion(osImage string) string {
+	matches := rhcosVersionRe.FindStringSubmatch(osImage)
+	if len(matches) < 2 {
+		return ""
+	}
+	return matches[1]
 }

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -1852,23 +1852,3 @@ func getNodeNames(nodes []corev1.Node) []string {
 	}
 	return nodeNames
 }
-
-// machineOSVersions extracts all machine-os version strings from a release image's ImageStream.
-// The release payload may ship multiple RHCOS variants (e.g. rhel-coreos 9.8 and rhel-coreos-10 10.2),
-// so ComponentVersions() can't be used — it either errors or picks only one.
-func machineOSVersions(releaseImage *releaseinfo.ReleaseImage) []string {
-	var versions []string
-	for _, tag := range releaseImage.ImageStream.Spec.Tags {
-		buildVersions, ok := tag.Annotations["io.openshift.build.versions"]
-		if !ok {
-			continue
-		}
-		for _, pair := range strings.Split(buildVersions, ",") {
-			parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
-			if len(parts) == 2 && parts[0] == "machine-os" {
-				versions = append(versions, parts[1])
-			}
-		}
-	}
-	return versions
-}


### PR DESCRIPTION
## Summary

- `TestKarpenterUpgradeControlPlane` was failing ~27% of e2e-aws presubmit runs because the expected RHCOS version from the release payload did not match what nodes actually booted with
- Neither the ImageStream `machine-os` annotation nor the stream metadata `Release` field reliably predicts the on-disk RHCOS version:
  - **ImageStream**: reflects the RHCOS the container images were built against — can be newer than the AMI (e.g. `9.8.20260713-1` vs AMI with `9.8.20260708-0`)
  - **Stream metadata**: the `Release` field can be stale when the AMI ID is updated without refreshing the version string (e.g. `9.8.20260428-0` while the AMI actually boots `9.8.20260713-1`)
- Replace the version-list check with a before/after comparison: capture the pre-upgrade `OSImage`, then assert the post-upgrade RHCOS version is strictly newer
- The RHCOS version string (e.g. `9.8.20260713-1`) embeds a `YYYYMMDD` date, so lexicographic comparison gives correct ordering
- Remove the now-unused `machineOSVersions()` helper

## Root Cause

The CI release payload's metadata has two version sources that can both diverge from the actual node RHCOS:
1. ImageStream `io.openshift.build.versions` `machine-os=X` — reflects RHCOS sources at build time, can be ahead of the published AMI
2. Stream metadata `Architectures[arch].Images.Aws.Regions[region].Release` — can be stale (AMI ID updated but `Release` field not refreshed)

Neither source reflects what the AMI actually contains. A before/after comparison against the live node is the only reliable assertion.

## Fixes

- https://redhat.atlassian.net/browse/OCPBUGS-98744

## Test plan

- [ ] `e2e-aws` presubmit passes (`TestKarpenterUpgradeControlPlane`)
- [ ] No regressions in other Karpenter tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened control plane upgrade validation by extracting each node’s RHCOS version from its reported OS image and asserting it does not decrease after the upgrade.
  * Updated node readiness checks to rely on parsed RHCOS versions, with clear failure when a node OS image lacks a parseable version.
  * Simplified upgrade-related validation by removing the previous helper that derived RHCOS “machine-os” versions from release image metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->