### PR TITLE
OCPBUGS-99014: Authenticate Konnectivity agents with cluster CA

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -209,6 +209,8 @@ spec:
         - /etc/konnectivity/cluster/tls.crt
         - --cluster-key
         - /etc/konnectivity/cluster/tls.key
+        - --cluster-ca-cert
+        - /etc/konnectivity/ca/ca.crt
         - --server-cert
         - /etc/konnectivity/server/tls.crt
         - --server-key

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/GCP/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/GCP/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -212,6 +212,8 @@ spec:
         - /etc/konnectivity/cluster/tls.crt
         - --cluster-key
         - /etc/konnectivity/cluster/tls.key
+        - --cluster-ca-cert
+        - /etc/konnectivity/ca/ca.crt
         - --server-cert
         - /etc/konnectivity/server/tls.crt
         - --server-key

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -202,6 +202,8 @@ spec:
         - /etc/konnectivity/cluster/tls.crt
         - --cluster-key
         - /etc/konnectivity/cluster/tls.key
+        - --cluster-ca-cert
+        - /etc/konnectivity/ca/ca.crt
         - --server-cert
         - /etc/konnectivity/server/tls.crt
         - --server-key

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -202,6 +202,8 @@ spec:
         - /etc/konnectivity/cluster/tls.crt
         - --cluster-key
         - /etc/konnectivity/cluster/tls.key
+        - --cluster-ca-cert
+        - /etc/konnectivity/ca/ca.crt
         - --server-cert
         - /etc/konnectivity/server/tls.crt
         - --server-key

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -202,6 +202,8 @@ spec:
         - /etc/konnectivity/cluster/tls.crt
         - --cluster-key
         - /etc/konnectivity/cluster/tls.key
+        - --cluster-ca-cert
+        - /etc/konnectivity/ca/ca.crt
         - --server-cert
         - /etc/konnectivity/server/tls.crt
         - --server-key

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -202,6 +202,8 @@ spec:
         - /etc/konnectivity/cluster/tls.crt
         - --cluster-key
         - /etc/konnectivity/cluster/tls.key
+        - --cluster-ca-cert
+        - /etc/konnectivity/ca/ca.crt
         - --server-cert
         - /etc/konnectivity/server/tls.crt
         - --server-key

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/assets_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/assets_test.go
@@ -52,6 +52,28 @@ func TestLoadDeploymentManifest(t *testing.T) {
 	}
 }
 
+func TestKonnectivityServerAuthenticatesAgents(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	deployment, err := LoadDeploymentManifest("kube-apiserver")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var konnectivityServer *corev1.Container
+	for i := range deployment.Spec.Template.Spec.Containers {
+		if deployment.Spec.Template.Spec.Containers[i].Name == "konnectivity-server" {
+			konnectivityServer = &deployment.Spec.Template.Spec.Containers[i]
+			break
+		}
+	}
+
+	g.Expect(konnectivityServer).ToNot(BeNil())
+	g.Expect(konnectivityServer.Args).To(ContainElements(
+		"--cluster-ca-cert",
+		"/etc/konnectivity/ca/ca.crt",
+	))
+}
+
 func TestLoadStatefulSetManifest(t *testing.T) {
 	t.Parallel()
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/assets_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/assets_test.go
@@ -1,6 +1,7 @@
 package assets
 
 import (
+	"slices"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -57,7 +58,12 @@ func TestKonnectivityServerAuthenticatesAgents(t *testing.T) {
 	g := NewWithT(t)
 
 	deployment, err := LoadDeploymentManifest("kube-apiserver")
-	g.Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		t.Fatalf("failed to load kube-apiserver deployment manifest: %v", err)
+	}
+	if deployment == nil {
+		t.Fatal("kube-apiserver deployment manifest is nil")
+	}
 
 	var konnectivityServer *corev1.Container
 	for i := range deployment.Spec.Template.Spec.Containers {
@@ -67,11 +73,15 @@ func TestKonnectivityServerAuthenticatesAgents(t *testing.T) {
 		}
 	}
 
-	g.Expect(konnectivityServer).ToNot(BeNil())
-	g.Expect(konnectivityServer.Args).To(ContainElements(
-		"--cluster-ca-cert",
-		"/etc/konnectivity/ca/ca.crt",
-	))
+	if konnectivityServer == nil {
+		t.Fatal("konnectivity-server container not found")
+	}
+
+	clusterCAFlagIndex := slices.Index(konnectivityServer.Args, "--cluster-ca-cert")
+	if clusterCAFlagIndex == -1 || clusterCAFlagIndex+1 >= len(konnectivityServer.Args) {
+		t.Fatal("--cluster-ca-cert flag or its value not found")
+	}
+	g.Expect(konnectivityServer.Args[clusterCAFlagIndex+1]).To(Equal("/etc/konnectivity/ca/ca.crt"))
 }
 
 func TestLoadStatefulSetManifest(t *testing.T) {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/deployment.yaml
@@ -132,6 +132,8 @@ spec:
         - /etc/konnectivity/cluster/tls.crt
         - --cluster-key
         - /etc/konnectivity/cluster/tls.key
+        - --cluster-ca-cert
+        - /etc/konnectivity/ca/ca.crt
         - --server-cert
         - /etc/konnectivity/server/tls.crt
         - --server-key


### PR DESCRIPTION
## What this PR does / why we need it:

The Konnectivity proxy-server currently accepts agent connections without validating client certificates because its agent listener is not configured with a cluster CA. A reachable client can therefore connect without a certificate signed by the hosted cluster's Konnectivity CA.

Configure `--cluster-ca-cert` with the existing mounted Konnectivity CA bundle. Legitimate agents already use certificates signed by this CA. Add a regression test that verifies the embedded kube-apiserver manifest retains the authentication setting.

## Which issue(s) this PR fixes:

OCPBUGS-99014

## Special notes for your reviewer:

Focused tests passed:
`GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor go test -race ./control-plane-operator/controllers/hostedcontrolplane/v2/assets ./control-plane-operator/controllers/hostedcontrolplane/v2/kas`

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Konnectivity server configuration to authenticate agents using the cluster CA certificate.
  * Ensured the kube-apiserver deployment passes the `--cluster-ca-cert` argument pointing to the mounted Konnectivity CA file.
* **Tests**
  * Added a unit test that verifies the Konnectivity server container exists in the kube-apiserver manifest and includes the correct `--cluster-ca-cert` setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->