### PR TITLE
CNTRLPLANE-3791: fix: revert api-lint --whole-files to avoid surfacing pre-existing violations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,18 +102,16 @@ $(KUBEAPILINTER_PLUGIN): $(TOOLS_DIR)/go.mod # Build kube-api-linter as Go plugi
 
 # When not otherwise set, diff/lint against the upstream main branch.
 # This is always set in OpenShift CI.
-# Falls back through: upstream remote/main → local main → empty (lint all files).
 UPSTREAM_REMOTE ?= $(shell git remote -v 2>/dev/null | grep 'openshift/hypershift.*fetch' | head -1 | cut -f1)
-PULL_BASE_SHA ?= $(if $(UPSTREAM_REMOTE),$(shell git rev-parse $(UPSTREAM_REMOTE)/main 2>/dev/null),)
-PULL_BASE_SHA := $(if $(PULL_BASE_SHA),$(PULL_BASE_SHA),$(shell git rev-parse main 2>/dev/null))
+PULL_BASE_SHA ?= $(if $(UPSTREAM_REMOTE),$(shell git rev-parse $(UPSTREAM_REMOTE)/main), $(shell git rev-parse main))
 
 .PHONY: api-lint
 api-lint: $(GOLANGCI_LINT) $(KUBEAPILINTER_PLUGIN)
-	cd api && $(GOLANGCI_LINT) run --config ./.golangci.yml --modules-download-mode=readonly -v $(if $(PULL_BASE_SHA),--new-from-rev=$(PULL_BASE_SHA) --whole-files)
+	cd api && $(GOLANGCI_LINT) run --config ./.golangci.yml --modules-download-mode=readonly -v --new-from-rev=${PULL_BASE_SHA}
 
 .PHONY: api-lint-fix
 api-lint-fix: $(GOLANGCI_LINT) $(KUBEAPILINTER_PLUGIN)
-	cd api && $(GOLANGCI_LINT) run --config ./.golangci.yml --fix -v $(if $(PULL_BASE_SHA),--new-from-rev=$(PULL_BASE_SHA) --whole-files)
+	cd api && $(GOLANGCI_LINT) run --config ./.golangci.yml --fix -v --new-from-rev=${PULL_BASE_SHA}
 
 .PHONY: lint
 lint: generate


### PR DESCRIPTION
## What this PR does / why we need it:

Reverts the `api-lint` and `api-lint-fix` Makefile targets to use `--new-from-rev` without `--whole-files`. The `--whole-files` flag (added in #9016) causes the entire file to be linted when any line changes, surfacing pre-existing violations that the PR author did not introduce.

This restores the original behavior where only changed lines are checked. A follow-up Jira ticket will track fixing all pre-existing linter violations so `--whole-files` (or full-file linting) can be re-enabled.

## Which issue(s) this PR fixes:

Addresses feedback from #9063

## Special notes for your reviewer:

This is an alternative to #9063 which proposed removing `--new-from-rev` entirely and fixing all ~570 pre-existing violations. This PR takes the simpler approach of reverting to the original scoping while a Jira ticket tracks the full cleanup.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved API linting consistency by reliably determining the comparison point.
  - Updated API lint and auto-fix commands to focus on changes relative to the resolved base revision.
  - Removed fallback behavior that linted entire files when the base revision was unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->