### PR TITLE
feat(monitoring): add azmonitoring.coreos.com/v1 as alternative monitoring API group

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -15,6 +15,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	cmdutil "github.com/openshift/hypershift/cmd/util"
 	controlplaneoperatoroverrides "github.com/openshift/hypershift/hypershift-operator/controlplaneoperator-overrides"
+	"github.com/openshift/hypershift/support/azmonitoring"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/metrics"
@@ -539,6 +540,7 @@ type HyperShiftOperatorDeployment struct {
 	IncludeVersion                          bool
 	UWMTelemetry                            bool
 	RHOBSMonitoring                         bool
+	AZMonitoring                            bool
 	CVOPrometheusURL                        string
 	MonitoringDashboards                    bool
 	CertRotationScale                       time.Duration
@@ -870,6 +872,9 @@ func (o HyperShiftOperatorDeployment) buildEnvVars() []corev1.EnvVar {
 	}
 	if o.RHOBSMonitoring {
 		envVars = append(envVars, corev1.EnvVar{Name: rhobsmonitoring.EnvironmentVariable, Value: "1"})
+	}
+	if o.AZMonitoring {
+		envVars = append(envVars, corev1.EnvVar{Name: azmonitoring.EnvironmentVariable, Value: "1"})
 	}
 	if o.CVOPrometheusURL != "" {
 		envVars = append(envVars, corev1.EnvVar{Name: config.CVOPrometheusURLEnvVar, Value: o.CVOPrometheusURL})
@@ -1230,6 +1235,7 @@ func (o HyperShiftOperatorServiceAccount) Build() *corev1.ServiceAccount {
 type HyperShiftOperatorClusterRole struct {
 	EnableCVOManagementClusterMetricsAccess bool
 	RHOBSMonitoring                         bool
+	AZMonitoring                            bool
 	ManagedService                          string
 	EnableAuditLogPersistence               bool
 }
@@ -1303,6 +1309,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 					"cluster.x-k8s.io",
 					"monitoring.coreos.com",
 					"monitoring.rhobs",
+					"azmonitoring.coreos.com",
 				},
 				Resources: []string{rbacv1.ResourceAll},
 				Verbs:     []string{rbacv1.VerbAll},
@@ -1389,7 +1396,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				Verbs:     []string{rbacv1.VerbAll},
 			},
 			{
-				APIGroups: []string{"monitoring.coreos.com", "monitoring.rhobs"},
+				APIGroups: []string{"monitoring.coreos.com", "monitoring.rhobs", "azmonitoring.coreos.com"},
 				Resources: []string{"podmonitors"},
 				Verbs:     []string{"get", "list", "watch", "create", "update"},
 			},
@@ -1529,7 +1536,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 			},
 		},
 	}
-	if o.EnableCVOManagementClusterMetricsAccess || o.RHOBSMonitoring {
+	if o.EnableCVOManagementClusterMetricsAccess || o.RHOBSMonitoring || o.AZMonitoring {
 		role.Rules = append(role.Rules,
 			rbacv1.PolicyRule{
 				APIGroups: []string{"metrics.k8s.io"},
@@ -2041,7 +2048,7 @@ func (o HyperShiftReaderClusterRole) Build() *rbacv1.ClusterRole {
 				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
-				APIGroups: []string{"monitoring.coreos.com", "monitoring.rhobs"},
+				APIGroups: []string{"monitoring.coreos.com", "monitoring.rhobs", "azmonitoring.coreos.com"},
 				Resources: []string{"podmonitors"},
 				Verbs:     []string{"get", "list", "watch"},
 			},

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -9,6 +9,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	controlplaneoperatoroverrides "github.com/openshift/hypershift/hypershift-operator/controlplaneoperator-overrides"
+	"github.com/openshift/hypershift/support/azmonitoring"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
 
@@ -969,6 +970,15 @@ func TestBuildEnvVars(t *testing.T) {
 			},
 			expectContains: []corev1.EnvVar{
 				{Name: rhobsmonitoring.EnvironmentVariable, Value: "1"},
+			},
+		},
+		{
+			name: "When AZMonitoring is enabled, it should include the env var",
+			deployment: HyperShiftOperatorDeployment{
+				AZMonitoring: true,
+			},
+			expectContains: []corev1.EnvVar{
+				{Name: azmonitoring.EnvironmentVariable, Value: "1"},
 			},
 		},
 		{

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/sharedingress"
 	hyperapi "github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/azmonitoring"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
@@ -139,6 +140,7 @@ type Options struct {
 	WaitUntilAvailable                        bool
 	WaitUntilEstablished                      bool
 	RHOBSMonitoring                           bool
+	AZMonitoring                              bool
 	CVOPrometheusURL                          string
 	SLOsAlerts                                bool
 	MonitoringDashboards                      bool
@@ -341,6 +343,9 @@ func (o *Options) validateImageConfig() []error {
 	if o.RHOBSMonitoring && os.Getenv(rhobsmonitoring.EnvironmentVariable) != "1" {
 		errs = append(errs, fmt.Errorf("when invoking this command with the --rhobs-monitoring flag, the RHOBS_MONITORING environment variable must be set to \"1\""))
 	}
+	if o.AZMonitoring && os.Getenv(azmonitoring.EnvironmentVariable) != "1" {
+		errs = append(errs, fmt.Errorf("when invoking this command with the --az-monitoring flag, the AZ_MONITORING environment variable must be set to \"1\""))
+	}
 	if o.CertRotationScale > 24*time.Hour {
 		errs = append(errs, fmt.Errorf("cannot set --cert-rotation-scale longer than 24h, invalid value: %s", o.CertRotationScale.String()))
 	}
@@ -377,10 +382,16 @@ func (o *Options) validateScaleFromZeroConfig() []error {
 func (o *Options) validateMonitoringConfig() []error {
 	var errs []error
 	if o.RHOBSMonitoring && o.EnableCVOManagementClusterMetricsAccess {
-		errs = append(errs, fmt.Errorf("when invoking this command with the --rhobs-monitoring flag, the --enable-cvo-management-cluster-metrics-access flag is not supported "))
+		errs = append(errs, fmt.Errorf("when invoking this command with the --rhobs-monitoring flag, the --enable-cvo-management-cluster-metrics-access flag is not supported"))
 	}
-	if len(o.CVOPrometheusURL) > 0 && !o.RHOBSMonitoring && !o.EnableCVOManagementClusterMetricsAccess {
-		errs = append(errs, fmt.Errorf("--cvo-prometheus-url requires either --rhobs-monitoring or --enable-cvo-management-cluster-metrics-access to be enabled"))
+	if o.AZMonitoring && o.EnableCVOManagementClusterMetricsAccess {
+		errs = append(errs, fmt.Errorf("when invoking this command with the --az-monitoring flag, the --enable-cvo-management-cluster-metrics-access flag is not supported"))
+	}
+	if o.RHOBSMonitoring && o.AZMonitoring {
+		errs = append(errs, fmt.Errorf("--rhobs-monitoring and --az-monitoring are mutually exclusive; only one alternative monitoring group can be active"))
+	}
+	if len(o.CVOPrometheusURL) > 0 && !o.RHOBSMonitoring && !o.AZMonitoring && !o.EnableCVOManagementClusterMetricsAccess {
+		errs = append(errs, fmt.Errorf("--cvo-prometheus-url requires either --rhobs-monitoring, --az-monitoring, or --enable-cvo-management-cluster-metrics-access to be enabled"))
 	}
 	return errs
 }
@@ -487,6 +498,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.WaitUntilAvailable, "wait-until-available", opts.WaitUntilAvailable, "If true, pauses installation until hypershift operator has been rolled out and its webhook service is available (if installing the webhook)")
 	cmd.Flags().BoolVar(&opts.WaitUntilEstablished, "wait-until-crds-established", opts.WaitUntilEstablished, "If true, pauses installation until all custom resource definitions are established before applying other manifests.")
 	cmd.PersistentFlags().BoolVar(&opts.RHOBSMonitoring, "rhobs-monitoring", opts.RHOBSMonitoring, "If true, HyperShift will generate and use the RHOBS version of monitoring resources (ServiceMonitors, PodMonitors, etc). For ROSA HCP, this also enables the Cluster Version Operator to query the RHOBS Prometheus for conditional update evaluation. Use --cvo-prometheus-url to override the default Prometheus endpoint.")
+	cmd.PersistentFlags().BoolVar(&opts.AZMonitoring, "az-monitoring", opts.AZMonitoring, "If true, HyperShift will generate and use the Azure monitoring version of monitoring resources (ServiceMonitors, PodMonitors, etc) under the azmonitoring.coreos.com API group. Mutually exclusive with --rhobs-monitoring.")
 	cmd.PersistentFlags().StringVar(&opts.CVOPrometheusURL, "cvo-prometheus-url", opts.CVOPrometheusURL, "Prometheus URL for the Cluster Version Operator to query metrics for conditional update risk evaluation. Only effective when --rhobs-monitoring or --enable-cvo-management-cluster-metrics-access is enabled. If not specified, defaults to the RHOBS monitoring stack for ROSA HCP, or the Thanos querier for self-managed HyperShift.")
 	cmd.PersistentFlags().BoolVar(&opts.SLOsAlerts, "slos-alerts", opts.SLOsAlerts, "If true, HyperShift will generate and use the prometheus alerts for monitoring HostedCluster and NodePools")
 	cmd.PersistentFlags().BoolVar(&opts.MonitoringDashboards, "monitoring-dashboards", opts.MonitoringDashboards, "If true, HyperShift will generate a monitoring dashboard for every HostedCluster that it creates")
@@ -1372,6 +1384,7 @@ func setupOperatorResources(opts Options, userCABundleCM *corev1.ConfigMap, trus
 		IncludeVersion:                          !opts.Template,
 		UWMTelemetry:                            opts.EnableUWMTelemetryRemoteWrite,
 		RHOBSMonitoring:                         opts.RHOBSMonitoring,
+		AZMonitoring:                            opts.AZMonitoring,
 		CVOPrometheusURL:                        opts.CVOPrometheusURL,
 		MonitoringDashboards:                    opts.MonitoringDashboards,
 		CertRotationScale:                       opts.CertRotationScale,
@@ -1575,6 +1588,7 @@ func setupRBAC(opts Options, operatorNamespace *corev1.Namespace) (*corev1.Servi
 	operatorClusterRole := assets.HyperShiftOperatorClusterRole{
 		EnableCVOManagementClusterMetricsAccess: opts.EnableCVOManagementClusterMetricsAccess,
 		RHOBSMonitoring:                         opts.RHOBSMonitoring,
+		AZMonitoring:                            opts.AZMonitoring,
 		ManagedService:                          opts.ManagedService,
 		EnableAuditLogPersistence:               opts.EnableAuditLogPersistence,
 	}.Build()

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -1750,6 +1750,30 @@ func TestValidateMonitoringConfig(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "When both AZ monitoring and CVO management cluster metrics access are set, it should fail",
+			opts: Options{
+				AZMonitoring:                            true,
+				EnableCVOManagementClusterMetricsAccess: true,
+			},
+			expectError: true,
+		},
+		{
+			name: "When both AZ monitoring and RHOBS monitoring are set, it should fail",
+			opts: Options{
+				AZMonitoring:    true,
+				RHOBSMonitoring: true,
+			},
+			expectError: true,
+		},
+		{
+			name: "When CVO prometheus URL is set with AZ monitoring, it should pass",
+			opts: Options{
+				CVOPrometheusURL: "https://prometheus.example.com",
+				AZMonitoring:     true,
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/assets.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/assets.go
@@ -5,10 +5,12 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"os"
 	"path"
 	"text/template"
 
 	hyperapi "github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/azmonitoring"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -84,7 +86,9 @@ func LoadManifestInto(componentName string, fileName string, into client.Object)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load %s manifest: %w", filePath, err)
 	}
-	return obj.(client.Object), gvk, err
+	clientObj := obj.(client.Object)
+	rewriteMonitoringGVK(clientObj, gvk)
+	return clientObj, gvk, err
 }
 
 // LoadManifestTemplated reads the raw asset bytes, renders them as a Go text/template
@@ -120,7 +124,9 @@ func LoadManifestTemplated(componentName, fileName string, templateData map[stri
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load templated %s manifest: %w", filePath, err)
 	}
-	return obj.(client.Object), gvk, err
+	clientObj := obj.(client.Object)
+	rewriteMonitoringGVK(clientObj, gvk)
+	return clientObj, gvk, err
 }
 
 // LoadStatefulSetManifestTemplated loads a statefulset manifest with template rendering.
@@ -138,6 +144,14 @@ func LoadStatefulSetManifestTemplated(componentName string, templateData map[str
 		return nil, fmt.Errorf("expected StatefulSet but got %T", obj)
 	}
 	return sts, nil
+}
+
+func rewriteMonitoringGVK(obj client.Object, gvk *schema.GroupVersionKind) {
+	if os.Getenv(azmonitoring.EnvironmentVariable) == "1" && gvk.Group == "monitoring.coreos.com" {
+		newGVK := schema.GroupVersionKind{Group: azmonitoring.SchemeGroupVersion.Group, Version: gvk.Version, Kind: gvk.Kind}
+		obj.GetObjectKind().SetGroupVersionKind(newGVK)
+		*gvk = newGVK
+	}
 }
 
 func ForEachManifest(componentName string, action func(manifestName string) error) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-network-operator/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-network-operator/role.yaml
@@ -42,6 +42,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - azmonitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - '*'
+- apiGroups:
   - hypershift.openshift.io
   resources:
   - hostedcontrolplanes

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/control-plane-operator/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/control-plane-operator/role.yaml
@@ -26,6 +26,7 @@ rules:
   - cluster.x-k8s.io
   - monitoring.coreos.com
   - monitoring.rhobs
+  - azmonitoring.coreos.com
   - capi-provider.agent-install.openshift.io
   resources:
   - '*'

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/role.yaml
@@ -73,6 +73,7 @@ rules:
   - apiGroups:
       - "monitoring.coreos.com"
       - "monitoring.rhobs"
+      - "azmonitoring.coreos.com"
     resources:
       - "podmonitors"
     verbs:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/azmonitoring"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -126,6 +127,12 @@ func buildCNOEnvVars(cpContext component.WorkloadContext) []corev1.EnvVar {
 	if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" {
 		cnoEnv = append(cnoEnv, corev1.EnvVar{
 			Name:  rhobsmonitoring.EnvironmentVariable,
+			Value: "1",
+		})
+	}
+	if os.Getenv(azmonitoring.EnvironmentVariable) == "1" {
+		cnoEnv = append(cnoEnv, corev1.EnvVar{
+			Name:  azmonitoring.EnvironmentVariable,
 			Value: "1",
 		})
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/deployment.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/azmonitoring"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
@@ -118,6 +119,14 @@ func (cpo *ControlPlaneOperatorOptions) adaptDeployment(cpContext component.Work
 			c.Env = append(c.Env,
 				corev1.EnvVar{
 					Name:  rhobsmonitoring.EnvironmentVariable,
+					Value: "1",
+				},
+			)
+		}
+		if os.Getenv(azmonitoring.EnvironmentVariable) == "1" {
+			c.Env = append(c.Env,
+				corev1.EnvVar{
+					Name:  azmonitoring.EnvironmentVariable,
 					Value: "1",
 				},
 			)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/azmonitoring"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
@@ -65,6 +66,14 @@ func (karp *KarpenterOperatorOptions) adaptDeployment(cpContext component.Worklo
 				c.Env = append(c.Env,
 					corev1.EnvVar{
 						Name:  rhobsmonitoring.EnvironmentVariable,
+						Value: "1",
+					},
+				)
+			}
+			if os.Getenv(azmonitoring.EnvironmentVariable) == "1" {
+				c.Env = append(c.Env,
+					corev1.EnvVar{
+						Name:  azmonitoring.EnvironmentVariable,
 						Value: "1",
 					},
 				)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment_test.go
@@ -7,6 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
+	"github.com/openshift/hypershift/support/azmonitoring"
 	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
@@ -24,6 +25,7 @@ func TestAdaptDeployment(t *testing.T) {
 		controlPlaneOperatorImage string
 		ignitionEndpoint          string
 		rhobsEnabled              bool
+		azMonitoringEnabled       bool
 		validateFunc              func(t *testing.T, g Gomega, opts *KarpenterOperatorOptions, cpContext controlplanecomponent.WorkloadContext)
 	}{
 		{
@@ -155,6 +157,51 @@ func TestAdaptDeployment(t *testing.T) {
 			},
 		},
 		{
+			name:                    "When AZ monitoring is enabled on AWS, it should set environment variable",
+			platformType:            hyperv1.AWSPlatform,
+			awsRegion:               "us-east-1",
+			hyperShiftOperatorImage: "quay.io/hypershift/operator:latest",
+			ignitionEndpoint:        "https://ignition.example.com",
+			azMonitoringEnabled:     true,
+			validateFunc: func(t *testing.T, g Gomega, opts *KarpenterOperatorOptions, cpContext controlplanecomponent.WorkloadContext) {
+				t.Helper()
+				deploymentObj, err := assets.LoadDeploymentManifest(ComponentName)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				err = opts.adaptDeployment(cpContext, deploymentObj)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				g.Expect(container).ToNot(BeNil(), "container %s should exist", ComponentName)
+				g.Expect(container.Env).To(ContainElement(
+					corev1.EnvVar{
+						Name:  azmonitoring.EnvironmentVariable,
+						Value: "1",
+					},
+				))
+			},
+		},
+		{
+			name:                    "When AZ monitoring is disabled on AWS, it should not set environment variable",
+			platformType:            hyperv1.AWSPlatform,
+			awsRegion:               "us-east-1",
+			hyperShiftOperatorImage: "quay.io/hypershift/operator:latest",
+			ignitionEndpoint:        "https://ignition.example.com",
+			azMonitoringEnabled:     false,
+			validateFunc: func(t *testing.T, g Gomega, opts *KarpenterOperatorOptions, cpContext controlplanecomponent.WorkloadContext) {
+				t.Helper()
+				deploymentObj, err := assets.LoadDeploymentManifest(ComponentName)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				err = opts.adaptDeployment(cpContext, deploymentObj)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				g.Expect(container).ToNot(BeNil(), "container %s should exist", ComponentName)
+				g.Expect(podspec.FindEnvVar(azmonitoring.EnvironmentVariable, container.Env)).To(BeNil())
+			},
+		},
+		{
 			name:                    "When platform is not AWS, it should only set basic configuration",
 			platformType:            hyperv1.AzurePlatform,
 			hyperShiftOperatorImage: "quay.io/hypershift/operator:latest",
@@ -196,6 +243,11 @@ func TestAdaptDeployment(t *testing.T) {
 				t.Setenv(rhobsmonitoring.EnvironmentVariable, "1")
 			} else {
 				t.Setenv(rhobsmonitoring.EnvironmentVariable, "")
+			}
+			if tc.azMonitoringEnabled {
+				t.Setenv(azmonitoring.EnvironmentVariable, "1")
+			} else {
+				t.Setenv(azmonitoring.EnvironmentVariable, "")
 			}
 
 			hcp := &hyperv1.HostedControlPlane{

--- a/support/api/scheme.go
+++ b/support/api/scheme.go
@@ -12,6 +12,7 @@ import (
 	hyperv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1"
 	schedulingv1alpha1 "github.com/openshift/hypershift/api/scheduling/v1alpha1"
+	"github.com/openshift/hypershift/support/azmonitoring"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -140,6 +141,11 @@ func init() {
 		_ = apiserverconfigv1.AddToScheme(scheme)
 		if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" {
 			_ = rhobsmonitoring.AddToScheme(scheme)
+			if sd.includeAllMonitoring {
+				_ = prometheusoperatorv1.AddToScheme(scheme)
+			}
+		} else if os.Getenv(azmonitoring.EnvironmentVariable) == "1" {
+			_ = azmonitoring.AddToScheme(scheme)
 			if sd.includeAllMonitoring {
 				_ = prometheusoperatorv1.AddToScheme(scheme)
 			}

--- a/support/azmonitoring/scheme.go
+++ b/support/azmonitoring/scheme.go
@@ -1,0 +1,41 @@
+package azmonitoring
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+// SchemeGroupVersion is the group version used to register these objects
+var SchemeGroupVersion = schema.GroupVersion{Group: "azmonitoring.coreos.com", Version: "v1"}
+
+// EnvironmentVariable indicates whether Azure monitoring resources should be used
+var EnvironmentVariable = "AZ_MONITORING"
+
+var (
+	// localSchemeBuilder and AddToScheme will stay in k8s.io/kubernetes.
+	SchemeBuilder      runtime.SchemeBuilder
+	localSchemeBuilder = &SchemeBuilder
+	AddToScheme        = localSchemeBuilder.AddToScheme
+)
+
+func init() {
+	// We only register manually written functions here. The registration of the
+	// generated functions takes place in the generated files. The separation
+	// makes the code compile even when the generated files are missing.
+	localSchemeBuilder.Register(addKnownTypes)
+}
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&prometheusoperatorv1.ServiceMonitor{},
+		&prometheusoperatorv1.ServiceMonitorList{},
+		&prometheusoperatorv1.PodMonitor{},
+		&prometheusoperatorv1.PodMonitorList{},
+	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/support/azmonitoring/scheme.go
+++ b/support/azmonitoring/scheme.go
@@ -35,6 +35,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&prometheusoperatorv1.ServiceMonitorList{},
 		&prometheusoperatorv1.PodMonitor{},
 		&prometheusoperatorv1.PodMonitorList{},
+		&prometheusoperatorv1.PrometheusRule{},
+		&prometheusoperatorv1.PrometheusRuleList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil


### PR DESCRIPTION
## What this PR does / why we need it:
ARO-HCP needs HyperShift's ServiceMonitor/PodMonitor resources under a separate API group so an Azure-native monitoring pipeline can consume them independently from the platform's monitoring.coreos.com resources.

Uses the same scheme-level API group swap pattern as RHOBS: when --az-monitoring is passed to `hypershift install` (with AZ_MONITORING=1), the operator and downstream components (CPO, CNO, karpenter-operator) create monitoring resources under azmonitoring.coreos.com/v1.

## Which issue(s) this PR fixes:
https://redhat.atlassian.net/browse/AROSLSRE-1483

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--az-monitoring` installation option for Azure monitoring.
  * Azure monitoring settings now propagate to hosted control plane components via an environment flag.
  * Extended RBAC to support Azure Monitoring resources (including `ServiceMonitor`, `PodMonitor`, and `PrometheusRule`).
* **Bug Fixes**
  * Azure monitoring can now be used with a CVO Prometheus URL.
* **Tests**
  * Added coverage for Azure monitoring configuration, environment variables, deployments, validation, and related RBAC handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->