### PR TITLE
CNTRLPLANE-3774: [release-4.22] fix: control-plane-operator: improve opaque conditions

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1,11 +1,13 @@
 package hostedcontrolplane
 
 import (
+	"bufio"
 	"context"
 	crand "crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
 	"os"
@@ -923,9 +925,9 @@ func (r *HostedControlPlaneReconciler) healthCheckKASLoadBalancers(ctx context.C
 		// When the cluster is private, checking the load balancers will depend on whether the load balancer is
 		// using the right subnets. To avoid uncertainty, we'll limit the check to the service endpoint.
 		if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
-			return healthCheckKASEndpoint(manifests.KubeAPIServerService("").Name, config.KASSVCIBMCloudPort)
+			return healthCheckKASEndpoint(ctx, manifests.KubeAPIServerService("").Name, config.KASSVCIBMCloudPort)
 		}
-		return healthCheckKASEndpoint(manifests.KubeAPIServerService("").Name, config.KASSVCPort)
+		return healthCheckKASEndpoint(ctx, manifests.KubeAPIServerService("").Name, config.KASSVCPort)
 	case serviceStrategy.Type == hyperv1.Route:
 		if hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform {
 			externalRoute := manifests.KubeAPIServerExternalPublicRoute(hcp.Namespace)
@@ -937,7 +939,7 @@ func (r *HostedControlPlaneReconciler) healthCheckKASLoadBalancers(ctx context.C
 			if err != nil {
 				return err
 			}
-			return healthCheckKASEndpoint(endpoint, port)
+			return healthCheckKASEndpoint(ctx, endpoint, port)
 		}
 	case serviceStrategy.Type == hyperv1.LoadBalancer:
 		svc := manifests.KubeAPIServerService(hcp.Namespace)
@@ -955,9 +957,21 @@ func (r *HostedControlPlaneReconciler) healthCheckKASLoadBalancers(ctx context.C
 		if err := r.Get(ctx, client.ObjectKeyFromObject(svc), svc); err != nil {
 			return fmt.Errorf("failed to get kube apiserver service: %w", err)
 		}
-		if len(svc.Status.LoadBalancer.Ingress) == 0 ||
-			svc.Status.LoadBalancer.Ingress[0].Hostname == "" && svc.Status.LoadBalancer.Ingress[0].IP == "" {
-			return fmt.Errorf("APIServer load balancer is not provisioned")
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			msg := fmt.Sprintf("%s load balancer is not provisioned; %v since creation.", svc.Name, duration.ShortHumanDuration(time.Since(svc.ObjectMeta.CreationTimestamp.Time)))
+			messageCollector := events.NewMessageCollector(ctx, r.Client)
+			eventMessages, err := messageCollector.ErrorMessages(svc)
+			if err != nil {
+				return fmt.Errorf("%s; additionally: failed to get events for service %s/%s: %w", msg, svc.Namespace, svc.Name, err)
+			}
+			if len(eventMessages) > 0 {
+				msg = fmt.Sprintf("%s load balancer is not provisioned: %s", svc.Name, strings.Join(eventMessages, "; "))
+			}
+			return fmt.Errorf("%s", msg)
+		}
+		if svc.Status.LoadBalancer.Ingress[0].Hostname == "" && svc.Status.LoadBalancer.Ingress[0].IP == "" {
+			return fmt.Errorf("APIServer load balancer %s/%s has ingress entry with no hostname or IP",
+				svc.Namespace, svc.Name)
 		}
 		LBIngress := svc.Status.LoadBalancer.Ingress[0]
 		ingressPoint := ""
@@ -966,25 +980,57 @@ func (r *HostedControlPlaneReconciler) healthCheckKASLoadBalancers(ctx context.C
 		} else if LBIngress.IP != "" {
 			ingressPoint = LBIngress.IP
 		}
-		return healthCheckKASEndpoint(ingressPoint, port)
+		return healthCheckKASEndpoint(ctx, ingressPoint, port)
 	}
 	return nil
 }
 
-func healthCheckKASEndpoint(ingressPoint string, port int) error {
-	healthEndpoint := fmt.Sprintf("https://%s:%d/healthz", ingressPoint, port)
+func healthCheckKASEndpoint(ctx context.Context, ingressPoint string, port int) error {
+	healthEndpoint := fmt.Sprintf("https://%s:%d/healthz?verbose", ingressPoint, port)
 
 	httpClient := util.InsecureHTTPClient()
 	httpClient.Timeout = 10 * time.Second
-	resp, err := httpClient.Get(healthEndpoint)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthEndpoint, nil)
 	if err != nil {
 		return err
 	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("health check to APIServer endpoint %s failed: %w", ingressPoint, err)
+	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("APIServer endpoint %s is not healthy", ingressPoint)
+		failingChecks := parseFailingHealthChecks(resp.Body)
+		if len(failingChecks) > 0 {
+			return fmt.Errorf("APIServer endpoint %s is not healthy (status %d): failing health checks: %s",
+				ingressPoint, resp.StatusCode, strings.Join(failingChecks, ", "))
+		}
+		return fmt.Errorf("APIServer endpoint %s is not healthy (status %d)", ingressPoint, resp.StatusCode)
 	}
 	return nil
+}
+
+// parseFailingHealthChecks reads a verbose /healthz response body and returns
+// the names of checks that are marked as failing (lines starting with "[-]").
+func parseFailingHealthChecks(body io.Reader) []string {
+	var failing []string
+	scanner := bufio.NewScanner(body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "[-]") {
+			// Format: "[-]<name> failed: reason withheld"
+			name := strings.TrimPrefix(line, "[-]")
+			if idx := strings.Index(name, " failed:"); idx > 0 {
+				name = name[:idx]
+			}
+			failing = append(failing, name)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		failing = append(failing, fmt.Sprintf("(error reading response: %v)", err))
+	}
+	return failing
 }
 
 // controlPlaneComponentsAvailable checks that all ControlPlaneComponents in the namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
@@ -192,11 +192,12 @@ func (r *Reconciler) AdmitHCPManagedRoutes(ctx context.Context, hcp *hyperv1.Hos
 			}
 		}
 		if route.Annotations[netutil.RouteStatusWriterAnnotation] != "hcp-router" {
+			routeBeforeAnnotation := route.DeepCopy()
 			if route.Annotations == nil {
 				route.Annotations = map[string]string{}
 			}
 			route.Annotations[netutil.RouteStatusWriterAnnotation] = "hcp-router"
-			if err := r.Client.Patch(ctx, route, client.MergeFrom(originalRoute)); err != nil {
+			if err := r.Client.Patch(ctx, route, client.MergeFrom(routeBeforeAnnotation)); err != nil {
 				return fmt.Errorf("failed to update route %s status-writer annotation: %w", route.Name, err)
 			}
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
@@ -191,6 +191,15 @@ func (r *Reconciler) AdmitHCPManagedRoutes(ctx context.Context, hcp *hyperv1.Hos
 				return fmt.Errorf("failed to update route %s status: %w", route.Name, err)
 			}
 		}
+		if route.Annotations[netutil.RouteStatusWriterAnnotation] != "hcp-router" {
+			if route.Annotations == nil {
+				route.Annotations = map[string]string{}
+			}
+			route.Annotations[netutil.RouteStatusWriterAnnotation] = "hcp-router"
+			if err := r.Client.Patch(ctx, route, client.MergeFrom(originalRoute)); err != nil {
+				return fmt.Errorf("failed to update route %s status-writer annotation: %w", route.Name, err)
+			}
+		}
 	}
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
@@ -191,12 +191,12 @@ func (r *Reconciler) AdmitHCPManagedRoutes(ctx context.Context, hcp *hyperv1.Hos
 				return fmt.Errorf("failed to update route %s status: %w", route.Name, err)
 			}
 		}
-		if route.Annotations[netutil.RouteStatusWriterAnnotation] != "hcp-router" {
+		if route.Annotations[util.RouteStatusWriterAnnotation] != "hcp-router" {
 			routeBeforeAnnotation := route.DeepCopy()
 			if route.Annotations == nil {
 				route.Annotations = map[string]string{}
 			}
-			route.Annotations[netutil.RouteStatusWriterAnnotation] = "hcp-router"
+			route.Annotations[util.RouteStatusWriterAnnotation] = "hcp-router"
 			if err := r.Client.Patch(ctx, route, client.MergeFrom(routeBeforeAnnotation)); err != nil {
 				return fmt.Errorf("failed to update route %s status-writer annotation: %w", route.Name, err)
 			}

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -100,6 +100,14 @@ func ReconcileRouteStatus(route *routev1.Route, externalHostname, internalHostna
 		canonicalHostName = externalHostname
 	}
 
+	// When the router host is not yet known, we must not write route status with
+	// an empty RouterCanonicalHostname. Doing so overwrites a previously-valid
+	// value and causes health checks to report "route not admitted", flapping the
+	// HostedCluster Available condition.
+	if canonicalHostName == "" {
+		return
+	}
+
 	// Skip reconciliation if ingress status.ingress has already been populated and canonical hostname is the same
 	if len(route.Status.Ingress) > 0 && route.Status.Ingress[0].RouterCanonicalHostname == canonicalHostName {
 		return

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
@@ -16,8 +16,9 @@ import (
 // GetHealthcheckEndpoint determines the appropriate endpoint and port for healthcheck based on the route and configuration
 func GetHealthcheckEndpointForRoute(externalRoute *routev1.Route, hcp *hyperv1.HostedControlPlane) (endpoint string, port int, err error) {
 	if len(externalRoute.Status.Ingress) == 0 {
-		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: route has no ingress status",
-			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host)
+		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: route has no ingress status; last status writer: %s",
+			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host,
+			externalRoute.Annotations[netutil.RouteStatusWriterAnnotation])
 	}
 	if externalRoute.Status.Ingress[0].RouterCanonicalHostname == "" {
 		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: %s; last status writer: %s",

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
@@ -15,16 +15,20 @@ import (
 
 // GetHealthcheckEndpoint determines the appropriate endpoint and port for healthcheck based on the route and configuration
 func GetHealthcheckEndpointForRoute(externalRoute *routev1.Route, hcp *hyperv1.HostedControlPlane) (endpoint string, port int, err error) {
+	statusWriter := externalRoute.Annotations[netutil.RouteStatusWriterAnnotation]
+	if statusWriter == "" {
+		statusWriter = "(none)"
+	}
 	if len(externalRoute.Status.Ingress) == 0 {
 		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: route has no ingress status; last status writer: %s",
 			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host,
-			externalRoute.Annotations[netutil.RouteStatusWriterAnnotation])
+			statusWriter)
 	}
 	if externalRoute.Status.Ingress[0].RouterCanonicalHostname == "" {
 		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: %s; last status writer: %s",
 			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host,
 			routeIngressDiagnostic(externalRoute.Status.Ingress[0]),
-			externalRoute.Annotations[netutil.RouteStatusWriterAnnotation])
+			statusWriter)
 	}
 
 	endpoint = externalRoute.Status.Ingress[0].RouterCanonicalHostname

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
@@ -20,9 +20,10 @@ func GetHealthcheckEndpointForRoute(externalRoute *routev1.Route, hcp *hyperv1.H
 			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host)
 	}
 	if externalRoute.Status.Ingress[0].RouterCanonicalHostname == "" {
-		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: %s",
+		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: %s; last status writer: %s",
 			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host,
-			routeIngressDiagnostic(externalRoute.Status.Ingress[0]))
+			routeIngressDiagnostic(externalRoute.Status.Ingress[0]),
+			externalRoute.Annotations[netutil.RouteStatusWriterAnnotation])
 	}
 
 	endpoint = externalRoute.Status.Ingress[0].RouterCanonicalHostname

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
@@ -15,7 +15,7 @@ import (
 
 // GetHealthcheckEndpoint determines the appropriate endpoint and port for healthcheck based on the route and configuration
 func GetHealthcheckEndpointForRoute(externalRoute *routev1.Route, hcp *hyperv1.HostedControlPlane) (endpoint string, port int, err error) {
-	statusWriter := externalRoute.Annotations[netutil.RouteStatusWriterAnnotation]
+	statusWriter := externalRoute.Annotations[util.RouteStatusWriterAnnotation]
 	if statusWriter == "" {
 		statusWriter = "(none)"
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
@@ -2,6 +2,7 @@ package kas
 
 import (
 	"fmt"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -14,8 +15,14 @@ import (
 
 // GetHealthcheckEndpoint determines the appropriate endpoint and port for healthcheck based on the route and configuration
 func GetHealthcheckEndpointForRoute(externalRoute *routev1.Route, hcp *hyperv1.HostedControlPlane) (endpoint string, port int, err error) {
-	if len(externalRoute.Status.Ingress) == 0 || externalRoute.Status.Ingress[0].RouterCanonicalHostname == "" {
-		return "", 0, fmt.Errorf("APIServer external route not admitted")
+	if len(externalRoute.Status.Ingress) == 0 {
+		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: route has no ingress status",
+			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host)
+	}
+	if externalRoute.Status.Ingress[0].RouterCanonicalHostname == "" {
+		return "", 0, fmt.Errorf("APIServer external route %s/%s (host: %s) not admitted: %s",
+			externalRoute.Namespace, externalRoute.Name, externalRoute.Spec.Host,
+			routeIngressDiagnostic(externalRoute.Status.Ingress[0]))
 	}
 
 	endpoint = externalRoute.Status.Ingress[0].RouterCanonicalHostname
@@ -35,4 +42,23 @@ func GetHealthcheckEndpointForRoute(externalRoute *routev1.Route, hcp *hyperv1.H
 	}
 
 	return endpoint, port, nil
+}
+
+// routeIngressDiagnostic produces a human-readable summary of a RouteIngress
+// entry that has been populated but lacks a RouterCanonicalHostname.
+func routeIngressDiagnostic(ingress routev1.RouteIngress) string {
+	parts := []string{
+		fmt.Sprintf("router %q has not set a canonical hostname", ingress.RouterName),
+	}
+	for _, cond := range ingress.Conditions {
+		detail := fmt.Sprintf("%s=%s", cond.Type, cond.Status)
+		if cond.Reason != "" {
+			detail += fmt.Sprintf(" reason=%s", cond.Reason)
+		}
+		if cond.Message != "" {
+			detail += fmt.Sprintf(" message=%q", cond.Message)
+		}
+		parts = append(parts, detail)
+	}
+	return strings.Join(parts, "; ")
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck_test.go
@@ -12,30 +12,83 @@ import (
 	"github.com/openshift/hypershift/support/config"
 
 	routev1 "github.com/openshift/api/route/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetHealthcheckEndpoint(t *testing.T) {
 	tests := []struct {
-		name             string
-		route            *routev1.Route
-		hcp              *hyperv1.HostedControlPlane
-		useSharedIngress bool
-		expectedEndpoint string
-		expectedPort     int
-		expectedError    string
+		name                    string
+		route                   *routev1.Route
+		hcp                     *hyperv1.HostedControlPlane
+		useSharedIngress        bool
+		expectedEndpoint        string
+		expectedPort            int
+		expectedErrorSubstrings []string
 	}{
 		{
-			name: "when route is not admitted, it should return error",
+			name: "When route has no ingress status, it should return error with no ingress detail",
 			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver",
+					Namespace: "clusters-test",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "api.test.example.com",
+				},
 				Status: routev1.RouteStatus{
 					Ingress: []routev1.RouteIngress{},
 				},
 			},
-			hcp:           &hyperv1.HostedControlPlane{},
-			expectedError: "APIServer external route not admitted",
+			hcp: &hyperv1.HostedControlPlane{},
+			expectedErrorSubstrings: []string{
+				"clusters-test/kube-apiserver",
+				"api.test.example.com",
+				"route has no ingress status",
+			},
 		},
 		{
-			name: "when route is admitted without shared ingress, it should return canonical hostname",
+			name: "When route has ingress but no canonical hostname, it should return error with router diagnostic",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver",
+					Namespace: "clusters-test",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "api.test.example.com",
+				},
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							RouterName:              "default",
+							RouterCanonicalHostname: "",
+							Conditions: []routev1.RouteIngressCondition{
+								{
+									Type:    routev1.RouteAdmitted,
+									Status:  corev1.ConditionFalse,
+									Reason:  "HostAlreadyClaimed",
+									Message: "route foo already exposes api.test.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{},
+			expectedErrorSubstrings: []string{
+				"clusters-test/kube-apiserver",
+				"api.test.example.com",
+				"not admitted",
+				"default",
+				"has not set a canonical hostname",
+				"Admitted=False",
+				"HostAlreadyClaimed",
+				"route foo already exposes",
+			},
+		},
+		{
+			name: "When route is admitted without shared ingress, it should return canonical hostname",
 			route: &routev1.Route{
 				Status: routev1.RouteStatus{
 					Ingress: []routev1.RouteIngress{
@@ -51,7 +104,7 @@ func TestGetHealthcheckEndpoint(t *testing.T) {
 			expectedPort:     443,
 		},
 		{
-			name: "when using shared ingress, it should return route host",
+			name: "When using shared ingress, it should return route host",
 			route: &routev1.Route{
 				Spec: routev1.RouteSpec{
 					Host: "route.example.com",
@@ -87,7 +140,7 @@ func TestGetHealthcheckEndpoint(t *testing.T) {
 			expectedPort:     sharedingress.ExternalDNSLBPort,
 		},
 		{
-			name: "when using shared ingress with CIDR blocks, it should return KAS service",
+			name: "When using shared ingress with CIDR blocks, it should return KAS service",
 			route: &routev1.Route{
 				Spec: routev1.RouteSpec{
 					Host: "route.example.com",
@@ -140,9 +193,11 @@ func TestGetHealthcheckEndpoint(t *testing.T) {
 
 			endpoint, port, err := GetHealthcheckEndpointForRoute(tc.route, tc.hcp)
 
-			if tc.expectedError != "" {
+			if len(tc.expectedErrorSubstrings) > 0 {
 				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).To(Equal(tc.expectedError))
+				for _, substr := range tc.expectedErrorSubstrings {
+					g.Expect(err.Error()).To(ContainSubstring(substr))
+				}
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(endpoint).To(Equal(tc.expectedEndpoint))

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck_test.go
@@ -46,6 +46,7 @@ func TestGetHealthcheckEndpoint(t *testing.T) {
 				"clusters-test/kube-apiserver",
 				"api.test.example.com",
 				"route has no ingress status",
+				"last status writer:",
 			},
 		},
 		{

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck_test.go
@@ -85,6 +85,7 @@ func TestGetHealthcheckEndpoint(t *testing.T) {
 				"Admitted=False",
 				"HostAlreadyClaimed",
 				"route foo already exposes",
+				"last status writer:",
 			},
 		},
 		{

--- a/hypershift-operator/controllers/sharedingress/router_test.go
+++ b/hypershift-operator/controllers/sharedingress/router_test.go
@@ -4,6 +4,9 @@ import (
 	"reflect"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
+	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/hypershift/support/config"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -139,4 +142,73 @@ func TestReconcileRouterPodDisruptionBudget(t *testing.T) {
 			t.Errorf("Expected unhealthyPodEvictionPolicy to be AlwaysAllow, got %v", *pdb.Spec.UnhealthyPodEvictionPolicy)
 		}
 	})
+}
+
+func TestReconcileRouteStatus(t *testing.T) {
+	tests := []struct {
+		name              string
+		route             *routev1.Route
+		canonicalHostname string
+		expectUpdate      bool
+		expectedHostname  string
+	}{
+		{
+			name: "When canonical hostname is set, it should update route ingress",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{Host: "api.test.example.com"},
+			},
+			canonicalHostname: "lb.example.com",
+			expectUpdate:      true,
+			expectedHostname:  "lb.example.com",
+		},
+		{
+			name: "When canonical hostname matches existing, it should not update",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{Host: "api.test.example.com"},
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							RouterCanonicalHostname: "lb.example.com",
+							RouterName:              "router",
+						},
+					},
+				},
+			},
+			canonicalHostname: "lb.example.com",
+			expectUpdate:      false,
+			expectedHostname:  "lb.example.com",
+		},
+		{
+			name: "When canonical hostname changes, it should update route ingress",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{Host: "api.test.example.com"},
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							RouterCanonicalHostname: "old-lb.example.com",
+							RouterName:              "router",
+						},
+					},
+				},
+			},
+			canonicalHostname: "new-lb.example.com",
+			expectUpdate:      true,
+			expectedHostname:  "new-lb.example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			original := tc.route.DeepCopy()
+			ReconcileRouteStatus(tc.route, tc.canonicalHostname)
+			if tc.expectUpdate {
+				g.Expect(tc.route.Status.Ingress).To(HaveLen(1))
+				g.Expect(tc.route.Status.Ingress[0].RouterCanonicalHostname).To(Equal(tc.expectedHostname))
+				g.Expect(tc.route.Status.Ingress[0].RouterName).To(Equal("router"))
+			} else {
+				g.Expect(tc.route.Status).To(Equal(original.Status))
+			}
+		})
+	}
 }

--- a/hypershift-operator/controllers/sharedingress/router_test.go
+++ b/hypershift-operator/controllers/sharedingress/router_test.go
@@ -6,8 +6,9 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/hypershift/support/config"
+
+	routev1 "github.com/openshift/api/route/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
+++ b/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
@@ -251,6 +251,15 @@ func (r *SharedIngressReconciler) reconcileRouter(ctx context.Context, pullSecre
 				return fmt.Errorf("failed to update route %s status: %w", route.Name, err)
 			}
 		}
+		if route.Annotations[netutil.RouteStatusWriterAnnotation] != "shared-ingress" {
+			if route.Annotations == nil {
+				route.Annotations = map[string]string{}
+			}
+			route.Annotations[netutil.RouteStatusWriterAnnotation] = "shared-ingress"
+			if err := r.Client.Patch(ctx, &route, client.MergeFrom(originalRoute)); err != nil {
+				return fmt.Errorf("failed to update route %s status-writer annotation: %w", route.Name, err)
+			}
+		}
 	}
 
 	routerDeploymentOwnerRef := supportconfig.OwnerRefFrom(deployment)

--- a/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
+++ b/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
@@ -252,11 +252,12 @@ func (r *SharedIngressReconciler) reconcileRouter(ctx context.Context, pullSecre
 			}
 		}
 		if route.Annotations[netutil.RouteStatusWriterAnnotation] != "shared-ingress" {
+			routeBeforeAnnotation := route.DeepCopy()
 			if route.Annotations == nil {
 				route.Annotations = map[string]string{}
 			}
 			route.Annotations[netutil.RouteStatusWriterAnnotation] = "shared-ingress"
-			if err := r.Client.Patch(ctx, &route, client.MergeFrom(originalRoute)); err != nil {
+			if err := r.Client.Patch(ctx, &route, client.MergeFrom(routeBeforeAnnotation)); err != nil {
 				return fmt.Errorf("failed to update route %s status-writer annotation: %w", route.Name, err)
 			}
 		}

--- a/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
+++ b/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
@@ -221,8 +221,15 @@ func (r *SharedIngressReconciler) reconcileRouter(ctx context.Context, pullSecre
 	// and causes the CPO health check to report "route not admitted", flapping the
 	// HostedCluster Available condition.
 	if canonicalHostname == "" {
-		log.Log.Info("shared ingress LB has no hostname or IP; skipping route status reconciliation",
-			"service", client.ObjectKeyFromObject(svc))
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			log.Log.Info("shared ingress LB is not provisioned; skipping route status reconciliation",
+				"service", client.ObjectKeyFromObject(svc),
+				"serviceSince", svc.CreationTimestamp.Time)
+		} else {
+			log.Log.Info("shared ingress LB has ingress entry with no hostname or IP; skipping route status reconciliation",
+				"service", client.ObjectKeyFromObject(svc),
+				"ingressEntries", len(svc.Status.LoadBalancer.Ingress))
+		}
 		return nil
 	}
 

--- a/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
+++ b/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
@@ -251,12 +251,12 @@ func (r *SharedIngressReconciler) reconcileRouter(ctx context.Context, pullSecre
 				return fmt.Errorf("failed to update route %s status: %w", route.Name, err)
 			}
 		}
-		if route.Annotations[netutil.RouteStatusWriterAnnotation] != "shared-ingress" {
+		if route.Annotations[util.RouteStatusWriterAnnotation] != "shared-ingress" {
 			routeBeforeAnnotation := route.DeepCopy()
 			if route.Annotations == nil {
 				route.Annotations = map[string]string{}
 			}
-			route.Annotations[netutil.RouteStatusWriterAnnotation] = "shared-ingress"
+			route.Annotations[util.RouteStatusWriterAnnotation] = "shared-ingress"
 			if err := r.Client.Patch(ctx, &route, client.MergeFrom(routeBeforeAnnotation)); err != nil {
 				return fmt.Errorf("failed to update route %s status-writer annotation: %w", route.Name, err)
 			}

--- a/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
+++ b/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
@@ -216,6 +216,16 @@ func (r *SharedIngressReconciler) reconcileRouter(ctx context.Context, pullSecre
 		}
 	}
 
+	// When the LB has no hostname or IP, we must not write route status with an
+	// empty RouterCanonicalHostname. Doing so overwrites a previously-valid value
+	// and causes the CPO health check to report "route not admitted", flapping the
+	// HostedCluster Available condition.
+	if canonicalHostname == "" {
+		log.Log.Info("shared ingress LB has no hostname or IP; skipping route status reconciliation",
+			"service", client.ObjectKeyFromObject(svc))
+		return nil
+	}
+
 	routeList := &routev1.RouteList{}
 	// If the hypershift.openshift.io/hosted-control-plane label is not present,
 	// then it means the route should be fulfilled by the management cluster's router.

--- a/support/util/route.go
+++ b/support/util/route.go
@@ -17,6 +17,12 @@ import (
 const HCPRouteLabel = "hypershift.openshift.io/hosted-control-plane"
 const InternalRouteLabel = "hypershift.openshift.io/internal-route"
 
+// RouteStatusWriterAnnotation identifies which controller last wrote a route's
+// Status.Ingress. Both the shared ingress controller and the CPO's HCP router
+// use RouterName "router", making their writes indistinguishable from the route
+// object alone. This annotation resolves that ambiguity for diagnosis.
+const RouteStatusWriterAnnotation = "hypershift.openshift.io/route-status-writer"
+
 // RemoveLabelMarker is a sentinel value that can be set on a label to indicate
 // that the label should be removed during metadata preservation in ApplyManifest.
 // This allows adapt functions to explicitly request label removal even when using


### PR DESCRIPTION
Backport of #8804 to release-4.22.

## Summary

- Improved KubeAPI health checks to use verbose `/healthz?verbose` output, surfacing which specific health checks are failing and adding endpoint context on request failures
- Improved load balancer and endpoint health diagnostics, distinguishing "not yet provisioned" from "missing ingress hostname/IP" with event details
- Expanded Route-based readiness errors with richer ingress/admission condition details when required routing attributes are absent
- More reliable Route status reconciliation by preventing overwrites when router hostnames aren't known
- Added `hypershift.openshift.io/route-status-writer` annotation to attribute route status writes to either "shared-ingress" or "hcp-router"

## Backport Adaptations

- Replaced `netutil.RouteStatusWriterAnnotation` with `util.RouteStatusWriterAnnotation` since `support/netutil` doesn't exist on release-4.22
- Inlined `k8sutil.CollectLBMessageIfNotProvisioned` since `support/k8sutil` doesn't exist on release-4.22
- Updated `healthCheckKASEndpoint` callers to pass `ctx` parameter (function signature change was part of the PR but callers needed manual fixup due to cherry-pick context differences)