### PR TITLE
OCPBUGS-96899: Bump go-toolset to 1.25.9 to address CVE-2025-61729

### DIFF
--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1754467841 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778054913 AS builder
 
 WORKDIR /hypershift
 

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1754467841 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778054913 AS builder
 
 WORKDIR /hypershift
 


### PR DESCRIPTION
  ## Summary

  Updates the Go toolset builder image to address security vulnerability [CVE-2025-61729](https://access.redhat.com/security/cve/cve-2025-61729)

  ## Changes

  - **Containerfile.control-plane**: Bump `ubi9/go-toolset` from `1.24.4-1754467841` to `1.25.9-1778054913`
  - **Containerfile.operator**: Bump `ubi9/go-toolset` from `1.24.4-1754467841` to `1.25.9-1778054913`

  ## CVE Details

  **[CVE-2025-61729](https://access.redhat.com/security/cve/cve-2025-61729)**: Unbounded string concatenation in `crypto/x509.Certificate.Verify()`

  This vulnerability could lead to denial of service through excessive memory consumption during certificate verification. The fix is included in the updated Go toolset version.

  ## Impact

 - **Builder-only change**: Only affects the build environment
  - **No code changes**: `go.mod` remains at Go 1.24.4 for compatibility

  ## Testing
[x] make control-plane-operator control-plane-pki-operator
[x] make hypershift hypershift-operator karpenter-operator
[x] make test

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.