### PR TITLE
NE-2815: feat: configure HAProxy version selection

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/AROSwift/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/AROSwift/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -68,6 +68,12 @@ spec:
         - openshift-ingress-operator
         - --image
         - $(IMAGE)
+        - --haproxy-image
+        - 2.8=$(HAPROXY_28_IMAGE)
+        - --haproxy-image
+        - 3.2=$(HAPROXY_32_IMAGE)
+        - --default-haproxy-version
+        - $(DEFAULT_HAPROXY_VERSION)
         - --canary-image
         - $(CANARY_IMAGE)
         - --release-version
@@ -79,6 +85,12 @@ spec:
           value: 4.18.0
         - name: IMAGE
           value: haproxy-router
+        - name: HAPROXY_28_IMAGE
+          value: haproxy-router-haproxy28
+        - name: HAPROXY_32_IMAGE
+          value: haproxy-router-haproxy32
+        - name: DEFAULT_HAPROXY_VERSION
+          value: "3.2"
         - name: CANARY_IMAGE
           value: cluster-ingress-operator
         - name: KUBECONFIG

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/GCP/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/GCP/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -68,6 +68,12 @@ spec:
         - openshift-ingress-operator
         - --image
         - $(IMAGE)
+        - --haproxy-image
+        - 2.8=$(HAPROXY_28_IMAGE)
+        - --haproxy-image
+        - 3.2=$(HAPROXY_32_IMAGE)
+        - --default-haproxy-version
+        - $(DEFAULT_HAPROXY_VERSION)
         - --canary-image
         - $(CANARY_IMAGE)
         - --release-version
@@ -79,6 +85,12 @@ spec:
           value: 4.18.0
         - name: IMAGE
           value: haproxy-router
+        - name: HAPROXY_28_IMAGE
+          value: haproxy-router-haproxy28
+        - name: HAPROXY_32_IMAGE
+          value: haproxy-router-haproxy32
+        - name: DEFAULT_HAPROXY_VERSION
+          value: "3.2"
         - name: CANARY_IMAGE
           value: cluster-ingress-operator
         - name: KUBECONFIG

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -68,6 +68,12 @@ spec:
         - openshift-ingress-operator
         - --image
         - $(IMAGE)
+        - --haproxy-image
+        - 2.8=$(HAPROXY_28_IMAGE)
+        - --haproxy-image
+        - 3.2=$(HAPROXY_32_IMAGE)
+        - --default-haproxy-version
+        - $(DEFAULT_HAPROXY_VERSION)
         - --canary-image
         - $(CANARY_IMAGE)
         - --release-version
@@ -79,6 +85,12 @@ spec:
           value: 4.18.0
         - name: IMAGE
           value: haproxy-router
+        - name: HAPROXY_28_IMAGE
+          value: haproxy-router-haproxy28
+        - name: HAPROXY_32_IMAGE
+          value: haproxy-router-haproxy32
+        - name: DEFAULT_HAPROXY_VERSION
+          value: "3.2"
         - name: CANARY_IMAGE
           value: cluster-ingress-operator
         - name: KUBECONFIG

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/ModernTLS/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/ModernTLS/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -68,6 +68,12 @@ spec:
         - openshift-ingress-operator
         - --image
         - $(IMAGE)
+        - --haproxy-image
+        - 2.8=$(HAPROXY_28_IMAGE)
+        - --haproxy-image
+        - 3.2=$(HAPROXY_32_IMAGE)
+        - --default-haproxy-version
+        - $(DEFAULT_HAPROXY_VERSION)
         - --canary-image
         - $(CANARY_IMAGE)
         - --release-version
@@ -79,6 +85,12 @@ spec:
           value: 4.18.0
         - name: IMAGE
           value: haproxy-router
+        - name: HAPROXY_28_IMAGE
+          value: haproxy-router-haproxy28
+        - name: HAPROXY_32_IMAGE
+          value: haproxy-router-haproxy32
+        - name: DEFAULT_HAPROXY_VERSION
+          value: "3.2"
         - name: CANARY_IMAGE
           value: cluster-ingress-operator
         - name: KUBECONFIG

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -68,6 +68,12 @@ spec:
         - openshift-ingress-operator
         - --image
         - $(IMAGE)
+        - --haproxy-image
+        - 2.8=$(HAPROXY_28_IMAGE)
+        - --haproxy-image
+        - 3.2=$(HAPROXY_32_IMAGE)
+        - --default-haproxy-version
+        - $(DEFAULT_HAPROXY_VERSION)
         - --canary-image
         - $(CANARY_IMAGE)
         - --release-version
@@ -79,6 +85,12 @@ spec:
           value: 4.18.0
         - name: IMAGE
           value: haproxy-router
+        - name: HAPROXY_28_IMAGE
+          value: haproxy-router-haproxy28
+        - name: HAPROXY_32_IMAGE
+          value: haproxy-router-haproxy32
+        - name: DEFAULT_HAPROXY_VERSION
+          value: "3.2"
         - name: CANARY_IMAGE
           value: cluster-ingress-operator
         - name: KUBECONFIG

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -68,6 +68,12 @@ spec:
         - openshift-ingress-operator
         - --image
         - $(IMAGE)
+        - --haproxy-image
+        - 2.8=$(HAPROXY_28_IMAGE)
+        - --haproxy-image
+        - 3.2=$(HAPROXY_32_IMAGE)
+        - --default-haproxy-version
+        - $(DEFAULT_HAPROXY_VERSION)
         - --canary-image
         - $(CANARY_IMAGE)
         - --release-version
@@ -79,6 +85,12 @@ spec:
           value: 4.18.0
         - name: IMAGE
           value: haproxy-router
+        - name: HAPROXY_28_IMAGE
+          value: haproxy-router-haproxy28
+        - name: HAPROXY_32_IMAGE
+          value: haproxy-router-haproxy32
+        - name: DEFAULT_HAPROXY_VERSION
+          value: "3.2"
         - name: CANARY_IMAGE
           value: cluster-ingress-operator
         - name: KUBECONFIG

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ingress-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ingress-operator/deployment.yaml
@@ -26,6 +26,12 @@ spec:
         - openshift-ingress-operator
         - --image
         - $(IMAGE)
+        - --haproxy-image
+        - 2.8=$(HAPROXY_28_IMAGE)
+        - --haproxy-image
+        - 3.2=$(HAPROXY_32_IMAGE)
+        - --default-haproxy-version
+        - $(DEFAULT_HAPROXY_VERSION)
         - --canary-image
         - $(CANARY_IMAGE)
         - --release-version
@@ -36,6 +42,12 @@ spec:
         - name: RELEASE_VERSION
           value: ""
         - name: IMAGE
+          value: ""
+        - name: HAPROXY_28_IMAGE
+          value: ""
+        - name: HAPROXY_32_IMAGE
+          value: ""
+        - name: DEFAULT_HAPROXY_VERSION
           value: ""
         - name: CANARY_IMAGE
           value: ""

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/deployment.go
@@ -19,6 +19,15 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			Name: "IMAGE", Value: cpContext.UserReleaseImageProvider.GetImage("haproxy-router"),
 		})
 		podspec.UpsertEnvVar(c, corev1.EnvVar{
+			Name: "HAPROXY_28_IMAGE", Value: cpContext.UserReleaseImageProvider.GetImage("haproxy-router-haproxy28"),
+		})
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
+			Name: "HAPROXY_32_IMAGE", Value: cpContext.UserReleaseImageProvider.GetImage("haproxy-router-haproxy32"),
+		})
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
+			Name: "DEFAULT_HAPROXY_VERSION", Value: "3.2",
+		})
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name: "CANARY_IMAGE", Value: cpContext.UserReleaseImageProvider.GetImage("cluster-ingress-operator"),
 		})
 


### PR DESCRIPTION

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

Configures Hypershift with the new command-line options used to declare the available HAProxy versions in the current release, as well as the default HAProxy version in case it is not provided in the IngressController resource.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/NE-2815

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring HAProxy 2.8 and 3.2 image variants.
  * Added a configurable default HAProxy version for ingress deployments.
  * These settings can now be supplied at runtime through deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->