### PR TITLE
NO-JIRA: fix data race in TestEnqueueNodePoolsForCloudConfig

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -3864,7 +3864,11 @@ func TestEnqueueNodePoolsForCloudConfig(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			c := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tc.objects...).Build()
+			objs := make([]client.Object, len(tc.objects))
+			for i, o := range tc.objects {
+				objs[i] = o.DeepCopyObject().(client.Object)
+			}
+			c := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objs...).Build()
 			r := &NodePoolReconciler{Client: c}
 
 			result := r.enqueueNodePoolsForCloudConfig(context.Background(), tc.cm)


### PR DESCRIPTION
## Summary

- DeepCopy shared test objects before passing them to the fake client builder
- Parallel subtests were sharing the same HostedControlPlane and NodePool pointers, and `fake.NewClientBuilder().WithObjects()` mutates `ResourceVersion` on the objects causing a data race
- Pre-existing flaky test found while running the test suite with `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by using independent copies of Kubernetes objects during setup.
  * Prevented test data from being unintentionally modified across test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->