### PR TITLE
[TEST ONLY] test(azure): enable Global Pull Secret test in Azure CI 

### DIFF
--- a/test/e2e/v2/internal/env_vars.go
+++ b/test/e2e/v2/internal/env_vars.go
@@ -208,11 +208,6 @@ func init() {
 		"Azure DiskEncryptionSet resource ID for disk encryption NodePool tests.",
 		false,
 	)
-	RegisterEnvVar(
-		"E2E_ADDITIONAL_PULL_SECRET_FILE",
-		"Path to an additional pull secret file for the global pull secret lifecycle test.",
-		false,
-	)
 	// External OIDC test environment variables
 	RegisterEnvVar(
 		"E2E_EXTERNAL_OIDC_CA_BUNDLE_FILE",

--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -148,6 +148,10 @@ func (a *AzurePlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Clust
 			Variant:    "external-oidc",
 			OutputFile: "cluster-name-external-oidc",
 		},
+		{
+			Variant:    "global-pull-secret",
+			OutputFile: "cluster-name-global-pull-secret",
+		},
 	}
 }
 
@@ -353,13 +357,19 @@ func (a *AzurePlatformConfig) TestMatrix(releaseImage string) TestMatrix {
 				Name:        "autoscaling",
 				ClusterFile: "cluster-name-autoscaling",
 				LabelFilter: "nodepool-autoscaling",
-				JUnitFile:   "junit_nodepool_autoscaling.xml",
+				JUnitFile:   "junit_self_managed_azure_nodepool_autoscaling.xml",
 			},
 			{
 				Name:        "external-oidc",
 				ClusterFile: "cluster-name-external-oidc",
 				LabelFilter: "external-oidc",
 				JUnitFile:   "junit_self_managed_azure_external_oidc.xml",
+			},
+			{
+				Name:        "global-pull-secret",
+				ClusterFile: "cluster-name-global-pull-secret",
+				LabelFilter: "global-pull-secret",
+				JUnitFile:   "junit_self_managed_azure_global_pull_secret.xml",
 			},
 		},
 		Sequential: []SequentialGroup{

--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -362,14 +362,8 @@ func (a *AzurePlatformConfig) TestMatrix(releaseImage string) TestMatrix {
 			{
 				Name:        "external-oidc",
 				ClusterFile: "cluster-name-external-oidc",
-				LabelFilter: "external-oidc",
+				LabelFilter: "external-oidc ||global-pull-secret",
 				JUnitFile:   "junit_self_managed_azure_external_oidc.xml",
-			},
-			{
-				Name:        "global-pull-secret",
-				ClusterFile: "cluster-name-global-pull-secret",
-				LabelFilter: "global-pull-secret",
-				JUnitFile:   "junit_self_managed_azure_global_pull_secret.xml",
 			},
 		},
 		Sequential: []SequentialGroup{

--- a/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -63,14 +62,6 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 				Skip("global pull secret test is only supported on public clusters")
 			}
 
-			additionalPullSecretFile := internal.GetEnvVarValue("E2E_ADDITIONAL_PULL_SECRET_FILE")
-			if additionalPullSecretFile == "" {
-				Skip("E2E_ADDITIONAL_PULL_SECRET_FILE not set, skipping global pull secret test")
-			}
-
-			additionalPullSecretData, err := os.ReadFile(additionalPullSecretFile)
-			Expect(err).NotTo(HaveOccurred(), "failed to read additional pull secret file %s", additionalPullSecretFile)
-
 			tc.ValidateHostedClusterClient()
 			hcClient := tc.GetHostedClusterClient()
 
@@ -95,6 +86,7 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 			nodeCount := *np.Spec.Replicas
 
 			var dummyPullSecretData = []byte(`{"auths": {"quay.io": {"auth": "YWRtaW46cGFzc3dvcmQ="}}}`)
+			var updatedPullSecretData = []byte(`{"auths": {"registry.example.com": {"auth": "dXNlcjpwYXNzd29yZA=="}}}`)
 
 			By("verifying in-place management-cluster pull secret propagation without rollout")
 			if !e2eutil.IsLessThan(e2eutil.Version422) {
@@ -132,7 +124,7 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 			additionalPS := hccomanifests.AdditionalPullSecret()
 			Expect(hcClient.Get(tc.Context, crclient.ObjectKeyFromObject(additionalPS), additionalPS)).To(Succeed(),
 				"failed to get additional-pull-secret")
-			additionalPS.Data[corev1.DockerConfigJsonKey] = additionalPullSecretData
+			additionalPS.Data[corev1.DockerConfigJsonKey] = updatedPullSecretData
 			Expect(hcClient.Update(tc.Context, additionalPS)).To(Succeed(),
 				"failed to update additional-pull-secret with valid data")
 

--- a/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
@@ -65,22 +65,11 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 			tc.ValidateHostedClusterClient()
 			hcClient := tc.GetHostedClusterClient()
 
-			npList := &hyperv1.NodePoolList{}
-			Expect(tc.MgmtClient.List(tc.Context, npList, crclient.InNamespace(hc.Namespace))).To(Succeed(),
-				"failed to list NodePools")
-			Expect(npList.Items).NotTo(BeEmpty(), "expected at least one NodePool")
-
-			var np *hyperv1.NodePool
-			for i := range npList.Items {
-				candidate := &npList.Items[i]
-				if candidate.Spec.Management.UpgradeType != hyperv1.UpgradeTypeInPlace &&
-					candidate.Spec.Replicas != nil &&
-					*candidate.Spec.Replicas > 0 {
-					np = candidate
-					break
-				}
-			}
-			if np == nil {
+			np := getDefaultNodePool(tc.Context, tc.MgmtClient, hc)
+			if np == nil ||
+				np.Spec.Management.UpgradeType == hyperv1.UpgradeTypeInPlace ||
+				np.Spec.Replicas == nil ||
+				*np.Spec.Replicas == 0 {
 				Skip("no suitable NodePool found (need non-InPlace upgrade type with replicas > 0)")
 			}
 			nodeCount := *np.Spec.Replicas
@@ -241,25 +230,27 @@ func verifyPullSecretPropagation(tc *internal.TestContext, hc *hyperv1.HostedClu
 	}, 150*time.Second, 5*time.Second).Should(BeTrue(),
 		"kube-system/original-pull-secret did not propagate dummy entry")
 
-	nodePool := &hyperv1.NodePool{}
-	Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKeyFromObject(np), nodePool)).To(Succeed())
-	foundUpdatingConfig := false
-	for _, cond := range nodePool.Status.Conditions {
-		if cond.Type == hyperv1.NodePoolUpdatingConfigConditionType {
-			foundUpdatingConfig = true
-			Expect(string(cond.Status)).To(Equal(string(metav1.ConditionFalse)),
-				"UpdatingConfig should be False — in-place pull secret update must not trigger a rollout")
-			break
+	Consistently(func(g Gomega) {
+		nodePool := &hyperv1.NodePool{}
+		g.Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKeyFromObject(np), nodePool)).To(Succeed())
+		foundUpdatingConfig := false
+		for _, cond := range nodePool.Status.Conditions {
+			if cond.Type == hyperv1.NodePoolUpdatingConfigConditionType {
+				foundUpdatingConfig = true
+				g.Expect(string(cond.Status)).To(Equal(string(metav1.ConditionFalse)),
+					"UpdatingConfig should be False — in-place pull secret update must not trigger a rollout")
+				break
+			}
 		}
-	}
-	Expect(foundUpdatingConfig).To(BeTrue(),
-		"NodePool %s should have UpdatingConfig condition", nodePool.Name)
+		g.Expect(foundUpdatingConfig).To(BeTrue(),
+			"NodePool %s should have UpdatingConfig condition", nodePool.Name)
+	}, 10*time.Second, time.Second).Should(Succeed())
 
 	nodeList := &corev1.NodeList{}
 	Expect(hcClient.List(tc.Context, nodeList, crclient.MatchingLabels{
 		hyperv1.NodePoolLabel: np.Name,
 	})).To(Succeed())
-	Expect(len(nodeList.Items)).To(Equal(int(nodeCount)),
+	Expect(nodeList.Items).To(HaveLen(int(nodeCount)),
 		"node count changed — unexpected rollout")
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

Related to https://github.com/openshift/hypershift/pull/9073 . 
Test co-locating the test with other tests.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved Azure end-to-end coverage for global pull secret lifecycle, including a dedicated cluster variant for global pull secret output.
  - Strengthened validation that in-place pull secret updates don’t trigger node rollouts (consistent condition checks over time).
  - Updated pull secret test setup to use built-in dummy Docker config data and smarter default node pool selection.
  - Refined Azure test matrix reporting for autoscaling and expanded external OIDC labeling to include global pull secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->