### PR TITLE
WIP: feat(releaseinfo): add Prometheus metrics for mirror lookup instrumentation

### DIFF
--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -244,6 +245,8 @@ func NewStartCommand() *cobra.Command {
 
 func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	log.Info("Starting hypershift-operator-manager", "version", supportedversion.String())
+	// Sample 1-in-5 mutex contention events for pprof; nearly zero overhead.
+	runtime.SetMutexProfileFraction(5)
 
 	if err := validateStartOptions(opts, log); err != nil {
 		return err

--- a/support/releaseinfo/metrics.go
+++ b/support/releaseinfo/metrics.go
@@ -1,0 +1,44 @@
+package releaseinfo
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	mirrorResultHit         = "mirror_hit"
+	mirrorResultUnavailable = "mirror_unavailable"
+	mirrorResultError       = "mirror_error"
+	mirrorResultFallback    = "fallback"
+)
+
+var (
+	lookupDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "hypershift_release_image_lookup_duration_seconds",
+		Help: "Wall-clock time in seconds for a release image mirror resolution, including lock wait and registry I/O. " +
+			"Subtract hypershift_release_image_lookup_lock_wait_seconds to isolate registry I/O time.",
+		Buckets: []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
+	})
+
+	lockWaitDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "hypershift_release_image_lookup_lock_wait_seconds",
+		Help: "Time in seconds spent blocked waiting to acquire the mirror resolution mutex. " +
+			"High values indicate callers are serialized behind a slow lookup.",
+		Buckets: []float64{0.001, 0.01, 0.1, 0.5, 1, 5, 10},
+	})
+
+	mirrorLookupTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "hypershift_release_image_mirror_lookup_total",
+		Help: "Total release image mirror resolution attempts by outcome: " +
+			"mirror_hit (mirror found and verified), mirror_unavailable (mirror found but repo unreachable), " +
+			"mirror_error (delegate lookup failed), fallback (no mirror matched, used original image).",
+	}, []string{"result"})
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		lookupDuration,
+		lockWaitDuration,
+		mirrorLookupTotal,
+	)
+}

--- a/support/releaseinfo/registry_image_content_policies.go
+++ b/support/releaseinfo/registry_image_content_policies.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
@@ -28,8 +29,11 @@ type ProviderWithOpenShiftImageRegistryOverridesDecorator struct {
 }
 
 func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) Lookup(ctx context.Context, image string, pullSecret []byte) (*ReleaseImage, error) {
+	start := time.Now()
 	p.lock.Lock()
 	defer p.lock.Unlock()
+	lockWaitDuration.Observe(time.Since(start).Seconds())
+	defer func() { lookupDuration.Observe(time.Since(start).Seconds()) }()
 
 	repoSetup := p.repoSetupFn
 	if repoSetup == nil {
@@ -49,19 +53,23 @@ func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) Lookup(ctx contex
 					// Verify mirror image availability.
 					if _, _, err = repoSetup(ctx, replacedImage, pullSecret); err == nil {
 						p.mirroredReleaseImage = replacedImage
+						mirrorLookupTotal.WithLabelValues(mirrorResultHit).Inc()
 						return releaseImage, nil
 					}
-					logger.Info("WARNING: The current mirrors image is unavailable, continue Scanning multiple mirrors", "error", err.Error(), "mirror image", image)
+					logger.Info("WARNING: The current mirror image is unavailable, continue scanning multiple mirrors", "error", err.Error(), "mirror image", image)
+					mirrorLookupTotal.WithLabelValues(mirrorResultUnavailable).Inc()
 					continue
 				}
 
 				logger.Error(err, "Failed to look up release image using registry mirror", "registry mirror", registryReplacement)
+				mirrorLookupTotal.WithLabelValues(mirrorResultError).Inc()
 			}
 		}
 	}
 
 	// Reset mirrored release image when falling back to original
 	p.mirroredReleaseImage = ""
+	mirrorLookupTotal.WithLabelValues(mirrorResultFallback).Inc()
 	return p.Delegate.Lookup(ctx, image, pullSecret)
 }
 


### PR DESCRIPTION
Replace ad-hoc debug logging with Prometheus histograms and counters for release image mirror lookup duration, mutex contention, and per-mirror outcomes. Enable Go runtime mutex profiling at 20% sampling for passive contention visibility via pprof.

 - Telemeter: Not forwarded
  - Cardinality: Negligible. The histograms have no labels; the counter has one label with 4 bounded values. ~30 time series total
  - Dashboards/recording rules: No updates needed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics to track release image mirror lookup performance, including lookup duration, mutex lock wait time, and outcome counts (hit, unavailable, error, fallback).
  * Enhanced instrumentation and logging during mirror scanning to improve observability of mirror behavior.

* **Performance / Diagnostics**
  * Enabled mutex profiling for the operator manager to support performance investigations.

* **Bug Fixes**
  * Improved fallback handling by resetting mirrored-image state earlier to ensure accurate fallback behavior tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->