### PR TITLE
CNTRLPLANE-3890: Add product-cli unit tests for HCP create cluster

### DIFF
--- a/product-cli/cmd/cluster/agent/create_test.go
+++ b/product-cli/cmd/cluster/agent/create_test.go
@@ -1,0 +1,150 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/cmd/cluster/agent"
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/testutil"
+	"github.com/openshift/hypershift/test/integration/framework"
+
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "When Agent create command is created, it should have 'agent' as use",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+				g.Expect(cmd.Use).To(Equal("agent"))
+			},
+		},
+		{
+			name: "When Agent create command is created, it should mark agent-namespace as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+
+				agentNSFlag := cmd.Flag("agent-namespace")
+				g.Expect(agentNSFlag).ToNot(BeNil())
+				g.Expect(agentNSFlag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(agentNSFlag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When Agent create command is added to a parent, pull-secret should be inherited",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+
+				parent := &cobra.Command{Use: "cluster"}
+				core.BindOptions(opts, parent.PersistentFlags())
+
+				cmd := NewCreateCommand(opts)
+				parent.AddCommand(cmd)
+
+				pullSecretFlag := cmd.InheritedFlags().Lookup("pull-secret")
+				g.Expect(pullSecretFlag).ToNot(BeNil(), "pull-secret should be inherited from parent command")
+			},
+		},
+		{
+			name: "When Agent create command is created, it should register exactly the expected flags",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+
+				expectedFlags := []string{
+					"agent-namespace",
+					"agentLabelSelector",
+					"api-server-address",
+				}
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				sort.Strings(actualFlags)
+				g.Expect(actualFlags).To(Equal(expectedFlags))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.test(t)
+		})
+	}
+}
+
+func TestCreateCluster(t *testing.T) {
+	utilrand.Seed(1234567890)
+	certs.UnsafeSeed(1234567890)
+	ctx := framework.InterruptableContext(t.Context())
+
+	tempDir := t.TempDir()
+
+	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
+	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
+		t.Fatalf("failed to write pullSecret: %v", err)
+	}
+
+	for _, testCase := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "When minimal flags are provided, it should render correctly",
+			args: []string{
+				"--api-server-address=fakeAddress",
+				"--render-sensitive",
+				"--name=example",
+				"--pull-secret=" + pullSecretFile,
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
+			coreOpts := core.DefaultOptions()
+			core.BindOptions(coreOpts, flags)
+			agentOpts := agent.DefaultOptions()
+			agent.BindOptions(agentOpts, flags)
+			if err := flags.Parse(testCase.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			tempDir := t.TempDir()
+			manifestsFile := filepath.Join(tempDir, "manifests.yaml")
+			coreOpts.Render = true
+			coreOpts.RenderInto = manifestsFile
+
+			if err := core.CreateCluster(ctx, coreOpts, agentOpts); err != nil {
+				t.Fatalf("failed to create cluster: %v", err)
+			}
+
+			manifests, err := os.ReadFile(manifestsFile)
+			if err != nil {
+				t.Fatalf("failed to read manifests file: %v", err)
+			}
+			testutil.CompareWithFixture(t, manifests)
+		})
+	}
+}

--- a/product-cli/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_When_minimal_flags_are_provided__it_should_render_correctly.yaml
+++ b/product-cli/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_When_minimal_flags_are_provided__it_should_render_correctly.yaml
@@ -1,0 +1,135 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clusters
+spec: {}
+status: {}
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: ZmFrZQ==
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-pull-secret
+  namespace: clusters
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: capi-provider-role
+rules:
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - agents
+  verbs:
+  - '*'
+---
+apiVersion: v1
+data:
+  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  autoscaling: {}
+  capabilities: {}
+  configuration: {}
+  controllerAvailabilityPolicy: SingleReplica
+  dns:
+    baseDomain: example.com
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: 8Gi
+        type: PersistentVolume
+    managementType: Managed
+  fips: false
+  infraID: example-sffhb
+  networking:
+    clusterNetwork:
+    - cidr: 10.132.0.0/14
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - cidr: 172.31.0.0/16
+  olmCatalogPlacement: management
+  platform:
+    agent:
+      agentNamespace: ""
+    type: Agent
+  pullSecret:
+    name: example-pull-secret
+  release:
+    image: ""
+  secretEncryption:
+    aescbc:
+      activeKey:
+        name: example-etcd-encryption-key
+    type: aescbc
+  services:
+  - service: APIServer
+    servicePublishingStrategy:
+      nodePort:
+        address: fakeAddress
+      type: NodePort
+  - service: Ignition
+    servicePublishingStrategy:
+      nodePort:
+        address: fakeAddress
+      type: NodePort
+  - service: Konnectivity
+    servicePublishingStrategy:
+      nodePort:
+        address: fakeAddress
+      type: NodePort
+  - service: OAuthServer
+    servicePublishingStrategy:
+      nodePort:
+        address: fakeAddress
+      type: NodePort
+  - service: OIDC
+    servicePublishingStrategy:
+      nodePort:
+        address: fakeAddress
+      type: NodePort
+  sshKey: {}
+status:
+  controlPlaneEndpoint:
+    host: ""
+    port: 0
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  arch: amd64
+  clusterName: example
+  management:
+    autoRepair: false
+    upgradeType: InPlace
+  nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
+  platform:
+    agent: {}
+    type: Agent
+  release:
+    image: ""
+  replicas: 0
+status:
+  replicas: 0
+---

--- a/product-cli/cmd/cluster/aws/create_test.go
+++ b/product-cli/cmd/cluster/aws/create_test.go
@@ -1,0 +1,303 @@
+package aws
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftaws "github.com/openshift/hypershift/cmd/cluster/aws"
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/testutil"
+	"github.com/openshift/hypershift/test/integration/framework"
+
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "When AWS create command is created, it should have 'aws' as use",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+				g.Expect(cmd.Use).To(Equal("aws"))
+			},
+		},
+		{
+			name: "When AWS create command is created, it should set release stream to default",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				_ = NewCreateCommand(opts)
+				g.Expect(opts.ReleaseStream).To(Equal(config.DefaultReleaseStream))
+			},
+		},
+		{
+			name: "When AWS create command is created, it should default region to us-east-1",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+				g.Expect(cmd.Flag("region").DefValue).To(Equal("us-east-1"))
+			},
+		},
+		{
+			name: "When AWS create command is created, it should default root-volume-type to gp3",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+				g.Expect(cmd.Flag("root-volume-type").DefValue).To(Equal("gp3"))
+			},
+		},
+		{
+			name: "When AWS create command is created, it should default root-volume-size to 120",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+				g.Expect(cmd.Flag("root-volume-size").DefValue).To(Equal("120"))
+			},
+		},
+		{
+			name: "When AWS create command is created, it should default endpoint-access to Public",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+				g.Expect(cmd.Flag("endpoint-access").DefValue).To(Equal("Public"))
+			},
+		},
+		{
+			name: "When AWS create command is created, it should register product credential flags",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+
+				g.Expect(cmd.Flag("role-arn")).ToNot(BeNil(), "role-arn flag should be registered")
+				g.Expect(cmd.Flag("sts-creds")).ToNot(BeNil(), "sts-creds flag should be registered")
+			},
+		},
+		{
+			name: "When AWS create command is created, it should not register developer-only flags",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+
+				g.Expect(cmd.Flag("iam-json")).To(BeNil(), "iam-json is a developer-only flag")
+				g.Expect(cmd.Flag("single-nat-gateway")).To(BeNil(), "single-nat-gateway is a developer-only flag")
+			},
+		},
+		{
+			name: "When AWS create command is added to a parent, pull-secret should be inherited",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+
+				parent := &cobra.Command{Use: "cluster"}
+				core.BindOptions(opts, parent.PersistentFlags())
+
+				cmd := NewCreateCommand(opts)
+				parent.AddCommand(cmd)
+
+				pullSecretFlag := cmd.InheritedFlags().Lookup("pull-secret")
+				g.Expect(pullSecretFlag).ToNot(BeNil(), "pull-secret should be inherited from parent command")
+			},
+		},
+		{
+			name: "When AWS create command is created, it should register exactly the expected flags",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+
+				expectedFlags := []string{
+					"additional-tags",
+					"auto-node",
+					"enable-proxy",
+					"enable-secure-proxy",
+					"endpoint-access",
+					"instance-type",
+					"kms-key-arn",
+					"multi-arch",
+					"oidc-issuer-url",
+					"private-zones-in-cluster-account",
+					"proxy-vpc-endpoint-service-name",
+					"public-only",
+					"region",
+					"role-arn",
+					"root-volume-iops",
+					"root-volume-kms-key",
+					"root-volume-size",
+					"root-volume-type",
+					"sa-token-issuer-private-key-path",
+					"secret-creds",
+					"shared-role",
+					"sts-creds",
+					"use-rosa-managed-policies",
+					"vpc-cidr",
+					"zones",
+				}
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				sort.Strings(actualFlags)
+				g.Expect(actualFlags).To(Equal(expectedFlags))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.test(t)
+		})
+	}
+}
+
+func TestCreateCluster(t *testing.T) {
+	utilrand.Seed(1234567890)
+	certs.UnsafeSeed(1234567890)
+	ctx := framework.InterruptableContext(t.Context())
+	tempDir := t.TempDir()
+	t.Setenv("FAKE_CLIENT", "true")
+
+	rawCreds, err := json.Marshal(&awsutil.STSCreds{
+		Credentials: awsutil.Credentials{
+			AccessKeyId:     "fakeAccessKeyId",
+			SecretAccessKey: "fakeSecretAccessKey",
+			SessionToken:    "fakeSessionToken",
+			Expiration:      "fakeExpiration",
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal creds: %v", err)
+	}
+	credentialsFile := filepath.Join(tempDir, "credentials.yaml")
+	if err := os.WriteFile(credentialsFile, rawCreds, 0600); err != nil {
+		t.Fatalf("failed to write creds: %v", err)
+	}
+
+	rawIAM, err := json.Marshal(&awsinfra.CreateIAMOutput{
+		Region:      "fakeRegion",
+		ProfileName: "fakeProfileName",
+		InfraID:     "fakeInfraID",
+		IssuerURL:   "fakeIssuerURL",
+		Roles: hyperv1.AWSRolesRef{
+			IngressARN:              "fakeIngressARN",
+			ImageRegistryARN:        "fakeImageRegistryARN",
+			StorageARN:              "fakeStorageARN",
+			NetworkARN:              "fakeNetworkARN",
+			KubeCloudControllerARN:  "fakeKubeCloudControllerARN",
+			NodePoolManagementARN:   "fakeNodePoolManagementARN",
+			ControlPlaneOperatorARN: "fakeControlPlaneOperatorARN",
+		},
+		KMSKeyARN:          "fakeKMSKeyARN",
+		KMSProviderRoleARN: "fakeKMSProviderRoleARN",
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal iam: %v", err)
+	}
+	iamFile := filepath.Join(tempDir, "iam.json")
+	if err := os.WriteFile(iamFile, rawIAM, 0600); err != nil {
+		t.Fatalf("failed to write iam: %v", err)
+	}
+
+	rawInfra, err := json.Marshal(&awsinfra.CreateInfraOutput{
+		Region:      "fakeRegion",
+		Zone:        "fakeZone",
+		InfraID:     "fakeInfraID",
+		MachineCIDR: "192.0.2.0/24",
+		VPCID:       "fakeVPCID",
+		Zones: []*awsinfra.CreateInfraOutputZone{
+			{
+				Name:     "fakeName",
+				SubnetID: "fakeSubnetID",
+			},
+		},
+		Name:             "fakeName",
+		BaseDomain:       "fakeBaseDomain",
+		BaseDomainPrefix: "fakeBaseDomainPrefix",
+		PublicZoneID:     "fakePublicZoneID",
+		PrivateZoneID:    "fakePrivateZoneID",
+		LocalZoneID:      "fakeLocalZoneID",
+		ProxyAddr:        "fakeProxyAddr",
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal infra: %v", err)
+	}
+	infraFile := filepath.Join(tempDir, "infra.json")
+	if err := os.WriteFile(infraFile, rawInfra, 0600); err != nil {
+		t.Fatalf("failed to write infra: %v", err)
+	}
+
+	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
+	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
+		t.Fatalf("failed to write pullSecret: %v", err)
+	}
+
+	for _, testCase := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "When minimal flags are provided, it should render correctly",
+			args: []string{
+				"--sts-creds=" + credentialsFile,
+				"--infra-json=" + infraFile,
+				"--iam-json=" + iamFile,
+				"--role-arn=fakeRoleARN",
+				"--pull-secret=" + pullSecretFile,
+				"--render-sensitive",
+				"--name=example",
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
+			coreOpts := core.DefaultOptions()
+			core.BindDeveloperOptions(coreOpts, flags)
+			awsOpts := hypershiftaws.DefaultOptions()
+			hypershiftaws.BindDeveloperOptions(awsOpts, flags)
+			if err := flags.Parse(testCase.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			tempDir := t.TempDir()
+			manifestsFile := filepath.Join(tempDir, "manifests.yaml")
+			coreOpts.Render = true
+			coreOpts.RenderInto = manifestsFile
+
+			if err := core.CreateCluster(ctx, coreOpts, awsOpts); err != nil {
+				t.Fatalf("failed to create cluster: %v", err)
+			}
+
+			manifests, err := os.ReadFile(manifestsFile)
+			if err != nil {
+				t.Fatalf("failed to read manifests file: %v", err)
+			}
+			testutil.CompareWithFixture(t, manifests)
+		})
+	}
+}

--- a/product-cli/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_When_minimal_flags_are_provided__it_should_render_correctly.yaml
+++ b/product-cli/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_When_minimal_flags_are_provided__it_should_render_correctly.yaml
@@ -1,0 +1,138 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clusters
+spec: {}
+status: {}
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: ZmFrZQ==
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-pull-secret
+  namespace: clusters
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  autoscaling: {}
+  capabilities: {}
+  configuration:
+    proxy:
+      httpProxy: fakeProxyAddr
+      httpsProxy: fakeProxyAddr
+      trustedCA:
+        name: ""
+  controllerAvailabilityPolicy: SingleReplica
+  dns:
+    baseDomain: fakeBaseDomain
+    baseDomainPrefix: fakeBaseDomainPrefix
+    privateZoneID: fakePrivateZoneID
+    publicZoneID: fakePublicZoneID
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: 8Gi
+          storageClassName: gp3-csi
+        type: PersistentVolume
+    managementType: Managed
+  fips: false
+  infraID: fakeInfraID
+  issuerURL: fakeIssuerURL
+  networking:
+    clusterNetwork:
+    - cidr: 10.132.0.0/14
+    machineNetwork:
+    - cidr: 192.0.2.0/24
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - cidr: 172.31.0.0/16
+  olmCatalogPlacement: management
+  platform:
+    aws:
+      cloudProviderConfig:
+        subnet:
+          id: fakeSubnetID
+        vpc: fakeVPCID
+        zone: fakeName
+      endpointAccess: Public
+      multiArch: false
+      region: us-east-1
+      rolesRef:
+        controlPlaneOperatorARN: fakeControlPlaneOperatorARN
+        imageRegistryARN: fakeImageRegistryARN
+        ingressARN: fakeIngressARN
+        kubeCloudControllerARN: fakeKubeCloudControllerARN
+        networkARN: fakeNetworkARN
+        nodePoolManagementARN: fakeNodePoolManagementARN
+        storageARN: fakeStorageARN
+    type: AWS
+  pullSecret:
+    name: example-pull-secret
+  release:
+    image: ""
+  secretEncryption:
+    kms:
+      aws:
+        activeKey:
+          arn: fakeKMSKeyARN
+        auth:
+          awsKms: fakeKMSProviderRoleARN
+        region: us-east-1
+      provider: AWS
+    type: kms
+  services:
+  - service: APIServer
+    servicePublishingStrategy:
+      type: LoadBalancer
+  - service: Ignition
+    servicePublishingStrategy:
+      type: Route
+  - service: Konnectivity
+    servicePublishingStrategy:
+      type: Route
+  - service: OAuthServer
+    servicePublishingStrategy:
+      type: Route
+  sshKey: {}
+status:
+  controlPlaneEndpoint:
+    host: ""
+    port: 0
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: example-fakeName
+  namespace: clusters
+spec:
+  arch: amd64
+  clusterName: example
+  management:
+    autoRepair: false
+    upgradeType: Replace
+  nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
+  platform:
+    aws:
+      instanceProfile: fakeProfileName
+      instanceType: m5.large
+      rootVolume:
+        size: 120
+        type: gp3
+      subnet:
+        id: fakeSubnetID
+    type: AWS
+  release:
+    image: ""
+  replicas: 0
+status:
+  replicas: 0
+---

--- a/product-cli/cmd/cluster/azure/create_test.go
+++ b/product-cli/cmd/cluster/azure/create_test.go
@@ -1,14 +1,28 @@
 package azure
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/gomega"
 
+	hypershiftazure "github.com/openshift/hypershift/cmd/cluster/azure"
 	"github.com/openshift/hypershift/cmd/cluster/core"
+	azureinfra "github.com/openshift/hypershift/cmd/infra/azure"
+	"github.com/openshift/hypershift/cmd/util"
+	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/testutil"
+	"github.com/openshift/hypershift/test/integration/framework"
+
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+
+	"sigs.k8s.io/yaml"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func TestNewCreateCommand(t *testing.T) {
@@ -78,6 +92,97 @@ func TestNewCreateCommand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			tt.test(t)
+		})
+	}
+}
+
+func TestCreateCluster(t *testing.T) {
+	utilrand.Seed(1234567890)
+	certs.UnsafeSeed(1234567890)
+	ctx := framework.InterruptableContext(t.Context())
+	t.Setenv("FAKE_CLIENT", "true")
+
+	tempDir := t.TempDir()
+
+	rawCreds, err := yaml.Marshal(&util.AzureCreds{
+		SubscriptionID: "fakeSubscriptionID",
+		ClientID:       "fakeClientID",
+		ClientSecret:   "fakeClientSecret",
+		TenantID:       "fakeTenantID",
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal creds: %v", err)
+	}
+	credentialsFile := filepath.Join(tempDir, "credentials.yaml")
+	if err := os.WriteFile(credentialsFile, rawCreds, 0600); err != nil {
+		t.Fatalf("failed to write creds: %v", err)
+	}
+
+	rawInfra, err := json.Marshal(&azureinfra.CreateInfraOutput{
+		BaseDomain:        "fakeBaseDomain",
+		PublicZoneID:      "fakePublicZoneID",
+		PrivateZoneID:     "fakePrivateZoneID",
+		Location:          "fakeLocation",
+		ResourceGroupName: "fakeResourceGroupName",
+		VNetID:            "fakeVNetID",
+		SubnetID:          "fakeSubnetID",
+		BootImageID:       "fakeBootImageID",
+		InfraID:           "fakeInfraID",
+		SecurityGroupID:   "fakeSecurityGroupID",
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal infra: %v", err)
+	}
+	infraFile := filepath.Join(tempDir, "infra.json")
+	if err := os.WriteFile(infraFile, rawInfra, 0600); err != nil {
+		t.Fatalf("failed to write infra: %v", err)
+	}
+
+	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
+	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
+		t.Fatalf("failed to write pullSecret: %v", err)
+	}
+
+	for _, testCase := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "When minimal flags are provided, it should render correctly",
+			args: []string{
+				"--azure-creds=" + credentialsFile,
+				"--infra-json=" + infraFile,
+				"--render-sensitive",
+				"--name=example",
+				"--pull-secret=" + pullSecretFile,
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
+			coreOpts := core.DefaultOptions()
+			core.BindOptions(coreOpts, flags)
+			hypershiftazure.BindProductCoreFlags(coreOpts, flags)
+			azureOpts := hypershiftazure.DefaultOptions()
+			hypershiftazure.BindProductFlags(azureOpts, flags)
+			if err := flags.Parse(testCase.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			tempDir := t.TempDir()
+			manifestsFile := filepath.Join(tempDir, "manifests.yaml")
+			coreOpts.Render = true
+			coreOpts.RenderInto = manifestsFile
+
+			if err := core.CreateCluster(ctx, coreOpts, azureOpts); err != nil {
+				t.Fatalf("failed to create cluster: %v", err)
+			}
+
+			manifests, err := os.ReadFile(manifestsFile)
+			if err != nil {
+				t.Fatalf("failed to read manifests file: %v", err)
+			}
+			testutil.CompareWithFixture(t, manifests)
 		})
 	}
 }

--- a/product-cli/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_When_minimal_flags_are_provided__it_should_render_correctly.yaml
+++ b/product-cli/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_When_minimal_flags_are_provided__it_should_render_correctly.yaml
@@ -1,0 +1,139 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clusters
+spec: {}
+status: {}
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: ZmFrZQ==
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-pull-secret
+  namespace: clusters
+---
+apiVersion: v1
+data:
+  AZURE_SUBSCRIPTION_ID: ZmFrZVN1YnNjcmlwdGlvbklE
+  AZURE_TENANT_ID: ZmFrZVRlbmFudElE
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-cloud-credentials
+  namespace: clusters
+---
+apiVersion: v1
+data:
+  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  autoscaling: {}
+  capabilities: {}
+  configuration: {}
+  controllerAvailabilityPolicy: SingleReplica
+  dns:
+    baseDomain: fakeBaseDomain
+    privateZoneID: fakePrivateZoneID
+    publicZoneID: fakePublicZoneID
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: 8Gi
+        type: PersistentVolume
+    managementType: Managed
+  fips: false
+  infraID: fakeInfraID
+  networking:
+    clusterNetwork:
+    - cidr: 10.132.0.0/14
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - cidr: 172.31.0.0/16
+  olmCatalogPlacement: management
+  platform:
+    azure:
+      azureAuthenticationConfig:
+        azureAuthenticationConfigType: ManagedIdentities
+      location: fakeLocation
+      resourceGroup: fakeResourceGroupName
+      securityGroupID: fakeSecurityGroupID
+      subnetID: fakeSubnetID
+      subscriptionID: fakeSubscriptionID
+      tenantID: fakeTenantID
+      vnetID: fakeVNetID
+    type: Azure
+  pullSecret:
+    name: example-pull-secret
+  release:
+    image: ""
+  secretEncryption:
+    aescbc:
+      activeKey:
+        name: example-etcd-encryption-key
+    type: aescbc
+  services:
+  - service: APIServer
+    servicePublishingStrategy:
+      type: LoadBalancer
+  - service: Ignition
+    servicePublishingStrategy:
+      type: Route
+  - service: Konnectivity
+    servicePublishingStrategy:
+      type: Route
+  - service: OAuthServer
+    servicePublishingStrategy:
+      type: Route
+  sshKey: {}
+status:
+  controlPlaneEndpoint:
+    host: ""
+    port: 0
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  arch: amd64
+  clusterName: example
+  management:
+    autoRepair: false
+    upgradeType: Replace
+  nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
+  platform:
+    azure:
+      image:
+        imageID: fakeBootImageID
+        type: ImageID
+      osDisk:
+        diskStorageAccountType: Premium_LRS
+        sizeGiB: 120
+      subnetID: fakeSubnetID
+      vmSize: Standard_D4s_v5
+    type: Azure
+  release:
+    image: ""
+  replicas: 0
+status:
+  replicas: 0
+---

--- a/product-cli/cmd/cluster/kubevirt/create_test.go
+++ b/product-cli/cmd/cluster/kubevirt/create_test.go
@@ -1,0 +1,184 @@
+package kubevirt
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/testutil"
+	"github.com/openshift/hypershift/test/integration/framework"
+
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "When KubeVirt create command is created, it should have 'kubevirt' as use",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+				g.Expect(cmd.Use).To(Equal("kubevirt"))
+			},
+		},
+		{
+			name: "When KubeVirt create command is created, it should register infra-kubeconfig-file flag",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+				g.Expect(cmd.Flag("infra-kubeconfig-file")).ToNot(BeNil())
+			},
+		},
+		{
+			name: "When KubeVirt create command is created, it should register nodepool flags",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+
+				g.Expect(cmd.Flag("memory")).ToNot(BeNil())
+				g.Expect(cmd.Flag("cores")).ToNot(BeNil())
+				g.Expect(cmd.Flag("root-volume-storage-class")).ToNot(BeNil())
+				g.Expect(cmd.Flag("root-volume-size")).ToNot(BeNil())
+			},
+		},
+		{
+			name: "When KubeVirt create command is created, it should not register developer-only flags",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+
+				g.Expect(cmd.Flag("api-server-address")).To(BeNil(), "api-server-address is a developer-only flag")
+				g.Expect(cmd.Flag("service-publishing-strategy")).To(BeNil(), "service-publishing-strategy is a developer-only flag")
+				g.Expect(cmd.Flag("containerdisk")).To(BeNil(), "containerdisk is a developer-only flag")
+			},
+		},
+		{
+			name: "When KubeVirt create command is added to a parent, pull-secret should be inherited",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+
+				parent := &cobra.Command{Use: "cluster"}
+				core.BindOptions(opts, parent.PersistentFlags())
+
+				cmd := NewCreateCommand(opts)
+				parent.AddCommand(cmd)
+
+				pullSecretFlag := cmd.InheritedFlags().Lookup("pull-secret")
+				g.Expect(pullSecretFlag).ToNot(BeNil(), "pull-secret should be inherited from parent command")
+			},
+		},
+		{
+			name: "When KubeVirt create command is created, it should register exactly the expected flags",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+
+				expectedFlags := []string{
+					"additional-network",
+					"attach-default-network",
+					"cores",
+					"host-device-name",
+					"infra-kubeconfig-file",
+					"infra-namespace",
+					"infra-storage-class-mapping",
+					"infra-volumesnapshot-class-mapping",
+					"memory",
+					"network-multiqueue",
+					"qos-class",
+					"root-volume-access-modes",
+					"root-volume-cache-strategy",
+					"root-volume-size",
+					"root-volume-storage-class",
+					"root-volume-volume-mode",
+					"vm-node-selector",
+				}
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				sort.Strings(actualFlags)
+				g.Expect(actualFlags).To(Equal(expectedFlags))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.test(t)
+		})
+	}
+}
+
+func TestCreateCluster(t *testing.T) {
+	utilrand.Seed(1234567890)
+	certs.UnsafeSeed(1234567890)
+	ctx := framework.InterruptableContext(t.Context())
+	tempDir := t.TempDir()
+	t.Setenv("FAKE_CLIENT", "true")
+
+	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
+	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
+		t.Fatalf("failed to write pullSecret: %v", err)
+	}
+
+	for _, testCase := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "When minimal flags are provided, it should render correctly",
+			args: []string{
+				"--render-sensitive",
+				"--name=example",
+				"--pull-secret=" + pullSecretFile,
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
+			coreOpts := core.DefaultOptions()
+			core.BindOptions(coreOpts, flags)
+			kubevirtOpts := kubevirt.DefaultOptions()
+			kubevirt.BindOptions(kubevirtOpts, flags)
+			if err := flags.Parse(testCase.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			tempDir := t.TempDir()
+			manifestsFile := filepath.Join(tempDir, "manifests.yaml")
+			coreOpts.Render = true
+			coreOpts.RenderInto = manifestsFile
+
+			if err := core.CreateCluster(ctx, coreOpts, kubevirtOpts); err != nil {
+				t.Fatalf("failed to create cluster: %v", err)
+			}
+
+			manifests, err := os.ReadFile(manifestsFile)
+			if err != nil {
+				t.Fatalf("failed to read manifests file: %v", err)
+			}
+			testutil.CompareWithFixture(t, manifests)
+		})
+	}
+}

--- a/product-cli/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_When_minimal_flags_are_provided__it_should_render_correctly.yaml
+++ b/product-cli/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_When_minimal_flags_are_provided__it_should_render_correctly.yaml
@@ -1,0 +1,119 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clusters
+spec: {}
+status: {}
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: ZmFrZQ==
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-pull-secret
+  namespace: clusters
+---
+apiVersion: v1
+data:
+  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  autoscaling: {}
+  capabilities: {}
+  configuration: {}
+  controllerAvailabilityPolicy: SingleReplica
+  dns:
+    baseDomain: ""
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: 8Gi
+        type: PersistentVolume
+    managementType: Managed
+  fips: false
+  infraID: example-sffhb
+  networking:
+    clusterNetwork:
+    - cidr: 10.132.0.0/14
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - cidr: 172.31.0.0/16
+  olmCatalogPlacement: management
+  platform:
+    kubevirt:
+      baseDomainPassthrough: true
+    type: KubeVirt
+  pullSecret:
+    name: example-pull-secret
+  release:
+    image: ""
+  secretEncryption:
+    aescbc:
+      activeKey:
+        name: example-etcd-encryption-key
+    type: aescbc
+  services:
+  - service: APIServer
+    servicePublishingStrategy:
+      type: LoadBalancer
+  - service: Ignition
+    servicePublishingStrategy:
+      type: Route
+  - service: Konnectivity
+    servicePublishingStrategy:
+      type: Route
+  - service: OAuthServer
+    servicePublishingStrategy:
+      type: Route
+  sshKey: {}
+status:
+  controlPlaneEndpoint:
+    host: ""
+    port: 0
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  arch: amd64
+  clusterName: example
+  management:
+    autoRepair: false
+    upgradeType: Replace
+  nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
+  platform:
+    kubevirt:
+      attachDefaultNetwork: true
+      compute:
+        cores: 2
+        memory: 4Gi
+      networkInterfaceMultiqueue: Enable
+      rootVolume:
+        persistent:
+          size: 32Gi
+        type: Persistent
+    type: KubeVirt
+  release:
+    image: ""
+  replicas: 0
+status:
+  replicas: 0
+---

--- a/product-cli/cmd/cluster/openstack/create_test.go
+++ b/product-cli/cmd/cluster/openstack/create_test.go
@@ -1,0 +1,202 @@
+package openstack
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/cluster/openstack"
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/testutil"
+	"github.com/openshift/hypershift/test/integration/framework"
+
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "When OpenStack create command is created, it should have 'openstack' as use",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+				g.Expect(cmd.Use).To(Equal("openstack"))
+			},
+		},
+		{
+			name: "When OpenStack create command is created, it should register credential flags",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+
+				g.Expect(cmd.Flag("openstack-credentials-file")).ToNot(BeNil())
+				g.Expect(cmd.Flag("openstack-ca-cert-file")).ToNot(BeNil())
+			},
+		},
+		{
+			name: "When OpenStack create command is created, it should register cloud configuration flags",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+
+				g.Expect(cmd.Flag("openstack-cloud")).ToNot(BeNil())
+				g.Expect(cmd.Flag("openstack-external-network-id")).ToNot(BeNil())
+				g.Expect(cmd.Flag("openstack-ingress-floating-ip")).ToNot(BeNil())
+				g.Expect(cmd.Flag("openstack-dns-nameservers")).ToNot(BeNil())
+			},
+		},
+		{
+			name: "When OpenStack create command is created, it should register nodepool flags",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+
+				g.Expect(cmd.Flag("openstack-node-flavor")).ToNot(BeNil())
+				g.Expect(cmd.Flag("openstack-node-image-name")).ToNot(BeNil())
+				g.Expect(cmd.Flag("openstack-node-availability-zone")).ToNot(BeNil())
+			},
+		},
+		{
+			name: "When OpenStack create command is added to a parent, pull-secret should be inherited",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+
+				parent := &cobra.Command{Use: "cluster"}
+				core.BindOptions(opts, parent.PersistentFlags())
+
+				cmd := NewCreateCommand(opts)
+				parent.AddCommand(cmd)
+
+				pullSecretFlag := cmd.InheritedFlags().Lookup("pull-secret")
+				g.Expect(pullSecretFlag).ToNot(BeNil(), "pull-secret should be inherited from parent command")
+			},
+		},
+		{
+			name: "When OpenStack create command is created, it should register exactly the expected flags",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				opts := core.DefaultOptions()
+				cmd := NewCreateCommand(opts)
+
+				expectedFlags := []string{
+					"openstack-ca-cert-file",
+					"openstack-cloud",
+					"openstack-credentials-file",
+					"openstack-dns-nameservers",
+					"openstack-external-network-id",
+					"openstack-ingress-floating-ip",
+					"openstack-node-additional-port",
+					"openstack-node-availability-zone",
+					"openstack-node-flavor",
+					"openstack-node-image-name",
+				}
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				sort.Strings(actualFlags)
+				g.Expect(actualFlags).To(Equal(expectedFlags))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.test(t)
+		})
+	}
+}
+
+func TestCreateCluster(t *testing.T) {
+	utilrand.Seed(1234567890)
+	certs.UnsafeSeed(1234567890)
+	ctx := framework.InterruptableContext(t.Context())
+	tempDir := t.TempDir()
+	t.Setenv("FAKE_CLIENT", "true")
+	t.Setenv("OS_CLOUD", "")
+
+	cloudsYAML := map[string]interface{}{
+		"clouds": map[string]interface{}{
+			"openstack": map[string]interface{}{
+				"auth": map[string]interface{}{
+					"auth_url": "fakeAuthURL",
+				},
+			},
+		},
+	}
+	cloudsData, err := yaml.Marshal(cloudsYAML)
+	if err != nil {
+		t.Fatalf("failed to marshal clouds.yaml: %v", err)
+	}
+	credentialsFile := filepath.Join(tempDir, "clouds.yaml")
+	if err := os.WriteFile(credentialsFile, cloudsData, 0600); err != nil {
+		t.Fatalf("failed to write creds: %v", err)
+	}
+
+	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
+	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
+		t.Fatalf("failed to write pullSecret: %v", err)
+	}
+
+	for _, testCase := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "When minimal flags are provided, it should render correctly",
+			args: []string{
+				"--openstack-credentials-file=" + credentialsFile,
+				"--openstack-node-flavor=m1.xlarge",
+				"--openstack-node-image-name=rhcos",
+				"--pull-secret=" + pullSecretFile,
+				"--render-sensitive",
+				"--name=example",
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
+			coreOpts := core.DefaultOptions()
+			core.BindOptions(coreOpts, flags)
+			openstackOpts := openstack.DefaultOptions()
+			openstack.BindOptions(openstackOpts, flags)
+			if err := flags.Parse(testCase.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			tempDir := t.TempDir()
+			manifestsFile := filepath.Join(tempDir, "manifests.yaml")
+			coreOpts.Render = true
+			coreOpts.RenderInto = manifestsFile
+
+			if err := core.CreateCluster(ctx, coreOpts, openstackOpts); err != nil {
+				t.Fatalf("failed to create cluster: %v", err)
+			}
+
+			manifests, err := os.ReadFile(manifestsFile)
+			if err != nil {
+				t.Fatalf("failed to read manifests file: %v", err)
+			}
+			testutil.CompareWithFixture(t, manifests)
+		})
+	}
+}

--- a/product-cli/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_When_minimal_flags_are_provided__it_should_render_correctly.yaml
+++ b/product-cli/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_When_minimal_flags_are_provided__it_should_render_correctly.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clusters
+spec: {}
+status: {}
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: ZmFrZQ==
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-pull-secret
+  namespace: clusters
+---
+apiVersion: v1
+data:
+  clouds.yaml: Y2xvdWRzOgogICAgb3BlbnN0YWNrOgogICAgICAgIGF1dGg6CiAgICAgICAgICAgIGF1dGhfdXJsOiBmYWtlQXV0aFVSTAo=
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-cloud-credentials
+  namespace: clusters
+type: Opaque
+---
+apiVersion: v1
+data:
+  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  autoscaling: {}
+  capabilities: {}
+  configuration: {}
+  controllerAvailabilityPolicy: SingleReplica
+  dns:
+    baseDomain: ""
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: 8Gi
+        type: PersistentVolume
+    managementType: Managed
+  fips: false
+  infraID: example-sffhb
+  networking:
+    clusterNetwork:
+    - cidr: 10.132.0.0/14
+    machineNetwork:
+    - cidr: 10.0.0.0/16
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - cidr: 172.31.0.0/16
+  olmCatalogPlacement: management
+  platform:
+    openstack:
+      identityRef:
+        cloudName: openstack
+        name: example-cloud-credentials
+    type: OpenStack
+  pullSecret:
+    name: example-pull-secret
+  release:
+    image: ""
+  secretEncryption:
+    aescbc:
+      activeKey:
+        name: example-etcd-encryption-key
+    type: aescbc
+  services:
+  - service: APIServer
+    servicePublishingStrategy:
+      type: LoadBalancer
+  - service: Ignition
+    servicePublishingStrategy:
+      type: Route
+  - service: Konnectivity
+    servicePublishingStrategy:
+      type: Route
+  - service: OAuthServer
+    servicePublishingStrategy:
+      type: Route
+  sshKey: {}
+status:
+  controlPlaneEndpoint:
+    host: ""
+    port: 0
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  arch: amd64
+  clusterName: example
+  management:
+    autoRepair: false
+    upgradeType: Replace
+  nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
+  platform:
+    openstack:
+      flavor: m1.xlarge
+      imageName: rhcos
+    type: OpenStack
+  release:
+    image: ""
+  replicas: 0
+status:
+  replicas: 0
+---


### PR DESCRIPTION
The four platforms — AWS, KubeVirt, OpenStack, and Agent — have no product-cli cluster creation tests at all.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

| File | Subtests | What's Tested |
| --- | --- | --- |
| aws/create_test.go | 10 | Use field, release stream, region/volume/endpoint defaults, product credential flags, developer-only flag exclusion, pull-secret required, exact 25-flag enumeration |
| kubevirt/create_test.go | 5 | Use field, infra-kubeconfig-file, nodepool flags, developer-only flag exclusion, exact 17-flag enumeration |
| openstack/create_test.go | 5 | Use field, credential flags, cloud config flags, nodepool flags, exact 10-flag enumeration |
| agent/create_test.go | 4 | Use field, agent-namespace required, pull-secret required (with parent command), exact 3-flag enumeration |



## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3890

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added/expanded unit and manifest-rendering tests for cluster creation commands across agent, AWS, KubeVirt, OpenStack, and Azure.
  * Verified each create command’s identity plus key default values (including release stream–related behavior where applicable).
  * Confirmed correct inheritance of shared options such as `pull-secret`.
  * Ensured developer-only flags are excluded and validated the exact allowlisted set of user-facing flags (including required flag annotations for shell completion).
  * Compared rendered manifests against stored fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->