### PR TITLE
CNTRLPLANE-3897: Add product-cli unit tests for create nodepool

### DIFF
--- a/product-cli/cmd/nodepool/agent/create_test.go
+++ b/product-cli/cmd/nodepool/agent/create_test.go
@@ -1,0 +1,113 @@
+package agent
+
+import (
+	"sort"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftagent "github.com/openshift/hypershift/cmd/nodepool/agent"
+	"github.com/openshift/hypershift/cmd/nodepool/core"
+	"github.com/openshift/hypershift/support/testutil"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		verify func(t *testing.T)
+	}{
+		"When Agent nodepool create command is created, it should have 'agent' as use": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Use).To(Equal("agent"))
+			},
+		},
+		"When Agent nodepool create command is created, it should register agentLabelSelector flag": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Flag("agentLabelSelector")).ToNot(BeNil())
+			},
+		},
+		"When Agent nodepool create command is created, it should register exactly the expected flags": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				expectedFlags := []string{
+					"agentLabelSelector",
+				}
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				sort.Strings(actualFlags)
+				g.Expect(actualFlags).To(Equal(expectedFlags))
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			test.verify(t)
+		})
+	}
+}
+
+func TestUpdateNodePool(t *testing.T) {
+	for _, testCase := range []struct {
+		name               string
+		agentLabelSelector string
+	}{
+		{
+			name:               "When empty label selector is provided, it should generate correct nodepool",
+			agentLabelSelector: "",
+		},
+		{
+			name:               "When single label selector is provided, it should generate correct nodepool",
+			agentLabelSelector: "size=large",
+		},
+		{
+			name:               "When multi label selector is provided, it should generate correct nodepool",
+			agentLabelSelector: "size=large,zone notin (az1,az2)",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			// Agent platform does not implement the DefaultOptions → Validate → Complete
+			// pipeline used by other platforms; it only exposes NewAgentPlatformCreateOptions
+			// with a single AgentLabelSelector field, so we wire the flag value manually.
+			cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+			if testCase.agentLabelSelector != "" {
+				if err := cmd.Flags().Parse([]string{"--agentLabelSelector=" + testCase.agentLabelSelector}); err != nil {
+					t.Fatalf("failed to parse flags: %v", err)
+				}
+			}
+
+			platformOpts := hypershiftagent.NewAgentPlatformCreateOptions(&cobra.Command{})
+			platformOpts.AgentLabelSelector = cmd.Flags().Lookup("agentLabelSelector").Value.String()
+
+			nodePool := &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Arch: string(hyperv1.ArchitectureAMD64),
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.AgentPlatform,
+					},
+				},
+			}
+
+			if err := platformOpts.UpdateNodePool(ctx, nodePool, nil, nil); err != nil {
+				t.Fatalf("failed to update nodepool: %v", err)
+			}
+
+			testutil.CompareWithFixture(t, nodePool.Spec.Platform.Agent)
+		})
+	}
+}

--- a/product-cli/cmd/nodepool/agent/testdata/zz_fixture_TestUpdateNodePool_When_empty_label_selector_is_provided__it_should_generate_correct_nodepool.yaml
+++ b/product-cli/cmd/nodepool/agent/testdata/zz_fixture_TestUpdateNodePool_When_empty_label_selector_is_provided__it_should_generate_correct_nodepool.yaml
@@ -1,0 +1,1 @@
+agentLabelSelector: {}

--- a/product-cli/cmd/nodepool/agent/testdata/zz_fixture_TestUpdateNodePool_When_multi_label_selector_is_provided__it_should_generate_correct_nodepool.yaml
+++ b/product-cli/cmd/nodepool/agent/testdata/zz_fixture_TestUpdateNodePool_When_multi_label_selector_is_provided__it_should_generate_correct_nodepool.yaml
@@ -1,0 +1,9 @@
+agentLabelSelector:
+  matchExpressions:
+  - key: zone
+    operator: NotIn
+    values:
+    - az1
+    - az2
+  matchLabels:
+    size: large

--- a/product-cli/cmd/nodepool/agent/testdata/zz_fixture_TestUpdateNodePool_When_single_label_selector_is_provided__it_should_generate_correct_nodepool.yaml
+++ b/product-cli/cmd/nodepool/agent/testdata/zz_fixture_TestUpdateNodePool_When_single_label_selector_is_provided__it_should_generate_correct_nodepool.yaml
@@ -1,0 +1,3 @@
+agentLabelSelector:
+  matchLabels:
+    size: large

--- a/product-cli/cmd/nodepool/aws/create_test.go
+++ b/product-cli/cmd/nodepool/aws/create_test.go
@@ -1,0 +1,170 @@
+package aws
+
+import (
+	"sort"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftaws "github.com/openshift/hypershift/cmd/nodepool/aws"
+	"github.com/openshift/hypershift/cmd/nodepool/core"
+	"github.com/openshift/hypershift/support/testutil"
+
+	"k8s.io/utils/ptr"
+
+	"github.com/spf13/pflag"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		verify func(t *testing.T)
+	}{
+		"When AWS nodepool create command is created, it should have 'aws' as use": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Use).To(Equal("aws"))
+			},
+		},
+		"When AWS nodepool create command is created, it should default root-volume-type to gp3": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Flag("root-volume-type").DefValue).To(Equal("gp3"))
+			},
+		},
+		"When AWS nodepool create command is created, it should default root-volume-size to 120": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Flag("root-volume-size").DefValue).To(Equal("120"))
+			},
+		},
+		"When AWS nodepool create command is created, it should register exactly the expected flags": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				expectedFlags := []string{
+					"instance-profile",
+					"instance-type",
+					"root-volume-iops",
+					"root-volume-kms-key",
+					"root-volume-size",
+					"root-volume-type",
+					"securitygroup-id",
+					"subnet-id",
+				}
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				sort.Strings(actualFlags)
+				g.Expect(actualFlags).To(Equal(expectedFlags))
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			test.verify(t)
+		})
+	}
+}
+
+func TestUpdateNodePool(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "When minimal configuration is provided, it should generate correct nodepool",
+			args: []string{
+				"--instance-type=m5.large",
+				"--subnet-id=subnet-test123",
+			},
+		},
+		{
+			name: "When full configuration is provided, it should generate correct nodepool",
+			args: []string{
+				"--instance-type=m5.xlarge",
+				"--subnet-id=subnet-test456",
+				"--securitygroup-id=sg-test789",
+				"--instance-profile=test-worker-profile",
+				"--root-volume-type=gp3",
+				"--root-volume-size=150",
+				"--root-volume-iops=5000",
+				"--root-volume-kms-key=arn:aws:kms:us-east-1:123456789012:key/test-key",
+			},
+		},
+		{
+			name: "When subnet-id is omitted, it should use the hosted cluster default subnet",
+			args: []string{
+				"--instance-type=m5.large",
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
+			coreOpts := &core.CreateNodePoolOptions{
+				Name:        "test-nodepool",
+				Namespace:   "clusters",
+				ClusterName: "test-cluster",
+				Replicas:    3,
+				Arch:        string(hyperv1.ArchitectureAMD64),
+			}
+			awsOpts := hypershiftaws.DefaultOptions()
+			hypershiftaws.BindDeveloperOptions(awsOpts, flags)
+
+			if err := flags.Parse(testCase.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			validOpts, err := awsOpts.Validate(ctx, coreOpts)
+			if err != nil {
+				t.Fatalf("validation failed: %v", err)
+			}
+
+			completedOpts, err := validOpts.Complete(ctx, coreOpts)
+			if err != nil {
+				t.Fatalf("completion failed: %v", err)
+			}
+
+			nodePool := &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Arch: coreOpts.Arch,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.AWSPlatform,
+					},
+				},
+			}
+
+			hcluster := &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					InfraID: "test-infra",
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							CloudProviderConfig: &hyperv1.AWSCloudProviderConfig{
+								Subnet: &hyperv1.AWSResourceReference{
+									ID: ptr.To("subnet-default"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			if err := completedOpts.UpdateNodePool(ctx, nodePool, hcluster, nil); err != nil {
+				t.Fatalf("failed to update nodepool: %v", err)
+			}
+
+			testutil.CompareWithFixture(t, nodePool.Spec.Platform.AWS)
+		})
+	}
+}

--- a/product-cli/cmd/nodepool/aws/testdata/zz_fixture_TestUpdateNodePool_When_full_configuration_is_provided__it_should_generate_correct_nodepool.yaml
+++ b/product-cli/cmd/nodepool/aws/testdata/zz_fixture_TestUpdateNodePool_When_full_configuration_is_provided__it_should_generate_correct_nodepool.yaml
@@ -1,0 +1,11 @@
+instanceProfile: test-worker-profile
+instanceType: m5.xlarge
+rootVolume:
+  encryptionKey: arn:aws:kms:us-east-1:123456789012:key/test-key
+  iops: 5000
+  size: 150
+  type: gp3
+securityGroups:
+- id: sg-test789
+subnet:
+  id: subnet-test456

--- a/product-cli/cmd/nodepool/aws/testdata/zz_fixture_TestUpdateNodePool_When_minimal_configuration_is_provided__it_should_generate_correct_nodepool.yaml
+++ b/product-cli/cmd/nodepool/aws/testdata/zz_fixture_TestUpdateNodePool_When_minimal_configuration_is_provided__it_should_generate_correct_nodepool.yaml
@@ -1,0 +1,7 @@
+instanceProfile: test-infra-worker
+instanceType: m5.large
+rootVolume:
+  size: 120
+  type: gp3
+subnet:
+  id: subnet-test123

--- a/product-cli/cmd/nodepool/aws/testdata/zz_fixture_TestUpdateNodePool_When_subnet_id_is_omitted__it_should_use_the_hosted_cluster_default_subnet.yaml
+++ b/product-cli/cmd/nodepool/aws/testdata/zz_fixture_TestUpdateNodePool_When_subnet_id_is_omitted__it_should_use_the_hosted_cluster_default_subnet.yaml
@@ -1,0 +1,7 @@
+instanceProfile: test-infra-worker
+instanceType: m5.large
+rootVolume:
+  size: 120
+  type: gp3
+subnet:
+  id: subnet-default

--- a/product-cli/cmd/nodepool/azure/create_test.go
+++ b/product-cli/cmd/nodepool/azure/create_test.go
@@ -1,0 +1,179 @@
+package azure
+
+import (
+	"sort"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftazure "github.com/openshift/hypershift/cmd/nodepool/azure"
+	"github.com/openshift/hypershift/cmd/nodepool/core"
+	"github.com/openshift/hypershift/support/testutil"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	testSubscriptionID       = "12345678-1234-1234-1234-123456789abc"
+	testResourceGroup        = "my-rg"
+	testVnetName             = "my-vnet"
+	testSubnetName           = "my-subnet"
+	testMarketplacePublisher = "redhat"
+	testMarketplaceOffer     = "aro4"
+	testMarketplaceSKU       = "aro_414"
+	testMarketplaceVersion   = "414.1.20240101"
+	testInstanceType         = "Standard_D4s_v5"
+)
+
+var testSubnetID = "/subscriptions/" + testSubscriptionID + "/resourceGroups/" + testResourceGroup +
+	"/providers/Microsoft.Network/virtualNetworks/" + testVnetName + "/subnets/" + testSubnetName
+
+func TestNewCreateCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		verify func(t *testing.T)
+	}{
+		"When Azure nodepool create command is created, it should have 'azure' as use": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Use).To(Equal("azure"))
+			},
+		},
+		"When Azure nodepool create command is created, it should default root-disk-size to 120": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Flag("root-disk-size").DefValue).To(Equal("120"))
+			},
+		},
+		"When Azure nodepool create command is created, it should default disk-storage-account-type to Premium_LRS": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Flag("disk-storage-account-type").DefValue).To(Equal("Premium_LRS"))
+			},
+		},
+		"When Azure nodepool create command is created, it should register exactly the expected flags": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				expectedFlags := []string{
+					"availability-zone",
+					"diagnostics-storage-account-type",
+					"diagnostics-storage-account-uri",
+					"disk-encryption-set-id",
+					"disk-storage-account-type",
+					"enable-ephemeral-disk",
+					"encryption-at-host",
+					"image-generation",
+					"instance-type",
+					"marketplace-offer",
+					"marketplace-publisher",
+					"marketplace-sku",
+					"marketplace-version",
+					"nodepool-subnet-id",
+					"root-disk-size",
+				}
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				sort.Strings(actualFlags)
+				g.Expect(actualFlags).To(Equal(expectedFlags))
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			test.verify(t)
+		})
+	}
+}
+
+func TestUpdateNodePool(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "When minimal configuration is provided, it should generate correct nodepool",
+			args: []string{
+				"--instance-type=" + testInstanceType,
+				"--nodepool-subnet-id=" + testSubnetID,
+				"--marketplace-publisher=" + testMarketplacePublisher,
+				"--marketplace-offer=" + testMarketplaceOffer,
+				"--marketplace-sku=" + testMarketplaceSKU,
+				"--marketplace-version=" + testMarketplaceVersion,
+			},
+		},
+		{
+			name: "When full configuration is provided, it should generate correct nodepool",
+			args: []string{
+				"--instance-type=Standard_D8s_v5",
+				"--nodepool-subnet-id=" + testSubnetID,
+				"--marketplace-publisher=" + testMarketplacePublisher,
+				"--marketplace-offer=" + testMarketplaceOffer,
+				"--marketplace-sku=" + testMarketplaceSKU,
+				"--marketplace-version=" + testMarketplaceVersion,
+				"--image-generation=Gen2",
+				"--root-disk-size=256",
+				"--availability-zone=1",
+				"--disk-storage-account-type=StandardSSD_LRS",
+				"--disk-encryption-set-id=/subscriptions/test/resourceGroups/test/providers/Microsoft.Compute/diskEncryptionSets/test-des",
+				"--enable-ephemeral-disk=true",
+				"--encryption-at-host=Enabled",
+				"--diagnostics-storage-account-type=UserManaged",
+				"--diagnostics-storage-account-uri=https://testdiag.blob.core.windows.net",
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
+			coreOpts := &core.CreateNodePoolOptions{
+				Name:        "test-nodepool",
+				Namespace:   "clusters",
+				ClusterName: "test-cluster",
+				Replicas:    3,
+				Arch:        string(hyperv1.ArchitectureAMD64),
+			}
+			azureOpts := hypershiftazure.DefaultOptions()
+			hypershiftazure.BindProductFlags(azureOpts, flags)
+
+			if err := flags.Parse(testCase.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			validOpts, err := azureOpts.Validate(ctx, coreOpts)
+			if err != nil {
+				t.Fatalf("validation failed: %v", err)
+			}
+
+			completedOpts, err := validOpts.Complete(ctx, coreOpts)
+			if err != nil {
+				t.Fatalf("completion failed: %v", err)
+			}
+
+			nodePool := &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Arch: coreOpts.Arch,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.AzurePlatform,
+					},
+				},
+			}
+
+			if err := completedOpts.UpdateNodePool(ctx, nodePool, nil, nil); err != nil {
+				t.Fatalf("failed to update nodepool: %v", err)
+			}
+
+			testutil.CompareWithFixture(t, nodePool.Spec.Platform.Azure)
+		})
+	}
+}

--- a/product-cli/cmd/nodepool/azure/testdata/zz_fixture_TestUpdateNodePool_When_full_configuration_is_provided__it_should_generate_correct_nodepool.yaml
+++ b/product-cli/cmd/nodepool/azure/testdata/zz_fixture_TestUpdateNodePool_When_full_configuration_is_provided__it_should_generate_correct_nodepool.yaml
@@ -1,0 +1,21 @@
+availabilityZone: "1"
+diagnostics:
+  storageAccountType: UserManaged
+  userManaged:
+    storageAccountURI: https://testdiag.blob.core.windows.net
+encryptionAtHost: Enabled
+image:
+  azureMarketplace:
+    imageGeneration: Gen2
+    offer: aro4
+    publisher: redhat
+    sku: aro_414
+    version: 414.1.20240101
+  type: AzureMarketplace
+osDisk:
+  diskStorageAccountType: StandardSSD_LRS
+  encryptionSetID: /subscriptions/test/resourceGroups/test/providers/Microsoft.Compute/diskEncryptionSets/test-des
+  persistence: Ephemeral
+  sizeGiB: 256
+subnetID: /subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet
+vmSize: Standard_D8s_v5

--- a/product-cli/cmd/nodepool/azure/testdata/zz_fixture_TestUpdateNodePool_When_minimal_configuration_is_provided__it_should_generate_correct_nodepool.yaml
+++ b/product-cli/cmd/nodepool/azure/testdata/zz_fixture_TestUpdateNodePool_When_minimal_configuration_is_provided__it_should_generate_correct_nodepool.yaml
@@ -1,0 +1,12 @@
+image:
+  azureMarketplace:
+    offer: aro4
+    publisher: redhat
+    sku: aro_414
+    version: 414.1.20240101
+  type: AzureMarketplace
+osDisk:
+  diskStorageAccountType: Premium_LRS
+  sizeGiB: 120
+subnetID: /subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet
+vmSize: Standard_D4s_v5

--- a/product-cli/cmd/nodepool/kubevirt/create_test.go
+++ b/product-cli/cmd/nodepool/kubevirt/create_test.go
@@ -1,0 +1,192 @@
+package kubevirt
+
+import (
+	"sort"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/cmd/nodepool/core"
+	kubevirtnodepool "github.com/openshift/hypershift/cmd/nodepool/kubevirt"
+	"github.com/openshift/hypershift/support/testutil"
+
+	"github.com/spf13/pflag"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		verify func(t *testing.T)
+	}{
+		"When KubeVirt nodepool create command is created, it should have 'kubevirt' as use": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Use).To(Equal("kubevirt"))
+			},
+		},
+		"When KubeVirt nodepool create command is created, it should default memory to 4Gi": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Flag("memory").DefValue).To(Equal("4Gi"))
+			},
+		},
+		"When KubeVirt nodepool create command is created, it should default cores to 2": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Flag("cores").DefValue).To(Equal("2"))
+			},
+		},
+		"When KubeVirt nodepool create command is created, it should default root-volume-size to 32": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Flag("root-volume-size").DefValue).To(Equal("32"))
+			},
+		},
+		"When KubeVirt nodepool create command is created, it should default qos-class to Burstable": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Flag("qos-class").DefValue).To(Equal("Burstable"))
+			},
+		},
+		"When KubeVirt nodepool create command is created, it should default network-multiqueue to Enable": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Flag("network-multiqueue").DefValue).To(Equal("Enable"))
+			},
+		},
+		"When KubeVirt nodepool create command is created, it should default attach-default-network to true": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Flag("attach-default-network").DefValue).To(Equal("true"))
+			},
+		},
+		"When KubeVirt nodepool create command is created, it should not register developer-only flags": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Flag("containerdisk")).To(BeNil(), "containerdisk is a developer-only flag")
+			},
+		},
+		"When KubeVirt nodepool create command is created, it should register exactly the expected flags": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				expectedFlags := []string{
+					"additional-network",
+					"attach-default-network",
+					"cores",
+					"host-device-name",
+					"memory",
+					"network-multiqueue",
+					"qos-class",
+					"root-volume-access-modes",
+					"root-volume-cache-strategy",
+					"root-volume-size",
+					"root-volume-storage-class",
+					"root-volume-volume-mode",
+					"vm-node-selector",
+				}
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				sort.Strings(actualFlags)
+				g.Expect(actualFlags).To(Equal(expectedFlags))
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			test.verify(t)
+		})
+	}
+}
+
+func TestUpdateNodePool(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "When minimal configuration is provided, it should generate correct nodepool",
+			args: []string{
+				"--cores=2",
+				"--memory=4Gi",
+				"--root-volume-size=32",
+			},
+		},
+		{
+			name: "When full configuration is provided, it should generate correct nodepool",
+			args: []string{
+				"--cores=4",
+				"--memory=8Gi",
+				"--root-volume-size=64",
+				"--root-volume-storage-class=fast-storage",
+				"--root-volume-access-modes=ReadWriteOnce",
+				"--root-volume-volume-mode=Block",
+				"--root-volume-cache-strategy=None",
+				"--network-multiqueue=Enable",
+				"--qos-class=Guaranteed",
+				"--additional-network=name:default/nad1",
+				"--attach-default-network=false",
+				"--vm-node-selector=role=kubevirt,size=large",
+				"--host-device-name=testdevice,count:1",
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
+			coreOpts := &core.CreateNodePoolOptions{
+				Name:        "test-nodepool",
+				Namespace:   "clusters",
+				ClusterName: "test-cluster",
+				Replicas:    3,
+				Arch:        string(hyperv1.ArchitectureAMD64),
+			}
+			kubevirtOpts := kubevirtnodepool.DefaultOptions()
+			kubevirtnodepool.BindOptions(kubevirtOpts, flags)
+
+			if err := flags.Parse(testCase.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			validOpts, err := kubevirtOpts.Validate(ctx, coreOpts)
+			if err != nil {
+				t.Fatalf("validation failed: %v", err)
+			}
+
+			completedOpts, err := validOpts.Complete(ctx, coreOpts)
+			if err != nil {
+				t.Fatalf("completion failed: %v", err)
+			}
+
+			nodePool := &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Arch: coreOpts.Arch,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+					},
+				},
+			}
+
+			if err := completedOpts.UpdateNodePool(ctx, nodePool, nil, nil); err != nil {
+				t.Fatalf("failed to update nodepool: %v", err)
+			}
+
+			testutil.CompareWithFixture(t, nodePool.Spec.Platform.Kubevirt)
+		})
+	}
+}

--- a/product-cli/cmd/nodepool/kubevirt/testdata/zz_fixture_TestUpdateNodePool_When_full_configuration_is_provided__it_should_generate_correct_nodepool.yaml
+++ b/product-cli/cmd/nodepool/kubevirt/testdata/zz_fixture_TestUpdateNodePool_When_full_configuration_is_provided__it_should_generate_correct_nodepool.yaml
@@ -1,0 +1,24 @@
+additionalNetworks:
+- name: default/nad1
+attachDefaultNetwork: false
+compute:
+  cores: 4
+  memory: 8Gi
+  qosClass: Guaranteed
+hostDevices:
+- count: 1
+  deviceName: testdevice
+networkInterfaceMultiqueue: Enable
+nodeSelector:
+  role: kubevirt
+  size: large
+rootVolume:
+  cacheStrategy:
+    type: None
+  persistent:
+    accessModes:
+    - ReadWriteOnce
+    size: 64Gi
+    storageClass: fast-storage
+    volumeMode: Block
+  type: Persistent

--- a/product-cli/cmd/nodepool/kubevirt/testdata/zz_fixture_TestUpdateNodePool_When_minimal_configuration_is_provided__it_should_generate_correct_nodepool.yaml
+++ b/product-cli/cmd/nodepool/kubevirt/testdata/zz_fixture_TestUpdateNodePool_When_minimal_configuration_is_provided__it_should_generate_correct_nodepool.yaml
@@ -1,0 +1,9 @@
+attachDefaultNetwork: true
+compute:
+  cores: 2
+  memory: 4Gi
+networkInterfaceMultiqueue: Enable
+rootVolume:
+  persistent:
+    size: 32Gi
+  type: Persistent

--- a/product-cli/cmd/nodepool/openstack/create_test.go
+++ b/product-cli/cmd/nodepool/openstack/create_test.go
@@ -1,0 +1,145 @@
+package openstack
+
+import (
+	"sort"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/cmd/nodepool/core"
+	openstacknodepool "github.com/openshift/hypershift/cmd/nodepool/openstack"
+	"github.com/openshift/hypershift/support/testutil"
+
+	"github.com/spf13/pflag"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		verify func(t *testing.T)
+	}{
+		"When OpenStack nodepool create command is created, it should have 'openstack' as use": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Use).To(Equal("openstack"))
+			},
+		},
+		"When OpenStack nodepool create command is created, it should register nodepool flags": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				g.Expect(cmd.Flag("openstack-node-flavor")).ToNot(BeNil())
+				g.Expect(cmd.Flag("openstack-node-image-name")).ToNot(BeNil())
+				g.Expect(cmd.Flag("openstack-node-availability-zone")).ToNot(BeNil())
+			},
+		},
+		"When OpenStack nodepool create command is created, it should register exactly the expected flags": {
+			verify: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand(&core.CreateNodePoolOptions{})
+				expectedFlags := []string{
+					"openstack-node-additional-port",
+					"openstack-node-availability-zone",
+					"openstack-node-flavor",
+					"openstack-node-image-name",
+				}
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				sort.Strings(actualFlags)
+				g.Expect(actualFlags).To(Equal(expectedFlags))
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			test.verify(t)
+		})
+	}
+}
+
+func TestUpdateNodePool(t *testing.T) {
+	for _, testCase := range []struct {
+		name        string
+		args        []string
+		expectError bool
+	}{
+		{
+			name: "When minimal configuration is provided, it should generate correct nodepool",
+			args: []string{
+				"--openstack-node-flavor=m1.large",
+				"--openstack-node-image-name=rhcos-openstack",
+			},
+		},
+		{
+			name: "When full configuration with availability zone is provided, it should generate correct nodepool",
+			args: []string{
+				"--openstack-node-flavor=m1.xlarge",
+				"--openstack-node-image-name=rhcos-openstack-latest",
+				"--openstack-node-availability-zone=nova",
+				"--openstack-node-additional-port=network-id:40a355cb-596d-495c-8766-419d98cadd57",
+			},
+		},
+		{
+			name:        "When flavor is empty, it should return a validation error",
+			args:        []string{},
+			expectError: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
+			coreOpts := &core.CreateNodePoolOptions{
+				Name:        "test-nodepool",
+				Namespace:   "clusters",
+				ClusterName: "test-cluster",
+				Replicas:    3,
+				Arch:        string(hyperv1.ArchitectureAMD64),
+			}
+			openstackOpts := openstacknodepool.DefaultOptions()
+			openstacknodepool.BindOptions(openstackOpts, flags)
+
+			if err := flags.Parse(testCase.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			validOpts, err := openstackOpts.Validate(ctx, coreOpts)
+			if testCase.expectError {
+				g := NewWithT(t)
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			if err != nil {
+				t.Fatalf("validation failed: %v", err)
+			}
+
+			completedOpts, err := validOpts.Complete(ctx, coreOpts)
+			if err != nil {
+				t.Fatalf("completion failed: %v", err)
+			}
+
+			// Platform.Type is intentionally omitted here because OpenStack's
+			// UpdateNodePool sets it internally, unlike other platforms.
+			nodePool := &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Arch: coreOpts.Arch,
+				},
+			}
+
+			if err := completedOpts.UpdateNodePool(ctx, nodePool, nil, nil); err != nil {
+				t.Fatalf("failed to update nodepool: %v", err)
+			}
+
+			g := NewWithT(t)
+			g.Expect(nodePool.Spec.Platform.Type).To(Equal(hyperv1.OpenStackPlatform))
+			testutil.CompareWithFixture(t, nodePool.Spec.Platform.OpenStack)
+		})
+	}
+}

--- a/product-cli/cmd/nodepool/openstack/testdata/zz_fixture_TestUpdateNodePool_When_full_configuration_with_availability_zone_is_provided__it_should_generate_correct_nodepool.yaml
+++ b/product-cli/cmd/nodepool/openstack/testdata/zz_fixture_TestUpdateNodePool_When_full_configuration_with_availability_zone_is_provided__it_should_generate_correct_nodepool.yaml
@@ -1,0 +1,6 @@
+additionalPorts:
+- network:
+    id: 40a355cb-596d-495c-8766-419d98cadd57
+availabilityZone: nova
+flavor: m1.xlarge
+imageName: rhcos-openstack-latest

--- a/product-cli/cmd/nodepool/openstack/testdata/zz_fixture_TestUpdateNodePool_When_minimal_configuration_is_provided__it_should_generate_correct_nodepool.yaml
+++ b/product-cli/cmd/nodepool/openstack/testdata/zz_fixture_TestUpdateNodePool_When_minimal_configuration_is_provided__it_should_generate_correct_nodepool.yaml
@@ -1,0 +1,2 @@
+flavor: m1.large
+imageName: rhcos-openstack


### PR DESCRIPTION
None of the 5 platforms - Agent, AWS, Azure, KubeVirt, and OpenStack had nodepool create commands.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:


| File | Subtests | What's Tested |
| --- | -------- | -------------- |
| aws/create_test.go | 4 | Use field, root-volume-type default (`gp3`), root-volume-size default (`120`), exact 8-flag enumeration |
| azure/create_test.go | 4 | Use field, root-disk-size default (`120`), disk-storage-account-type default (`Premium_LRS`), exact 15-flag enumeration |
| kubevirt/create_test.go | 9 | Use field, memory default (`4Gi`), cores default (`2`), root-volume-size default (`32`), qos-class default (`Burstable`), network-multiqueue default (`Enable`), attach-default-network default (`true`), developer-only flag exclusion (`containerdisk`), exact 13-flag enumeration |
| openstack/create_test.go | 3 | Use field, nodepool flags registered, exact 4-flag enumeration |
| agent/create_test.go | 3 | Use field, agentLabelSelector flag registered, exact 1-flag enumeration |

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3897

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added provider-specific coverage for nodepool “create” commands (Agent, AWS, Azure, KubeVirt, OpenStack).
  * Verified each command’s identity, exact CLI flag sets, provider defaults, and correct parsing for minimal/full argument sets.
  * Added end-to-end validations that parsed flags flow through validation/completion into node pool platform updates, matching expected fixtures (including Agent label-selector empty/single/multi cases).
  * For OpenStack, added negative coverage to confirm invalid inputs fail validation; for KubeVirt, confirmed developer-only options are not exposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->