### PR TITLE
chore: remove --new-from-rev scoping from api-lint to prove pre-exist…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,11 +109,11 @@ PULL_BASE_SHA := $(if $(PULL_BASE_SHA),$(PULL_BASE_SHA),$(shell git rev-parse ma
 
 .PHONY: api-lint
 api-lint: $(GOLANGCI_LINT) $(KUBEAPILINTER_PLUGIN)
-	cd api && $(GOLANGCI_LINT) run --config ./.golangci.yml --modules-download-mode=readonly -v $(if $(PULL_BASE_SHA),--new-from-rev=$(PULL_BASE_SHA) --whole-files)
+	cd api && $(GOLANGCI_LINT) run --config ./.golangci.yml --modules-download-mode=readonly -v
 
 .PHONY: api-lint-fix
 api-lint-fix: $(GOLANGCI_LINT) $(KUBEAPILINTER_PLUGIN)
-	cd api && $(GOLANGCI_LINT) run --config ./.golangci.yml --fix -v $(if $(PULL_BASE_SHA),--new-from-rev=$(PULL_BASE_SHA) --whole-files)
+	cd api && $(GOLANGCI_LINT) run --config ./.golangci.yml --fix -v
 
 .PHONY: lint
 lint: generate


### PR DESCRIPTION
…ing failures

The api-lint and api-lint-fix targets use --new-from-rev=$(PULL_BASE_SHA) --whole-files, which scopes linting to files changed since the base SHA. On main this means zero files are scanned, hiding 50 pre-existing kube-api-linter violations in hosted_controlplane.go and hostedcluster_types.go.

Any PR that touches either of those files triggers the full-file scan, and the auto-fixer produces broken code (e.g. +kubebuilder:default → +default, +kubebuilder:validation:Pattern → +kubebuilder:validation:XValidation), causing make lint-fix to fail.

This commit removes the scoping to expose the issue in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API linting commands to run consistently across the full API directory.
  * Removed conditional linting behavior based on pull request revision settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->