### PR TITLE
CNTRLPLANE-3862: fix(ci): reintroduce verify-ci make target for GHA verify workflow

### DIFF
--- a/.github/workflows/verify-reusable.yaml
+++ b/.github/workflows/verify-reusable.yaml
@@ -20,21 +20,4 @@ jobs:
           if [ -n "${{ github.base_ref }}" ]; then
             git fetch origin "${{ github.base_ref }}:${{ github.base_ref }}"
           fi
-      - run: make generate update
-      - run: make staticcheck
-      - run: make fmt
-      - run: make vet
-      - run: make verify-api-deps
-      - run: make verify-crd-schema
-      - run: make verify-docs-nav
-      - run: |
-          git update-index --refresh
-          git diff-index --cached --quiet --ignore-submodules HEAD --
-          git diff-files --quiet --ignore-submodules
-          git diff --exit-code HEAD --
-          STATUS=$(git status -s)
-          if [ -n "$STATUS" ]; then
-            echo "untracked files detected:"
-            echo "$STATUS"
-            exit 1
-          fi
+      - run: make verify-ci

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ lint-fix: generate
 
 .PHONY: verify-git-clean
 verify-git-clean:
+	git update-index --refresh
 	git diff-index --cached --quiet --ignore-submodules HEAD --
 	git diff-files --quiet --ignore-submodules
 	git diff --exit-code HEAD --
@@ -159,6 +160,10 @@ verify-crd-schema: $(CRD_SCHEMA_CHECK) ## Verify CRD schemas for breaking change
 
 .PHONY: verify-parallel
 verify-parallel: verify-codespell verify-codecov verify-api-deps verify-crd-schema lint cpo-container-sync run-gitlint verify-docs-nav
+
+.PHONY: verify-ci
+verify-ci: generate update staticcheck fmt vet verify-api-deps verify-crd-schema verify-docs-nav ## Run the same checks as the GHA verify workflow.
+	$(MAKE) verify-git-clean
 
 .PHONY: verify
 verify: generate update staticcheck fmt vet


### PR DESCRIPTION
## Summary
* Reintroduce `make verify-ci` target matching the exact checks the GHA verify workflow runs
* Update the GHA verify workflow to use `make verify-ci` instead of inline steps
* Add missing `git update-index --refresh` to `verify-git-clean`

### Why
The `verify-ci` target was removed in https://github.com/openshift/hypershift/pull/8051 but the GHA verify workflow continued running the same steps inline. This made it impossible to reproduce GHA verify failures locally with a single command - developers had to manually run each step or use `make verify` which runs additional checks (codespell, lint, gitlint) not in the GHA workflow.

### What changed
* **Makefile**: added `verify-ci` target with dependencies: `generate update staticcheck fmt vet verify-api-deps verify-crd-schema verify-docs-nav` followed by `verify-git-clean`
* **Makefile**: added `git update-index --refresh` to `verify-git-clean` to match what GHA was doing inline
* **.github/workflows/verify-reusable.yaml**: replaced 8 inline `run` steps with `make verify-ci`

## Test plan
* [x] `make verify-ci` runs all checks and passes locally
* [x] `make verify` still works (verify-ci is a subset, not a replacement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated continuous integration verification into a single automated command.
  * Improved detection of uncommitted changes during verification by refreshing Git status before running checks.
  * Continued validating generated files, formatting, static analysis, APIs, schemas, documentation navigation, and repository cleanliness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->