### PR TITLE
OCPBUGS-99329: avoid cache miss false-negative on credential Secret lookup

### DIFF
--- a/api/hypershift/v1beta1/etcdbackup_types.go
+++ b/api/hypershift/v1beta1/etcdbackup_types.go
@@ -20,11 +20,12 @@ const (
 	// BackupCompleted indicates whether the etcd backup has completed.
 	BackupCompleted ConditionType = "BackupCompleted"
 
-	BackupSucceededReason  string = "BackupSucceeded"
-	BackupFailedReason     string = "BackupFailed"
-	BackupInProgressReason string = "BackupInProgress"
-	BackupRejectedReason   string = "BackupRejected"
-	EtcdUnhealthyReason    string = "EtcdUnhealthy"
+	BackupSucceededReason             string = "BackupSucceeded"
+	BackupFailedReason                string = "BackupFailed"
+	BackupInProgressReason            string = "BackupInProgress"
+	BackupRejectedReason              string = "BackupRejected"
+	BackupWaitingForCredentialsReason string = "BackupWaitingForCredentials"
+	EtcdUnhealthyReason               string = "EtcdUnhealthy"
 )
 
 // HCPEtcdBackupStorageType is the type of storage for etcd backups.

--- a/hypershift-operator/controllers/etcdbackup/reconciler.go
+++ b/hypershift-operator/controllers/etcdbackup/reconciler.go
@@ -80,6 +80,7 @@ const (
 // etcd snapshot and upload Jobs in the HyperShift Operator namespace.
 type HCPEtcdBackupReconciler struct {
 	client.Client
+	APIReader               client.Reader
 	OperatorNamespace       string
 	ReleaseProvider         releaseinfo.ProviderWithOpenShiftImageRegistryOverrides
 	HypershiftOperatorImage string
@@ -124,6 +125,22 @@ func (r *HCPEtcdBackupReconciler) setFailedConditionAndUpdate(ctx context.Contex
 	return ctrl.Result{}, nil
 }
 
+func (r *HCPEtcdBackupReconciler) getCredentialSecret(ctx context.Context, name string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: name, Namespace: r.OperatorNamespace}
+	err := r.Get(ctx, key, secret)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to get credential Secret: %w", err)
+	}
+	if apierrors.IsNotFound(err) {
+		err = r.APIReader.Get(ctx, key, secret)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get credential Secret: %w", err)
+		}
+	}
+	return secret, err
+}
+
 func (r *HCPEtcdBackupReconciler) validatePrerequisites(ctx context.Context, backup *hyperv1.HCPEtcdBackup) (ctrl.Result, bool, error) {
 	credentialSecretName, err := r.getCredentialSecretName(backup)
 	if err != nil {
@@ -134,17 +151,15 @@ func (r *HCPEtcdBackupReconciler) validatePrerequisites(ctx context.Context, bac
 		return result, true, nil
 	}
 
-	credSecret := &corev1.Secret{}
-	if err := r.Get(ctx, types.NamespacedName{Name: credentialSecretName, Namespace: r.OperatorNamespace}, credSecret); err != nil {
-		if apierrors.IsNotFound(err) {
-			result, updateErr := r.setFailedConditionAndUpdate(ctx, backup, hyperv1.BackupFailedReason,
-				fmt.Sprintf("credential Secret %q not found in namespace %q", credentialSecretName, r.OperatorNamespace))
-			if updateErr != nil {
-				return result, true, updateErr
-			}
-			return result, true, nil
+	if _, credErr := r.getCredentialSecret(ctx, credentialSecretName); apierrors.IsNotFound(credErr) {
+		result, updateErr := r.setFailedConditionAndUpdate(ctx, backup, hyperv1.BackupFailedReason,
+			fmt.Sprintf("credential Secret %q not found in namespace %q", credentialSecretName, r.OperatorNamespace))
+		if updateErr != nil {
+			return result, true, updateErr
 		}
-		return ctrl.Result{}, true, fmt.Errorf("failed to get credential Secret: %w", err)
+		return result, true, nil
+	} else if credErr != nil {
+		return ctrl.Result{}, true, credErr
 	}
 	return ctrl.Result{}, false, nil
 }
@@ -156,13 +171,13 @@ func (r *HCPEtcdBackupReconciler) createResourcesAndJob(ctx context.Context, bac
 	if err != nil {
 		return r.setFailedConditionAndUpdate(ctx, backup, hyperv1.BackupFailedReason, err.Error())
 	}
-	credSecret := &corev1.Secret{}
-	if err := r.Get(ctx, types.NamespacedName{Name: credentialSecretName, Namespace: r.OperatorNamespace}, credSecret); err != nil {
-		if apierrors.IsNotFound(err) {
-			return r.setFailedConditionAndUpdate(ctx, backup, hyperv1.BackupFailedReason,
-				fmt.Sprintf("credential Secret %q not found in namespace %q", credentialSecretName, r.OperatorNamespace))
-		}
-		return ctrl.Result{}, fmt.Errorf("failed to get credential Secret: %w", err)
+	credSecret, err := r.getCredentialSecret(ctx, credentialSecretName)
+	if apierrors.IsNotFound(err) {
+		return r.setFailedConditionAndUpdate(ctx, backup, hyperv1.BackupFailedReason,
+			fmt.Sprintf("credential Secret %q not found in namespace %q", credentialSecretName, r.OperatorNamespace))
+	}
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	creds := resolveCredentials(backup.Spec.Storage.StorageType, credSecret)

--- a/hypershift-operator/controllers/etcdbackup/reconciler.go
+++ b/hypershift-operator/controllers/etcdbackup/reconciler.go
@@ -74,6 +74,19 @@ const (
 	mountPathAWSIAMToken = "/var/run/secrets/aws-iam-token"
 
 	requeueInterval = 10 * time.Second
+
+	// credentialWaitRequeueInterval is the requeue delay while waiting for the
+	// credential Secret to appear in the cache. This is the safety net that backs
+	// up the Secret watch in case the watch event is missed.
+	credentialWaitRequeueInterval = 30 * time.Second
+
+	// credentialWaitTimeout bounds how long a backup waits for its credential
+	// Secret to appear before it is marked terminally failed. Measured from the
+	// backup's CreationTimestamp. Set above the OADP plugin's 30s credential
+	// timeout plus cache lag and the exponential requeue backoff so the informer
+	// race is absorbed, while an orphaned waiter that will never resolve is
+	// eventually failed and cleaned up.
+	credentialWaitTimeout = 2 * time.Minute
 )
 
 // HCPEtcdBackupReconciler reconciles HCPEtcdBackup resources by orchestrating
@@ -105,6 +118,10 @@ func (r *HCPEtcdBackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}}
 			},
 		)).
+		// Watch credential Secrets in the operator namespace so a backup waiting
+		// for its credential Secret is re-reconciled as soon as the Secret lands
+		// in the cache, rather than only on the requeue interval.
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.backupsForCredentialSecret)).
 		WithOptions(controller.Options{
 			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](1*time.Second, 30*time.Second),
 		}).
@@ -124,6 +141,82 @@ func (r *HCPEtcdBackupReconciler) setFailedConditionAndUpdate(ctx context.Contex
 	return ctrl.Result{}, nil
 }
 
+// setWaitingConditionAndUpdate marks the backup as waiting (non-terminal) and
+// requeues so reconciliation resumes when the awaited resource appears. This is
+// used for transient preconditions like the credential Secret not yet being
+// visible in the cache, which must NOT be treated as a permanent failure.
+func (r *HCPEtcdBackupReconciler) setWaitingConditionAndUpdate(ctx context.Context, backup *hyperv1.HCPEtcdBackup, reason, message string) (ctrl.Result, error) {
+	r.setCondition(backup, metav1.Condition{
+		Type:    string(hyperv1.BackupCompleted),
+		Status:  metav1.ConditionFalse,
+		Reason:  reason,
+		Message: message,
+	})
+	if err := r.Status().Update(ctx, backup); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
+	}
+	return ctrl.Result{RequeueAfter: credentialWaitRequeueInterval}, nil
+}
+
+// handleMissingCredentialSecret marks the backup as waiting for its credential
+// Secret, or, once the wait deadline (measured from CreationTimestamp) is
+// exceeded, as terminally failed so shared RBAC/NetworkPolicy resources are
+// cleaned up and retention can proceed instead of the CR being orphaned.
+func (r *HCPEtcdBackupReconciler) handleMissingCredentialSecret(ctx context.Context, backup *hyperv1.HCPEtcdBackup, credentialSecretName string) (ctrl.Result, error) {
+	if time.Since(backup.CreationTimestamp.Time) > credentialWaitTimeout {
+		return r.setFailedConditionAndUpdate(ctx, backup, hyperv1.BackupFailedReason,
+			fmt.Sprintf("timed out after %s waiting for credential Secret %q in namespace %q",
+				credentialWaitTimeout, credentialSecretName, r.OperatorNamespace))
+	}
+	return r.setWaitingConditionAndUpdate(ctx, backup, hyperv1.BackupWaitingForCredentialsReason,
+		fmt.Sprintf("waiting for credential Secret %q in namespace %q", credentialSecretName, r.OperatorNamespace))
+}
+
+// getCredentialSecret looks up the credential Secret from the cache. The raw
+// error is returned so callers can distinguish NotFound (a transient cache miss
+// while waiting for the Secret to land) from other failures.
+func (r *HCPEtcdBackupReconciler) getCredentialSecret(ctx context.Context, name string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: name, Namespace: r.OperatorNamespace}
+	if err := r.Get(ctx, key, secret); err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
+// backupsForCredentialSecret maps a credential Secret in the operator namespace
+// to the non-terminal HCPEtcdBackup(s) that reference it, so those backups are
+// re-reconciled as soon as the Secret lands in the cache.
+func (r *HCPEtcdBackupReconciler) backupsForCredentialSecret(ctx context.Context, obj client.Object) []reconcile.Request {
+	if obj.GetNamespace() != r.OperatorNamespace {
+		return nil
+	}
+
+	backupList := &hyperv1.HCPEtcdBackupList{}
+	if err := r.List(ctx, backupList); err != nil {
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for i := range backupList.Items {
+		backup := &backupList.Items[i]
+		if isTerminal(backup) {
+			continue
+		}
+		credentialSecretName, err := r.getCredentialSecretName(backup)
+		if err != nil || credentialSecretName != obj.GetName() {
+			continue
+		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      backup.Name,
+				Namespace: backup.Namespace,
+			},
+		})
+	}
+	return requests
+}
+
 func (r *HCPEtcdBackupReconciler) validatePrerequisites(ctx context.Context, backup *hyperv1.HCPEtcdBackup) (ctrl.Result, bool, error) {
 	credentialSecretName, err := r.getCredentialSecretName(backup)
 	if err != nil {
@@ -134,17 +227,18 @@ func (r *HCPEtcdBackupReconciler) validatePrerequisites(ctx context.Context, bac
 		return result, true, nil
 	}
 
-	credSecret := &corev1.Secret{}
-	if err := r.Get(ctx, types.NamespacedName{Name: credentialSecretName, Namespace: r.OperatorNamespace}, credSecret); err != nil {
-		if apierrors.IsNotFound(err) {
-			result, updateErr := r.setFailedConditionAndUpdate(ctx, backup, hyperv1.BackupFailedReason,
-				fmt.Sprintf("credential Secret %q not found in namespace %q", credentialSecretName, r.OperatorNamespace))
-			if updateErr != nil {
-				return result, true, updateErr
-			}
-			return result, true, nil
+	if _, credErr := r.getCredentialSecret(ctx, credentialSecretName); apierrors.IsNotFound(credErr) {
+		// The Secret may not yet be visible in the cache (informer race). Mark the
+		// backup as waiting (non-terminal) and requeue; the Secret watch re-triggers
+		// reconciliation as soon as it lands. Once the wait deadline is exceeded the
+		// backup is failed terminally so shared resources are cleaned up.
+		result, updateErr := r.handleMissingCredentialSecret(ctx, backup, credentialSecretName)
+		if updateErr != nil {
+			return result, true, updateErr
 		}
-		return ctrl.Result{}, true, fmt.Errorf("failed to get credential Secret: %w", err)
+		return result, true, nil
+	} else if credErr != nil {
+		return ctrl.Result{}, true, fmt.Errorf("failed to get credential Secret: %w", credErr)
 	}
 	return ctrl.Result{}, false, nil
 }
@@ -156,12 +250,13 @@ func (r *HCPEtcdBackupReconciler) createResourcesAndJob(ctx context.Context, bac
 	if err != nil {
 		return r.setFailedConditionAndUpdate(ctx, backup, hyperv1.BackupFailedReason, err.Error())
 	}
-	credSecret := &corev1.Secret{}
-	if err := r.Get(ctx, types.NamespacedName{Name: credentialSecretName, Namespace: r.OperatorNamespace}, credSecret); err != nil {
-		if apierrors.IsNotFound(err) {
-			return r.setFailedConditionAndUpdate(ctx, backup, hyperv1.BackupFailedReason,
-				fmt.Sprintf("credential Secret %q not found in namespace %q", credentialSecretName, r.OperatorNamespace))
-		}
+	credSecret, err := r.getCredentialSecret(ctx, credentialSecretName)
+	if apierrors.IsNotFound(err) {
+		// Transient cache miss — wait for the Secret rather than failing terminally,
+		// up to the wait deadline, after which the backup is failed terminally.
+		return r.handleMissingCredentialSecret(ctx, backup, credentialSecretName)
+	}
+	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get credential Secret: %w", err)
 	}
 

--- a/hypershift-operator/controllers/etcdbackup/reconciler_test.go
+++ b/hypershift-operator/controllers/etcdbackup/reconciler_test.go
@@ -74,6 +74,7 @@ func newReconciler(objs ...client.Object) *HCPEtcdBackupReconciler {
 
 	return &HCPEtcdBackupReconciler{
 		Client:                  fakeClient,
+		APIReader:               fakeClient,
 		OperatorNamespace:       testHONamespace,
 		ReleaseProvider:         &fakeReleaseProvider{},
 		HypershiftOperatorImage: "quay.io/hypershift/hypershift:latest",

--- a/hypershift-operator/controllers/etcdbackup/reconciler_test.go
+++ b/hypershift-operator/controllers/etcdbackup/reconciler_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func TestMain(m *testing.M) {
@@ -86,6 +87,10 @@ func newHCPEtcdBackup() *hyperv1.HCPEtcdBackup {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testBackupName,
 			Namespace: testHCPNamespace,
+			// Real backups are always stamped by the API server; the fake client is
+			// not, so set a recent timestamp to keep the credential-wait deadline
+			// (credentialWaitTimeout) from tripping immediately in tests.
+			CreationTimestamp: metav1.Now(),
 		},
 		Spec: hyperv1.HCPEtcdBackupSpec{
 			Storage: hyperv1.HCPEtcdBackupStorage{
@@ -388,12 +393,12 @@ func TestReconcile(t *testing.T) {
 		g.Expect(result).To(Equal(ctrl.Result{}))
 	})
 
-	t.Run("When credential Secret does not exist it should set BackupFailed without creating RBAC or NetworkPolicy", func(t *testing.T) {
+	t.Run("When credential Secret does not exist it should wait (non-terminal) and requeue without creating RBAC or NetworkPolicy", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		backup := newHCPEtcdBackup()
 		hcp := newHostedControlPlane()
 		sts := newEtcdStatefulSet(3, 3)
-		// No credential secret — should trigger BackupFailed before creating any resources
+		// No credential secret — should mark waiting and requeue before creating any resources.
 		r := newReconciler(backup, hcp, sts)
 		ctx := context.Background()
 
@@ -404,15 +409,17 @@ func TestReconcile(t *testing.T) {
 			},
 		})
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result).To(Equal(ctrl.Result{}))
+		g.Expect(result).To(Equal(ctrl.Result{RequeueAfter: credentialWaitRequeueInterval}))
 
 		updated := &hyperv1.HCPEtcdBackup{}
 		g.Expect(r.Get(ctx, types.NamespacedName{Name: testBackupName, Namespace: testHCPNamespace}, updated)).To(Succeed())
 		g.Expect(updated.Status.Conditions).To(HaveLen(1))
 		g.Expect(updated.Status.Conditions[0].Type).To(Equal(string(hyperv1.BackupCompleted)))
 		g.Expect(updated.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
-		g.Expect(updated.Status.Conditions[0].Reason).To(Equal(hyperv1.BackupFailedReason))
+		g.Expect(updated.Status.Conditions[0].Reason).To(Equal(hyperv1.BackupWaitingForCredentialsReason))
 		g.Expect(updated.Status.Conditions[0].Message).To(ContainSubstring("credential Secret"))
+		// Waiting is non-terminal so the backup can still recover.
+		g.Expect(isTerminal(updated)).To(BeFalse())
 
 		// Verify no RBAC or NetworkPolicy was created (early validation prevents resource waste)
 		g.Expect(r.Get(ctx, types.NamespacedName{Name: RBACName, Namespace: testHCPNamespace}, &rbacv1.Role{})).ToNot(Succeed())
@@ -1985,12 +1992,12 @@ func TestGetHostedControlPlane(t *testing.T) {
 
 func TestValidatePrerequisites(t *testing.T) {
 	tests := []struct {
-		name        string
-		backup      *hyperv1.HCPEtcdBackup
-		objects     []client.Object
-		expectDone  bool
-		expectError bool
-		expectFail  bool
+		name         string
+		backup       *hyperv1.HCPEtcdBackup
+		objects      []client.Object
+		expectDone   bool
+		expectError  bool
+		expectReason string
 	}{
 		{
 			name:   "When credential secret exists, it should return done=false (proceed)",
@@ -2006,11 +2013,11 @@ func TestValidatePrerequisites(t *testing.T) {
 			expectDone: false,
 		},
 		{
-			name:       "When credential secret is missing, it should set BackupFailed and return done=true",
-			backup:     newHCPEtcdBackup(),
-			objects:    []client.Object{},
-			expectDone: true,
-			expectFail: true,
+			name:         "When credential secret is missing, it should wait (non-terminal) and return done=true",
+			backup:       newHCPEtcdBackup(),
+			objects:      []client.Object{},
+			expectDone:   true,
+			expectReason: hyperv1.BackupWaitingForCredentialsReason,
 		},
 		{
 			name: "When storage type is unsupported, it should set BackupFailed and return done=true",
@@ -2025,9 +2032,9 @@ func TestValidatePrerequisites(t *testing.T) {
 					},
 				},
 			},
-			objects:    []client.Object{},
-			expectDone: true,
-			expectFail: true,
+			objects:      []client.Object{},
+			expectDone:   true,
+			expectReason: hyperv1.BackupFailedReason,
 		},
 	}
 
@@ -2047,12 +2054,12 @@ func TestValidatePrerequisites(t *testing.T) {
 			}
 			g.Expect(done).To(Equal(tt.expectDone))
 
-			if tt.expectFail {
+			if tt.expectReason != "" {
 				updated := &hyperv1.HCPEtcdBackup{}
 				g.Expect(r.Get(t.Context(), types.NamespacedName{Name: tt.backup.Name, Namespace: tt.backup.Namespace}, updated)).To(Succeed())
 				cond := meta.FindStatusCondition(updated.Status.Conditions, string(hyperv1.BackupCompleted))
 				g.Expect(cond).ToNot(BeNil())
-				g.Expect(cond.Reason).To(Equal(hyperv1.BackupFailedReason))
+				g.Expect(cond.Reason).To(Equal(tt.expectReason))
 			}
 		})
 	}
@@ -2138,9 +2145,29 @@ func TestCreateResourcesAndJob(t *testing.T) {
 		g.Expect(updated.Status.Conditions[0].Message).To(ContainSubstring("pull secret"))
 	})
 
-	t.Run("When credential secret is not found it should set BackupFailed", func(t *testing.T) {
+	t.Run("When credential secret is not found it should wait (non-terminal) and requeue", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		backup := newHCPEtcdBackup()
+		hcp := newHostedControlPlane()
+		r := newReconciler(backup, hcp) // no credential secret
+		ctx := context.Background()
+
+		result, err := r.createResourcesAndJob(ctx, backup, hcp)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{RequeueAfter: credentialWaitRequeueInterval}))
+
+		updated := &hyperv1.HCPEtcdBackup{}
+		g.Expect(r.Get(ctx, types.NamespacedName{Name: testBackupName, Namespace: testHCPNamespace}, updated)).To(Succeed())
+		g.Expect(updated.Status.Conditions[0].Reason).To(Equal(hyperv1.BackupWaitingForCredentialsReason))
+		g.Expect(updated.Status.Conditions[0].Message).To(ContainSubstring("credential Secret"))
+		g.Expect(isTerminal(updated)).To(BeFalse())
+	})
+
+	t.Run("When credential secret is not found past the wait deadline it should fail terminally", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		backup := newHCPEtcdBackup()
+		// Created longer ago than credentialWaitTimeout so the wait deadline is exceeded.
+		backup.CreationTimestamp = metav1.NewTime(time.Now().Add(-(credentialWaitTimeout + time.Minute)))
 		hcp := newHostedControlPlane()
 		r := newReconciler(backup, hcp) // no credential secret
 		ctx := context.Background()
@@ -2152,7 +2179,96 @@ func TestCreateResourcesAndJob(t *testing.T) {
 		updated := &hyperv1.HCPEtcdBackup{}
 		g.Expect(r.Get(ctx, types.NamespacedName{Name: testBackupName, Namespace: testHCPNamespace}, updated)).To(Succeed())
 		g.Expect(updated.Status.Conditions[0].Reason).To(Equal(hyperv1.BackupFailedReason))
-		g.Expect(updated.Status.Conditions[0].Message).To(ContainSubstring("credential Secret"))
+		g.Expect(updated.Status.Conditions[0].Message).To(ContainSubstring("timed out"))
+		g.Expect(isTerminal(updated)).To(BeTrue())
+	})
+}
+
+func TestReconcileRecoversWhenCredentialSecretAppears(t *testing.T) {
+	t.Run("When the credential Secret is missing then created it should wait then proceed without failing terminally", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		backup := newHCPEtcdBackup()
+		hcp := newHostedControlPlane()
+		sts := newEtcdStatefulSet(3, 3)
+		pullSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: pullSecretName, Namespace: testHCPNamespace},
+			Data:       map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`)},
+		}
+		// Credential Secret intentionally absent for the first reconcile.
+		r := newReconciler(backup, hcp, sts, pullSecret)
+		ctx := context.Background()
+
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Name: testBackupName, Namespace: testHCPNamespace}}
+
+		// First reconcile: credential Secret not yet in cache -> wait, non-terminal, requeue.
+		result, err := r.Reconcile(ctx, req)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{RequeueAfter: credentialWaitRequeueInterval}))
+
+		waiting := &hyperv1.HCPEtcdBackup{}
+		g.Expect(r.Get(ctx, req.NamespacedName, waiting)).To(Succeed())
+		g.Expect(waiting.Status.Conditions[0].Reason).To(Equal(hyperv1.BackupWaitingForCredentialsReason))
+		g.Expect(isTerminal(waiting)).To(BeFalse())
+
+		// The credential Secret lands.
+		credSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "aws-creds", Namespace: testHONamespace},
+			Data:       map[string][]byte{"credentials": []byte("fake-creds")},
+		}
+		g.Expect(r.Create(ctx, credSecret)).To(Succeed())
+
+		// Second reconcile: prerequisites satisfied -> Job created, backup in progress.
+		result, err = r.Reconcile(ctx, req)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result.RequeueAfter).To(Equal(requeueInterval))
+
+		updated := &hyperv1.HCPEtcdBackup{}
+		g.Expect(r.Get(ctx, req.NamespacedName, updated)).To(Succeed())
+		g.Expect(updated.Status.Conditions[0].Reason).To(Equal(hyperv1.BackupInProgressReason))
+
+		jobList := &batchv1.JobList{}
+		g.Expect(r.List(ctx, jobList, client.InNamespace(testHONamespace))).To(Succeed())
+		g.Expect(jobList.Items).To(HaveLen(1))
+	})
+}
+
+func TestBackupsForCredentialSecret(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// Non-terminal backup referencing credential Secret "aws-creds".
+	waitingBackup := newHCPEtcdBackup()
+
+	// Terminal (failed) backup referencing the same credential Secret name.
+	terminalBackup := newHCPEtcdBackup()
+	terminalBackup.Name = "terminal-backup"
+	terminalBackup.Status.Conditions = []metav1.Condition{{
+		Type:   string(hyperv1.BackupCompleted),
+		Status: metav1.ConditionFalse,
+		Reason: hyperv1.BackupFailedReason,
+	}}
+
+	r := newReconciler(waitingBackup, terminalBackup)
+	ctx := context.Background()
+
+	newSecret := func(name, namespace string) *corev1.Secret {
+		return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	}
+
+	t.Run("When a matching credential Secret lands in the operator namespace it enqueues only the non-terminal backup", func(t *testing.T) {
+		requests := r.backupsForCredentialSecret(ctx, newSecret("aws-creds", testHONamespace))
+		g.Expect(requests).To(ConsistOf(reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: testBackupName, Namespace: testHCPNamespace},
+		}))
+	})
+
+	t.Run("When the Secret name does not match any backup it enqueues nothing", func(t *testing.T) {
+		requests := r.backupsForCredentialSecret(ctx, newSecret("other-creds", testHONamespace))
+		g.Expect(requests).To(BeEmpty())
+	})
+
+	t.Run("When the Secret is in a different namespace it enqueues nothing", func(t *testing.T) {
+		requests := r.backupsForCredentialSecret(ctx, newSecret("aws-creds", testHCPNamespace))
+		g.Expect(requests).To(BeEmpty())
 	})
 }
 

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -861,6 +861,7 @@ func setupSupportControllers(mgr ctrl.Manager, opts *StartOptions, mgmtClusterCa
 	if featuregate.Gate().Enabled(featuregate.HCPEtcdBackup) {
 		etcdBackupReconciler := &etcdbackup.HCPEtcdBackupReconciler{
 			Client:                  mgr.GetClient(),
+			APIReader:               mgr.GetAPIReader(),
 			OperatorNamespace:       opts.Namespace,
 			ReleaseProvider:         registryProvider.ReleaseProvider,
 			HypershiftOperatorImage: operatorImage,

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/etcdbackup_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/etcdbackup_types.go
@@ -20,11 +20,12 @@ const (
 	// BackupCompleted indicates whether the etcd backup has completed.
 	BackupCompleted ConditionType = "BackupCompleted"
 
-	BackupSucceededReason  string = "BackupSucceeded"
-	BackupFailedReason     string = "BackupFailed"
-	BackupInProgressReason string = "BackupInProgress"
-	BackupRejectedReason   string = "BackupRejected"
-	EtcdUnhealthyReason    string = "EtcdUnhealthy"
+	BackupSucceededReason             string = "BackupSucceeded"
+	BackupFailedReason                string = "BackupFailed"
+	BackupInProgressReason            string = "BackupInProgress"
+	BackupRejectedReason              string = "BackupRejected"
+	BackupWaitingForCredentialsReason string = "BackupWaitingForCredentials"
+	EtcdUnhealthyReason               string = "EtcdUnhealthy"
 )
 
 // HCPEtcdBackupStorageType is the type of storage for etcd backups.


### PR DESCRIPTION
## What this PR does / why we need it:
Use cache-first with APIReader fallback in getCredentialSecret to prevent the informer cache race where the controller reconciles a new HCPEtcdBackup before the credential Secret's watch event is processed, causing a terminal BackupFailed on a Secret that exists in the API server.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/OCPBUGS-99329

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Backups now wait and retry when the credential Secret is temporarily unavailable instead of failing permanently.
  - Backups automatically resume when the required Secret is created.
  - Improved status reporting identifies backups waiting for credentials.
  - Only affected, non-terminal backups are reprocessed when credentials become available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->