### PR TITLE
[release-4.16] OCPBUGS-99075: fix(backport): konnectivity agent auth

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -914,6 +914,8 @@ func buildKonnectivityServerContainer(image string, serverCount int, cipherSuite
 			cpath(konnectivityVolumeServerCerts().Name, corev1.TLSPrivateKeyKey),
 			"--server-ca-cert",
 			cpath(kasVolumeKonnectivityCA().Name, certs.CASignerCertMapKey),
+			"--cluster-ca-cert",
+			cpath(kasVolumeKonnectivityCA().Name, certs.CASignerCertMapKey),
 			"--server-port",
 			strconv.Itoa(KonnectivityServerLocalPort),
 			"--agent-port",

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment_test.go
@@ -1,15 +1,32 @@
 package kas
 
 import (
+	"slices"
 	"testing"
 
 	. "github.com/onsi/gomega"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/util"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestKonnectivityServerAuthenticatesAgents(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	c := util.BuildContainer(konnectivityServerContainer(), buildKonnectivityServerContainer("test-image", 3, nil))
+
+	clusterCAFlagIndex := slices.Index(c.Args, "--cluster-ca-cert")
+	if clusterCAFlagIndex == -1 || clusterCAFlagIndex+1 >= len(c.Args) {
+		t.Fatal("--cluster-ca-cert flag or its value not found in konnectivity-server args")
+	}
+	g.Expect(c.Args[clusterCAFlagIndex+1]).To(Equal("/etc/konnectivity/ca/ca.crt"))
+}
 
 // Ensure certain deployment fields do not get set
 func TestReconcileKubeAPIServerDeploymentNoChanges(t *testing.T) {


### PR DESCRIPTION
## What this PR does / why we need it:
Backport of #9031 to `release-4.16`.

## Special notes for your reviewer:
Testing Plan: 
[test-ocpbugs-99014.md](https://github.com/user-attachments/files/30336565/test-ocpbugs-99014.md)


## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.