### PR TITLE
AUTOSCALE-166: fix yq dependency for running upstream karpenter tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -672,7 +672,7 @@ cpo-container-sync:
 # - current context to be set to a hosted cluster with AutoNode enabled.
 # - an annotation to be applied to the HCP to stop reconcillation (hypershift.openshift.io/karpenter-core-e2e-override=true)
 .PHONY: karpenter-upstream-e2e
-karpenter-upstream-e2e:
+karpenter-upstream-e2e: $(YQ)
 	./karpenter-operator/e2e/upstream-e2e.sh
 
 ## --------------------------------------

--- a/karpenter-operator/e2e/adjust-ec2nodeclass.sh
+++ b/karpenter-operator/e2e/adjust-ec2nodeclass.sh
@@ -2,8 +2,12 @@
 
 FILE=$1
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+YQ="${REPO_ROOT}/hack/tools/bin/yq"
+
 # delete metadata fields
-yq 'del(.metadata.creationTimestamp, .metadata.generation, .metadata.managedFields, .metadata.resourceVersion, .metadata.selfLink, .metadata.uid)' -i "$FILE"
+$YQ 'del(.metadata.creationTimestamp, .metadata.generation, .metadata.managedFields, .metadata.resourceVersion, .metadata.selfLink, .metadata.uid)' -i "$FILE"
 
 # delete status
-yq 'del(.status)' -i "$FILE"
+$YQ 'del(.status)' -i "$FILE"


### PR DESCRIPTION
## What this PR does / why we need it:
Updates the yq dependency for running upstream karpenter tests using the `karpenter-upstream-e2e` make target to use the repo's yq.

## Which issue(s) this PR fixes:
Fixes issue related to [AUTOSCALE-166](https://redhat.atlassian.net/browse/AUTOSCALE-166?focusedCommentId=16851181). 
Updates the make target and adjust-ec2nodeclass.sh script to use the repo's managed yq tool instead of relying on a manually downloaded yq.

## Special notes for your reviewer:
Related PR for adding upstream regression tests to aws-karpenter-provider-aws: https://github.com/openshift/release/pull/82258

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test execution reliability by ensuring required YAML tooling is available before running the upstream scenario.
  * Updated end-to-end configuration adjustment scripts to use the repository-provided tooling consistently.
  * Improved consistency when stripping generated metadata and status fields from test YAML inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->