### PR TITLE
OCPBUGS-99272: Auto-remove capi-provider resource limits with user-override detection

### DIFF
--- a/support/controlplane-component/controlplane-component.go
+++ b/support/controlplane-component/controlplane-component.go
@@ -367,7 +367,8 @@ func (c *controlPlaneWorkload[T]) reconcileWorkload(cpContext ControlPlaneContex
 		existingResources[container.Name] = container.Resources
 	}
 
-	if err := c.setDefaultOptions(cpContext, workloadObj, existingResources); err != nil {
+	oldWorkloadAnnotations := oldWorkloadObj.GetAnnotations()
+	if err := c.setDefaultOptions(cpContext, workloadObj, existingResources, oldWorkloadAnnotations); err != nil {
 		return err
 	}
 

--- a/support/controlplane-component/defaults.go
+++ b/support/controlplane-component/defaults.go
@@ -2,9 +2,12 @@ package controlplanecomponent
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"slices"
+	"sort"
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -43,6 +46,23 @@ const (
 	// podSafeToEvictLocalVolumesAnnotation is an annotation denoting the local volumes of a pod that can be safely evicted.
 	// This is needed for the CA operator to make sure it can properly drain the nodes with those volumes.
 	podSafeToEvictLocalVolumesAnnotation = "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes"
+
+	// limitsRemovedAnnotation tracks containers whose resource limits have been
+	// automatically removed because the manifest no longer specifies them.
+	// The value is a comma-separated list of container names. When a user manually
+	// re-adds limits to a container that is already listed here, the operator
+	// detects this and preserves the user's limits on subsequent reconciliations.
+	limitsRemovedAnnotation = "component.hypershift.openshift.io/limits-removed"
+
+	// containerResourcesHashAnnotation records a hash of the final container resource
+	// requirements after all modifications. This ensures DeepDerivative detects
+	// resource changes (e.g. limit removal) even when the new value is a subset
+	// of the old value.
+	containerResourcesHashAnnotation = "component.hypershift.openshift.io/container-resources-hash"
+
+	// capiProviderComponentName is the component name for the CAPI provider deployment.
+	// Limit removal logic is scoped to this component only.
+	capiProviderComponentName = "capi-provider"
 )
 
 var (
@@ -60,7 +80,7 @@ var (
 	}
 )
 
-func (c *controlPlaneWorkload[T]) setDefaultOptions(cpContext ControlPlaneContext, workloadObj T, existingResources map[string]corev1.ResourceRequirements) error {
+func (c *controlPlaneWorkload[T]) setDefaultOptions(cpContext ControlPlaneContext, workloadObj T, existingResources map[string]corev1.ResourceRequirements, oldWorkloadAnnotations map[string]string) error {
 	hcp := cpContext.HCP
 
 	labels := workloadObj.GetLabels()
@@ -156,12 +176,54 @@ func (c *controlPlaneWorkload[T]) setDefaultOptions(cpContext ControlPlaneContex
 		}
 	}
 
-	// preserve existing resource requirements.
+	// Reconcile container resource requirements.
+	// The default contract preserves existing resources so that user overrides
+	// (e.g. via kubectl edit) are not reverted.
+	//
+	// For the capi-provider component only, when the manifest intentionally
+	// removes limits (no limits in manifest but limits exist on the live
+	// object), the operator removes them automatically and records the
+	// container in the limitsRemovedAnnotation. If the user later re-adds
+	// limits to a container already listed in that annotation, the operator
+	// detects this as a deliberate user override and preserves the user's
+	// resources from that point on.
 	for idx, container := range podTemplateSpec.Spec.Containers {
-		if res, exist := existingResources[container.Name]; exist {
-			podTemplateSpec.Spec.Containers[idx].Resources = res
+		existing, hasExisting := existingResources[container.Name]
+		if !hasExisting {
+			// No existing deployment or container is new — use manifest resources.
+			continue
 		}
+
+		if c.Name() == capiProviderComponentName {
+			manifestHasLimits := len(container.Resources.Limits) > 0
+			existingHasLimits := len(existing.Limits) > 0
+
+			if !manifestHasLimits && existingHasLimits {
+				// Manifest says no limits but the live object has them.
+				if limitsAlreadyRemoved(oldWorkloadAnnotations, container.Name) {
+					// We already removed limits before, but the user re-added them.
+					// Respect the user's override — preserve existing resources.
+					podTemplateSpec.Spec.Containers[idx].Resources = existing
+				} else {
+					// First time: manifest wants no limits. Use manifest resources
+					// (which have no limits) and record that we removed them.
+					markLimitsRemoved(workloadObj, container.Name)
+				}
+				continue
+			}
+		}
+
+		// Default: preserve existing resources.
+		podTemplateSpec.Spec.Containers[idx].Resources = existing
 	}
+
+	// Record a hash of the final container resources on the pod template so
+	// that DeepDerivative detects changes even when the new value is a subset
+	// of the old (e.g. limits removed).
+	if podTemplateSpec.Annotations == nil {
+		podTemplateSpec.Annotations = map[string]string{}
+	}
+	podTemplateSpec.Annotations[containerResourcesHashAnnotation] = computeContainerResourcesHash(podTemplateSpec.Spec.Containers)
 
 	// set PriorityClassName
 	podTemplateSpec.Spec.PriorityClassName = priorityClass(c.Name(), hcp)
@@ -702,4 +764,60 @@ func debugComponentsSet(hcp *hyperv1.HostedControlPlane) sets.Set[string] {
 
 func clusterKey(hcp *hyperv1.HostedControlPlane) string {
 	return hcp.Namespace
+}
+
+// limitsAlreadyRemoved returns true if the given container name is listed in the
+// limitsRemovedAnnotation on the workload. This indicates the operator previously
+// removed limits for this container, so if limits are now present, a user must
+// have re-added them.
+func limitsAlreadyRemoved(annotations map[string]string, containerName string) bool {
+	val, ok := annotations[limitsRemovedAnnotation]
+	if !ok || val == "" {
+		return false
+	}
+	return slices.Contains(strings.Split(val, ","), containerName)
+}
+
+// markLimitsRemoved adds a container name to the limitsRemovedAnnotation on the
+// workload object. The annotation value is a comma-separated list of container names.
+func markLimitsRemoved(obj client.Object, containerName string) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	existing := annotations[limitsRemovedAnnotation]
+	if existing == "" {
+		annotations[limitsRemovedAnnotation] = containerName
+	} else {
+		// Avoid duplicates.
+		if slices.Contains(strings.Split(existing, ","), containerName) {
+			return
+		}
+		annotations[limitsRemovedAnnotation] = existing + "," + containerName
+	}
+	obj.SetAnnotations(annotations)
+}
+
+// computeContainerResourcesHash computes a stable hash of container resource
+// requirements. This hash is stored as a pod template annotation so that
+// DeepDerivative detects resource changes even when the new value is a subset
+// of the old (e.g. limits removed).
+func computeContainerResourcesHash(containers []corev1.Container) string {
+	type containerResources struct {
+		Name      string                      `json:"name"`
+		Resources corev1.ResourceRequirements `json:"resources"`
+	}
+	resources := make([]containerResources, 0, len(containers))
+	for _, c := range containers {
+		resources = append(resources, containerResources{
+			Name:      c.Name,
+			Resources: c.Resources,
+		})
+	}
+	sort.Slice(resources, func(i, j int) bool {
+		return resources[i].Name < resources[j].Name
+	})
+	data, _ := json.Marshal(resources)
+	hash := sha256.Sum256(data)
+	return fmt.Sprintf("%x", hash[:8])
 }

--- a/support/controlplane-component/defaults_test.go
+++ b/support/controlplane-component/defaults_test.go
@@ -670,7 +670,7 @@ func TestSetDefaultOptions(t *testing.T) {
 			SetDefaultSecurityContext: true,
 			DefaultSecurityContextUID: int64(1002),
 			Client:                    fake.NewClientBuilder().WithScheme(scheme).Build(),
-		}, workloadObject, nil)
+		}, workloadObject, nil, nil)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(workloadObject.Spec.Template.Spec.SecurityContext.RunAsUser).To(Equal(ptr.To(int64(1002))))
 		g.Expect(workloadObject.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(ptr.To(int64(1002))))
@@ -688,7 +688,7 @@ func TestSetDefaultOptions(t *testing.T) {
 		expectedResources  corev1.ResourceRequirements
 	}{
 		{
-			name: "When existing resources have both requests and limits it should fully preserve them",
+			name: "When existing resources have both requests and limits it should fully preserve them for non-capi-provider components",
 			containerResources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -770,7 +770,7 @@ func TestSetDefaultOptions(t *testing.T) {
 				HCP:                  hcp,
 				Client:               fake.NewClientBuilder().WithScheme(scheme).Build(),
 				ReleaseImageProvider: releaseProvider,
-			}, deployment, test.existingResources)
+			}, deployment, test.existingResources, nil)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(deployment.Spec.Template.Spec.Containers[0].Resources).To(Equal(test.expectedResources))
@@ -823,7 +823,7 @@ func TestSetDefaultOptions(t *testing.T) {
 				HCP:                  hcp,
 				Client:               fake.NewClientBuilder().WithScheme(scheme).Build(),
 				ReleaseImageProvider: releaseProvider,
-			}, deployment, nil)
+			}, deployment, nil, nil)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			if test.expectSet {
@@ -834,4 +834,543 @@ func TestSetDefaultOptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLimitsAlreadyRemoved(t *testing.T) {
+	tests := []struct {
+		name          string
+		annotations   map[string]string
+		containerName string
+		expected      bool
+	}{
+		{
+			name:          "When annotations are nil it should return false",
+			annotations:   nil,
+			containerName: "kube-apiserver",
+			expected:      false,
+		},
+		{
+			name:          "When annotation is empty it should return false",
+			annotations:   map[string]string{limitsRemovedAnnotation: ""},
+			containerName: "kube-apiserver",
+			expected:      false,
+		},
+		{
+			name:          "When container is listed it should return true",
+			annotations:   map[string]string{limitsRemovedAnnotation: "kube-apiserver"},
+			containerName: "kube-apiserver",
+			expected:      true,
+		},
+		{
+			name:          "When container is listed among others it should return true",
+			annotations:   map[string]string{limitsRemovedAnnotation: "sidecar,kube-apiserver,another"},
+			containerName: "kube-apiserver",
+			expected:      true,
+		},
+		{
+			name:          "When container is not listed it should return false",
+			annotations:   map[string]string{limitsRemovedAnnotation: "sidecar,another"},
+			containerName: "kube-apiserver",
+			expected:      false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			result := limitsAlreadyRemoved(test.annotations, test.containerName)
+			g.Expect(result).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestMarkLimitsRemoved(t *testing.T) {
+	tests := []struct {
+		name               string
+		existingAnnotation string
+		containerName      string
+		expectedAnnotation string
+	}{
+		{
+			name:               "When annotations are empty it should add the container",
+			existingAnnotation: "",
+			containerName:      "kube-apiserver",
+			expectedAnnotation: "kube-apiserver",
+		},
+		{
+			name:               "When a container already exists it should append the new container",
+			existingAnnotation: "sidecar",
+			containerName:      "kube-apiserver",
+			expectedAnnotation: "sidecar,kube-apiserver",
+		},
+		{
+			name:               "When container is already listed it should not duplicate",
+			existingAnnotation: "kube-apiserver",
+			containerName:      "kube-apiserver",
+			expectedAnnotation: "kube-apiserver",
+		},
+		{
+			name:               "When container is already in a multi-item list it should not duplicate",
+			existingAnnotation: "sidecar,kube-apiserver",
+			containerName:      "kube-apiserver",
+			expectedAnnotation: "sidecar,kube-apiserver",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			deployment := &appsv1.Deployment{}
+			if test.existingAnnotation != "" {
+				deployment.SetAnnotations(map[string]string{
+					limitsRemovedAnnotation: test.existingAnnotation,
+				})
+			}
+			markLimitsRemoved(deployment, test.containerName)
+			g.Expect(deployment.GetAnnotations()[limitsRemovedAnnotation]).To(Equal(test.expectedAnnotation))
+		})
+	}
+}
+
+func TestComputeContainerResourcesHash(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	containers := []corev1.Container{
+		{
+			Name: "kube-apiserver",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+			},
+		},
+	}
+
+	// Same input should produce the same hash.
+	hash1 := computeContainerResourcesHash(containers)
+	hash2 := computeContainerResourcesHash(containers)
+	g.Expect(hash1).To(Equal(hash2))
+	g.Expect(hash1).NotTo(BeEmpty())
+
+	// Different input should produce a different hash.
+	containersWithLimits := []corev1.Container{
+		{
+			Name: "kube-apiserver",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+	}
+	hash3 := computeContainerResourcesHash(containersWithLimits)
+	g.Expect(hash3).NotTo(Equal(hash1))
+
+	// Order independence: containers sorted by name.
+	containersA := []corev1.Container{
+		{Name: "a", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}}},
+		{Name: "b", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}}},
+	}
+	containersB := []corev1.Container{
+		{Name: "b", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}}},
+		{Name: "a", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}}},
+	}
+	g.Expect(computeContainerResourcesHash(containersA)).To(Equal(computeContainerResourcesHash(containersB)))
+}
+
+func TestLimitRemovalAndPreservation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := hyperv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add hyperv1 to scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add appsv1 to scheme: %v", err)
+	}
+
+	releaseProvider := imageprovider.NewFromImages(map[string]string{
+		"hyperkube":     "quay.io/test/hyperkube:latest",
+		"capi-provider": "quay.io/test/capi-provider:latest",
+	})
+
+	t.Run("When capi-provider manifest has no limits and existing has limits with no annotation it should remove limits and set annotation", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+
+		workload := &controlPlaneWorkload[*appsv1.Deployment]{
+			name:             "capi-provider",
+			workloadProvider: &deploymentProvider{},
+			ComponentOptions: &testComponent{},
+		}
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "capi-provider",
+								Image: "capi-provider",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("100m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									// No limits in manifest.
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		existingResources := map[string]corev1.ResourceRequirements{
+			"capi-provider": {
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		}
+
+		err := workload.setDefaultOptions(ControlPlaneContext{
+			HCP:                  &hyperv1.HostedControlPlane{},
+			Client:               fake.NewClientBuilder().WithScheme(scheme).Build(),
+			ReleaseImageProvider: releaseProvider,
+		}, deployment, existingResources, nil)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Limits should be removed (manifest resources used).
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Resources.Limits).To(BeNil())
+		g.Expect(container.Resources.Requests).To(Equal(corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		}))
+
+		// Annotation should be set on the deployment.
+		g.Expect(deployment.GetAnnotations()[limitsRemovedAnnotation]).To(Equal("capi-provider"))
+	})
+
+	t.Run("When capi-provider manifest has no limits and existing has limits with annotation set it should preserve user override", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+
+		workload := &controlPlaneWorkload[*appsv1.Deployment]{
+			name:             "capi-provider",
+			workloadProvider: &deploymentProvider{},
+			ComponentOptions: &testComponent{},
+		}
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "capi-provider",
+								Image: "capi-provider",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("100m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									// No limits in manifest.
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		existingResources := map[string]corev1.ResourceRequirements{
+			"capi-provider": {
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+		}
+
+		// Simulate that limits were already removed before (user re-added them).
+		oldAnnotations := map[string]string{
+			limitsRemovedAnnotation: "capi-provider",
+		}
+
+		err := workload.setDefaultOptions(ControlPlaneContext{
+			HCP:                  &hyperv1.HostedControlPlane{},
+			Client:               fake.NewClientBuilder().WithScheme(scheme).Build(),
+			ReleaseImageProvider: releaseProvider,
+		}, deployment, existingResources, oldAnnotations)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// User's override should be preserved.
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Resources).To(Equal(existingResources["capi-provider"]))
+	})
+
+	t.Run("When non-capi-provider manifest has no limits and existing has limits it should always preserve existing resources", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+
+		workload := &controlPlaneWorkload[*appsv1.Deployment]{
+			name:             "kube-apiserver",
+			workloadProvider: &deploymentProvider{},
+			ComponentOptions: &testComponent{},
+		}
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "kube-apiserver",
+								Image: "hyperkube",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("100m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									// No limits in manifest.
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		existingResources := map[string]corev1.ResourceRequirements{
+			"kube-apiserver": {
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		}
+
+		err := workload.setDefaultOptions(ControlPlaneContext{
+			HCP:                  &hyperv1.HostedControlPlane{},
+			Client:               fake.NewClientBuilder().WithScheme(scheme).Build(),
+			ReleaseImageProvider: releaseProvider,
+		}, deployment, existingResources, nil)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Non-capi-provider components always preserve existing resources.
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Resources).To(Equal(existingResources["kube-apiserver"]))
+	})
+
+	t.Run("When capi-provider manifest has no limits and existing has no limits it should preserve existing resources", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+
+		workload := &controlPlaneWorkload[*appsv1.Deployment]{
+			name:             "capi-provider",
+			workloadProvider: &deploymentProvider{},
+			ComponentOptions: &testComponent{},
+		}
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "capi-provider",
+								Image: "capi-provider",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("100m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		existingResources := map[string]corev1.ResourceRequirements{
+			"capi-provider": {
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+				// No limits on existing either.
+			},
+		}
+
+		err := workload.setDefaultOptions(ControlPlaneContext{
+			HCP:                  &hyperv1.HostedControlPlane{},
+			Client:               fake.NewClientBuilder().WithScheme(scheme).Build(),
+			ReleaseImageProvider: releaseProvider,
+		}, deployment, existingResources, nil)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Neither has limits, so existing resources are preserved.
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Resources).To(Equal(existingResources["capi-provider"]))
+	})
+
+	t.Run("When capi-provider manifest has limits and existing has limits it should preserve existing resources", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+
+		workload := &controlPlaneWorkload[*appsv1.Deployment]{
+			name:             "capi-provider",
+			workloadProvider: &deploymentProvider{},
+			ComponentOptions: &testComponent{},
+		}
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "capi-provider",
+								Image: "capi-provider",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("100m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("2Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		existingResources := map[string]corev1.ResourceRequirements{
+			"capi-provider": {
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+		}
+
+		err := workload.setDefaultOptions(ControlPlaneContext{
+			HCP:                  &hyperv1.HostedControlPlane{},
+			Client:               fake.NewClientBuilder().WithScheme(scheme).Build(),
+			ReleaseImageProvider: releaseProvider,
+		}, deployment, existingResources, nil)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Both have limits — existing resources should be preserved (current contract).
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Resources).To(Equal(existingResources["capi-provider"]))
+	})
+
+	t.Run("When there is no existing deployment it should use manifest resources as-is", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+
+		workload := &controlPlaneWorkload[*appsv1.Deployment]{
+			name:             "capi-provider",
+			workloadProvider: &deploymentProvider{},
+			ComponentOptions: &testComponent{},
+		}
+		manifestResources := corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		}
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:      "capi-provider",
+								Image:     "capi-provider",
+								Resources: manifestResources,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := workload.setDefaultOptions(ControlPlaneContext{
+			HCP:                  &hyperv1.HostedControlPlane{},
+			Client:               fake.NewClientBuilder().WithScheme(scheme).Build(),
+			ReleaseImageProvider: releaseProvider,
+		}, deployment, nil, nil)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Resources).To(Equal(manifestResources))
+	})
+
+	t.Run("When reconciling it should set container resources hash annotation on pod template", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+
+		workload := &controlPlaneWorkload[*appsv1.Deployment]{
+			name:             "capi-provider",
+			workloadProvider: &deploymentProvider{},
+			ComponentOptions: &testComponent{},
+		}
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "capi-provider",
+								Image: "capi-provider",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU: resource.MustParse("100m"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := workload.setDefaultOptions(ControlPlaneContext{
+			HCP:                  &hyperv1.HostedControlPlane{},
+			Client:               fake.NewClientBuilder().WithScheme(scheme).Build(),
+			ReleaseImageProvider: releaseProvider,
+		}, deployment, nil, nil)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(deployment.Spec.Template.Annotations).To(HaveKey(containerResourcesHashAnnotation))
+		g.Expect(deployment.Spec.Template.Annotations[containerResourcesHashAnnotation]).NotTo(BeEmpty())
+	})
 }


### PR DESCRIPTION
## Summary

- Fix CPOv2 framework unconditionally preserving container resource limits on the `capi-provider` deployment during reconciliation, which prevented manifest-driven limit removal from taking effect on upgrade
- **Scoped to `capi-provider` only** — all other components retain the existing behavior of unconditionally preserving existing resources
- When the manifest no longer specifies limits but the live `capi-provider` deployment has them, automatically remove the limits and record the action via a `limits-removed` annotation
- If a user manually re-adds limits to a container already listed in the annotation, the operator detects this as an intentional override and preserves the user's resources
- Add a container-resources-hash annotation on the pod template so DeepDerivative detects limit removal even when the new resource spec is a subset of the old one

## Test plan

- [x] Unit tests for `limitsAlreadyRemoved` annotation parsing
- [x] Unit tests for `markLimitsRemoved` annotation writing (including deduplication)
- [x] Unit tests for `computeContainerResourcesHash` stability and order independence
- [x] Unit test: capi-provider manifest has no limits, existing has limits, no annotation → limits removed, annotation set
- [x] Unit test: capi-provider manifest has no limits, existing has limits, annotation set → user override preserved
- [x] Unit test: capi-provider manifest has no limits, existing has no limits → existing resources preserved
- [x] Unit test: capi-provider manifest has limits, existing has limits → existing resources preserved
- [x] Unit test: non-capi-provider component with no manifest limits and existing limits → existing resources always preserved
- [x] Unit test: no existing deployment → manifest resources used as-is
- [x] Unit test: container-resources-hash annotation is set on pod template
- [ ] `e2e-aws-upgrade-hypershift-operator` — validates the rollout is safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload reconciliation to consider existing workload annotations when applying default options.
  * Updated `capi-provider` container resource reconciliation: when manifests omit limits, the operator now removes limits as needed while honoring prior user re-adds.
  * Added stable, order-independent hashing of per-container resource requirements to ensure changes are reliably detected and rolled out.
* **Tests**
  * Updated unit tests for the revised `setDefaultOptions` call signature.
  * Added coverage for limit-removal bookkeeping and deterministic resource hashing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->