### PR TITLE
CNTRLPLANE-3921: widen global-pull-secret-syncer DaemonSet-ready timeout

### DIFF
--- a/test/e2e/util/globalps.go
+++ b/test/e2e/util/globalps.go
@@ -179,7 +179,7 @@ func VerifyKubeletConfigWithDaemonSet(t *testing.T, ctx context.Context, guestCl
 	})
 
 	t.Log("Waiting for syncer DS rollout to complete before deploying verifier")
-	g.Expect(waitForDaemonSetRollout(t, ctx, guestClient, hccomanifests.GlobalPullSecretDSName, hccomanifests.GlobalPullSecretNamespace, expectedNodeCount)).To(Succeed())
+	g.Expect(waitForDaemonSetRollout(t, ctx, guestClient, hccomanifests.GlobalPullSecretDSName, hccomanifests.GlobalPullSecretNamespace, expectedNodeCount, globalPullSecretSyncerReadyTimeout)).To(Succeed())
 
 	t.Log("Creating kubelet config verifier DaemonSet")
 	err := CreateKubeletConfigVerifierDaemonSet(ctx, guestClient, dsImage)
@@ -187,7 +187,7 @@ func VerifyKubeletConfigWithDaemonSet(t *testing.T, ctx context.Context, guestCl
 
 	t.Log("Waiting for OVN, GlobalPullSecret, Konnectivity and kubelet config verifier DaemonSets to be ready")
 	g.Expect(waitForDaemonSetReady(t, ctx, guestClient, "ovnkube-node", "openshift-ovn-kubernetes", expectedNodeCount)).To(Succeed())
-	g.Expect(waitForDaemonSetReady(t, ctx, guestClient, hccomanifests.GlobalPullSecretDSName, hccomanifests.GlobalPullSecretNamespace, expectedNodeCount)).To(Succeed())
+	g.Expect(waitForGlobalPullSecretSyncerReady(t, ctx, guestClient, expectedNodeCount)).To(Succeed())
 	konnectivityDS := hccomanifests.KonnectivityAgentDaemonSet()
 	g.Expect(waitForDaemonSetReady(t, ctx, guestClient, konnectivityDS.Name, konnectivityDS.Namespace, expectedNodeCount)).To(Succeed())
 	g.Expect(waitForDaemonSetReady(t, ctx, guestClient, KubeletConfigVerifierDaemonSetName, KubeletConfigVerifierNamespace, expectedNodeCount)).To(Succeed())
@@ -198,10 +198,10 @@ func VerifyKubeletConfigWithDaemonSet(t *testing.T, ctx context.Context, guestCl
 // must be updated with the latest template AND ready. This catches the case where
 // HCCO updates the pod template (e.g. new configSeed) and the DS controller is
 // still replacing pods.
-func waitForDaemonSetRollout(t *testing.T, ctx context.Context, client crclient.Client, name, namespace string, minExpected int32) error {
+func waitForDaemonSetRollout(t *testing.T, ctx context.Context, client crclient.Client, name, namespace string, minExpected int32, timeout time.Duration) error {
 	t.Logf("Waiting for %s DaemonSet rollout to complete (min expected: %d)", name, minExpected)
 
-	return wait.PollUntilContextTimeout(ctx, 10*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (done bool, err error) {
 		ds := &appsv1.DaemonSet{}
 		if err := client.Get(ctx, crclient.ObjectKey{Name: name, Namespace: namespace}, ds); err != nil {
 			t.Logf("Failed to get DaemonSet %s: %v", name, err)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2170,7 +2170,7 @@ func EnsureGlobalPullSecret(t *testing.T, ctx context.Context, mgmtClient crclie
 
 		t.Run("Wait for critical DaemonSets to be ready - first check", func(t *testing.T) {
 			g.Expect(waitForDaemonSetReady(t, ctx, guestClient, "ovnkube-node", "openshift-ovn-kubernetes", nodeCount)).To(Succeed())
-			g.Expect(waitForDaemonSetReady(t, ctx, guestClient, hccomanifests.GlobalPullSecretDSName, hccomanifests.GlobalPullSecretNamespace, nodeCount)).To(Succeed())
+			g.Expect(waitForGlobalPullSecretSyncerReady(t, ctx, guestClient, nodeCount)).To(Succeed())
 			konnectivityDS := hccomanifests.KonnectivityAgentDaemonSet()
 			g.Expect(waitForDaemonSetReady(t, ctx, guestClient, konnectivityDS.Name, konnectivityDS.Namespace, nodeCount)).To(Succeed())
 		})
@@ -2212,7 +2212,7 @@ func EnsureGlobalPullSecret(t *testing.T, ctx context.Context, mgmtClient crclie
 
 		t.Run("Wait for critical DaemonSets to be ready - second check", func(t *testing.T) {
 			g.Expect(waitForDaemonSetReady(t, ctx, guestClient, "ovnkube-node", "openshift-ovn-kubernetes", nodeCount)).To(Succeed())
-			g.Expect(waitForDaemonSetReady(t, ctx, guestClient, hccomanifests.GlobalPullSecretDSName, hccomanifests.GlobalPullSecretNamespace, nodeCount)).To(Succeed())
+			g.Expect(waitForGlobalPullSecretSyncerReady(t, ctx, guestClient, nodeCount)).To(Succeed())
 			konnectivityDS := hccomanifests.KonnectivityAgentDaemonSet()
 			g.Expect(waitForDaemonSetReady(t, ctx, guestClient, konnectivityDS.Name, konnectivityDS.Namespace, nodeCount)).To(Succeed())
 		})
@@ -2249,7 +2249,7 @@ func EnsureGlobalPullSecret(t *testing.T, ctx context.Context, mgmtClient crclie
 		// Wait for all DaemonSets to be ready after nodes stabilize
 		t.Run("Wait for pull secret synchronization to stabilize across all nodes", func(t *testing.T) {
 			t.Log("Waiting for GlobalPullSecretDaemonSet to process the deletion and stabilize all nodes")
-			g.Expect(waitForDaemonSetReady(t, ctx, guestClient, hccomanifests.GlobalPullSecretDSName, hccomanifests.GlobalPullSecretNamespace, nodeCount)).To(Succeed())
+			g.Expect(waitForGlobalPullSecretSyncerReady(t, ctx, guestClient, nodeCount)).To(Succeed())
 		})
 
 		// Check if the config.json is updated in all of the nodes
@@ -2278,12 +2278,38 @@ func createAdditionalPullSecret(ctx context.Context, guestClient crclient.Client
 	return nil
 }
 
+// globalPullSecretSyncerReadyTimeout is used instead of the default DaemonSet-ready
+// timeout for checks against global-pull-secret-syncer specifically. That DaemonSet's
+// status.observedGeneration is updated by the guest cluster's kube-controller-manager,
+// which can have a multi-minute availability gap during early cluster life (observed:
+// a management-cluster node eviction forces a KCM pod replacement, and the replacement's
+// container creation hits a transient upstream kubelet Secret-decode race —
+// "illegal base64 data at input byte N" — before recovering on its own). This is not a
+// HyperShift code path and cannot be fixed here; the observed gap was ~20-21 minutes
+// across two independent CI failures, so 40 minutes leaves comfortable margin while
+// keeping the common case (which passes in under a second) essentially unaffected.
+const globalPullSecretSyncerReadyTimeout = 40 * time.Minute
+
 // waitForDaemonSetReady waits for a DaemonSet to have all pods ready.
 // minExpected is a sanity check to ensure we don't succeed when DesiredNumberScheduled is temporarily 0.
 func waitForDaemonSetReady(t *testing.T, ctx context.Context, client crclient.Client, name, namespace string, minExpected int32) error {
+	return waitForDaemonSetReadyWithTimeout(t, ctx, client, name, namespace, minExpected, 20*time.Minute)
+}
+
+// waitForGlobalPullSecretSyncerReady is waitForDaemonSetReady for
+// global-pull-secret-syncer specifically, using globalPullSecretSyncerReadyTimeout
+// instead of the default budget. See that constant's doc comment for why.
+func waitForGlobalPullSecretSyncerReady(t *testing.T, ctx context.Context, client crclient.Client, minExpected int32) error {
+	return waitForDaemonSetReadyWithTimeout(t, ctx, client, hccomanifests.GlobalPullSecretDSName, hccomanifests.GlobalPullSecretNamespace, minExpected, globalPullSecretSyncerReadyTimeout)
+}
+
+// waitForDaemonSetReadyWithTimeout is waitForDaemonSetReady with a caller-supplied
+// timeout, for DaemonSets that need a longer budget than the default. See
+// globalPullSecretSyncerReadyTimeout for why this is needed at all.
+func waitForDaemonSetReadyWithTimeout(t *testing.T, ctx context.Context, client crclient.Client, name, namespace string, minExpected int32, timeout time.Duration) error {
 	t.Logf("Waiting for %s DaemonSet to be ready (min expected: %d)", name, minExpected)
 
-	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 20*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (done bool, err error) {
 		daemonSet := &appsv1.DaemonSet{}
 		err = client.Get(ctx, crclient.ObjectKey{Name: name, Namespace: namespace}, daemonSet)
 		if err != nil {

--- a/test/e2e/util/util_test.go
+++ b/test/e2e/util/util_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"crypto/x509"
 	"testing"
 	"time"
@@ -8,10 +9,16 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hccomanifests "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/certs"
 
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestAllowedCIDRsTargetService(t *testing.T) {
@@ -204,6 +211,194 @@ func TestGenerateCustomCertificate(t *testing.T) {
 			// Verify the private key can be parsed
 			_, err = certs.PemToPrivateKey(keyPEM)
 			g.Expect(err).NotTo(HaveOccurred())
+		})
+	}
+}
+
+func TestWaitForDaemonSetReadyWithTimeout(t *testing.T) {
+	const (
+		dsName      = hccomanifests.GlobalPullSecretDSName
+		dsNamespace = hccomanifests.GlobalPullSecretNamespace
+		minExpected = int32(3)
+	)
+
+	readyDaemonSet := func() *appsv1.DaemonSet {
+		return &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       dsName,
+				Namespace:  dsNamespace,
+				Generation: 3,
+			},
+			Status: appsv1.DaemonSetStatus{
+				ObservedGeneration:     3,
+				DesiredNumberScheduled: minExpected,
+				UpdatedNumberScheduled: minExpected,
+				NumberReady:            minExpected,
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		daemonSet *appsv1.DaemonSet
+		expectErr bool
+	}{
+		{
+			name:      "When DaemonSet status matches generation and all pods are ready and updated, it should succeed",
+			daemonSet: readyDaemonSet(),
+		},
+		{
+			name: "When status.observedGeneration lags metadata.generation, it should time out",
+			daemonSet: func() *appsv1.DaemonSet {
+				ds := readyDaemonSet()
+				ds.Status.ObservedGeneration = 2
+				return ds
+			}(),
+			expectErr: true,
+		},
+		{
+			name: "When fewer pods are ready than desired, it should time out",
+			daemonSet: func() *appsv1.DaemonSet {
+				ds := readyDaemonSet()
+				ds.Status.NumberReady = minExpected - 1
+				return ds
+			}(),
+			expectErr: true,
+		},
+		{
+			name: "When rollout has not updated all pods yet, it should time out",
+			daemonSet: func() *appsv1.DaemonSet {
+				ds := readyDaemonSet()
+				ds.Status.UpdatedNumberScheduled = minExpected - 1
+				return ds
+			}(),
+			expectErr: true,
+		},
+		{
+			name: "When DesiredNumberScheduled has not yet reached minExpected, it should time out",
+			daemonSet: func() *appsv1.DaemonSet {
+				ds := readyDaemonSet()
+				ds.Status.DesiredNumberScheduled = minExpected - 1
+				ds.Status.UpdatedNumberScheduled = minExpected - 1
+				ds.Status.NumberReady = minExpected - 1
+				return ds
+			}(),
+			expectErr: true,
+		},
+		{
+			name:      "When the DaemonSet does not exist, it should time out",
+			daemonSet: nil,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			builder := fake.NewClientBuilder().WithScheme(api.Scheme)
+			if tt.daemonSet != nil {
+				builder = builder.WithObjects(tt.daemonSet)
+			}
+			client := builder.Build()
+
+			// A short timeout keeps this test fast; wait.PollUntilContextTimeout's
+			// immediate=true still guarantees at least one real evaluation of the
+			// condition before the deadline is checked.
+			err := waitForDaemonSetReadyWithTimeout(t, context.Background(), client, dsName, dsNamespace, minExpected, 50*time.Millisecond)
+
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestWaitForDaemonSetRollout(t *testing.T) {
+	const (
+		dsName      = hccomanifests.GlobalPullSecretDSName
+		dsNamespace = hccomanifests.GlobalPullSecretNamespace
+		minExpected = int32(3)
+	)
+
+	rolledOutDaemonSet := func() *appsv1.DaemonSet {
+		return &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       dsName,
+				Namespace:  dsNamespace,
+				Generation: 3,
+			},
+			Status: appsv1.DaemonSetStatus{
+				ObservedGeneration:     3,
+				DesiredNumberScheduled: minExpected,
+				UpdatedNumberScheduled: minExpected,
+				NumberReady:            minExpected,
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		daemonSet *appsv1.DaemonSet
+		expectErr bool
+	}{
+		{
+			name:      "When rollout is complete and all pods are updated and ready, it should succeed",
+			daemonSet: rolledOutDaemonSet(),
+		},
+		{
+			name: "When status.observedGeneration lags metadata.generation, it should time out",
+			daemonSet: func() *appsv1.DaemonSet {
+				ds := rolledOutDaemonSet()
+				ds.Status.ObservedGeneration = 2
+				return ds
+			}(),
+			expectErr: true,
+		},
+		{
+			name: "When some pods are not yet updated, it should time out",
+			daemonSet: func() *appsv1.DaemonSet {
+				ds := rolledOutDaemonSet()
+				ds.Status.UpdatedNumberScheduled = minExpected - 1
+				return ds
+			}(),
+			expectErr: true,
+		},
+		{
+			name: "When some pods are not yet ready, it should time out",
+			daemonSet: func() *appsv1.DaemonSet {
+				ds := rolledOutDaemonSet()
+				ds.Status.NumberReady = minExpected - 1
+				return ds
+			}(),
+			expectErr: true,
+		},
+		{
+			name:      "When the DaemonSet does not exist, it should time out",
+			daemonSet: nil,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			builder := fake.NewClientBuilder().WithScheme(api.Scheme)
+			if tt.daemonSet != nil {
+				builder = builder.WithObjects(tt.daemonSet)
+			}
+			client := builder.Build()
+
+			err := waitForDaemonSetRollout(t, context.Background(), client, dsName, dsNamespace, minExpected, 50*time.Millisecond)
+
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:

`EnsureGlobalPullSecret` (in `pull-ci-openshift-hypershift-main-e2e-aws`) intermittently fails polling `global-pull-secret-syncer`'s DaemonSet `status.observedGeneration` within its 20-minute budget:

```
util.go:2295: DaemonSet global-pull-secret-syncer status has not observed generation 3 yet (current 2)
```

Investigation (ground-truth CI artifact analysis across 3 failing runs + 1 passing baseline) found the DaemonSet is never actually stuck — it fully converges by end-of-test in every failing run. The real cause: `status.observedGeneration` is set by the guest cluster's `kube-controller-manager`, which can have a multi-minute availability gap during early cluster life. In two independently-examined failing runs, a management-cluster node eviction forced a KCM pod replacement, and the replacement's container creation hit a transient, externally-documented upstream kubelet Secret-decode race (`illegal base64 data at input byte N` — see [kubernetes/kubectl#1405](https://github.com/kubernetes/kubectl/issues/1405), [kubernetes/kubernetes#76667](https://github.com/kubernetes/kubernetes/issues/76667)) before recovering on its own within a few minutes.

Neither the node eviction nor the kubelet race is a HyperShift code path, so this widens the test's timeout for `global-pull-secret-syncer` specifically (20min → 40min — roughly 2x the worst observed gap of ~20-21 minutes) rather than changing any product code. The common case is unaffected: the passing baseline's equivalent check resolves in under a second.

### CI runs reviewed

| Run | PR | Date | Result | KCM Secret-decode race confirmed? |
|-----|-----|------|--------|-----------------------------------|
| #8581 run A | #8581 | 2026-07-23 | FAIL | Not checked (artifacts available) |
| #8581 run B | #8581 | 2026-07-26 | FAIL | Yes — `illegal base64 data at input byte 3` |
| PR #8938 | #8938 | 2026-07-26 | FAIL | Yes — identical error, same byte offset |
| #9066 baseline | — | 2026-07-26 | PASS | N/A (no eviction occurred) |

All 3 failing runs show `global-pull-secret-syncer` fully converged (`generation=4, observedGeneration=4, 3/3 ready, 3/3 updated`) by end-of-test dump — the DaemonSet is never permanently stuck.

### Changes

- Extracts `waitForDaemonSetReady`'s hardcoded timeout into a parameterized `waitForDaemonSetReadyWithTimeout`, keeping the original 20-minute default for unrelated callers (ovnkube-node, konnectivity-agent, kubelet-config-verifier, Cilium).
- Adds `waitForGlobalPullSecretSyncerReady`, a helper bundling the DaemonSet name/namespace/timeout so the widened timeout is defined once, not repeated at each call site.
- Adds a `timeout` parameter to `waitForDaemonSetRollout` (previously hardcoded at 5 min); caller passes `globalPullSecretSyncerReadyTimeout`.
- Adds unit tests for both modified/extracted functions using a fake client, covering the generation-lag gate this investigation was about.

## Which issue(s) this PR fixes:
Fixes [CNTRLPLANE-3921](https://redhat.atlassian.net/browse/CNTRLPLANE-3921)

## Special notes for your reviewer:

This is a test-only, root-cause-targeted timeout increase — no product code is touched. Full investigation writeup with evidence available on request; the short version is in the commit message. Two earlier hypotheses (HCCO startup-sequencing timing, `globalps` reconcile-watch churn) were investigated and ruled out via direct log/event evidence before landing on the kube-controller-manager finding above — happy to share the fuller trail if useful for review.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin