### PR TITLE
CNTRLPLANE-3893: Add product-cli unit tests for destroy cluster

### DIFF
--- a/product-cli/cmd/cluster/agent/destroy_test.go
+++ b/product-cli/cmd/cluster/agent/destroy_test.go
@@ -1,0 +1,46 @@
+package agent
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+
+	"github.com/spf13/pflag"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		verify func(t *testing.T, opts *core.DestroyOptions)
+	}{
+		"When Agent destroy command is created, it should have 'agent' as use": {
+			verify: func(t *testing.T, opts *core.DestroyOptions) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand(opts)
+				g.Expect(cmd.Use).To(Equal("agent"))
+			},
+		},
+		"When Agent destroy command is created, it should register no platform-specific flags": {
+			verify: func(t *testing.T, opts *core.DestroyOptions) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand(opts)
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				g.Expect(actualFlags).To(BeEmpty())
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			opts := &core.DestroyOptions{}
+			test.verify(t, opts)
+		})
+	}
+}

--- a/product-cli/cmd/cluster/azure/destroy_test.go
+++ b/product-cli/cmd/cluster/azure/destroy_test.go
@@ -1,0 +1,94 @@
+package azure
+
+import (
+	"sort"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		verify func(t *testing.T, opts *core.DestroyOptions)
+	}{
+		"When Azure destroy command is created, it should have 'azure' as use": {
+			verify: func(t *testing.T, opts *core.DestroyOptions) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand(opts)
+				g.Expect(cmd.Use).To(Equal("azure"))
+			},
+		},
+		"When Azure destroy command is created, it should default location to eastus": {
+			verify: func(t *testing.T, opts *core.DestroyOptions) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand(opts)
+				g.Expect(opts.AzurePlatform.Location).To(Equal("eastus"))
+				g.Expect(cmd.Flag("location").DefValue).To(Equal("eastus"))
+			},
+		},
+		"When Azure destroy command is created, it should mark azure-creds as required": {
+			verify: func(t *testing.T, opts *core.DestroyOptions) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand(opts)
+
+				azureCredsFlag := cmd.Flag("azure-creds")
+				g.Expect(azureCredsFlag).ToNot(BeNil())
+				g.Expect(azureCredsFlag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(azureCredsFlag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		"When Azure destroy command is created, it should mark dns-zone-rg-name as required": {
+			verify: func(t *testing.T, opts *core.DestroyOptions) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand(opts)
+
+				dnsZoneFlag := cmd.Flag("dns-zone-rg-name")
+				g.Expect(dnsZoneFlag).ToNot(BeNil())
+				g.Expect(dnsZoneFlag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(dnsZoneFlag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		"When Azure destroy command is created, it should default preserve-resource-group to false": {
+			verify: func(t *testing.T, opts *core.DestroyOptions) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand(opts)
+				g.Expect(opts.AzurePlatform.PreserveResourceGroup).To(BeFalse())
+				g.Expect(cmd.Flag("preserve-resource-group").DefValue).To(Equal("false"))
+			},
+		},
+		"When Azure destroy command is created, it should register exactly the expected flags": {
+			verify: func(t *testing.T, opts *core.DestroyOptions) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand(opts)
+				expectedFlags := []string{
+					"azure-creds",
+					"dns-zone-rg-name",
+					"location",
+					"preserve-resource-group",
+					"resource-group-name",
+				}
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				sort.Strings(actualFlags)
+				g.Expect(actualFlags).To(Equal(expectedFlags))
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			opts := &core.DestroyOptions{}
+			test.verify(t, opts)
+		})
+	}
+}

--- a/product-cli/cmd/cluster/kubevirt/destroy_test.go
+++ b/product-cli/cmd/cluster/kubevirt/destroy_test.go
@@ -1,0 +1,46 @@
+package kubevirt
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+
+	"github.com/spf13/pflag"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		verify func(t *testing.T, opts *core.DestroyOptions)
+	}{
+		"When KubeVirt destroy command is created, it should have 'kubevirt' as use": {
+			verify: func(t *testing.T, opts *core.DestroyOptions) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand(opts)
+				g.Expect(cmd.Use).To(Equal("kubevirt"))
+			},
+		},
+		"When KubeVirt destroy command is created, it should register no platform-specific flags": {
+			verify: func(t *testing.T, opts *core.DestroyOptions) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand(opts)
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				g.Expect(actualFlags).To(BeEmpty())
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			opts := &core.DestroyOptions{}
+			test.verify(t, opts)
+		})
+	}
+}

--- a/product-cli/cmd/cluster/openstack/destroy_test.go
+++ b/product-cli/cmd/cluster/openstack/destroy_test.go
@@ -1,0 +1,46 @@
+package openstack
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+
+	"github.com/spf13/pflag"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		verify func(t *testing.T, opts *core.DestroyOptions)
+	}{
+		"When OpenStack destroy command is created, it should have 'openstack' as use": {
+			verify: func(t *testing.T, opts *core.DestroyOptions) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand(opts)
+				g.Expect(cmd.Use).To(Equal("openstack"))
+			},
+		},
+		"When OpenStack destroy command is created, it should register no platform-specific flags": {
+			verify: func(t *testing.T, opts *core.DestroyOptions) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand(opts)
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				g.Expect(actualFlags).To(BeEmpty())
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			opts := &core.DestroyOptions{}
+			test.verify(t, opts)
+		})
+	}
+}


### PR DESCRIPTION
The four platforms - Agent, Azure, KubeVirt and OpenStack have no product-cli cluster destroy tests at all.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

| File | Subtests | What's tested |
| --- | --- | --- |
| azure/destroy_test.go | 6 | Use field, location default (`eastus`), azure-creds required, dns-zone-rg-name required, preserve-resource-group default (`false`), exact 5-flag enumeration |
| kubevirt/destroy_test.go | 2 | Use field, no platform-specific flags |
| openstack/destroy_test.go | 2 | Use field, no platform-specific flags |
| agent/destroy_test.go | 2 | Use field, no platform-specific flags |


## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3893

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for cluster destroy commands across Agent, Azure, KubeVirt, and OpenStack platforms.
  * Verified command names, supported flags, default values, and required Azure options.
  * Confirmed Azure resource preservation defaults to disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->