### PR TITLE
ACM-38185: chore(owners): add ACM HyperShift owners for product-cli

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -104,6 +104,16 @@ filters:
   "^kubernetes-default-proxy/.*":
     labels:
     - area/control-plane-operator
+  "^product-cli/.*":
+    labels:
+    - area/cli
+    reviewers:
+    - acm-hypershift-reviewers
+  "^product-cli/cmd/fromhub/.*":
+    approvers:
+    - acm-hypershift-approvers
+    reviewers:
+    - acm-hypershift-reviewers
   "^support/.*":
     labels:
     - area/control-plane-operator

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,4 +1,10 @@
 aliases:
+  acm-hypershift-approvers:
+    - yiraeChristineKim
+    - kurwang
+  acm-hypershift-reviewers:
+    - yiraeChristineKim
+    - kurwang
   api-approvers:
     - enxebre
     - csrwng


### PR DESCRIPTION
## What this PR does / why we need it:

Add OWNERS coverage for the `hcp` product CLI so ACM HyperShift team members are requested as reviewers (and as approvers for from-hub).

HyperShift uses filter-based root `OWNERS` + `OWNERS_ALIASES` (not per-directory OWNERS files). This change:

- Adds `acm-hypershift-approvers` / `acm-hypershift-reviewers` aliases
- Labels `product-cli/**` with `area/cli` and assigns ACM HyperShift reviewers
- Assigns ACM HyperShift approvers + reviewers for `product-cli/cmd/fromhub/**` (future from-hub CLI work)

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/ACM-38185

## Special notes for your reviewer:

- Follows the same alias/filter pattern as kubevirt/openstack platform owners
- Approvers are scoped to `fromhub` only; broader `product-cli` gets reviewers + `area/cli` so platform-specific CLI paths remain under core/platform owners
- `product-cli/cmd/fromhub/` does not need to exist yet for the filter to apply later

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ownership and review-routing rules for the product CLI code.
  * Added approval requirements for the “fromhub” CLI command area.
  * Updated internal review aliases to support consistent assignment of reviewers and approvers.
  * No customer-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->