### PR TITLE
NO-JIRA: Rebuild local tools when source files change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,10 +187,10 @@ $(GENAPIDOCS): $(TOOLS_DIR)/go.mod
 $(MOCKGEN): ${TOOLS_DIR}/go.mod
 	cd $(TOOLS_DIR); $(GO) build -tags=tools -o $(BIN_DIR)/mockgen go.uber.org/mock/mockgen
 
-$(VERIFY_API_DEPS): $(TOOLS_DIR)/go.mod # Build verify-api-deps tool
+$(VERIFY_API_DEPS): $(TOOLS_DIR)/go.mod $(wildcard $(TOOLS_DIR)/verify-api-deps/*.go) # Build verify-api-deps tool
 	cd $(TOOLS_DIR); $(GO) build -o $(BIN_DIR)/verify-api-deps ./verify-api-deps
 
-$(CRD_SCHEMA_CHECK): $(TOOLS_DIR)/go.mod # Build crd-schema-check tool
+$(CRD_SCHEMA_CHECK): $(TOOLS_DIR)/go.mod $(wildcard $(TOOLS_DIR)/crd-schema-check/*.go) # Build crd-schema-check tool
 	cd $(TOOLS_DIR); $(GO) build -o $(BIN_DIR)/crd-schema-check ./crd-schema-check
 
 .PHONY: generate


### PR DESCRIPTION
## What

Add source file dependencies (`$(wildcard .../*.go)`) to the `crd-schema-check` and `verify-api-deps` Make targets so the binaries are rebuilt when their Go source files change.

## Why

These two tools are built from local source under `hack/tools/`, but their Make targets only depended on `$(TOOLS_DIR)/go.mod`. This means if a commit modifies the tool source (e.g. the go-git worktree fix in #8975), rebasing picks up the new source but `make verify` keeps running the stale binary because it's newer than `go.mod`.

I hit this while working in a git worktree after rebasing onto `upstream/main` — the `crd-schema-check` binary was 4 minutes older than the source fix, so Make skipped the rebuild and the worktree fix never took effect.

The other tools in the Makefile (`controller-gen`, `staticcheck`, etc.) build from vendored modules where `go.mod` is the correct dependency. Only `crd-schema-check` and `verify-api-deps` have local `.go` source that can change independently.

## Change

```diff
-$(VERIFY_API_DEPS): $(TOOLS_DIR)/go.mod
+$(VERIFY_API_DEPS): $(TOOLS_DIR)/go.mod $(wildcard $(TOOLS_DIR)/verify-api-deps/*.go)

-$(CRD_SCHEMA_CHECK): $(TOOLS_DIR)/go.mod
+$(CRD_SCHEMA_CHECK): $(TOOLS_DIR)/go.mod $(wildcard $(TOOLS_DIR)/crd-schema-check/*.go)
```

/area tooling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool verification and schema-check builds now automatically rebuild when their Go source files change.
  * Prevents stale tool binaries from being used after source updates.
  * Ensures validation results consistently reflect the latest source changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->