### PR TITLE
CNTRLPLANE-3862: fix(cpo): regenerate stale ModernTLS test fixtures

### DIFF
--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
@@ -3810,6 +3810,68 @@ spec:
                             x-kubernetes-validations:
                             - message: mtu is immutable once set
                               rule: self == oldSelf
+                          v4InternalSubnet:
+                            description: |-
+                              v4InternalSubnet configures the IPv4 subnet used by OVN-Kubernetes for gateway
+                              router logical router port (LRP) addresses and masquerade/SNAT traffic within
+                              the OVN logical topology. It must not overlap with any other subnet being used
+                              by OpenShift or by the node network. The size of the subnet must be larger than
+                              the number of nodes.
+                              This field is distinct from ipv4.internalJoinSubnet, which configures the subnet
+                              for the join switch that interconnects per-node gateway routers with the cluster
+                              router. Both default to 100.64.0.0/16 but control different OVN-Kubernetes
+                              internal networks and can be configured independently to avoid overlaps with
+                              existing network infrastructure.
+                              Once set, the value is immutable and cannot be modified in subsequent updates.
+                              The default is 100.64.0.0/16.
+                              The value must be in IPv4 CIDR notation (e.g., 192.168.0.0/16), consisting of
+                              four decimal octets (0-255) separated by dots, followed by a slash and a prefix
+                              length. The prefix length must be between 0 and 30 inclusive, and the first
+                              octet must not be 0.
+                              The value must be between 9 and 18 characters in length.
+                              This field is immutable once set.
+                            maxLength: 18
+                            minLength: 9
+                            type: string
+                            x-kubernetes-validations:
+                            - message: v4InternalSubnet is immutable once set
+                              rule: self == oldSelf
+                            - message: Subnet must be in a valid IPv4 CIDR format
+                              rule: isCIDR(self) && cidr(self).ip().family() == 4
+                            - message: subnet must be in the range /0 to /30 inclusive
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 30
+                            - message: first IP address octet must not be 0
+                              rule: isCIDR(self) && cidr(self).ip().family() == 4
+                                && int(self.split('.')[0]) > 0
+                          v6InternalSubnet:
+                            description: |-
+                              v6InternalSubnet configures the IPv6 subnet used by OVN-Kubernetes for gateway
+                              router logical router port (LRP) addresses and masquerade/SNAT traffic within
+                              the OVN logical topology. It must not overlap with any other subnet being used
+                              by OpenShift or by the node network. The size of the subnet must be larger than
+                              the number of nodes.
+                              This field is distinct from ipv6.internalJoinSubnet, which configures the subnet
+                              for the join switch that interconnects per-node gateway routers with the cluster
+                              router. Both default to fd98::/64 but control different OVN-Kubernetes internal
+                              networks and can be configured independently to avoid overlaps with existing
+                              network infrastructure.
+                              Once set, the value is immutable and cannot be modified in subsequent updates.
+                              The default is fd98::/64.
+                              The value must be in IPv6 CIDR notation (e.g., fd98::/64), consisting of an
+                              IPv6 address followed by a slash and a prefix length. The prefix length must
+                              be between 0 and 125 inclusive.
+                              The value must be between 4 and 48 characters in length.
+                              This field is immutable once set.
+                            maxLength: 48
+                            minLength: 4
+                            type: string
+                            x-kubernetes-validations:
+                            - message: v6InternalSubnet is immutable once set
+                              rule: self == oldSelf
+                            - message: Subnet must be in valid IPv6 CIDR format
+                              rule: isCIDR(self) && cidr(self).ip().family() == 6
+                            - message: subnet must be in the range /0 to /125 inclusive
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 125
                         type: object
                         x-kubernetes-validations:
                         - message: internalJoinSubnet and internalTransitSwitchSubnet
@@ -3834,6 +3896,12 @@ spec:
                             once set
                           rule: '!has(oldSelf.ipv6) || !has(oldSelf.ipv6.internalTransitSwitchSubnet)
                             || (has(self.ipv6) && has(self.ipv6.internalTransitSwitchSubnet))'
+                        - message: v4InternalSubnet is immutable once set and cannot
+                            be removed
+                          rule: '!has(oldSelf.v4InternalSubnet) || has(self.v4InternalSubnet)'
+                        - message: v6InternalSubnet is immutable once set and cannot
+                            be removed
+                          rule: '!has(oldSelf.v6InternalSubnet) || has(self.v6InternalSubnet)'
                     type: object
                     x-kubernetes-validations:
                     - message: ovnKubernetesConfig is immutable once set and cannot

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
@@ -3696,6 +3696,68 @@ spec:
                             x-kubernetes-validations:
                             - message: mtu is immutable once set
                               rule: self == oldSelf
+                          v4InternalSubnet:
+                            description: |-
+                              v4InternalSubnet configures the IPv4 subnet used by OVN-Kubernetes for gateway
+                              router logical router port (LRP) addresses and masquerade/SNAT traffic within
+                              the OVN logical topology. It must not overlap with any other subnet being used
+                              by OpenShift or by the node network. The size of the subnet must be larger than
+                              the number of nodes.
+                              This field is distinct from ipv4.internalJoinSubnet, which configures the subnet
+                              for the join switch that interconnects per-node gateway routers with the cluster
+                              router. Both default to 100.64.0.0/16 but control different OVN-Kubernetes
+                              internal networks and can be configured independently to avoid overlaps with
+                              existing network infrastructure.
+                              Once set, the value is immutable and cannot be modified in subsequent updates.
+                              The default is 100.64.0.0/16.
+                              The value must be in IPv4 CIDR notation (e.g., 192.168.0.0/16), consisting of
+                              four decimal octets (0-255) separated by dots, followed by a slash and a prefix
+                              length. The prefix length must be between 0 and 30 inclusive, and the first
+                              octet must not be 0.
+                              The value must be between 9 and 18 characters in length.
+                              This field is immutable once set.
+                            maxLength: 18
+                            minLength: 9
+                            type: string
+                            x-kubernetes-validations:
+                            - message: v4InternalSubnet is immutable once set
+                              rule: self == oldSelf
+                            - message: Subnet must be in a valid IPv4 CIDR format
+                              rule: isCIDR(self) && cidr(self).ip().family() == 4
+                            - message: subnet must be in the range /0 to /30 inclusive
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 30
+                            - message: first IP address octet must not be 0
+                              rule: isCIDR(self) && cidr(self).ip().family() == 4
+                                && int(self.split('.')[0]) > 0
+                          v6InternalSubnet:
+                            description: |-
+                              v6InternalSubnet configures the IPv6 subnet used by OVN-Kubernetes for gateway
+                              router logical router port (LRP) addresses and masquerade/SNAT traffic within
+                              the OVN logical topology. It must not overlap with any other subnet being used
+                              by OpenShift or by the node network. The size of the subnet must be larger than
+                              the number of nodes.
+                              This field is distinct from ipv6.internalJoinSubnet, which configures the subnet
+                              for the join switch that interconnects per-node gateway routers with the cluster
+                              router. Both default to fd98::/64 but control different OVN-Kubernetes internal
+                              networks and can be configured independently to avoid overlaps with existing
+                              network infrastructure.
+                              Once set, the value is immutable and cannot be modified in subsequent updates.
+                              The default is fd98::/64.
+                              The value must be in IPv6 CIDR notation (e.g., fd98::/64), consisting of an
+                              IPv6 address followed by a slash and a prefix length. The prefix length must
+                              be between 0 and 125 inclusive.
+                              The value must be between 4 and 48 characters in length.
+                              This field is immutable once set.
+                            maxLength: 48
+                            minLength: 4
+                            type: string
+                            x-kubernetes-validations:
+                            - message: v6InternalSubnet is immutable once set
+                              rule: self == oldSelf
+                            - message: Subnet must be in valid IPv6 CIDR format
+                              rule: isCIDR(self) && cidr(self).ip().family() == 6
+                            - message: subnet must be in the range /0 to /125 inclusive
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 125
                         type: object
                         x-kubernetes-validations:
                         - message: internalJoinSubnet and internalTransitSwitchSubnet
@@ -3720,6 +3782,12 @@ spec:
                             once set
                           rule: '!has(oldSelf.ipv6) || !has(oldSelf.ipv6.internalTransitSwitchSubnet)
                             || (has(self.ipv6) && has(self.ipv6.internalTransitSwitchSubnet))'
+                        - message: v4InternalSubnet is immutable once set and cannot
+                            be removed
+                          rule: '!has(oldSelf.v4InternalSubnet) || has(self.v4InternalSubnet)'
+                        - message: v6InternalSubnet is immutable once set and cannot
+                            be removed
+                          rule: '!has(oldSelf.v6InternalSubnet) || has(self.v6InternalSubnet)'
                     type: object
                     x-kubernetes-validations:
                     - message: ovnKubernetesConfig is immutable once set and cannot

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_recording_rules_prometheusrule.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_recording_rules_prometheusrule.yaml
@@ -32,25 +32,25 @@ spec:
       labels:
         _id: ""
       record: cluster:kube_persistentvolume_plugin_type_counts:sum
-    - expr: sum by (instance) (etcd_mvcc_db_total_size_in_bytes{job="etcd"})
+    - expr: sum by (instance) (etcd_mvcc_db_total_size_in_bytes{job=~"etcd.*"})
       labels:
         _id: ""
       record: instance:etcd_mvcc_db_total_size_in_bytes:sum
-    - expr: histogram_quantile(0.99, sum by (instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m])))
+    - expr: histogram_quantile(0.99, sum by (instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~"etcd.*"}[5m])))
       labels:
         _id: ""
         quantile: "0.99"
       record: instance:etcd_disk_wal_fsync_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.99, sum by (instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m])))
+    - expr: histogram_quantile(0.99, sum by (instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket{job=~"etcd.*"}[5m])))
       labels:
         _id: ""
         quantile: "0.99"
       record: instance:etcd_network_peer_round_trip_time_seconds:histogram_quantile
-    - expr: sum by (instance) (etcd_mvcc_db_total_size_in_use_in_bytes{job="etcd"})
+    - expr: sum by (instance) (etcd_mvcc_db_total_size_in_use_in_bytes{job=~"etcd.*"})
       labels:
         _id: ""
       record: instance:etcd_mvcc_db_total_size_in_use_in_bytes:sum
-    - expr: histogram_quantile(0.99, sum by (instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m])))
+    - expr: histogram_quantile(0.99, sum by (instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~"etcd.*"}[5m])))
       labels:
         _id: ""
         quantile: "0.99"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/ModernTLS/zz_fixture_TestControlPlaneComponents_oauth_openshift_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/ModernTLS/zz_fixture_TestControlPlaneComponents_oauth_openshift_configmap.yaml
@@ -33,7 +33,7 @@ data:
       loginURL: https://:0
       masterCA: /etc/kubernetes/certs/master-ca/ca.crt
       masterPublicURL: https://:0
-      masterURL: https://:0
+      masterURL: https://oauth-openshift.hcp-namespace.svc.cluster.local:6443
       sessionConfig:
         sessionMaxAgeSeconds: 300
         sessionName: ssn

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/ModernTLS/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/ModernTLS/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,tmp-dir
-        component.hypershift.openshift.io/config-hash: 19dc307e3b105d4460b54b1d741638a595ac034ca0dd232cbcc341c5
+        component.hypershift.openshift.io/config-hash: 19dc307e38e3ff753b105d4460b54b1d741638a5a0dd232cbcc341c5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: oauth-openshift
@@ -95,7 +95,7 @@ spec:
         - name: ALL_PROXY
           value: socks5://127.0.0.1:8090
         - name: NO_PROXY
-          value: kube-apiserver,audit-webhook
+          value: kube-apiserver,audit-webhook,oauth-openshift.hcp-namespace.svc.cluster.local
         image: oauth-server
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -260,6 +260,24 @@ spec:
         name: availability-prober
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+      - args:
+        - -c
+        - |
+          #!/bin/sh
+          while ! nslookup etcd-client.$(POD_NAMESPACE).svc; do sleep 1; done
+        command:
+        - /bin/bash
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: wait-for-etcd
+        resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: hypershift-api-critical
       terminationGracePeriodSeconds: 120
       tolerations:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/ModernTLS/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/ModernTLS/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -88,6 +88,7 @@ spec:
         - /etc/openshift/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/openshift/kubeconfig/kubeconfig
+        - --tls-min-version=VersionTLS13
         command:
         - /bin/package-server
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/ModernTLS/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/ModernTLS/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
@@ -8,14 +8,13 @@ spec: {}
 status:
   conditions:
   - lastTransitionTime: null
-    message: router Deployment Available condition not found
+    message: deployments.apps "router" not found
     reason: NotFound
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for deployment router rollout to finish: 0 out of 3 new replicas
-      have been updated'
-    reason: WaitingForRolloutComplete
+    message: 'Waiting for Dependencies: ignition-server'
+    reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete
   resources:


### PR DESCRIPTION
## Summary
* ModernTLS fixtures from #8871 landed stale due to Tide merge skew - GHA tested against a base SHA from Jul 13 while 4 PRs merged between Jul 15-20 that changed component outputs
* Regenerated 6 ModernTLS fixture files to match current main
* Regenerated 2 EtcdSharding featuregated CRD manifests to include OVN v4/v6InternalSubnet fields from #8249

### Root cause timeline

:white_check_mark: **Jul 13 09:16 UTC** GHA `Unit Tests (cpo-hostedcontrolplane)` ran on https://github.com/openshift/hypershift/pull/8871 and passed against a base SHA that predated all merges below

:merged: **Jul 15 07:34 UTC** https://github.com/openshift/hypershift/pull/8971 merged, fixed router component ordering, updated default fixtures but not ModernTLS

:merged: **Jul 15 15:58 UTC** https://github.com/openshift/hypershift/pull/8940 merged, added wait-for-etcd init container to oauth-apiserver, updated default fixtures but not ModernTLS

:merged: **Jul 18 00:01 UTC** https://github.com/openshift/hypershift/pull/8705 merged, changed etcd job label regex in recording rules, updated default fixtures but not ModernTLS

:merged: **Jul 20 18:20 UTC** https://github.com/openshift/hypershift/pull/8772 merged, changed oauth-server masterURL to in-cluster URL, updated default fixtures but not ModernTLS

:warning: **Jul 20 18:55 UTC** https://github.com/openshift/hypershift/pull/8871 merged, added ModernTLS fixtures, 35 minutes after #8772. GHA was not re-run. Tide merged it based on the Jul 13 test result against a now-stale base.

:x: **Result**: 6 ModernTLS fixtures landed already out of date. `TestControlPlaneComponents` is broken on main since Jul 20 18:55 UTC.

Additionally, https://github.com/openshift/hypershift/pull/8249 merged after #8871 and added OVN subnet fields to the HostedCluster API without regenerating the EtcdSharding featuregated CRD manifests.

## Test plan
* [x] `UPDATE=true go test ./control-plane-operator/controllers/hostedcontrolplane/ -run TestControlPlaneComponents` regenerates fixtures
* [x] `go test ./control-plane-operator/controllers/hostedcontrolplane/ -run TestControlPlaneComponents` passes without UPDATE
* [x] `make generate update` produces no diff
* [x] `make verify` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)