### PR TITLE
OCPBUGS-83564: Apply registry overrides to release image pullspec before fetching

### DIFF
--- a/support/releaseinfo/registry_mirror_provider.go
+++ b/support/releaseinfo/registry_mirror_provider.go
@@ -28,7 +28,12 @@ func (p *RegistryMirrorProviderDecorator) Lookup(ctx context.Context, image stri
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	releaseImage, err := p.Delegate.Lookup(ctx, image, pullSecret)
+	// Apply registry overrides to the release image pullspec itself before
+	// fetching. Without this, non-OpenShift management clusters (which lack
+	// IDMS/ICSP) cannot redirect the initial registry pull to a mirror.
+	overriddenImage := registryoverride.Replace(image, p.RegistryOverrides)
+
+	releaseImage, err := p.Delegate.Lookup(ctx, overriddenImage, pullSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/support/releaseinfo/registry_mirror_provider_test.go
+++ b/support/releaseinfo/registry_mirror_provider_test.go
@@ -1,0 +1,137 @@
+package releaseinfo
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	imageapi "github.com/openshift/api/image/v1"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/coreos/stream-metadata-go/stream"
+)
+
+func TestRegistryMirrorProviderDecoratorLookup(t *testing.T) {
+	releaseImageWithTags := &ReleaseImage{
+		ImageStream: &imageapi.ImageStream{
+			Spec: imageapi.ImageStreamSpec{
+				Tags: []imageapi.TagReference{
+					{
+						Name: "hypershift",
+						From: &corev1.ObjectReference{
+							Name: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:def456",
+						},
+					},
+				},
+			},
+		},
+		StreamMetadata: &stream.Stream{},
+	}
+
+	releaseImageNoTags := &ReleaseImage{
+		ImageStream: &imageapi.ImageStream{
+			Spec: imageapi.ImageStreamSpec{},
+		},
+		StreamMetadata: &stream.Stream{},
+	}
+
+	tests := []struct {
+		name              string
+		image             string
+		registryOverrides map[string]string
+		delegateImage     *ReleaseImage
+		delegateErr       error
+		wantDelegateImage string
+		wantTagName       string
+		wantErr           bool
+		wantErrContains   string
+	}{
+		{
+			name:  "When registry overrides match the release image, it should pass the overridden image to the delegate",
+			image: "quay.io/openshift-release-dev/ocp-release-nightly@sha256:abc123",
+			registryOverrides: map[string]string{
+				"quay.io/openshift-release-dev": "myregistry.example.com/openshift-release-dev",
+			},
+			delegateImage:     releaseImageWithTags,
+			wantDelegateImage: "myregistry.example.com/openshift-release-dev/ocp-release-nightly@sha256:abc123",
+			wantTagName:       "myregistry.example.com/openshift-release-dev/ocp-v4.0-art-dev@sha256:def456",
+		},
+		{
+			name:  "When no registry override matches the image, it should pass the original image to the delegate",
+			image: "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
+			registryOverrides: map[string]string{
+				"registry.example.com/no-match": "mirror.example.com/no-match",
+			},
+			delegateImage:     releaseImageWithTags,
+			wantDelegateImage: "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
+		},
+		{
+			name:              "When registry overrides map is empty, it should pass the original image to the delegate",
+			image:             "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
+			registryOverrides: map[string]string{},
+			delegateImage:     releaseImageNoTags,
+			wantDelegateImage: "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
+		},
+		{
+			name:  "When the delegate returns an error, it should propagate the error",
+			image: "quay.io/org/repo@sha256:abc",
+			registryOverrides: map[string]string{
+				"quay.io": "mirror.example.com",
+			},
+			delegateErr:     fmt.Errorf("connection refused"),
+			wantErr:         true,
+			wantErrContains: "connection refused",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			var lookedUpImage string
+			provider := &RegistryMirrorProviderDecorator{
+				Delegate: &fakeProvider{
+					lookupFn: func(_ context.Context, image string, _ []byte) (*ReleaseImage, error) {
+						lookedUpImage = image
+						if tt.delegateErr != nil {
+							return nil, tt.delegateErr
+						}
+						return tt.delegateImage, nil
+					},
+				},
+				RegistryOverrides: tt.registryOverrides,
+				lock:              sync.Mutex{},
+			}
+
+			result, err := provider.Lookup(t.Context(), tt.image, []byte(`{"auths":{}}`))
+
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				if tt.wantErrContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.wantErrContains))
+				}
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(lookedUpImage).To(Equal(tt.wantDelegateImage))
+
+			if tt.wantTagName != "" {
+				g.Expect(result.ImageStream.Spec.Tags[0].From.Name).To(Equal(tt.wantTagName))
+			}
+		})
+	}
+}
+
+// fakeProvider is a test helper that delegates Lookup to a caller-supplied function.
+type fakeProvider struct {
+	lookupFn func(ctx context.Context, image string, pullSecret []byte) (*ReleaseImage, error)
+}
+
+func (f *fakeProvider) Lookup(ctx context.Context, image string, pullSecret []byte) (*ReleaseImage, error) {
+	return f.lookupFn(ctx, image, pullSecret)
+}


### PR DESCRIPTION
## What this PR does / why we need it:

On non-OpenShift management clusters (e.g., AKS), the `--registry-overrides` flag was not being applied to the release image pullspec when extracting release metadata. The `RegistryMirrorProviderDecorator` only applied overrides to component images *after* extraction, not to the release image used for the initial registry fetch.

Since non-OpenShift clusters lack IDMS/ICSP CRDs, the `ProviderWithOpenShiftImageRegistryOverridesDecorator` has an empty override map and cannot redirect the fetch either. This caused "unauthorized" errors when using nightly OCP releases that require authentication, because the fetch hit `quay.io` directly instead of the configured mirror registry.

This PR applies `registryoverride.Replace()` to the `image` parameter before delegating to the inner provider, so the release image pullspec is redirected to the configured mirror registry.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-83564

## Special notes for your reviewer:

The fix is a single line addition in `RegistryMirrorProviderDecorator.Lookup`. It reuses the existing `registryoverride.Replace` function (already used for component image overrides on line 45) to also override the release image pullspec before the initial fetch.

GA releases (`ocp-release`) were unaffected because they are publicly accessible. Nightly releases (`ocp-release-nightly`) require authentication, so without the override redirect to the mirror, the fetch fails.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registry mirror overrides are now applied before release image lookup, ensuring initial image pulls are redirected to the configured mirror.
  * Existing image reference rewriting remains supported for returned release metadata.
  * Improved validation covers matching overrides, unmatched registries, empty configurations, and lookup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->