### PR TITLE
Migrate CRI-O annotations to v2 format

### DIFF
--- a/docs/content/recipes/common/replace-crio-runtime.md
+++ b/docs/content/recipes/common/replace-crio-runtime.md
@@ -85,8 +85,8 @@ The following manifest sets `crun` as the default runtime.
 
     allowed_annotations = [
         "io.containers.trace-syscall",
-        "io.kubernetes.cri-o.Devices",
-        "io.kubernetes.cri-o.LinkLogs",
+        "devices.crio.io",
+        "link-logs.crio.io",
         "cpu-load-balancing.crio.io",
         "cpu-quota.crio.io",
         "irq-load-balancing.crio.io",
@@ -214,8 +214,8 @@ The following manifest sets `runc` as the default runtime.
 
     allowed_annotations = [
         "io.containers.trace-syscall",
-        "io.kubernetes.cri-o.Devices",
-        "io.kubernetes.cri-o.LinkLogs",
+        "devices.crio.io",
+        "link-logs.crio.io",
         "cpu-load-balancing.crio.io",
         "cpu-quota.crio.io",
         "irq-load-balancing.crio.io",

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -37350,8 +37350,8 @@ The following manifest sets `crun` as the default runtime.
 
     allowed_annotations = [
         "io.containers.trace-syscall",
-        "io.kubernetes.cri-o.Devices",
-        "io.kubernetes.cri-o.LinkLogs",
+        "devices.crio.io",
+        "link-logs.crio.io",
         "cpu-load-balancing.crio.io",
         "cpu-quota.crio.io",
         "irq-load-balancing.crio.io",
@@ -37479,8 +37479,8 @@ The following manifest sets `runc` as the default runtime.
 
     allowed_annotations = [
         "io.containers.trace-syscall",
-        "io.kubernetes.cri-o.Devices",
-        "io.kubernetes.cri-o.LinkLogs",
+        "devices.crio.io",
+        "link-logs.crio.io",
         "cpu-load-balancing.crio.io",
         "cpu-quota.crio.io",
         "irq-load-balancing.crio.io",


### PR DESCRIPTION
## What this PR does / why we need it:
CRI-O migrated its annotations from v1 (`io.kubernetes.cri-o.*`) to v2 (`*.crio.io`). This updates the allowed_annotations in docs to use the new format.

## Which issue(s) this PR fixes:
Ref https://github.com/cri-o/cri-o/issues/10194

## Special notes for your reviewer:
The old v1 annotations are deprecated and will be removed in a future CRI-O release.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.