### PR TITLE
CNTRLPLANE-3888: docs: add on-demand jira-agent triggering and plugin install instructions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
       - id: check-yaml
         name: Check yaml syntax
         args: [--allow-multiple-documents]
+        exclude: mkdocs\.yml$
         stages: [pre-commit]
       - id: trailing-whitespace
         name: Trim all whitespace from end of lines

--- a/docs/content/how-to/ci/ai-assisted-ci-jobs.md
+++ b/docs/content/how-to/ci/ai-assisted-ci-jobs.md
@@ -104,7 +104,13 @@ flowchart TD
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `JIRA_AGENT_MAX_ISSUES` | 1 | Maximum issues to process per run |
+| `JIRA_AGENT_ISSUE_KEY` | *(none)* | Process a single specific Jira issue instead of running the JQL query |
 | Rate limit | 60 seconds | Delay between processing issues |
+
+!!! tip ":zap: Trigger on demand"
+    You don't have to wait for the daily cron — trigger the jira-agent for a specific issue
+    immediately via the Gangway API or Claude Code. See
+    [Triggering Jobs On Demand](triggering-jobs-on-demand.md) for instructions.
 
 ---
 

--- a/docs/content/how-to/ci/triggering-jobs-on-demand.md
+++ b/docs/content/how-to/ci/triggering-jobs-on-demand.md
@@ -1,0 +1,152 @@
+# :zap: Triggering CI Jobs On Demand
+
+The HyperShift AI-assisted periodic jobs run on a schedule, but you can trigger them on demand via the [Gangway API](https://docs.ci.openshift.org/docs/how-tos/gangway/) to process specific issues or run jobs immediately.
+
+---
+
+## :wrench: Setup
+
+### :package: Install the OpenShift Developer Plugin Bundle
+
+Install the **openshift-developer** plugin bundle for Claude Code to get the CI, Jira, and code-review skills used by the HyperShift agentic workflows.
+
+=== ":zap: Quick Install"
+
+    ```bash
+    # Add the marketplaces (one-time)
+    claude plugin marketplace add openshift-eng/ai-helpers
+    claude plugin marketplace add RedHatProductSecurity/prodsec-skills
+
+    # Install the bundle
+    claude plugin install openshift-developer@ai-helpers
+    ```
+
+=== ":package: What's Included"
+
+    The `openshift-developer` bundle installs these plugins:
+
+    | Plugin | Purpose |
+    |--------|---------|
+    | `ci` | OpenShift CI / Prow job analysis, gangway triggers (`/ci:trigger-periodic`, `/ci:query-job-status`) |
+    | `jira` | Jira automation (`/jira:solve`, `/jira:ready-to-solve`) |
+    | `code-review` | Pre-commit and PR review (`/code-review:pr`, `/code-review:pre-commit-review`) |
+    | `golang` | Go development tools (gopls LSP, gofmt, golangci-lint) |
+    | `git` | Git workflow automation and conventional commit formatting |
+    | `prodsec-skills` | Product security guidance |
+
+!!! tip ":bulb: Non-Claude Code editors"
+    The bundle can also be installed via APM for other editors:
+
+    ```bash
+    apm install openshift-eng/ai-helpers/plugins/openshift-developer --global --target cursor
+    ```
+
+### :key: Authenticate to the CI Cluster
+
+You need to be logged in to the `app.ci` cluster to use the Gangway API.
+
+1. Visit the [app.ci console](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/)
+2. Log in with your Red Hat SSO credentials
+3. Click your username :material-arrow-right: **Copy login command**
+4. Paste and run the `oc login` command in your terminal
+
+Verify with:
+
+```bash
+oc whoami
+```
+
+---
+
+## :robot: Jira Agent
+
+**Full job name**: `periodic-ci-openshift-hypershift-main-periodic-jira-agent`
+
+### :dart: Trigger for a Specific Issue
+
+=== ":robot: Claude Code"
+
+    ```
+    /ci:trigger-periodic periodic-ci-openshift-hypershift-main-periodic-jira-agent \
+      MULTISTAGE_PARAM_OVERRIDE_JIRA_AGENT_ISSUE_KEY=CNTRLPLANE-1234
+    ```
+
+=== ":octicons-terminal-16: curl"
+
+    ```bash
+    curl -s -X POST \
+      -H "Authorization: Bearer $(oc whoami -t)" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "job_name": "periodic-ci-openshift-hypershift-main-periodic-jira-agent",
+        "job_execution_type": "1",
+        "pod_spec_options": {
+          "envs": {
+            "MULTISTAGE_PARAM_OVERRIDE_JIRA_AGENT_ISSUE_KEY": "CNTRLPLANE-1234"
+          }
+        }
+      }' \
+      https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com/v1/executions
+    ```
+
+    Replace `CNTRLPLANE-1234` with the Jira issue key you want the agent to process.
+
+!!! info ":gear: How the override works"
+    Setting `MULTISTAGE_PARAM_OVERRIDE_JIRA_AGENT_ISSUE_KEY` overrides the
+    `JIRA_AGENT_ISSUE_KEY` parameter in the multistage job. This tells the agent
+    to skip its normal JQL query and process only the specified issue with
+    `key = <issue-key>`.
+
+### :arrows_counterclockwise: Trigger with Default JQL
+
+Run the agent with its normal JQL query (picks up labeled, unprocessed issues):
+
+=== ":robot: Claude Code"
+
+    ```
+    /ci:trigger-periodic periodic-ci-openshift-hypershift-main-periodic-jira-agent
+    ```
+
+=== ":octicons-terminal-16: curl"
+
+    ```bash
+    curl -s -X POST \
+      -H "Authorization: Bearer $(oc whoami -t)" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "job_name": "periodic-ci-openshift-hypershift-main-periodic-jira-agent",
+        "job_execution_type": "1"
+      }' \
+      https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com/v1/executions
+    ```
+
+---
+
+## :mag: Checking Job Status
+
+The Gangway API response includes an execution ID. Use it to check the job status:
+
+=== ":robot: Claude Code"
+
+    ```
+    /ci:query-job-status <execution-id>
+    ```
+
+=== ":octicons-terminal-16: curl"
+
+    ```bash
+    curl -s -X GET \
+      -H "Authorization: Bearer $(oc whoami -t)" \
+      https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com/v1/executions/<execution-id>
+    ```
+
+Or find the run in the [Prow job history :octicons-link-external-16:](https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-main-periodic-jira-agent).
+
+---
+
+## :link: Related
+
+- [AI-Assisted CI Jobs](ai-assisted-ci-jobs.md) — overview of all HyperShift AI-assisted jobs
+- [Jira Agent Onboarding Guide](jira-agent-onboarding.md) — set up the jira-agent for your team
+- [Agentic SDLC](../agentic-sdlc.md) — the full agentic development workflow
+- [Gangway documentation :octicons-link-external-16:](https://docs.ci.openshift.org/docs/how-tos/gangway/) — upstream Gangway API docs

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -13937,7 +13937,13 @@ flowchart TD
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `JIRA_AGENT_MAX_ISSUES` | 1 | Maximum issues to process per run |
+| `JIRA_AGENT_ISSUE_KEY` | *(none)* | Process a single specific Jira issue instead of running the JQL query |
 | Rate limit | 60 seconds | Delay between processing issues |
+
+!!! tip ":zap: Trigger on demand"
+    You don't have to wait for the daily cron — trigger the jira-agent for a specific issue
+    immediately via the Gangway API or Claude Code. See
+    Triggering Jobs On Demand for instructions.
 
 ---
 
@@ -15271,6 +15277,164 @@ Post in #forum-ocp-hypershift and tag `@hypershift-engineering-ic` with:
 - V2 E2E Testing Overview — Architecture of the v2 test framework
 - CI Pipeline Configuration — How presubmit jobs are configured
 - Daily CI Health — Monitoring periodic and presubmit job health
+
+
+---
+
+## Source: docs/content/how-to/ci/triggering-jobs-on-demand.md
+
+# :zap: Triggering CI Jobs On Demand
+
+The HyperShift AI-assisted periodic jobs run on a schedule, but you can trigger them on demand via the Gangway API to process specific issues or run jobs immediately.
+
+---
+
+## :wrench: Setup
+
+### :package: Install the OpenShift Developer Plugin Bundle
+
+Install the **openshift-developer** plugin bundle for Claude Code to get the CI, Jira, and code-review skills used by the HyperShift agentic workflows.
+
+=== ":zap: Quick Install"
+
+    ```bash
+    # Add the marketplaces (one-time)
+    claude plugin marketplace add openshift-eng/ai-helpers
+    claude plugin marketplace add RedHatProductSecurity/prodsec-skills
+
+    # Install the bundle
+    claude plugin install openshift-developer@ai-helpers
+    ```
+
+=== ":package: What's Included"
+
+    The `openshift-developer` bundle installs these plugins:
+
+    | Plugin | Purpose |
+    |--------|---------|
+    | `ci` | OpenShift CI / Prow job analysis, gangway triggers (`/ci:trigger-periodic`, `/ci:query-job-status`) |
+    | `jira` | Jira automation (`/jira:solve`, `/jira:ready-to-solve`) |
+    | `code-review` | Pre-commit and PR review (`/code-review:pr`, `/code-review:pre-commit-review`) |
+    | `golang` | Go development tools (gopls LSP, gofmt, golangci-lint) |
+    | `git` | Git workflow automation and conventional commit formatting |
+    | `prodsec-skills` | Product security guidance |
+
+!!! tip ":bulb: Non-Claude Code editors"
+    The bundle can also be installed via APM for other editors:
+
+    ```bash
+    apm install openshift-eng/ai-helpers/plugins/openshift-developer --global --target cursor
+    ```
+
+### :key: Authenticate to the CI Cluster
+
+You need to be logged in to the `app.ci` cluster to use the Gangway API.
+
+1. Visit the app.ci console
+2. Log in with your Red Hat SSO credentials
+3. Click your username :material-arrow-right: **Copy login command**
+4. Paste and run the `oc login` command in your terminal
+
+Verify with:
+
+```bash
+oc whoami
+```
+
+---
+
+## :robot: Jira Agent
+
+**Full job name**: `periodic-ci-openshift-hypershift-main-periodic-jira-agent`
+
+### :dart: Trigger for a Specific Issue
+
+=== ":robot: Claude Code"
+
+    ```
+    /ci:trigger-periodic periodic-ci-openshift-hypershift-main-periodic-jira-agent \
+      MULTISTAGE_PARAM_OVERRIDE_JIRA_AGENT_ISSUE_KEY=CNTRLPLANE-1234
+    ```
+
+=== ":octicons-terminal-16: curl"
+
+    ```bash
+    curl -s -X POST \
+      -H "Authorization: Bearer $(oc whoami -t)" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "job_name": "periodic-ci-openshift-hypershift-main-periodic-jira-agent",
+        "job_execution_type": "1",
+        "pod_spec_options": {
+          "envs": {
+            "MULTISTAGE_PARAM_OVERRIDE_JIRA_AGENT_ISSUE_KEY": "CNTRLPLANE-1234"
+          }
+        }
+      }' \
+      https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com/v1/executions
+    ```
+
+    Replace `CNTRLPLANE-1234` with the Jira issue key you want the agent to process.
+
+!!! info ":gear: How the override works"
+    Setting `MULTISTAGE_PARAM_OVERRIDE_JIRA_AGENT_ISSUE_KEY` overrides the
+    `JIRA_AGENT_ISSUE_KEY` parameter in the multistage job. This tells the agent
+    to skip its normal JQL query and process only the specified issue with
+    `key = <issue-key>`.
+
+### :arrows_counterclockwise: Trigger with Default JQL
+
+Run the agent with its normal JQL query (picks up labeled, unprocessed issues):
+
+=== ":robot: Claude Code"
+
+    ```
+    /ci:trigger-periodic periodic-ci-openshift-hypershift-main-periodic-jira-agent
+    ```
+
+=== ":octicons-terminal-16: curl"
+
+    ```bash
+    curl -s -X POST \
+      -H "Authorization: Bearer $(oc whoami -t)" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "job_name": "periodic-ci-openshift-hypershift-main-periodic-jira-agent",
+        "job_execution_type": "1"
+      }' \
+      https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com/v1/executions
+    ```
+
+---
+
+## :mag: Checking Job Status
+
+The Gangway API response includes an execution ID. Use it to check the job status:
+
+=== ":robot: Claude Code"
+
+    ```
+    /ci:query-job-status <execution-id>
+    ```
+
+=== ":octicons-terminal-16: curl"
+
+    ```bash
+    curl -s -X GET \
+      -H "Authorization: Bearer $(oc whoami -t)" \
+      https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com/v1/executions/<execution-id>
+    ```
+
+Or find the run in the Prow job history :octicons-link-external-16:.
+
+---
+
+## :link: Related
+
+- AI-Assisted CI Jobs — overview of all HyperShift AI-assisted jobs
+- Jira Agent Onboarding Guide — set up the jira-agent for your team
+- Agentic SDLC — the full agentic development workflow
+- Gangway documentation :octicons-link-external-16: — upstream Gangway API docs
 
 
 ---

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -79,7 +79,9 @@ nav:
     - 'Reference': getting-started/onboarding/reference.md
 - 'How-to guides':
   - how-to/index.md
-  - 'Agentic SDLC': how-to/agentic-sdlc.md
+  - 'Agentic SDLC':
+    - how-to/agentic-sdlc.md
+    - 'Triggering Jobs On Demand': how-to/ci/triggering-jobs-on-demand.md
   - how-to/audit-log-persistence.md
   - 'Automated Machine Management':
     - how-to/automated-machine-management/index.md


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a new MkDocs documentation page for triggering the jira-agent periodic job on demand. Developers shouldn't have to wait for the daily cron to process their ticket — this page documents how to trigger it immediately via the Gangway API or the Claude Code `/ci:trigger-periodic` skill, including how to target a specific Jira issue with `MULTISTAGE_PARAM_OVERRIDE_JIRA_AGENT_ISSUE_KEY`.

Also documents how to install the `openshift-developer` Claude Code plugin bundle from ai-helpers, which includes the CI, Jira, and code-review skills used by HyperShift agentic workflows.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-3888

## Special notes for your reviewer:

- The page is placed under Agentic SDLC in the nav since it's a developer workflow, not a CI ops task
- The `.pre-commit-config.yaml` change excludes `mkdocs.yml` from `check-yaml` because the emoji extension uses `!!python/name` YAML tags that the standard parser can't handle
- `aggregated-docs.md` is auto-regenerated by `make verify-quick`

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] ~~This change includes unit tests.~~ (docs-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for triggering AI-assisted CI jobs on demand through the Gangway API or Claude Code.
  * Documented how to authenticate, monitor job status, and access execution history.
  * Added support for targeting a specific Jira issue through the `JIRA_AGENT_ISSUE_KEY` setting.
  * Linked the new guide in the How-to documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->