### PR TITLE
CNTRLPLANE-3920: Update OIDC deletion health check error matching for AWS SDK v2

### DIFF
--- a/control-plane-operator/controllers/healthcheck/aws.go
+++ b/control-plane-operator/controllers/healthcheck/aws.go
@@ -52,7 +52,7 @@ func awsHealthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedCont
 		if errors.As(err, &apiErr) {
 			// When apiErr.ErrorCode() is WebIdentityErr it's likely to be an external issue, e.g. the idp resource was deleted.
 			// We don't set apiErr.ErrorMessage() in the condition as it might contain aws requests IDs that would make the condition be updated in loop.
-			if apiErr.ErrorCode() == "WebIdentityErr" {
+			if apiErr.ErrorCode() == "WebIdentityErr" || apiErr.ErrorCode() == "InvalidIdentityToken" {
 				condition := metav1.Condition{
 					Type:               string(hyperv1.ValidAWSIdentityProvider),
 					ObservedGeneration: hcp.Generation,


### PR DESCRIPTION
## Summary
- Update the `ValidAWSIdentityProvider` health check to match the `InvalidIdentityToken` error code from AWS SDK v2, in addition to the existing `WebIdentityErr` check from SDK v1
- Without this fix, the `OIDCMissingFleetNotification` alert never fires when a customer deletes their OIDC provider, preventing automatic limited support placement

## Bug
https://redhat.atlassian.net/browse/CNTRLPLANE-3920

## Root Cause
The SDK v2 migration (CNTRLPLANE-2219, #7871) changed the error type from `awserr.Error` to `smithy.APIError`, but the error code check on [aws.go#L55](https://github.com/openshift/hypershift/blob/main/control-plane-operator/controllers/healthcheck/aws.go#L55) still checks for `"WebIdentityErr"` (SDK v1). The SDK v2 `smithy.APIError` returns `"InvalidIdentityToken"` instead, causing the condition to be set to `Unknown` (metric=2) instead of `False` (metric=1).

## Reproduction
Reproduced on integration HCP cluster `maclarkint0724` (MC `hs-mc-n1j3kghkg`):

1. Deleted the OIDC provider via `aws iam delete-open-id-connect-provider`
2. After health check cycle, observed `ValidAWSIdentityProvider` condition:
   - **status:** `Unknown` (expected: `False`)
   - **reason:** `AWSError` (expected: `InvalidIdentityProvider`)
   - **message:** `InvalidIdentityToken`
3. Metric `hypershift_cluster_invalid_aws_creds` reported `2` (expected: `1`)
4. `OIDCMissingFleetNotification` alert did not fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS identity provider health checks by treating additional invalid identity token errors as non-actionable identity issues.
  * Hosted control planes now set the `ValidAWSIdentityProvider` condition to “Invalid identity provider” for these cases, instead of showing an unknown/error state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->