### PR TITLE
Default --node-drain-timeout CLI flag to 60s

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -57,6 +57,7 @@ func DefaultOptions() *RawCreateOptions {
 		FeatureSet:                     string(configv1.Default),
 		EnableClusterCapabilities:      []string{},
 		DisableClusterCapabilities:     []string{},
+		NodeDrainTimeout:               60 * time.Second,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Change the default value of `--node-drain-timeout` from `0` (infinite) to `60s`

## What this PR does / why we need it

The default `--node-drain-timeout` of `0` means drain retries indefinitely. When deleting a hosted cluster, if a PodDisruptionBudget blocks pod eviction (e.g. `kube-storage-version-migrator` with `minAvailable: 1` and no `unhealthyPodEvictionPolicy: AlwaysAllow`), the CAPI machine drain hangs forever and the hosted cluster deletion never completes.

A 60s default gives a reasonable upper bound so drain eventually completes even when PDBs prevent eviction.

This only affects the CLI default — users can still explicitly set `--node-drain-timeout 0` to get the old behavior.

## Test plan
- [ ] `hcp create cluster --help` shows `60s` as the default
- [ ] CI presubmit jobs pass
- [ ] Hosted cluster deletion completes within ~60s when a PDB blocks drain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Set a 60-second default timeout for draining nodes during cluster creation.
  * Prevented cluster creation from proceeding with no node drain timeout configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->