### PR TITLE
OCPBUGS-99021: Use separate certificate signers for konnectivity

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1457,6 +1457,7 @@ func (r *HostedControlPlaneReconciler) reconcileOpenshiftCerts(ctx context.Conte
 }
 
 func (r *HostedControlPlaneReconciler) reconcileKonnectivityCerts(ctx context.Context, hcp *hyperv1.HostedControlPlane, p *pki.PKIParams, createOrUpdate upsert.CreateOrUpdateFN) error {
+	// Legacy signer preserved for backward compatibility during cert rotation.
 	konnectivitySigner := manifests.KonnectivitySignerSecret(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, konnectivitySigner, func() error {
 		return pki.ReconcileKonnectivitySignerSecret(konnectivitySigner, p.OwnerRef)
@@ -1464,37 +1465,68 @@ func (r *HostedControlPlaneReconciler) reconcileKonnectivityCerts(ctx context.Co
 		return fmt.Errorf("failed to reconcile konnectivity signer secret: %w", err)
 	}
 
+	// Dedicated signers — one per cert type for independent rotation/revocation.
+	serverServingSigner := manifests.KonnectivityServerServingSignerSecret(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, serverServingSigner, func() error {
+		return pki.ReconcileKonnectivityServerServingSignerSecret(serverServingSigner, p.OwnerRef)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile konnectivity server serving signer secret: %w", err)
+	}
+
+	clusterServingSigner := manifests.KonnectivityClusterServingSignerSecret(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, clusterServingSigner, func() error {
+		return pki.ReconcileKonnectivityClusterServingSignerSecret(clusterServingSigner, p.OwnerRef)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile konnectivity cluster serving signer secret: %w", err)
+	}
+
+	serverAuthSigner := manifests.KonnectivityServerAuthSignerSecret(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, serverAuthSigner, func() error {
+		return pki.ReconcileKonnectivityServerAuthSignerSecret(serverAuthSigner, p.OwnerRef)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile konnectivity server auth signer secret: %w", err)
+	}
+
+	clientAuthSigner := manifests.KonnectivityClientAuthSignerSecret(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, clientAuthSigner, func() error {
+		return pki.ReconcileKonnectivityClientAuthSignerSecret(clientAuthSigner, p.OwnerRef)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile konnectivity client auth signer secret: %w", err)
+	}
+
+	// Aggregate CA bundle includes legacy signer (for certs not yet rotated) plus all dedicated signers.
 	konnectivityCACM := manifests.KonnectivityCAConfigMap(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, konnectivityCACM, func() error {
-		return pki.ReconcileKonnectivityConfigMap(konnectivityCACM, p.OwnerRef, konnectivitySigner)
+		return pki.ReconcileKonnectivityConfigMap(konnectivityCACM, p.OwnerRef,
+			konnectivitySigner, serverServingSigner, clusterServingSigner, serverAuthSigner, clientAuthSigner)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile konnectivity CA config map: %w", err)
 	}
 
 	konnectivityServerSecret := manifests.KonnectivityServerSecret(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, konnectivityServerSecret, func() error {
-		return pki.ReconcileKonnectivityServerSecret(konnectivityServerSecret, konnectivitySigner, p.OwnerRef)
+		return pki.ReconcileKonnectivityServerSecret(konnectivityServerSecret, serverServingSigner, p.OwnerRef)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile konnectivity server cert: %w", err)
 	}
 
 	konnectivityClusterSecret := manifests.KonnectivityClusterSecret(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, konnectivityClusterSecret, func() error {
-		return pki.ReconcileKonnectivityClusterSecret(konnectivityClusterSecret, konnectivitySigner, p.OwnerRef, p.ExternalKconnectivityAddress)
+		return pki.ReconcileKonnectivityClusterSecret(konnectivityClusterSecret, clusterServingSigner, p.OwnerRef, p.ExternalKconnectivityAddress)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile konnectivity cluster cert: %w", err)
 	}
 
 	konnectivityClientSecret := manifests.KonnectivityClientSecret(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, konnectivityClientSecret, func() error {
-		return pki.ReconcileKonnectivityClientSecret(konnectivityClientSecret, konnectivitySigner, p.OwnerRef)
+		return pki.ReconcileKonnectivityClientSecret(konnectivityClientSecret, serverAuthSigner, p.OwnerRef)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile konnectivity client cert: %w", err)
 	}
 
 	konnectivityAgentSecret := manifests.KonnectivityAgentSecret(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, konnectivityAgentSecret, func() error {
-		return pki.ReconcileKonnectivityAgentSecret(konnectivityAgentSecret, konnectivitySigner, p.OwnerRef)
+		return pki.ReconcileKonnectivityAgentSecret(konnectivityAgentSecret, clientAuthSigner, p.OwnerRef)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile konnectivity agent cert: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -304,6 +304,22 @@ func KonnectivitySignerSecret(ns string) *corev1.Secret {
 	return secretFor(ns, "konnectivity-signer")
 }
 
+func KonnectivityServerServingSignerSecret(ns string) *corev1.Secret {
+	return secretFor(ns, "konnectivity-server-serving-signer")
+}
+
+func KonnectivityClusterServingSignerSecret(ns string) *corev1.Secret {
+	return secretFor(ns, "konnectivity-cluster-serving-signer")
+}
+
+func KonnectivityServerAuthSignerSecret(ns string) *corev1.Secret {
+	return secretFor(ns, "konnectivity-server-auth-signer")
+}
+
+func KonnectivityClientAuthSignerSecret(ns string) *corev1.Secret {
+	return secretFor(ns, "konnectivity-client-auth-signer")
+}
+
 func KonnectivityServerSecret(ns string) *corev1.Secret { return secretFor(ns, "konnectivity-server") }
 
 func KonnectivityClusterSecret(ns string) *corev1.Secret {

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -118,6 +118,6 @@ func ReconcileRootCAConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, ro
 	return reconcileAggregateCA(cm, ownerRef, sources...)
 }
 
-func ReconcileKonnectivityConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, konnectivityCA *corev1.Secret) error {
-	return reconcileAggregateCA(cm, ownerRef, konnectivityCA)
+func ReconcileKonnectivityConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, signers ...*corev1.Secret) error {
+	return reconcileAggregateCA(cm, ownerRef, signers...)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/konnectivity.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/konnectivity.go
@@ -13,6 +13,26 @@ func ReconcileKonnectivitySignerSecret(secret *corev1.Secret, ownerRef config.Ow
 	return reconcileSelfSignedCA(secret, ownerRef, "konnectivity-signer", "kubernetes")
 }
 
+// ReconcileKonnectivityServerServingSignerSecret creates a dedicated CA for the konnectivity-server local serving cert (port 8090).
+func ReconcileKonnectivityServerServingSignerSecret(secret *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSelfSignedCA(secret, ownerRef, "konnectivity-server-serving-signer", "kubernetes")
+}
+
+// ReconcileKonnectivityClusterServingSignerSecret creates a dedicated CA for the konnectivity-server cluster/agent-facing serving cert (port 8091).
+func ReconcileKonnectivityClusterServingSignerSecret(secret *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSelfSignedCA(secret, ownerRef, "konnectivity-cluster-serving-signer", "kubernetes")
+}
+
+// ReconcileKonnectivityServerAuthSignerSecret creates a dedicated CA for the konnectivity-client cert (KAS client auth to konnectivity-server).
+func ReconcileKonnectivityServerAuthSignerSecret(secret *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSelfSignedCA(secret, ownerRef, "konnectivity-server-auth-signer", "kubernetes")
+}
+
+// ReconcileKonnectivityClientAuthSignerSecret creates a dedicated CA for the konnectivity-agent cert (agent client auth to konnectivity-server).
+func ReconcileKonnectivityClientAuthSignerSecret(secret *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSelfSignedCA(secret, ownerRef, "konnectivity-client-auth-signer", "kubernetes")
+}
+
 func ReconcileKonnectivityServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
 	dnsNames := []string{
 		"localhost",

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/konnectivity_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/konnectivity_test.go
@@ -1,0 +1,128 @@
+package pki
+
+import (
+	"bytes"
+	"crypto/x509"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// reconcileTestSigner creates a signer secret using the production reconcile function.
+func reconcileTestSigner(t *testing.T, reconcile func(*corev1.Secret, config.OwnerRef) error) *corev1.Secret {
+	t.Helper()
+	secret := &corev1.Secret{}
+	if err := reconcile(secret, config.OwnerRef{}); err != nil {
+		t.Fatalf("failed to reconcile signer: %v", err)
+	}
+	return secret
+}
+
+func TestKonnectivitySeparateSigners(t *testing.T) {
+	t.Parallel()
+
+	// Exercise the production signer reconcile functions.
+	serverServingSigner := reconcileTestSigner(t, ReconcileKonnectivityServerServingSignerSecret)
+	clusterServingSigner := reconcileTestSigner(t, ReconcileKonnectivityClusterServingSignerSecret)
+	serverAuthSigner := reconcileTestSigner(t, ReconcileKonnectivityServerAuthSignerSecret)
+	clientAuthSigner := reconcileTestSigner(t, ReconcileKonnectivityClientAuthSignerSecret)
+	legacySigner := reconcileTestSigner(t, ReconcileKonnectivitySignerSecret)
+
+	ownerRef := config.OwnerRef{}
+
+	t.Run("server cert uses server-serving signer", func(t *testing.T) {
+		g := NewWithT(t)
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "clusters-test"},
+		}
+
+		err := ReconcileKonnectivityServerSecret(secret, serverServingSigner, ownerRef)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		cert, err := certs.PemToCertificate(secret.Data[corev1.TLSCertKey])
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cert.ExtKeyUsage).To(ContainElement(x509.ExtKeyUsageServerAuth))
+		g.Expect(cert.Issuer.CommonName).To(Equal("konnectivity-server-serving-signer"))
+	})
+
+	t.Run("cluster cert uses cluster-serving signer", func(t *testing.T) {
+		g := NewWithT(t)
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "clusters-test"},
+		}
+
+		err := ReconcileKonnectivityClusterSecret(secret, clusterServingSigner, ownerRef, "konnectivity.example.com")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		cert, err := certs.PemToCertificate(secret.Data[corev1.TLSCertKey])
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cert.ExtKeyUsage).To(ContainElement(x509.ExtKeyUsageServerAuth))
+		g.Expect(cert.Issuer.CommonName).To(Equal("konnectivity-cluster-serving-signer"))
+	})
+
+	t.Run("client cert uses server-auth signer", func(t *testing.T) {
+		g := NewWithT(t)
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "clusters-test"},
+		}
+
+		err := ReconcileKonnectivityClientSecret(secret, serverAuthSigner, ownerRef)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		cert, err := certs.PemToCertificate(secret.Data[corev1.TLSCertKey])
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cert.ExtKeyUsage).To(ContainElement(x509.ExtKeyUsageClientAuth))
+		g.Expect(cert.Issuer.CommonName).To(Equal("konnectivity-server-auth-signer"))
+	})
+
+	t.Run("agent cert uses client-auth signer", func(t *testing.T) {
+		g := NewWithT(t)
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "clusters-test"},
+		}
+
+		err := ReconcileKonnectivityAgentSecret(secret, clientAuthSigner, ownerRef)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		cert, err := certs.PemToCertificate(secret.Data[corev1.TLSCertKey])
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cert.ExtKeyUsage).To(ContainElement(x509.ExtKeyUsageClientAuth))
+		g.Expect(cert.Issuer.CommonName).To(Equal("konnectivity-client-auth-signer"))
+	})
+
+	t.Run("all signers produce distinct CA certs", func(t *testing.T) {
+		g := NewWithT(t)
+		signers := []*corev1.Secret{serverServingSigner, clusterServingSigner, serverAuthSigner, clientAuthSigner, legacySigner}
+		for i := range len(signers) {
+			for j := i + 1; j < len(signers); j++ {
+				g.Expect(bytes.Equal(
+					signers[i].Data[certs.CASignerCertMapKey],
+					signers[j].Data[certs.CASignerCertMapKey],
+				)).To(BeFalse(), "signers %d and %d should have different CA certs", i, j)
+			}
+		}
+	})
+
+	t.Run("CA bundle aggregates all signers including legacy", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{}
+
+		err := ReconcileKonnectivityConfigMap(cm, ownerRef,
+			legacySigner, serverServingSigner, clusterServingSigner, serverAuthSigner, clientAuthSigner)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		bundle := cm.Data[certs.CASignerCertMapKey]
+		for _, signer := range []*corev1.Secret{legacySigner, serverServingSigner, clusterServingSigner, serverAuthSigner, clientAuthSigner} {
+			ca := signer.Data[certs.CASignerCertMapKey]
+			_, err := certs.PemToCertificate(ca)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(bundle).To(ContainSubstring(string(ca)))
+		}
+	})
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Konnectivity previously used a single CA signer (`konnectivity-signer`) for all certificate types, which limited the ability to independently rotate, manage, and revoke certificates for different purposes.

This PR introduces four dedicated signers, one per certificate:

| Signer | Signs | Purpose |
|--------|-------|---------|
| `konnectivity-server-serving-signer` | `konnectivity-server` | Server local serving cert (port 8090, KAS-facing) |
| `konnectivity-cluster-serving-signer` | `konnectivity-cluster` | Cluster serving cert (port 8091, agent-facing) |
| `konnectivity-server-auth-signer` | `konnectivity-client` | KAS client auth to konnectivity-server |
| `konnectivity-client-auth-signer` | `konnectivity-agent` | Agent client auth to konnectivity-server |

The aggregate CA bundle ConfigMap (`konnectivity-ca-bundle`) includes all four new signer CAs plus the legacy signer CA for backward compatibility during the cert rotation window. Deployment manifests are unchanged since they reference the same ConfigMap name and mount paths.

### Backward compatibility

- The legacy `konnectivity-signer` secret is preserved and its CA is included in the aggregate bundle
- Existing certs signed by the old CA remain valid until their next rotation cycle
- No deployment YAML changes required — same ConfigMap name, same volume mounts

## Which issue(s) this PR fixes:

Fixes OCPBUGS-99021

## Special notes for your reviewer:

- The `ReconcileKonnectivityConfigMap` signature changed from accepting a single `*corev1.Secret` to variadic `...*corev1.Secret`, matching the existing `reconcileAggregateCA` pattern
- `ReconcileSignedCert` only re-signs certs when they expire or become invalid, so this change is safe for rolling updates — no immediate cert churn

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-99021`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent certificate authorities for each Konnectivity serving and authentication role.
  * Improved Konnectivity certificate rotation so individual certificate types can be rotated independently.
  * Updated Konnectivity components to use role-specific certificates while preserving compatibility with the existing signer.
  * Expanded the Konnectivity CA bundle to include all active signer certificates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->