### PR TITLE
CNTRLPLANE-400: feat(remediationAllowed in NP): propagate MHC RemediationAllowed to NodePool Ready condition

### DIFF
--- a/api/hypershift/v1beta1/nodepool_conditions.go
+++ b/api/hypershift/v1beta1/nodepool_conditions.go
@@ -49,6 +49,9 @@ const (
 	NodePoolUpdatingPlatformMachineTemplateConditionType = "UpdatingPlatformMachineTemplate"
 	// NodePoolReadyConditionType bubbles up CAPI MachineDeployment/MachineSet Ready condition.
 	// This is true when all replicas are ready Nodes.
+	// This may also be set to false when the MachineHealthCheck RemediationAllowed
+	// condition is false (reason TooManyUnhealthy), indicating that auto-repair is
+	// blocked because too many machines are unhealthy.
 	// When this is false for too long, NodePoolAllMachinesReadyConditionType and NodePoolAllNodesHealthyConditionType might provide more context.
 	NodePoolReadyConditionType = "Ready"
 	// NodePoolAllMachinesReadyConditionType bubbles up and aggregates CAPI Machine Ready condition.

--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -34,6 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/go-logr/logr"
 )
@@ -185,6 +187,20 @@ func (c *CAPI) Reconcile(ctx context.Context) error {
 			Reason:             hyperv1.AsExpectedReason,
 			ObservedGeneration: nodePool.Generation,
 		})
+
+		// When MHC RemediationAllowed is False, override the Ready condition to signal
+		// that auto-repair is blocked because too many machines are unhealthy.
+		if remediationAllowed := findMHCRemediationAllowedCondition(mhc.Status.Conditions); remediationAllowed != nil {
+			if remediationAllowed.Status == corev1.ConditionFalse {
+				SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+					Type:               hyperv1.NodePoolReadyConditionType,
+					Status:             corev1.ConditionFalse,
+					Reason:             remediationAllowed.Reason,
+					Message:            remediationAllowed.Message,
+					ObservedGeneration: nodePool.Generation,
+				})
+			}
+		}
 	} else {
 		err := c.Get(ctx, client.ObjectKeyFromObject(mhc), mhc)
 		if err != nil && !apierrors.IsNotFound(err) {
@@ -736,6 +752,13 @@ func (c *CAPI) reconcileMachineHealthCheck(ctx context.Context,
 		}
 	}
 
+	// Set the nodePoolAnnotation so the enqueueParentNodePool watch handler
+	// can map MHC changes back to the parent NodePool.
+	if mhc.Annotations == nil {
+		mhc.Annotations = map[string]string{}
+	}
+	mhc.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
+
 	resourcesName := generateName(capiClusterName, nodePool.Spec.ClusterName, nodePool.GetName())
 	mhc.Spec = capiv1.MachineHealthCheckSpec{
 		ClusterName: capiClusterName,
@@ -1178,6 +1201,15 @@ func (c *CAPI) spotMachineHealthCheck() *capiv1.MachineHealthCheck {
 // reconcileSpotMachineHealthCheck reconciles a MachineHealthCheck specifically for spot instances.
 // This MHC selects machines with the interruptibleInstanceLabel.
 func (c *CAPI) reconcileSpotMachineHealthCheck(_ context.Context, mhc *capiv1.MachineHealthCheck) error {
+	nodePool := c.nodePool
+
+	// Set the nodePoolAnnotation so the enqueueParentNodePool watch handler
+	// can map MHC changes back to the parent NodePool.
+	if mhc.Annotations == nil {
+		mhc.Annotations = map[string]string{}
+	}
+	mhc.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
+
 	// Spot instances need shorter timeouts for faster response to interruption
 	maxUnhealthy := intstr.FromString("100%")
 	timeOut := 8 * time.Minute
@@ -1404,4 +1436,45 @@ func (r *NodePoolReconciler) getMachinesForNodePool(ctx context.Context, nodePoo
 	}
 
 	return sortedByCreationTimestamp(machinesForNodePool), nil
+}
+
+// findMHCRemediationAllowedCondition finds the RemediationAllowed condition in a CAPI Conditions slice.
+func findMHCRemediationAllowedCondition(conditions capiv1.Conditions) *capiv1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == capiv1.RemediationAllowedCondition {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+// mhcRemediationAllowedChangedPredicate returns a predicate that filters MHC events
+// to only pass through when the RemediationAllowed condition has changed. Create and
+// Delete events always pass through; Update events are filtered to avoid unnecessary
+// NodePool reconciliations from unrelated MHC status field changes (e.g. CurrentHealthy,
+// Targets) that are already covered by MachineDeployment/MachineSet/Machine watches.
+func mhcRemediationAllowedChangedPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldMHC, ok := e.ObjectOld.(*capiv1.MachineHealthCheck)
+			if !ok {
+				return true
+			}
+			newMHC, ok := e.ObjectNew.(*capiv1.MachineHealthCheck)
+			if !ok {
+				return true
+			}
+			oldCond := findMHCRemediationAllowedCondition(oldMHC.Status.Conditions)
+			newCond := findMHCRemediationAllowedCondition(newMHC.Status.Conditions)
+			if oldCond == nil && newCond == nil {
+				return false
+			}
+			if oldCond == nil || newCond == nil {
+				return true
+			}
+			return oldCond.Status != newCond.Status ||
+				oldCond.Reason != newCond.Reason ||
+				oldCond.Message != newCond.Message
+		},
+	}
 }

--- a/hypershift-operator/controllers/nodepool/capi_test.go
+++ b/hypershift-operator/controllers/nodepool/capi_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/go-logr/logr"
 )
@@ -3721,6 +3722,377 @@ func TestMachineDeploymentComplete(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			g.Expect(MachineDeploymentComplete(tc.md)).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestReconcileMachineHealthCheckAnnotation(t *testing.T) {
+	t.Parallel()
+	t.Run("When reconcileMachineHealthCheck is called, it should set the nodePoolAnnotation on the MHC", func(t *testing.T) {
+		g := NewWithT(t)
+		np := &hyperv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "nodepool"},
+			Spec:       hyperv1.NodePoolSpec{ClusterName: "cluster"},
+		}
+		hc := &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster"}}
+		capi := &CAPI{
+			Token: &Token{
+				ConfigGenerator: &ConfigGenerator{
+					hostedCluster: hc,
+					nodePool:      np,
+				},
+			},
+			capiClusterName: "cluster",
+		}
+		mhc := &capiv1.MachineHealthCheck{}
+		err := capi.reconcileMachineHealthCheck(t.Context(), mhc)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(mhc.Annotations).To(HaveKeyWithValue(nodePoolAnnotation, "ns/nodepool"))
+	})
+	t.Run("When reconcileSpotMachineHealthCheck is called, it should set the nodePoolAnnotation on the spot MHC", func(t *testing.T) {
+		g := NewWithT(t)
+		np := &hyperv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "nodepool"},
+			Spec:       hyperv1.NodePoolSpec{ClusterName: "cluster"},
+		}
+		hc := &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster"}}
+		capi := &CAPI{
+			Token: &Token{
+				ConfigGenerator: &ConfigGenerator{
+					hostedCluster: hc,
+					nodePool:      np,
+				},
+			},
+			capiClusterName: "cluster",
+		}
+		mhc := &capiv1.MachineHealthCheck{}
+		err := capi.reconcileSpotMachineHealthCheck(t.Context(), mhc)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(mhc.Annotations).To(HaveKeyWithValue(nodePoolAnnotation, "ns/nodepool"))
+	})
+}
+
+func TestMHCRemediationAllowedBubbledUpToReady(t *testing.T) {
+	t.Parallel()
+
+	mhcMessage := "Remediation is not allowed, the number of not started or unhealthy machines exceeds maxUnhealthy (total: 5, unhealthy: 3, maxUnhealthy: 2)"
+	maxUnavailable := intstr.FromInt(0)
+	maxSurge := intstr.FromInt(1)
+	awsMachineTemplateName := "test-nodepool-28d5cf5a"
+	capiClusterName := "infra-id"
+
+	tests := []struct {
+		name                string
+		mhcConditions       capiv1.Conditions
+		expectedReadyStatus corev1.ConditionStatus
+		expectedReadyReason string
+		expectedMessage     string
+	}{
+		{
+			name: "When MHC RemediationAllowed is False, it should set Ready to False with TooManyUnhealthy reason",
+			mhcConditions: capiv1.Conditions{
+				{
+					Type:    capiv1.RemediationAllowedCondition,
+					Status:  corev1.ConditionFalse,
+					Reason:  capiv1.TooManyUnhealthyReason,
+					Message: mhcMessage,
+				},
+			},
+			expectedReadyStatus: corev1.ConditionFalse,
+			expectedReadyReason: capiv1.TooManyUnhealthyReason,
+			expectedMessage:     mhcMessage,
+		},
+		{
+			name: "When MHC RemediationAllowed is True, it should not override Ready",
+			mhcConditions: capiv1.Conditions{
+				{
+					Type:   capiv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			expectedReadyStatus: corev1.ConditionTrue,
+			expectedReadyReason: hyperv1.AsExpectedReason,
+		},
+		{
+			name:                "When MHC has no RemediationAllowed condition, it should not override Ready",
+			mhcConditions:       capiv1.Conditions{},
+			expectedReadyStatus: corev1.ConditionTrue,
+			expectedReadyReason: hyperv1.AsExpectedReason,
+		},
+		{
+			name: "When MHC RemediationAllowed is Unknown, it should not override Ready",
+			mhcConditions: capiv1.Conditions{
+				{
+					Type:   capiv1.RemediationAllowedCondition,
+					Status: corev1.ConditionUnknown,
+				},
+			},
+			expectedReadyStatus: corev1.ConditionTrue,
+			expectedReadyReason: hyperv1.AsExpectedReason,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			nodePool := &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-nodepool",
+					Namespace: "test-namespace",
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: "test-cluster",
+					Management: hyperv1.NodePoolManagement{
+						UpgradeType: hyperv1.UpgradeTypeReplace,
+						Replace: &hyperv1.ReplaceUpgrade{
+							Strategy: hyperv1.UpgradeStrategyRollingUpdate,
+							RollingUpdate: &hyperv1.RollingUpdate{
+								MaxUnavailable: &maxUnavailable,
+								MaxSurge:       &maxSurge,
+							},
+						},
+						AutoRepair: true,
+					},
+					Replicas: ptr.To[int32](3),
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSNodePoolPlatform{
+							AMI: "an-ami",
+						},
+					},
+				},
+				Status: hyperv1.NodePoolStatus{
+					Conditions: []hyperv1.NodePoolCondition{
+						{
+							Type:   hyperv1.NodePoolReachedIgnitionEndpoint,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			}
+
+			hostedCluster := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "test-namespace"},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							CloudProviderConfig:         &hyperv1.AWSCloudProviderConfig{},
+							ServiceEndpoints:            []hyperv1.AWSServiceEndpoint{},
+							RolesRef:                    hyperv1.AWSRolesRef{},
+							ResourceTags:                []hyperv1.AWSResourceTag{},
+							AdditionalAllowedPrincipals: []string{},
+						},
+					},
+				},
+			}
+
+			controlplaneNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+
+			// Build the CAPI struct first (without a client) so we can compute the
+			// UserDataSecret name and pre-populate the MachineDeployment with matching
+			// values. This prevents propagateVersionAndTemplate from returning early
+			// and skipping reconcileMachineDeploymentStatus.
+			capi := &CAPI{
+				Token: &Token{
+					ConfigGenerator: &ConfigGenerator{
+						hostedCluster:         hostedCluster,
+						nodePool:              nodePool,
+						controlplaneNamespace: controlplaneNamespace,
+						rolloutConfig: &rolloutConfig{
+							releaseImage: &releaseinfo.ReleaseImage{
+								ImageStream: &imageapi.ImageStream{
+									ObjectMeta: metav1.ObjectMeta{
+										Name: "target-version",
+									},
+								},
+							},
+						},
+					},
+					cpoCapabilities:        &CPOCapabilities{},
+					CreateOrUpdateProvider: upsert.New(false),
+				},
+				capiClusterName: capiClusterName,
+				ApplyProvider:   upsert.NewApplyProvider(false),
+			}
+
+			// Pre-create the MHC with the desired RemediationAllowed status condition.
+			// CreateOrUpdate in Reconcile() will Get this object (loading the status),
+			// then Update spec/annotations while preserving the status.
+			existingMHC := &capiv1.MachineHealthCheck{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nodePool.GetName(),
+					Namespace: controlplaneNamespace,
+				},
+				Status: capiv1.MachineHealthCheckStatus{
+					Conditions: tt.mhcConditions,
+				},
+			}
+
+			// Pre-create a MachineDeployment with Ready=True in status and matching
+			// DataSecretName/InfrastructureRef so that reconcileMachineDeploymentStatus
+			// runs (propagateVersionAndTemplate returns false) and sets Ready=True on
+			// the NodePool. This lets us verify that the RemediationAllowed check
+			// either overrides Ready or leaves it intact.
+			existingMD := &capiv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nodePool.GetName(),
+					Namespace: controlplaneNamespace,
+				},
+				Spec: capiv1.MachineDeploymentSpec{
+					Template: capiv1.MachineTemplateSpec{
+						Spec: capiv1.MachineSpec{
+							Bootstrap: capiv1.Bootstrap{
+								DataSecretName: ptr.To(capi.UserDataSecret().Name),
+							},
+							InfrastructureRef: corev1.ObjectReference{
+								Name: awsMachineTemplateName,
+							},
+						},
+					},
+				},
+				Status: capiv1.MachineDeploymentStatus{
+					Conditions: capiv1.Conditions{
+						{
+							Type:   capiv1.ReadyCondition,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			}
+
+			c := fake.NewClientBuilder().
+				WithScheme(api.Scheme).
+				WithObjects(nodePool, existingMHC, existingMD).
+				WithObjects(
+					&capiv1.MachineSet{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-machineset",
+							Namespace: controlplaneNamespace,
+							Annotations: map[string]string{
+								nodePoolAnnotation: client.ObjectKeyFromObject(nodePool).String(),
+							},
+						},
+						Spec: capiv1.MachineSetSpec{
+							Template: capiv1.MachineTemplateSpec{
+								Spec: capiv1.MachineSpec{
+									InfrastructureRef: corev1.ObjectReference{
+										Kind:       "AWSMachineTemplate",
+										APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+										Namespace:  controlplaneNamespace,
+										Name:       awsMachineTemplateName,
+									},
+								},
+							},
+						},
+					},
+					&capiaws.AWSMachineTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      awsMachineTemplateName,
+							Namespace: controlplaneNamespace,
+							Annotations: map[string]string{
+								nodePoolAnnotation: client.ObjectKeyFromObject(nodePool).String(),
+							},
+						},
+					},
+				).
+				Build()
+
+			// Now set the client on the CAPI struct.
+			capi.Client = c
+
+			ctx := ctrl.LoggerInto(t.Context(), logr.Discard())
+			err := capi.Reconcile(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			readyCond := FindStatusCondition(nodePool.Status.Conditions, hyperv1.NodePoolReadyConditionType)
+			g.Expect(readyCond).NotTo(BeNil())
+			g.Expect(readyCond.Status).To(Equal(tt.expectedReadyStatus))
+			g.Expect(readyCond.Reason).To(Equal(tt.expectedReadyReason))
+			if tt.expectedMessage != "" {
+				g.Expect(readyCond.Message).To(Equal(tt.expectedMessage))
+			}
+		})
+	}
+}
+
+func TestMHCRemediationAllowedChangedPredicate(t *testing.T) {
+	t.Parallel()
+
+	pred := mhcRemediationAllowedChangedPredicate()
+
+	tests := []struct {
+		name     string
+		oldConds capiv1.Conditions
+		newConds capiv1.Conditions
+		expected bool
+	}{
+		{
+			name:     "When RemediationAllowed changes from True to False, it should trigger reconciliation",
+			oldConds: capiv1.Conditions{{Type: capiv1.RemediationAllowedCondition, Status: corev1.ConditionTrue}},
+			newConds: capiv1.Conditions{{Type: capiv1.RemediationAllowedCondition, Status: corev1.ConditionFalse}},
+			expected: true,
+		},
+		{
+			name:     "When RemediationAllowed changes from False to True, it should trigger reconciliation",
+			oldConds: capiv1.Conditions{{Type: capiv1.RemediationAllowedCondition, Status: corev1.ConditionFalse}},
+			newConds: capiv1.Conditions{{Type: capiv1.RemediationAllowedCondition, Status: corev1.ConditionTrue}},
+			expected: true,
+		},
+		{
+			name:     "When RemediationAllowed appears for the first time, it should trigger reconciliation",
+			oldConds: capiv1.Conditions{},
+			newConds: capiv1.Conditions{{Type: capiv1.RemediationAllowedCondition, Status: corev1.ConditionTrue}},
+			expected: true,
+		},
+		{
+			name:     "When RemediationAllowed is removed, it should trigger reconciliation",
+			oldConds: capiv1.Conditions{{Type: capiv1.RemediationAllowedCondition, Status: corev1.ConditionTrue}},
+			newConds: capiv1.Conditions{},
+			expected: true,
+		},
+		{
+			name:     "When RemediationAllowed status is unchanged but Reason changes, it should trigger reconciliation",
+			oldConds: capiv1.Conditions{{Type: capiv1.RemediationAllowedCondition, Status: corev1.ConditionFalse, Reason: "ReasonA"}},
+			newConds: capiv1.Conditions{{Type: capiv1.RemediationAllowedCondition, Status: corev1.ConditionFalse, Reason: "ReasonB"}},
+			expected: true,
+		},
+		{
+			name:     "When RemediationAllowed status is unchanged but Message changes, it should trigger reconciliation",
+			oldConds: capiv1.Conditions{{Type: capiv1.RemediationAllowedCondition, Status: corev1.ConditionFalse, Reason: "TooManyUnhealthy", Message: "unhealthy: 3, maxUnhealthy: 2"}},
+			newConds: capiv1.Conditions{{Type: capiv1.RemediationAllowedCondition, Status: corev1.ConditionFalse, Reason: "TooManyUnhealthy", Message: "unhealthy: 4, maxUnhealthy: 2"}},
+			expected: true,
+		},
+		{
+			name:     "When RemediationAllowed status and Reason and Message are all unchanged, it should not trigger reconciliation",
+			oldConds: capiv1.Conditions{{Type: capiv1.RemediationAllowedCondition, Status: corev1.ConditionTrue}},
+			newConds: capiv1.Conditions{{Type: capiv1.RemediationAllowedCondition, Status: corev1.ConditionTrue}},
+			expected: false,
+		},
+		{
+			name:     "When neither old nor new has RemediationAllowed, it should not trigger reconciliation",
+			oldConds: capiv1.Conditions{},
+			newConds: capiv1.Conditions{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			e := event.UpdateEvent{
+				ObjectOld: &capiv1.MachineHealthCheck{
+					Status: capiv1.MachineHealthCheckStatus{Conditions: tt.oldConds},
+				},
+				ObjectNew: &capiv1.MachineHealthCheck{
+					Status: capiv1.MachineHealthCheckStatus{Conditions: tt.newConds},
+				},
+			}
+			g.Expect(pred.Update(e)).To(Equal(tt.expected))
 		})
 	}
 }

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -140,6 +140,7 @@ func (r *NodePoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&hyperv1.HostedCluster{}, handler.EnqueueRequestsFromMapFunc(r.enqueueNodePoolsForHostedCluster), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		Watches(&capiv1.MachineDeployment{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		Watches(&capiv1.MachineSet{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
+		Watches(&capiv1.MachineHealthCheck{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(predicate.And(mhcRemediationAllowedChangedPredicate(), supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient())))).
 		// We want to reconcile when the user data Secret or the token Secret is unexpectedly changed out of band.
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		// We want to reconcile when the ConfigMaps referenced by the spec.config and also the core ones change.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_conditions.go
@@ -49,6 +49,9 @@ const (
 	NodePoolUpdatingPlatformMachineTemplateConditionType = "UpdatingPlatformMachineTemplate"
 	// NodePoolReadyConditionType bubbles up CAPI MachineDeployment/MachineSet Ready condition.
 	// This is true when all replicas are ready Nodes.
+	// This may also be set to false when the MachineHealthCheck RemediationAllowed
+	// condition is false (reason TooManyUnhealthy), indicating that auto-repair is
+	// blocked because too many machines are unhealthy.
 	// When this is false for too long, NodePoolAllMachinesReadyConditionType and NodePoolAllNodesHealthyConditionType might provide more context.
 	NodePoolReadyConditionType = "Ready"
 	// NodePoolAllMachinesReadyConditionType bubbles up and aggregates CAPI Machine Ready condition.


### PR DESCRIPTION
## Summary

- Bubble up the CAPI MachineHealthCheck `RemediationAllowed` condition into the NodePool `Ready` condition. When `RemediationAllowed=False` (too many unhealthy machines exceed `maxUnhealthy`), the NodePool `Ready` condition is overridden to `False` with reason `TooManyUnhealthy` and the MHC's original message preserved.
- Add a MachineHealthCheck watch with a predicate filter so only `RemediationAllowed` condition changes (Status, Reason, or Message) trigger NodePool reconciliation, avoiding unnecessary reconciliations from unrelated MHC status field updates.
- Set `nodePoolAnnotation` on the MHC so the existing `enqueueParentNodePool` watch handler can map MHC events back to the parent NodePool.

## Test plan

- [x] `TestMHCRemediationAllowedBubbledUpToReady` — verifies Ready is overridden when RemediationAllowed=False, left untouched when True or absent
- [x] `TestMHCRemediationAllowedChangedPredicate` — verifies predicate filters Update events correctly (8 cases: Status changes, Reason-only change, Message-only change, condition appearing/disappearing, no-change cases)
- [x] `TestReconcileMachineHealthCheckAnnotation` — verifies nodePoolAnnotation is set on MHC
- [x] Full nodepool controller test suite passes
- [x] `make verify` passes (lint, gitlint, CRD schema check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * NodePool readiness now reflects when automatic machine repair is blocked by unhealthy machine limits.
  * NodePool status updates more accurately when machine health repair conditions change.
  * Improved association between health checks and their parent NodePools for reliable reconciliation.

* **Documentation**
  * Clarified the conditions under which a NodePool may be marked not ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->