### PR TITLE
CNTRLPLANE-2029: docs(backuprestore): add Agent and KubeVirt platform prerequisites

### DIFF
--- a/docs/content/how-to/disaster-recovery/backup-and-restore-oadp-1-5.md
+++ b/docs/content/how-to/disaster-recovery/backup-and-restore-oadp-1-5.md
@@ -91,15 +91,6 @@ Below are some samples of DPA configurations for the mentioned platforms
             credential:
               key: cloud
               name: cloud-credentials
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: us-east-1
-              profile: "volumeSnapshot"
-            credential:
-              key: cloud
-              name: cloud-credentials
       configuration:
         nodeAgent:
           enable: true
@@ -141,15 +132,6 @@ Below are some samples of DPA configurations for the mentioned platforms
               key: cloud
               name: cloud-credentials
               default: true
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: minio
-              profile: "default"
-            credential:
-              key: cloud
-              name: cloud-credentials
       configuration:
         nodeAgent:
           enable: true
@@ -183,15 +165,6 @@ Below are some samples of DPA configurations for the mentioned platforms
               prefix: backup-objects
             config:
               region: region-one
-              profile: "default"
-            credential:
-              key: cloud
-              name: cloud-credentials
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: minio
               profile: "default"
             credential:
               key: cloud

--- a/docs/content/how-to/disaster-recovery/backup-and-restore-oadp.md
+++ b/docs/content/how-to/disaster-recovery/backup-and-restore-oadp.md
@@ -71,15 +71,6 @@ Below are some samples of DPA configurations for the mentioned platforms
               key: cloud
               name: cloud-credentials
               default: true
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: minio
-              profile: "default"
-            credential:
-              key: cloud
-              name: cloud-credentials
       configuration:
         nodeAgent:
           enable: true
@@ -117,15 +108,6 @@ Below are some samples of DPA configurations for the mentioned platforms
             config:
               region: us-east-1
               profile: "backupStorage"
-            credential:
-              key: cloud
-              name: cloud-credentials
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: us-east-1
-              profile: "volumeSnapshot"
             credential:
               key: cloud
               name: cloud-credentials
@@ -169,15 +151,6 @@ Below are some samples of DPA configurations for the mentioned platforms
               bucket: example-oadp
               prefix: backup-objects
             provider: aws
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: region-one
-              profile: "default"
-            credential:
-              key: cloud
-              name: cloud-credentials
       configuration:
         nodeAgent:
           enable: true
@@ -221,15 +194,6 @@ Below are some samples of DPA configurations for the mentioned platforms
               bucket: example-oadp
               prefix: backup-objects
             provider: aws
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: region-one
-              profile: "default"
-            credential:
-              key: cloud
-              name: cloud-credentials
       configuration:
         nodeAgent:
           enable: true

--- a/docs/content/how-to/disaster-recovery/backup-and-restore-oadp.md
+++ b/docs/content/how-to/disaster-recovery/backup-and-restore-oadp.md
@@ -91,7 +91,7 @@ Below are some samples of DPA configurations for the mentioned platforms
             - csi
           customPlugins:
             - name: hypershift-oadp-plugin
-              image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+              image: quay.io/konveyor/hypershift-oadp-plugin:latest
           resourceTimeout: 2h
     ```
 
@@ -140,7 +140,7 @@ Below are some samples of DPA configurations for the mentioned platforms
             - csi
           customPlugins:
             - name: hypershift-oadp-plugin
-              image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+              image: quay.io/konveyor/hypershift-oadp-plugin:latest
           resourceTimeout: 2h
     ```
 
@@ -190,7 +190,7 @@ Below are some samples of DPA configurations for the mentioned platforms
             - csi
           customPlugins:
             - name: hypershift-oadp-plugin
-              image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+              image: quay.io/konveyor/hypershift-oadp-plugin:latest
           resourceTimeout: 2h
     ```
 
@@ -242,7 +242,7 @@ Below are some samples of DPA configurations for the mentioned platforms
             - csi
           customPlugins:
             - name: hypershift-oadp-plugin
-              image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+              image: quay.io/konveyor/hypershift-oadp-plugin:latest
           resourceTimeout: 2h
     ```
 

--- a/docs/content/how-to/disaster-recovery/platform-guides/agent.md
+++ b/docs/content/how-to/disaster-recovery/platform-guides/agent.md
@@ -55,15 +55,6 @@ spec:
           key: cloud
           name: cloud-credentials
           default: true
-  snapshotLocations:
-    - velero:
-        provider: aws
-        config:
-          region: minio
-          profile: "default"
-        credential:
-          key: cloud
-          name: cloud-credentials
   configuration:
     nodeAgent:
       enable: true

--- a/docs/content/how-to/disaster-recovery/platform-guides/aws.md
+++ b/docs/content/how-to/disaster-recovery/platform-guides/aws.md
@@ -100,15 +100,6 @@ spec:
         credential:
           key: cloud
           name: cloud-credentials
-  snapshotLocations:
-    - velero:
-        provider: aws
-        config:
-          region: us-east-1
-          profile: "volumeSnapshot"
-        credential:
-          key: cloud
-          name: cloud-credentials
   configuration:
     nodeAgent:
       enable: true

--- a/docs/content/how-to/disaster-recovery/platform-guides/kubevirt.md
+++ b/docs/content/how-to/disaster-recovery/platform-guides/kubevirt.md
@@ -44,15 +44,6 @@ spec:
           bucket: example-oadp
           prefix: backup-objects
         provider: aws
-  snapshotLocations:
-    - velero:
-        provider: aws
-        config:
-          region: region-one
-          profile: "default"
-        credential:
-          key: cloud
-          name: cloud-credentials
   configuration:
     nodeAgent:
       enable: true

--- a/docs/content/how-to/disaster-recovery/platform-guides/openstack.md
+++ b/docs/content/how-to/disaster-recovery/platform-guides/openstack.md
@@ -41,15 +41,6 @@ spec:
         credential:
           key: cloud
           name: cloud-credentials
-  snapshotLocations:
-    - velero:
-        provider: aws
-        config:
-          region: minio
-          profile: "default"
-        credential:
-          key: cloud
-          name: cloud-credentials
   configuration:
     nodeAgent:
       enable: true

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -17385,15 +17385,6 @@ Below are some samples of DPA configurations for the mentioned platforms
             credential:
               key: cloud
               name: cloud-credentials
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: us-east-1
-              profile: "volumeSnapshot"
-            credential:
-              key: cloud
-              name: cloud-credentials
       configuration:
         nodeAgent:
           enable: true
@@ -17435,15 +17426,6 @@ Below are some samples of DPA configurations for the mentioned platforms
               key: cloud
               name: cloud-credentials
               default: true
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: minio
-              profile: "default"
-            credential:
-              key: cloud
-              name: cloud-credentials
       configuration:
         nodeAgent:
           enable: true
@@ -17477,15 +17459,6 @@ Below are some samples of DPA configurations for the mentioned platforms
               prefix: backup-objects
             config:
               region: region-one
-              profile: "default"
-            credential:
-              key: cloud
-              name: cloud-credentials
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: minio
               profile: "default"
             credential:
               key: cloud
@@ -18414,15 +18387,6 @@ Below are some samples of DPA configurations for the mentioned platforms
               key: cloud
               name: cloud-credentials
               default: true
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: minio
-              profile: "default"
-            credential:
-              key: cloud
-              name: cloud-credentials
       configuration:
         nodeAgent:
           enable: true
@@ -18460,15 +18424,6 @@ Below are some samples of DPA configurations for the mentioned platforms
             config:
               region: us-east-1
               profile: "backupStorage"
-            credential:
-              key: cloud
-              name: cloud-credentials
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: us-east-1
-              profile: "volumeSnapshot"
             credential:
               key: cloud
               name: cloud-credentials
@@ -18512,15 +18467,6 @@ Below are some samples of DPA configurations for the mentioned platforms
               bucket: example-oadp
               prefix: backup-objects
             provider: aws
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: region-one
-              profile: "default"
-            credential:
-              key: cloud
-              name: cloud-credentials
       configuration:
         nodeAgent:
           enable: true
@@ -18564,15 +18510,6 @@ Below are some samples of DPA configurations for the mentioned platforms
               bucket: example-oadp
               prefix: backup-objects
             provider: aws
-      snapshotLocations:
-        - velero:
-            provider: aws
-            config:
-              region: region-one
-              profile: "default"
-            credential:
-              key: cloud
-              name: cloud-credentials
       configuration:
         nodeAgent:
           enable: true
@@ -22646,15 +22583,6 @@ spec:
           key: cloud
           name: cloud-credentials
           default: true
-  snapshotLocations:
-    - velero:
-        provider: aws
-        config:
-          region: minio
-          profile: "default"
-        credential:
-          key: cloud
-          name: cloud-credentials
   configuration:
     nodeAgent:
       enable: true
@@ -22887,15 +22815,6 @@ spec:
         config:
           region: us-east-1
           profile: "backupStorage"
-        credential:
-          key: cloud
-          name: cloud-credentials
-  snapshotLocations:
-    - velero:
-        provider: aws
-        config:
-          region: us-east-1
-          profile: "volumeSnapshot"
         credential:
           key: cloud
           name: cloud-credentials
@@ -23151,15 +23070,6 @@ spec:
           bucket: example-oadp
           prefix: backup-objects
         provider: aws
-  snapshotLocations:
-    - velero:
-        provider: aws
-        config:
-          region: region-one
-          profile: "default"
-        credential:
-          key: cloud
-          name: cloud-credentials
   configuration:
     nodeAgent:
       enable: true
@@ -23252,15 +23162,6 @@ spec:
           prefix: backup-objects
         config:
           region: region-one
-          profile: "default"
-        credential:
-          key: cloud
-          name: cloud-credentials
-  snapshotLocations:
-    - velero:
-        provider: aws
-        config:
-          region: minio
           profile: "default"
         credential:
           key: cloud

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -18434,7 +18434,7 @@ Below are some samples of DPA configurations for the mentioned platforms
             - csi
           customPlugins:
             - name: hypershift-oadp-plugin
-              image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+              image: quay.io/konveyor/hypershift-oadp-plugin:latest
           resourceTimeout: 2h
     ```
 
@@ -18483,7 +18483,7 @@ Below are some samples of DPA configurations for the mentioned platforms
             - csi
           customPlugins:
             - name: hypershift-oadp-plugin
-              image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+              image: quay.io/konveyor/hypershift-oadp-plugin:latest
           resourceTimeout: 2h
     ```
 
@@ -18533,7 +18533,7 @@ Below are some samples of DPA configurations for the mentioned platforms
             - csi
           customPlugins:
             - name: hypershift-oadp-plugin
-              image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+              image: quay.io/konveyor/hypershift-oadp-plugin:latest
           resourceTimeout: 2h
     ```
 
@@ -18585,7 +18585,7 @@ Below are some samples of DPA configurations for the mentioned platforms
             - csi
           customPlugins:
             - name: hypershift-oadp-plugin
-              image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+              image: quay.io/konveyor/hypershift-oadp-plugin:latest
           resourceTimeout: 2h
     ```
 

--- a/test/e2e/v2/backuprestore/README.md
+++ b/test/e2e/v2/backuprestore/README.md
@@ -21,7 +21,7 @@ The backup and restore tests validate the ability to:
 5. **Volume Snapshot Location**: Configured snapshot location
 6. **DataProtectionApplication**: This resource brings Velero pod that handles the backups
 7. **HyperShift CLI**: The `hypershift` binary must be available in your PATH
-8. **Platform**: Currently supports AWS platform only
+8. **Platform**: Supports AWS, Agent, and KubeVirt platforms
 
 #### Platform-specific Prerequisites
 
@@ -148,6 +148,166 @@ spec:
 EOF
 ```
 
+##### Agent and KubeVirt
+
+Agent and KubeVirt platforms might use MinIO as an S3-compatible object store instead of AWS S3. Both platforms use the same OADP setup. In CI, MinIO runs on the virthost at `192.168.111.1:9000`.
+
+* MinIO deployment
+
+Deploy MinIO as a container (adjust credentials and bucket name as needed):
+
+```bash
+minio_user="admin"
+minio_password="admin123"
+bucket_name="oadp-backup"
+
+mkdir -p /opt/minio/data
+podman network create minio-net
+podman run -d --name minio --network minio-net \
+  -p 9000:9000 -p 9001:9001 \
+  -e MINIO_ROOT_USER=$minio_user \
+  -e MINIO_ROOT_PASSWORD=$minio_password \
+  -v /opt/minio/data:/data:z \
+  quay.io/minio/minio server /data --console-address ":9001"
+# Note: The `:z` volume label is required on SELinux-enabled systems (RHEL, Fedora).
+
+# Create the backup bucket
+podman run --rm --network minio-net --entrypoint=/bin/sh quay.io/minio/mc -c "\
+  mc alias set myminio http://minio:9000 ${minio_user} ${minio_password} --api s3v4 && \
+  mc mb myminio/${bucket_name}"
+```
+
+The MinIO endpoint accessible from the management cluster depends on your environment. In CI, it is `192.168.111.1:9000` (the virthost IP). When running locally, use the host IP reachable from the cluster.
+
+* Secret
+
+Create an AWS-format credentials file for MinIO and apply the secret:
+
+```bash
+minio_user="admin"
+minio_password="admin123"
+
+cat <<EOF > /tmp/minio-credentials
+[default]
+aws_access_key_id = $minio_user
+aws_secret_access_key = $minio_password
+EOF
+
+secret_data="$(base64 -w 0 /tmp/minio-credentials)"
+
+cat <<EOF | oc apply -f -
+apiVersion: v1
+data:
+  credentials: $secret_data
+kind: Secret
+metadata:
+  name: cloud-credentials
+  namespace: openshift-adp
+type: Opaque
+EOF
+```
+
+* DataProtectionApplication
+
+The `aws` plugin is used even with MinIO since MinIO is S3-compatible.
+
+```bash
+cat <<EOF | oc apply -f -
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: dpa-sample
+  namespace: openshift-adp
+spec:
+  backupImages: false
+  configuration:
+    nodeAgent:
+      enable: true
+      uploaderType: kopia
+    velero:
+      customPlugins:
+        - name: hypershift-oadp-plugin
+          image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+      defaultPlugins:
+        - openshift
+        - aws
+        - kubevirt
+        - csi
+      noDefaultBackupLocation: true
+      logLevel: debug
+EOF
+```
+
+Note: For OpenShift ADP 1.5+, the customPlugins might be left out. Instead, the hypershift plugin can be listed directly under defaultPlugins as follows:
+```
+      defaultPlugins:
+        - openshift
+        - aws
+        - kubevirt
+        - csi
+        - hypershift
+```
+
+* BackupStorageLocation
+
+Key differences from AWS: `s3ForcePathStyle` is required for MinIO, and `s3Url` must point to the MinIO endpoint.
+
+```bash
+minio_endpoint="<minio_host_ip>"
+cluster_name="<cluster_name>"
+bucket_name="oadp-backup"
+
+cat <<EOF | oc apply -f -
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  name: $cluster_name
+  namespace: openshift-adp
+spec:
+  provider: aws
+  objectStorage:
+    bucket: $bucket_name
+    prefix: hcp
+  credential:
+    name: cloud-credentials
+    key: credentials
+  config:
+    region: minio
+    s3ForcePathStyle: "true"
+    s3Url: http://${minio_endpoint}:9000
+    insecureSkipTLSVerify: "true"
+EOF
+```
+
+* VolumeSnapshotLocation
+
+```bash
+cluster_name="<cluster_name>"
+
+cat <<EOF | oc apply -f -
+apiVersion: velero.io/v1
+kind: VolumeSnapshotLocation
+metadata:
+  name: $cluster_name
+  namespace: openshift-adp
+spec:
+  provider: aws
+  credential:
+    name: cloud-credentials
+    key: credentials
+  config:
+    region: minio
+EOF
+```
+
+##### Agent Platform Notes
+
+The backup/restore test framework handles these Agent-specific steps automatically:
+
+- **Before backup**: AgentMachine and AgentCluster resources are paused with the `cluster.x-k8s.io/paused` annotation to prevent CAPI reconciliation during the backup.
+- **Before breaking the control plane**: Agents are annotated with `agent-install.openshift.io/skip-spoke-cleanup` and ClusterDeployment is set with `preserveOnDelete` to prevent agents from being unbound and hosts from being rebooted.
+- **After restore**: CAPI resources are unpaused so reconciliation resumes.
+
 ## Test Structure
 
 The tests follow an ordered, serial execution flow:
@@ -228,7 +388,7 @@ Test artifacts are stored in the `ARTIFACT_DIR`:
 
 ## Known Limitations
 
-1. **Platform Support**: Currently only supports AWS platform
+1. **Platform Support**: Supports AWS, Agent, and KubeVirt platforms. The etcd snapshot test (`BackupRestoreEtcdSnapshot`) is AWS-only
 2. **Guest Cluster Validation**: Guest cluster health checks are skipped due to OCPBUGS-59876
 3. **Continual Operations**: Continual operation verification is skipped until CNTRLPLANE-2676 is implemented
 4. **Serial Execution**: Tests must run serially as it breaks the cluster

--- a/test/e2e/v2/backuprestore/README.md
+++ b/test/e2e/v2/backuprestore/README.md
@@ -18,10 +18,9 @@ The backup and restore tests validate the ability to:
 2. **Storage for OADP data**: Might be S3 bucket or other storage
 3. **Secret for accessing storage**
 4. **Backup Storage Location**: Configured storage location for backups (e.g., S3 bucket for AWS)
-5. **Volume Snapshot Location**: Configured snapshot location
-6. **DataProtectionApplication**: This resource brings Velero pod that handles the backups
-7. **HyperShift CLI**: The `hypershift` binary must be available in your PATH
-8. **Platform**: Supports AWS, Agent, and KubeVirt platforms
+5. **DataProtectionApplication**: This resource brings Velero pod that handles the backups
+6. **HyperShift CLI**: The `hypershift` binary must be available in your PATH
+7. **Platform**: Supports AWS, Agent, and KubeVirt platforms
 
 #### Platform-specific Prerequisites
 
@@ -158,11 +157,12 @@ The MinIO endpoint accessible from the management cluster depends on your enviro
 
 * Secret
 
-Create an AWS-format credentials file for MinIO and apply the secret:
+Create an AWS-format credentials file for MinIO and apply the secret. The variables must match the values used during MinIO deployment:
 
 ```bash
 minio_user="admin"
 minio_password="admin123"
+bucket_name="oadp-backup"
 
 cat <<EOF > /tmp/minio-credentials
 [default]

--- a/test/e2e/v2/backuprestore/README.md
+++ b/test/e2e/v2/backuprestore/README.md
@@ -162,7 +162,7 @@ minio_password="admin123"
 bucket_name="oadp-backup"
 
 mkdir -p /opt/minio/data
-podman network create minio-net
+podman network create minio-net 2>/dev/null || true
 podman run -d --name minio --network minio-net \
   -p 9000:9000 -p 9001:9001 \
   -e MINIO_ROOT_USER=$minio_user \
@@ -177,7 +177,7 @@ podman run --rm --network minio-net --entrypoint=/bin/sh quay.io/minio/mc -c "\
   mc mb myminio/${bucket_name}"
 ```
 
-The MinIO endpoint accessible from the management cluster depends on your environment. In CI, it is `192.168.111.1:9000` (the virthost IP). When running locally, use the host IP reachable from the cluster.
+The MinIO endpoint accessible from the management cluster depends on your environment. In CI, it is `192.168.111.1` (the virthost IP). When running locally, use the host IP reachable from the cluster.
 
 * Secret
 
@@ -239,7 +239,7 @@ EOF
 ```
 
 Note: For OpenShift ADP 1.5+, the customPlugins might be left out. Instead, the hypershift plugin can be listed directly under defaultPlugins as follows:
-```
+```yaml
       defaultPlugins:
         - openshift
         - aws
@@ -304,9 +304,13 @@ EOF
 
 The backup/restore test framework handles these Agent-specific steps automatically:
 
-- **Before backup**: AgentMachine and AgentCluster resources are paused with the `cluster.x-k8s.io/paused` annotation to prevent CAPI reconciliation during the backup.
+- **During backup**: AgentMachine and AgentCluster resources are paused with the `cluster.x-k8s.io/paused` annotation to prevent CAPI reconciliation before the backup and unpaused after backup.
 - **Before breaking the control plane**: Agents are annotated with `agent-install.openshift.io/skip-spoke-cleanup` and ClusterDeployment is set with `preserveOnDelete` to prevent agents from being unbound and hosts from being rebooted.
-- **After restore**: CAPI resources are unpaused so reconciliation resumes.
+- **After restore**: CAPI resources are unpaused because they were backed up while being paused and the restore operation brings them back as paused.
+
+##### KubeVirt Platform Notes
+
+KubeVirt requires no platform-specific pre/post steps beyond the shared OADP setup above.
 
 ## Test Structure
 

--- a/test/e2e/v2/backuprestore/README.md
+++ b/test/e2e/v2/backuprestore/README.md
@@ -125,29 +125,6 @@ spec:
 EOF
 ```
 
-* VolumeSnapshotLocation
-
-```bash
-cluster_name="<your_cluster_name>"
-region="<aws_region>"
-
-cat <<EOF | oc apply -f -
-apiVersion: velero.io/v1
-kind: VolumeSnapshotLocation
-metadata:
-  name: $cluster_name
-  namespace: openshift-adp
-spec:
-  provider: aws
-  credential:
-    name: $cluster_name
-    key: credentials
-  config:
-    region:  $region
-    profile: "default"
-EOF
-```
-
 ##### Agent and KubeVirt
 
 Agent and KubeVirt platforms might use MinIO as an S3-compatible object store instead of AWS S3. Both platforms use the same OADP setup. In CI, MinIO runs on the virthost at `192.168.111.1:9000`.
@@ -276,27 +253,6 @@ spec:
     s3ForcePathStyle: "true"
     s3Url: http://${minio_endpoint}:9000
     insecureSkipTLSVerify: "true"
-EOF
-```
-
-* VolumeSnapshotLocation
-
-```bash
-cluster_name="<cluster_name>"
-
-cat <<EOF | oc apply -f -
-apiVersion: velero.io/v1
-kind: VolumeSnapshotLocation
-metadata:
-  name: $cluster_name
-  namespace: openshift-adp
-spec:
-  provider: aws
-  credential:
-    name: cloud-credentials
-    key: credentials
-  config:
-    region: minio
 EOF
 ```
 

--- a/test/e2e/v2/backuprestore/README.md
+++ b/test/e2e/v2/backuprestore/README.md
@@ -74,7 +74,7 @@ spec:
     velero:
       customPlugins:
         - name: hypershift-oadp-plugin
-          image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+          image: quay.io/konveyor/hypershift-oadp-plugin:latest
       defaultPlugins:
         - openshift
         - aws
@@ -204,7 +204,7 @@ spec:
     velero:
       customPlugins:
         - name: hypershift-oadp-plugin
-          image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+          image: quay.io/konveyor/hypershift-oadp-plugin:latest
       defaultPlugins:
         - openshift
         - aws
@@ -232,7 +232,6 @@ Key differences from AWS: `s3ForcePathStyle` is required for MinIO, and `s3Url` 
 ```bash
 minio_endpoint="<minio_host_ip>"
 cluster_name="<cluster_name>"
-bucket_name="oadp-backup"
 
 cat <<EOF | oc apply -f -
 apiVersion: velero.io/v1


### PR DESCRIPTION
## What this PR does / why we need it:

  The backup/restore README only documented AWS prerequisites despite
  the tests already supporting Agent and KubeVirt platforms. Add a new
  section covering MinIO-based OADP setup (storage, credentials, DPA,
  BSL, VSL) used by both platforms in CI, and document Agent-specific
  CAPI resource pausing behavior during backup/restore operations.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-2029

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded backup and restore guidance for AWS, Agent, and KubeVirt platforms.
  * Added MinIO deployment, credentials, data protection, and backup storage configuration instructions.
  * Updated examples to use the Konveyor-hosted HyperShift OADP plugin image.
  * Clarified platform limitations and AWS-only etcd snapshot testing.
  * Removed the AWS volume snapshot location example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->