### PR TITLE
CNTRLPLANE-3919: data race in TestEnqueueNodePoolsForCloudConfig

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -3864,7 +3864,14 @@ func TestEnqueueNodePoolsForCloudConfig(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			c := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tc.objects...).Build()
+			// Deep-copy shared objects so parallel subtests don't race on
+			// ResourceVersion mutations inside fake.ClientBuilder.Build().
+			objs := make([]client.Object, len(tc.objects))
+			for i, obj := range tc.objects {
+				objs[i] = obj.DeepCopyObject().(client.Object)
+			}
+
+			c := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objs...).Build()
 			r := &NodePoolReconciler{Client: c}
 
 			result := r.enqueueNodePoolsForCloudConfig(context.Background(), tc.cm)


### PR DESCRIPTION
## Summary

- `TestEnqueueNodePoolsForCloudConfig` parallel subtests share mutable `HostedControlPlane` and `NodePool` object pointers. `fake.ClientBuilder.Build()` mutates these via `SetResourceVersion()`, causing a data race that fails the entire `nodepool` test package intermittently in `ci/prow/unit`.
- Deep-copy shared objects before passing them to `WithObjects()` so each parallel subtest operates on its own copy.

## Test plan

- [x] `go test -race -run TestEnqueueNodePoolsForCloudConfig -count=5 ./hypershift-operator/controllers/nodepool/` passes clean
- [x] Full nodepool controller unit test suite passes with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for parallel node pool controller tests.
  * Prevented shared test data from being mutated across concurrent test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->