### PR TITLE
ACM-38044: update Containerfile.cli base images to floating tags [release-4.18]

### DIFF
--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -1,8 +1,8 @@
-FROM registry.redhat.io/rhel9/go-toolset:1.24.6-1763548439 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 AS builder
 
 WORKDIR /hypershift
 
-COPY --chown=default . .
+COPY . .
 
 RUN make product-cli-release && \
     # Create tar.gz files for Linux architectures \
@@ -16,9 +16,9 @@ RUN make product-cli-release && \
       done; \
     done
 
-FROM registry.redhat.io/ubi9/nginx-124:1-1767745334
+FROM registry.redhat.io/ubi9/nginx-124:latest
 
-COPY --from=builder /hypershift/bin/    /opt/app-root/src/
+COPY --chown=1001:0 --from=builder /hypershift/bin/    /opt/app-root/src/
 RUN find /opt/app-root/src/ -type f ! -name "*.tar.gz" -delete
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -1,8 +1,8 @@
-FROM registry.redhat.io/rhel9/go-toolset:1.24.6-1763548439 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /hypershift
 
-COPY --chown=default . .
+COPY . .
 
 RUN make product-cli-release && \
     # Create tar.gz files for Linux architectures \
@@ -16,9 +16,9 @@ RUN make product-cli-release && \
       done; \
     done
 
-FROM registry.redhat.io/ubi9/nginx-124:1-1767745334
+FROM registry.redhat.io/ubi9/nginx-124:latest
 
-COPY --from=builder /hypershift/bin/    /opt/app-root/src/
+COPY --chown=1001:0 --from=builder /hypershift/bin/    /opt/app-root/src/
 RUN find /opt/app-root/src/ -type f ! -name "*.tar.gz" -delete
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary

Updates `Containerfile.cli` on `release-4.18` to use floating base image tags so each rebuild automatically picks up the latest CVE-fixed layers, improving the catalog security grade for `multicluster-engine/hypershift-cli-rhel9`.

## Changes

| Stage | Before | After |
|-------|--------|-------|
| Builder | `registry.redhat.io/rhel9/go-toolset:1.24.6-1763548439` | `brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24` |
| Runtime | `registry.redhat.io/ubi9/nginx-124:1-1767745334` | `registry.redhat.io/ubi9/nginx-124:latest` |
| Builder COPY | `COPY --chown=default . .` | `COPY . .` |
| Runtime COPY | `COPY --from=builder /hypershift/bin/ ...` | `COPY --chown=1001:0 --from=builder /hypershift/bin/ ...` |

## Why floating tags

The pinned/stale base images are contributing to a catalog grade of **D** for `multicluster-engine/hypershift-cli-rhel9` (MCE 2.8). Floating tags allow rebuilds to pick up current CVE-fixed layers automatically.

## Why `brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24`

Using the recommended Konflux/CPaaS builder image as suggested by @gparvin.

## Why `COPY . .` (no `--chown=default`)

The previous image (`go-toolset`) defined a `default` user, so `--chown=default` worked. The new `openshift-golang-builder` image does not define a `default` user, causing:

```
Error: building at STEP "COPY --chown=default . .": user: unknown user error looking up user "default"
```

Removing `--chown=default` fixes the build. The builder stage runs as root, which is expected for a build-only stage.

## Why `--chown=1001:0` on the runtime COPY

Because `--chown=default` was removed from the builder-stage COPY, the compiled binaries are owned by root. When copied into the runtime stage, the nginx process (uid 1001) cannot delete them during cleanup:

```
RUN find /opt/app-root/src/ -type f ! -name "*.tar.gz" -delete
`find: cannot delete '/opt/app-root/src/darwin/amd64/hcp': Permission denied
```

Adding `--chown=1001:0` to `COPY --from=builder` transfers ownership to the nginx user (uid 1001), allowing the `find -delete` step to succeed. This is the standard pattern for UBI-based runtime images running as a non-root user.

**Why only on this branch:** `release-4.19`, `release-4.20`, and `main` still use `registry.redhat.io/rhel9/go-toolset` as the builder, which does define a `default` user — so their `COPY --chown=default` continues to work and the binaries are already owned by the correct user when copied to the runtime stage. This change is a consequence of switching to `openshift-golang-builder` on `release-4.18`.

## Jira

https://redhat.atlassian.net/browse/ACM-38044

## Test plan

- [ ] Konflux build for MCE 2.8 passes without `Permission denied` errors
- [ ] Catalog grade for `hypershift-cli` improves after rebuild