### PR TITLE
OCPBUGS-99289: Exclude aggregated docs page from search index

### DIFF
--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # HyperShift Documentation (Aggregated)
 
 This file contains all HyperShift documentation aggregated into a single file

--- a/hack/tools/docs-aggregator/main.go
+++ b/hack/tools/docs-aggregator/main.go
@@ -42,6 +42,9 @@ func run() error {
 	// Build the aggregated content
 	var builder strings.Builder
 
+	// Write front matter to exclude from MkDocs search results
+	builder.WriteString("---\nsearch:\n  exclude: true\n---\n\n")
+
 	// Write header
 	builder.WriteString("# HyperShift Documentation (Aggregated)\n\n")
 	builder.WriteString("This file contains all HyperShift documentation aggregated into a single file\n")


### PR DESCRIPTION
## Summary
- The aggregated single-page doc (`reference/aggregated-docs.md`) matches every search term and always appears as the first result on hypershift.pages.dev, making search impractical for humans.
- Adds `search: exclude: true` front matter in the docs-aggregator tool so the page stays accessible by direct URL but is removed from the MkDocs search index.

## Test plan
- [ ] Build docs locally with `mkdocs serve` and verify the aggregated page no longer appears in search results
- [ ] Verify the aggregated page is still accessible via direct URL

Ref: [OCPBUGS-99289](https://redhat.atlassian.net/browse/OCPBUGS-99289)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the aggregated documentation output to include YAML front matter so the generated pages are excluded from MkDocs search indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->