### PR TITLE
OCPBUGS-94251: Add CEL duration validation to NodePool drain/detach timeouts

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -186,7 +186,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self.matches('^0s$') || self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))",message="nodeDrainTimeout must be a non-negative duration"
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
@@ -196,7 +197,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self.matches('^0s$') || self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))",message="nodeVolumeDetachTimeout must be a non-negative duration"
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// nodeLabels propagates a list of labels to Nodes, only once on creation.

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -184,6 +184,8 @@ type NodePoolSpec struct {
 	// The default value is 0, meaning that the node can retry drain without any time limitations.
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
+	// +kubebuilder:validation:Type:=string
+	// +kubebuilder:validation:XValidation:rule="self.matches('^([0-9]+(\\\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
@@ -191,6 +193,8 @@ type NodePoolSpec struct {
 	// After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
+	// +kubebuilder:validation:Type:=string
+	// +kubebuilder:validation:XValidation:rule="self.matches('^([0-9]+(\\\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// nodeLabels propagates a list of labels to Nodes, only once on creation.

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -185,7 +185,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self.matches('^([0-9]+(\\\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
+	// +kubebuilder:validation:XValidation:rule="!self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$') || duration(self) >= duration('0s')",message="nodeDrainTimeout must be a non-negative duration"
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
@@ -194,7 +195,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self.matches('^([0-9]+(\\\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
+	// +kubebuilder:validation:XValidation:rule="!self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$') || duration(self) >= duration('0s')",message="nodeVolumeDetachTimeout must be a non-negative duration"
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// nodeLabels propagates a list of labels to Nodes, only once on creation.

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -186,8 +186,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'",optionalOldSelf=true
-	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('0s')",message="nodeDrainTimeout must be a non-negative duration",optionalOldSelf=true
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
+	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('0s')",message="nodeDrainTimeout must be a non-negative duration"
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
@@ -197,8 +197,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'",optionalOldSelf=true
-	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('0s')",message="nodeVolumeDetachTimeout must be a non-negative duration",optionalOldSelf=true
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
+	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('0s')",message="nodeVolumeDetachTimeout must be a non-negative duration"
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// nodeLabels propagates a list of labels to Nodes, only once on creation.

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -181,22 +181,22 @@ type NodePoolSpec struct {
 	Config []corev1.LocalObjectReference `json:"config,omitempty"`
 
 	// nodeDrainTimeout is the maximum amount of time that the controller will spend on retrying to drain a node until it succeeds.
-	// The default value is 0, meaning that the node can retry drain without any time limitations.
+	// When omitted or set to 0s, the node can retry drain without any time limitations.
+	// Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
-	// +kubebuilder:validation:XValidation:rule="!self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$') || duration(self) >= duration('0s')",message="nodeDrainTimeout must be a non-negative duration"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^0s$') || self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
-	// The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+	// When omitted or set to 0s, the volumes will be detached from the node without any time limitations.
 	// After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
+	// Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
-	// +kubebuilder:validation:XValidation:rule="!self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$') || duration(self) >= duration('0s')",message="nodeVolumeDetachTimeout must be a non-negative duration"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^0s$') || self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// nodeLabels propagates a list of labels to Nodes, only once on creation.

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -186,8 +186,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
-	// +kubebuilder:validation:XValidation:rule="self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))",message="nodeDrainTimeout must be a non-negative duration"
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'",optionalOldSelf=true
+	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('0s')",message="nodeDrainTimeout must be a non-negative duration",optionalOldSelf=true
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
@@ -197,8 +197,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
-	// +kubebuilder:validation:XValidation:rule="self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))",message="nodeVolumeDetachTimeout must be a non-negative duration"
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'",optionalOldSelf=true
+	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('0s')",message="nodeVolumeDetachTimeout must be a non-negative duration",optionalOldSelf=true
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// nodeLabels propagates a list of labels to Nodes, only once on creation.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -317,7 +317,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -336,7 +338,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -313,6 +313,10 @@ spec:
                   The default value is 0, meaning that the node can retry drain without any time limitations.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeDrainTimeout must be a valid duration string with a
+                    unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -327,6 +331,10 @@ spec:
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeVolumeDetachTimeout must be a valid duration string
+                    with a unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -316,7 +316,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -334,7 +337,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -317,9 +317,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeDrainTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -338,9 +340,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -310,16 +310,14 @@ spec:
               nodeDrainTimeout:
                 description: |-
                   nodeDrainTimeout is the maximum amount of time that the controller will spend on retrying to drain a node until it succeeds.
-                  The default value is 0, meaning that the node can retry drain without any time limitations.
+                  When omitted or set to 0s, the node can retry drain without any time limitations.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
-                    unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeDrainTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -330,17 +328,15 @@ spec:
               nodeVolumeDetachTimeout:
                 description: |-
                   nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
-                  The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+                  When omitted or set to 0s, the volumes will be detached from the node without any time limitations.
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
-                    with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -317,7 +317,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -336,7 +338,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -313,6 +313,10 @@ spec:
                   The default value is 0, meaning that the node can retry drain without any time limitations.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeDrainTimeout must be a valid duration string with a
+                    unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -327,6 +331,10 @@ spec:
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeVolumeDetachTimeout must be a valid duration string
+                    with a unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -316,7 +316,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -334,7 +337,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -317,9 +317,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeDrainTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -338,9 +340,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -310,16 +310,14 @@ spec:
               nodeDrainTimeout:
                 description: |-
                   nodeDrainTimeout is the maximum amount of time that the controller will spend on retrying to drain a node until it succeeds.
-                  The default value is 0, meaning that the node can retry drain without any time limitations.
+                  When omitted or set to 0s, the node can retry drain without any time limitations.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
-                    unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeDrainTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -330,17 +328,15 @@ spec:
               nodeVolumeDetachTimeout:
                 description: |-
                   nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
-                  The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+                  When omitted or set to 0s, the volumes will be detached from the node without any time limitations.
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
-                    with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
@@ -317,7 +317,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -336,7 +338,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
@@ -316,7 +316,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -334,7 +337,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
@@ -313,6 +313,10 @@ spec:
                   The default value is 0, meaning that the node can retry drain without any time limitations.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeDrainTimeout must be a valid duration string with a
+                    unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -327,6 +331,10 @@ spec:
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeVolumeDetachTimeout must be a valid duration string
+                    with a unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
@@ -317,9 +317,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeDrainTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -338,9 +340,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
@@ -310,16 +310,14 @@ spec:
               nodeDrainTimeout:
                 description: |-
                   nodeDrainTimeout is the maximum amount of time that the controller will spend on retrying to drain a node until it succeeds.
-                  The default value is 0, meaning that the node can retry drain without any time limitations.
+                  When omitted or set to 0s, the node can retry drain without any time limitations.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
-                    unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeDrainTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -330,17 +328,15 @@ spec:
               nodeVolumeDetachTimeout:
                 description: |-
                   nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
-                  The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+                  When omitted or set to 0s, the volumes will be detached from the node without any time limitations.
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
-                    with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -317,7 +317,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -336,7 +338,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -313,6 +313,10 @@ spec:
                   The default value is 0, meaning that the node can retry drain without any time limitations.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeDrainTimeout must be a valid duration string with a
+                    unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -327,6 +331,10 @@ spec:
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeVolumeDetachTimeout must be a valid duration string
+                    with a unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -316,7 +316,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -334,7 +337,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -317,9 +317,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeDrainTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -338,9 +340,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -310,16 +310,14 @@ spec:
               nodeDrainTimeout:
                 description: |-
                   nodeDrainTimeout is the maximum amount of time that the controller will spend on retrying to drain a node until it succeeds.
-                  The default value is 0, meaning that the node can retry drain without any time limitations.
+                  When omitted or set to 0s, the node can retry drain without any time limitations.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
-                    unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeDrainTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -330,17 +328,15 @@ spec:
               nodeVolumeDetachTimeout:
                 description: |-
                   nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
-                  The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+                  When omitted or set to 0s, the volumes will be detached from the node without any time limitations.
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
-                    with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.validation.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.validation.testsuite.yaml
@@ -512,3 +512,209 @@ tests:
               id: "subnet-any"
           type: AWS
     expectedError: "The 'rollingUpdate' field can only be set when 'strategy' is 'RollingUpdate'"
+
+  # --- nodeDrainTimeout validation ---
+  - name: when nodeDrainTimeout has no unit suffix it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeDrainTimeout: "1"
+    expectedError: "nodeDrainTimeout must be a valid duration string with a unit suffix"
+
+  - name: when nodeDrainTimeout is a non-numeric string it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeDrainTimeout: "abc"
+    expectedError: "nodeDrainTimeout must be a valid duration string with a unit suffix"
+
+  - name: when nodeDrainTimeout is a valid simple duration it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeDrainTimeout: "30s"
+
+  - name: when nodeDrainTimeout is a valid compound duration it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeDrainTimeout: "1h30m"
+
+  # --- nodeVolumeDetachTimeout validation ---
+  - name: when nodeVolumeDetachTimeout has no unit suffix it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeVolumeDetachTimeout: "1"
+    expectedError: "nodeVolumeDetachTimeout must be a valid duration string with a unit suffix"
+
+  - name: when nodeVolumeDetachTimeout is a non-numeric string it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeVolumeDetachTimeout: "abc"
+    expectedError: "nodeVolumeDetachTimeout must be a valid duration string with a unit suffix"
+
+  - name: when nodeVolumeDetachTimeout is a valid simple duration it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeVolumeDetachTimeout: "5m"
+
+  - name: when nodeVolumeDetachTimeout is a valid compound duration it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeVolumeDetachTimeout: "2h45m"

--- a/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.validation.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.validation.testsuite.yaml
@@ -718,3 +718,157 @@ tests:
               id: "subnet-any"
           type: AWS
         nodeVolumeDetachTimeout: "2h45m"
+
+  # --- nodeDrainTimeout edge-case validation ---
+  - name: when nodeDrainTimeout is a leading-dot decimal duration it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeDrainTimeout: ".5s"
+
+  - name: when nodeDrainTimeout uses ASCII microsecond suffix it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeDrainTimeout: "100us"
+
+  - name: when nodeDrainTimeout overflows int64 nanoseconds it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeDrainTimeout: "999999999999h"
+    expectedError: "nodeDrainTimeout must be a non-negative duration"
+
+  # --- nodeVolumeDetachTimeout edge-case validation ---
+  - name: when nodeVolumeDetachTimeout is a leading-dot decimal duration it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeVolumeDetachTimeout: ".5s"
+
+  - name: when nodeVolumeDetachTimeout uses ASCII microsecond suffix it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeVolumeDetachTimeout: "100us"
+
+  - name: when nodeVolumeDetachTimeout overflows int64 nanoseconds it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeVolumeDetachTimeout: "999999999999h"
+    expectedError: "nodeVolumeDetachTimeout must be a non-negative duration"

--- a/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.validation.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.validation.testsuite.yaml
@@ -566,6 +566,31 @@ tests:
         nodeDrainTimeout: "abc"
     expectedError: "nodeDrainTimeout must be a valid duration string with a unit suffix"
 
+  - name: when nodeDrainTimeout is 0s it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeDrainTimeout: "0s"
+
   - name: when nodeDrainTimeout is a valid simple duration it should pass
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1
@@ -668,6 +693,31 @@ tests:
           type: AWS
         nodeVolumeDetachTimeout: "abc"
     expectedError: "nodeVolumeDetachTimeout must be a valid duration string with a unit suffix"
+
+  - name: when nodeVolumeDetachTimeout is 0s it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        nodeVolumeDetachTimeout: "0s"
 
   - name: when nodeVolumeDetachTimeout is a valid simple duration it should pass
     initial: |

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -320,7 +320,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -339,7 +341,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -319,7 +319,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -337,7 +340,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -316,6 +316,10 @@ spec:
                   The default value is 0, meaning that the node can retry drain without any time limitations.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeDrainTimeout must be a valid duration string with a
+                    unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -330,6 +334,10 @@ spec:
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeVolumeDetachTimeout must be a valid duration string
+                    with a unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -320,10 +320,8 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeDrainTimeout must be a non-negative duration
-                  optionalOldSelf: true
                   rule: duration(self) >= duration('0s')
               nodeLabels:
                 additionalProperties:
@@ -343,10 +341,8 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  optionalOldSelf: true
                   rule: duration(self) >= duration('0s')
               osImageStream:
                 description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -313,16 +313,14 @@ spec:
               nodeDrainTimeout:
                 description: |-
                   nodeDrainTimeout is the maximum amount of time that the controller will spend on retrying to drain a node until it succeeds.
-                  The default value is 0, meaning that the node can retry drain without any time limitations.
+                  When omitted or set to 0s, the node can retry drain without any time limitations.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
-                    unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeDrainTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -333,17 +331,15 @@ spec:
               nodeVolumeDetachTimeout:
                 description: |-
                   nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
-                  The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+                  When omitted or set to 0s, the volumes will be detached from the node without any time limitations.
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
-                    with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -320,9 +320,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeDrainTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -341,9 +343,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -320,7 +320,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -339,7 +341,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -316,6 +316,10 @@ spec:
                   The default value is 0, meaning that the node can retry drain without any time limitations.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeDrainTimeout must be a valid duration string with a
+                    unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -330,6 +334,10 @@ spec:
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeVolumeDetachTimeout must be a valid duration string
+                    with a unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -319,7 +319,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -337,7 +340,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -316,6 +316,10 @@ spec:
                   The default value is 0, meaning that the node can retry drain without any time limitations.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeDrainTimeout must be a valid duration string with a
+                    unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -330,39 +334,10 @@ spec:
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
-              osImageStream:
-                description: |-
-                  osImageStream specifies an OS stream to be used for nodes in this pool.
-
-                  This field can be optionally set to a known OSImageStream name to change
-                  the OS and Extension images with a well-known, tested, release-provided
-                  set of images. This enables a streamlined way of switching the pool's
-                  node OS to a different version than the cluster default, such as
-                  transitioning to a major RHEL version.
-
-                  When set, the referenced stream overrides the default OS images for the
-                  pool. When omitted, the pool uses the release version's default stream
-                  (rhel-9 for OCP < 5.0, rhel-10 for OCP >= 5.0).
-                  Changing this field triggers a rollout. Forward transitions
-                  (rhel-9 -> rhel-10) are allowed; backward transitions
-                  (rhel-10 -> rhel-9) are rejected by CEL validation because
-                  in-place OS downgrades are not supported.
-                properties:
-                  name:
-                    description: name is a required reference to an OSImageStream
-                      to be used for the pool.
-                    enum:
-                    - rhel-9
-                    - rhel-10
-                    type: string
-                required:
-                - name
-                type: object
                 x-kubernetes-validations:
-                - message: OS stream downgrade from rhel-10 to rhel-9 is not allowed;
-                    create a new NodePool instead
-                  rule: '!has(oldSelf.name) || oldSelf.name != ''rhel-10'' || (has(self.name)
-                    && self.name != ''rhel-9'')'
+                - message: nodeVolumeDetachTimeout must be a valid duration string
+                    with a unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.
@@ -619,60 +594,38 @@ spec:
                             == ''Spot'')'
                       resourceTags:
                         description: |-
-                          resourceTags is a list of additional tags to apply to AWS resources created
-                          for the NodePool. Changes to this field will be propagated in-place to AWS
-                          EC2 instances and their initial EBS volumes. Volumes created by the storage
-                          operator and attached to instances after they are created do not get these
-                          tags applied.
-                          These are merged with HostedCluster-level tags. By default, HostedCluster
-                          tags take precedence when both specify the same key. To allow a NodePool
-                          tag to override a specific HostedCluster tag, set overridePolicy to "Allow"
-                          on the HostedCluster tag.
-                          Tags that only exist at the NodePool level (no conflict) are always applied.
-                          These take precedence over tags defined out of band (i.e., tags added
-                          manually or by other tools outside of HyperShift) in AWS in case of
-                          conflicts.
+                          resourceTags is an optional list of additional tags to apply to AWS node
+                          instances. Changes to this field will be propagated in-place to AWS EC2 instances and their initial EBS volumes.
+                          Volumes created by the storage operator and attached to instances after they are created do not get these tags applied.
+
+                          These will be merged with HostedCluster scoped tags, which take precedence in case of conflicts.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
 
                           See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
                         items:
-                          description: |-
-                            AWSNodePoolResourceTag is a tag to apply to AWS resources created for a
-                            NodePool. These tags are merged with HostedCluster-level tags. By default,
-                            HostedCluster tags take precedence when both specify the same key. To allow
-                            a NodePool tag to override a specific HostedCluster tag, set overridePolicy
-                            to "Allow" on the HostedCluster tag.
+                          description: AWSResourceTag is a tag to apply to AWS resources
+                            created for the cluster.
                           properties:
                             key:
-                              description: |-
-                                key is the key of the tag.
-                                Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                              description: key is the key of the tag.
                               maxLength: 128
                               minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
-                              x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
                             value:
                               description: |-
                                 value is the value of the tag.
-                                Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
                                 requirements of all services.
                               maxLength: 256
                               minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
-                              x-kubernetes-validations:
-                              - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
                           required:
                           - key
                           - value
@@ -1561,9 +1514,6 @@ spec:
             - release
             type: object
             x-kubernetes-validations:
-            - message: osImageStream cannot be removed once set; create a new NodePool
-                instead
-              rule: '!has(oldSelf.osImageStream) || has(self.osImageStream)'
             - message: Arch is required once set
               rule: '!has(oldSelf.arch) || has(self.arch)'
             - message: Setting Arch to arm64 is only supported for AWS, Azure, Agent,
@@ -1708,22 +1658,6 @@ spec:
                     x-kubernetes-list-type: atomic
                 required:
                 - nodeVersions
-                type: object
-              osImageStream:
-                description: |-
-                  osImageStream reports the OS stream observed on the nodes in this pool.
-
-                  When omitted, the pool is using the release version's default OS images.
-                properties:
-                  name:
-                    description: name is a required reference to an OSImageStream
-                      to be used for the pool.
-                    enum:
-                    - rhel-9
-                    - rhel-10
-                    type: string
-                required:
-                - name
                 type: object
               platform:
                 description: platform holds the specific statuses

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -313,16 +313,14 @@ spec:
               nodeDrainTimeout:
                 description: |-
                   nodeDrainTimeout is the maximum amount of time that the controller will spend on retrying to drain a node until it succeeds.
-                  The default value is 0, meaning that the node can retry drain without any time limitations.
+                  When omitted or set to 0s, the node can retry drain without any time limitations.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
-                    unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeDrainTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -333,17 +331,48 @@ spec:
               nodeVolumeDetachTimeout:
                 description: |-
                   nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
-                  The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+                  When omitted or set to 0s, the volumes will be detached from the node without any time limitations.
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
-                    with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+              osImageStream:
+                description: |-
+                  osImageStream specifies an OS stream to be used for nodes in this pool.
+
+                  This field can be optionally set to a known OSImageStream name to change
+                  the OS and Extension images with a well-known, tested, release-provided
+                  set of images. This enables a streamlined way of switching the pool's
+                  node OS to a different version than the cluster default, such as
+                  transitioning to a major RHEL version.
+
+                  When set, the referenced stream overrides the default OS images for the
+                  pool. When omitted, the pool uses the release version's default stream
+                  (rhel-9 for OCP < 5.0, rhel-10 for OCP >= 5.0).
+                  Changing this field triggers a rollout. Forward transitions
+                  (rhel-9 -> rhel-10) are allowed; backward transitions
+                  (rhel-10 -> rhel-9) are rejected by CEL validation because
+                  in-place OS downgrades are not supported.
+                properties:
+                  name:
+                    description: name is a required reference to an OSImageStream
+                      to be used for the pool.
+                    enum:
+                    - rhel-9
+                    - rhel-10
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: OS stream downgrade from rhel-10 to rhel-9 is not allowed;
+                    create a new NodePool instead
+                  rule: '!has(oldSelf.name) || oldSelf.name != ''rhel-10'' || (has(self.name)
+                    && self.name != ''rhel-9'')'
               pausedUntil:
                 description: |-
                   pausedUntil is a field that can be used to pause reconciliation on the NodePool controller. Resulting in any change to the NodePool being ignored.
@@ -600,38 +629,60 @@ spec:
                             == ''Spot'')'
                       resourceTags:
                         description: |-
-                          resourceTags is an optional list of additional tags to apply to AWS node
-                          instances. Changes to this field will be propagated in-place to AWS EC2 instances and their initial EBS volumes.
-                          Volumes created by the storage operator and attached to instances after they are created do not get these tags applied.
-
-                          These will be merged with HostedCluster scoped tags, which take precedence in case of conflicts.
-                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
+                          resourceTags is a list of additional tags to apply to AWS resources created
+                          for the NodePool. Changes to this field will be propagated in-place to AWS
+                          EC2 instances and their initial EBS volumes. Volumes created by the storage
+                          operator and attached to instances after they are created do not get these
+                          tags applied.
+                          These are merged with HostedCluster-level tags. By default, HostedCluster
+                          tags take precedence when both specify the same key. To allow a NodePool
+                          tag to override a specific HostedCluster tag, set overridePolicy to "Allow"
+                          on the HostedCluster tag.
+                          Tags that only exist at the NodePool level (no conflict) are always applied.
+                          These take precedence over tags defined out of band (i.e., tags added
+                          manually or by other tools outside of HyperShift) in AWS in case of
+                          conflicts.
 
                           See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
                         items:
-                          description: AWSResourceTag is a tag to apply to AWS resources
-                            created for the cluster.
+                          description: |-
+                            AWSNodePoolResourceTag is a tag to apply to AWS resources created for a
+                            NodePool. These tags are merged with HostedCluster-level tags. By default,
+                            HostedCluster tags take precedence when both specify the same key. To allow
+                            a NodePool tag to override a specific HostedCluster tag, set overridePolicy
+                            to "Allow" on the HostedCluster tag.
                           properties:
                             key:
-                              description: key is the key of the tag.
+                              description: |-
+                                key is the key of the tag.
+                                Must be between 1 and 128 characters and may only contain letters, digits,
+                                and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: 'key must only contain letters, digits, and
+                                  the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
                             value:
                               description: |-
                                 value is the value of the tag.
+                                Must be between 1 and 256 characters and may only contain letters, digits,
+                                and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
                                 requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: 'value must only contain letters, digits,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
                           required:
                           - key
                           - value
@@ -1520,6 +1571,9 @@ spec:
             - release
             type: object
             x-kubernetes-validations:
+            - message: osImageStream cannot be removed once set; create a new NodePool
+                instead
+              rule: '!has(oldSelf.osImageStream) || has(self.osImageStream)'
             - message: Arch is required once set
               rule: '!has(oldSelf.arch) || has(self.arch)'
             - message: Setting Arch to arm64 is only supported for AWS, Azure, Agent,
@@ -1664,6 +1718,22 @@ spec:
                     x-kubernetes-list-type: atomic
                 required:
                 - nodeVersions
+                type: object
+              osImageStream:
+                description: |-
+                  osImageStream reports the OS stream observed on the nodes in this pool.
+
+                  When omitted, the pool is using the release version's default OS images.
+                properties:
+                  name:
+                    description: name is a required reference to an OSImageStream
+                      to be used for the pool.
+                    enum:
+                    - rhel-9
+                    - rhel-10
+                    type: string
+                required:
+                - name
                 type: object
               platform:
                 description: platform holds the specific statuses

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -320,10 +320,8 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeDrainTimeout must be a non-negative duration
-                  optionalOldSelf: true
                   rule: duration(self) >= duration('0s')
               nodeLabels:
                 additionalProperties:
@@ -343,10 +341,8 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  optionalOldSelf: true
                   rule: duration(self) >= duration('0s')
               osImageStream:
                 description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -320,9 +320,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeDrainTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -341,9 +343,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -320,7 +320,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -339,7 +341,9 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                  rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -319,7 +319,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeDrainTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -337,7 +340,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
+                - message: nodeVolumeDetachTimeout must be a non-negative duration
+                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
+                    || duration(self) >= duration(''0s'')'
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -316,6 +316,10 @@ spec:
                   The default value is 0, meaning that the node can retry drain without any time limitations.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeDrainTimeout must be a valid duration string with a
+                    unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -330,6 +334,10 @@ spec:
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
                   Changing this field propagate inplace into existing Nodes.
                 type: string
+                x-kubernetes-validations:
+                - message: nodeVolumeDetachTimeout must be a valid duration string
+                    with a unit suffix (e.g. 30s, 5m, 1h)
+                  rule: self.matches('^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -320,10 +320,8 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeDrainTimeout must be a non-negative duration
-                  optionalOldSelf: true
                   rule: duration(self) >= duration('0s')
               nodeLabels:
                 additionalProperties:
@@ -343,10 +341,8 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
-                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  optionalOldSelf: true
                   rule: duration(self) >= duration('0s')
               osImageStream:
                 description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -313,16 +313,14 @@ spec:
               nodeDrainTimeout:
                 description: |-
                   nodeDrainTimeout is the maximum amount of time that the controller will spend on retrying to drain a node until it succeeds.
-                  The default value is 0, meaning that the node can retry drain without any time limitations.
+                  When omitted or set to 0s, the node can retry drain without any time limitations.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
-                    unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeDrainTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -333,17 +331,15 @@ spec:
               nodeVolumeDetachTimeout:
                 description: |-
                   nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
-                  The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+                  When omitted or set to 0s, the volumes will be detached from the node without any time limitations.
                   After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
+                  Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
                   Changing this field propagate inplace into existing Nodes.
                 type: string
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
-                    with a unit suffix (e.g. 30s, 5m, 1h)
-                  rule: self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
-                - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: '!self.matches(''^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$'')
-                    || duration(self) >= duration(''0s'')'
+                    with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  rule: self.matches('^0s$') || self.matches('^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -320,9 +320,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeDrainTimeout must be a valid duration string with a
                     unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeDrainTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               nodeLabels:
                 additionalProperties:
                   type: string
@@ -341,9 +343,11 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeVolumeDetachTimeout must be a valid duration string
                     with a unit suffix (e.g. 30s, 5m, 1h) or '0s'
+                  optionalOldSelf: true
                   rule: self == '0s' || matches(self, '^(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')
                 - message: nodeVolumeDetachTimeout must be a non-negative duration
-                  rule: self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))
+                  optionalOldSelf: true
+                  rule: duration(self) >= duration('0s')
               osImageStream:
                 description: |-
                   osImageStream specifies an OS stream to be used for nodes in this pool.

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -41133,7 +41133,8 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>nodeDrainTimeout is the maximum amount of time that the controller will spend on retrying to drain a node until it succeeds.
-The default value is 0, meaning that the node can retry drain without any time limitations.
+When omitted or set to 0s, the node can retry drain without any time limitations.
+Valid values must be a Go duration string with a unit suffix, such as &ldquo;30s&rdquo;, &ldquo;5m&rdquo;, or &ldquo;1h&rdquo;.
 Changing this field propagate inplace into existing Nodes.</p>
 </td>
 </tr>
@@ -41149,8 +41150,9 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
-The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+When omitted or set to 0s, the volumes will be detached from the node without any time limitations.
 After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
+Valid values must be a Go duration string with a unit suffix, such as &ldquo;30s&rdquo;, &ldquo;5m&rdquo;, or &ldquo;1h&rdquo;.
 Changing this field propagate inplace into existing Nodes.</p>
 </td>
 </tr>
@@ -54441,7 +54443,8 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>nodeDrainTimeout is the maximum amount of time that the controller will spend on retrying to drain a node until it succeeds.
-The default value is 0, meaning that the node can retry drain without any time limitations.
+When omitted or set to 0s, the node can retry drain without any time limitations.
+Valid values must be a Go duration string with a unit suffix, such as &ldquo;30s&rdquo;, &ldquo;5m&rdquo;, or &ldquo;1h&rdquo;.
 Changing this field propagate inplace into existing Nodes.</p>
 </td>
 </tr>
@@ -54457,8 +54460,9 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
-The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+When omitted or set to 0s, the volumes will be detached from the node without any time limitations.
 After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
+Valid values must be a Go duration string with a unit suffix, such as &ldquo;30s&rdquo;, &ldquo;5m&rdquo;, or &ldquo;1h&rdquo;.
 Changing this field propagate inplace into existing Nodes.</p>
 </td>
 </tr>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1236,7 +1236,8 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>nodeDrainTimeout is the maximum amount of time that the controller will spend on retrying to drain a node until it succeeds.
-The default value is 0, meaning that the node can retry drain without any time limitations.
+When omitted or set to 0s, the node can retry drain without any time limitations.
+Valid values must be a Go duration string with a unit suffix, such as &ldquo;30s&rdquo;, &ldquo;5m&rdquo;, or &ldquo;1h&rdquo;.
 Changing this field propagate inplace into existing Nodes.</p>
 </td>
 </tr>
@@ -1252,8 +1253,9 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
-The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+When omitted or set to 0s, the volumes will be detached from the node without any time limitations.
 After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
+Valid values must be a Go duration string with a unit suffix, such as &ldquo;30s&rdquo;, &ldquo;5m&rdquo;, or &ldquo;1h&rdquo;.
 Changing this field propagate inplace into existing Nodes.</p>
 </td>
 </tr>
@@ -14544,7 +14546,8 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>nodeDrainTimeout is the maximum amount of time that the controller will spend on retrying to drain a node until it succeeds.
-The default value is 0, meaning that the node can retry drain without any time limitations.
+When omitted or set to 0s, the node can retry drain without any time limitations.
+Valid values must be a Go duration string with a unit suffix, such as &ldquo;30s&rdquo;, &ldquo;5m&rdquo;, or &ldquo;1h&rdquo;.
 Changing this field propagate inplace into existing Nodes.</p>
 </td>
 </tr>
@@ -14560,8 +14563,9 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
-The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+When omitted or set to 0s, the volumes will be detached from the node without any time limitations.
 After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
+Valid values must be a Go duration string with a unit suffix, such as &ldquo;30s&rdquo;, &ldquo;5m&rdquo;, or &ldquo;1h&rdquo;.
 Changing this field propagate inplace into existing Nodes.</p>
 </td>
 </tr>

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -186,7 +186,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self.matches('^0s$') || self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))",message="nodeDrainTimeout must be a non-negative duration"
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
@@ -196,7 +197,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self.matches('^0s$') || self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))",message="nodeVolumeDetachTimeout must be a non-negative duration"
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// nodeLabels propagates a list of labels to Nodes, only once on creation.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -184,6 +184,8 @@ type NodePoolSpec struct {
 	// The default value is 0, meaning that the node can retry drain without any time limitations.
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
+	// +kubebuilder:validation:Type:=string
+	// +kubebuilder:validation:XValidation:rule="self.matches('^([0-9]+(\\\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
@@ -191,6 +193,8 @@ type NodePoolSpec struct {
 	// After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
+	// +kubebuilder:validation:Type:=string
+	// +kubebuilder:validation:XValidation:rule="self.matches('^([0-9]+(\\\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// nodeLabels propagates a list of labels to Nodes, only once on creation.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -185,7 +185,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self.matches('^([0-9]+(\\\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
+	// +kubebuilder:validation:XValidation:rule="!self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$') || duration(self) >= duration('0s')",message="nodeDrainTimeout must be a non-negative duration"
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
@@ -194,7 +195,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self.matches('^([0-9]+(\\\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
+	// +kubebuilder:validation:XValidation:rule="!self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$') || duration(self) >= duration('0s')",message="nodeVolumeDetachTimeout must be a non-negative duration"
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// nodeLabels propagates a list of labels to Nodes, only once on creation.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -181,22 +181,22 @@ type NodePoolSpec struct {
 	Config []corev1.LocalObjectReference `json:"config,omitempty"`
 
 	// nodeDrainTimeout is the maximum amount of time that the controller will spend on retrying to drain a node until it succeeds.
-	// The default value is 0, meaning that the node can retry drain without any time limitations.
+	// When omitted or set to 0s, the node can retry drain without any time limitations.
+	// Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
-	// +kubebuilder:validation:XValidation:rule="!self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$') || duration(self) >= duration('0s')",message="nodeDrainTimeout must be a non-negative duration"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^0s$') || self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
-	// The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+	// When omitted or set to 0s, the volumes will be detached from the node without any time limitations.
 	// After the timeout, any remaining attached volumes will be ignored and the removal of the machine will continue.
+	// Valid values must be a Go duration string with a unit suffix, such as "30s", "5m", or "1h".
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h)"
-	// +kubebuilder:validation:XValidation:rule="!self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$') || duration(self) >= duration('0s')",message="nodeVolumeDetachTimeout must be a non-negative duration"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^0s$') || self.matches('^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// nodeLabels propagates a list of labels to Nodes, only once on creation.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -186,8 +186,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
-	// +kubebuilder:validation:XValidation:rule="self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))",message="nodeDrainTimeout must be a non-negative duration"
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeDrainTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'",optionalOldSelf=true
+	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('0s')",message="nodeDrainTimeout must be a non-negative duration",optionalOldSelf=true
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// nodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
@@ -197,8 +197,8 @@ type NodePoolSpec struct {
 	// Changing this field propagate inplace into existing Nodes.
 	// +optional
 	// +kubebuilder:validation:Type:=string
-	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'"
-	// +kubebuilder:validation:XValidation:rule="self == '0s' || (size(self) <= 23 && duration(self) >= duration('1ns'))",message="nodeVolumeDetachTimeout must be a non-negative duration"
+	// +kubebuilder:validation:XValidation:rule="self == '0s' || matches(self, '^(([0-9]+(\\\\.[0-9]+)?|\\\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$')",message="nodeVolumeDetachTimeout must be a valid duration string with a unit suffix (e.g. 30s, 5m, 1h) or '0s'",optionalOldSelf=true
+	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('0s')",message="nodeVolumeDetachTimeout must be a non-negative duration",optionalOldSelf=true
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// nodeLabels propagates a list of labels to Nodes, only once on creation.


### PR DESCRIPTION
## What this PR does / why we need it:

nodeDrainTimeout and nodeVolumeDetachTimeout on NodePoolSpec are *metav1.Duration with no CRD-level validation. Invalid strings like "1" (no unit suffix) pass admission, get stored in etcd, and crash the cluster-wide NodePool informer on deserialization (time.ParseDuration failure).

This PR adds XValidation CEL rules to both fields that validate the value matches Go duration syntax at admission time. Follows the HTTPKeepAliveTimeout precedent from openshift/api (operator/v1/types_ingress.go) for the CEL regex pattern and escaping.

Changes:
- api/hypershift/v1beta1/nodepool_types.go: Added +kubebuilder:validation:Type:=string and +kubebuilder:validation:XValidation markers to both fields
- Regenerated CRDs via make update
- Added 8 envtest test cases (4 per field: 2 invalid, 2 valid)

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-94251

## Special notes for your reviewer:

Follows the HTTPKeepAliveTimeout precedent from openshift/api for CEL regex escaping (four backslashes in the marker). MinLength/MaxLength omitted to avoid CRD schema check errors — the CEL regex already rejects empty/invalid strings.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how omitted or `0s` node drain and volume detach timeout values behave.
  * Added valid duration examples for timeout settings.

* **Bug Fixes**
  * Updated timeout validation to allow `0s` while continuing to require valid duration formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->