### PR TITLE
OCPBUGS-99883: fix(azure): cache VNet location validation and requeue on ARM 429 throttling

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -614,12 +614,14 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 
+	var configValidationErr error
 	{
 		condition := metav1.Condition{
 			Type:               string(hyperv1.ValidHostedControlPlaneConfiguration),
 			ObservedGeneration: hostedControlPlane.Generation,
 		}
 		if err := r.validateConfigAndClusterCapabilities(ctx, hostedControlPlane); err != nil {
+			configValidationErr = err
 			condition.Status = metav1.ConditionFalse
 			condition.Message = err.Error()
 			condition.Reason = hyperv1.InsufficientClusterCapabilitiesReason
@@ -709,6 +711,12 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	{
 		validConfig := meta.FindStatusCondition(hostedControlPlane.Status.Conditions, string(hyperv1.ValidHostedControlPlaneConfiguration))
 		if validConfig != nil && validConfig.Status == metav1.ConditionFalse {
+			// Transient Azure API failures (e.g. 429 rate limiting) should requeue
+			// respecting Retry-After rather than hard-blocking until an unrelated watch event.
+			if result, shouldRequeue := requeueOnAzureAPIError(configValidationErr); shouldRequeue {
+				r.Log.Info("Configuration validation hit a transient Azure API error, requeueing", "requeueAfter", result.RequeueAfter)
+				return result, nil
+			}
 			r.Log.Info("Configuration is invalid, reconciliation is blocked")
 			return reconcile.Result{}, nil
 		}
@@ -3226,8 +3234,36 @@ func (r *HostedControlPlaneReconciler) reconcileSREMetricsConfig(ctx context.Con
 	return nil
 }
 
+// shouldSkipAzureResourceGroupLocationValidation reports whether Azure ARM calls to
+// verify VNet/NSG/RG locations can be skipped because validation already succeeded for
+// the current generation. Locations are immutable for a given set of Azure resource IDs,
+// so re-checking on every reconcile is unnecessary and contributes to ARM throttling.
+func shouldSkipAzureResourceGroupLocationValidation(hcp *hyperv1.HostedControlPlane) bool {
+	validConfig := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ValidHostedControlPlaneConfiguration))
+	return validConfig != nil &&
+		validConfig.Status == metav1.ConditionTrue &&
+		validConfig.ObservedGeneration == hcp.Generation
+}
+
+// requeueOnAzureAPIError returns a RequeueAfter result when err wraps an Azure API
+// ResponseError (e.g. 429), using ClassifyAzureError for differentiated backoff that
+// respects the Retry-After header. Permanent validation failures that are not Azure
+// API errors return false so reconciliation remains hard-gated.
+func requeueOnAzureAPIError(err error) (ctrl.Result, bool) {
+	var respErr *azcore.ResponseError
+	if err == nil || !errors.As(err, &respErr) {
+		return ctrl.Result{}, false
+	}
+	requeueAfter, _ := hyperazureutil.ClassifyAzureError(err)
+	return ctrl.Result{RequeueAfter: requeueAfter}, true
+}
+
 // verifyResourceGroupLocationsMatch verifies the locations match for the VNET, network security group, and managed resource groups
 func (r *HostedControlPlaneReconciler) verifyResourceGroupLocationsMatch(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	if shouldSkipAzureResourceGroupLocationValidation(hcp) {
+		return nil
+	}
+
 	var (
 		creds     azcore.TokenCredential
 		found, ok bool

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -57,6 +57,8 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -4620,3 +4622,149 @@ var _ util.ImageMetadataProvider = &fakeVersionImageMetadataProvider{}
 
 // Compile-time assertion for clock interface used by tests.
 var _ clock.Clock = &testingclock.FakeClock{}
+
+func TestShouldSkipAzureResourceGroupLocationValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		hcp      *hyperv1.HostedControlPlane
+		expected bool
+	}{
+		{
+			name: "When condition is absent, it should not skip validation",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			},
+			expected: false,
+		},
+		{
+			name: "When condition is True for the current generation, it should skip validation",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{{
+						Type:               string(hyperv1.ValidHostedControlPlaneConfiguration),
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 2,
+					}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "When condition is True for a stale generation, it should not skip validation",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Generation: 3},
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{{
+						Type:               string(hyperv1.ValidHostedControlPlaneConfiguration),
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 2,
+					}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "When condition is False, it should not skip validation",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{{
+						Type:               string(hyperv1.ValidHostedControlPlaneConfiguration),
+						Status:             metav1.ConditionFalse,
+						ObservedGeneration: 1,
+					}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "When condition is Unknown, it should not skip validation",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{{
+						Type:               string(hyperv1.ValidHostedControlPlaneConfiguration),
+						Status:             metav1.ConditionUnknown,
+						ObservedGeneration: 1,
+					}},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			g.Expect(shouldSkipAzureResourceGroupLocationValidation(tt.hcp)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestRequeueOnAzureAPIError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		err                error
+		expectRequeue      bool
+		expectedRequeueFor time.Duration
+	}{
+		{
+			name:          "When error is nil, it should not requeue",
+			err:           nil,
+			expectRequeue: false,
+		},
+		{
+			name:          "When error is a permanent validation failure, it should not requeue",
+			err:           fmt.Errorf("the locations of the resource groups do not match"),
+			expectRequeue: false,
+		},
+		{
+			name: "When Azure returns 429 with Retry-After, it should requeue using that duration",
+			err: fmt.Errorf("failed to get vnet info: %w", &azcore.ResponseError{
+				StatusCode: http.StatusTooManyRequests,
+				RawResponse: &http.Response{
+					Header: http.Header{"Retry-After": {"120"}},
+				},
+			}),
+			expectRequeue:      true,
+			expectedRequeueFor: 120 * time.Second,
+		},
+		{
+			name: "When Azure returns 429 without Retry-After, it should requeue after the default 5 minutes",
+			err: fmt.Errorf("failed to get vnet info: %w", &azcore.ResponseError{
+				StatusCode:  http.StatusTooManyRequests,
+				RawResponse: &http.Response{Header: http.Header{}},
+			}),
+			expectRequeue:      true,
+			expectedRequeueFor: 5 * time.Minute,
+		},
+		{
+			name: "When Azure returns 403, it should requeue after 10 minutes",
+			err: fmt.Errorf("failed to get vnet info: %w", &azcore.ResponseError{
+				StatusCode: http.StatusForbidden,
+			}),
+			expectRequeue:      true,
+			expectedRequeueFor: 10 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			result, shouldRequeue := requeueOnAzureAPIError(tt.err)
+			g.Expect(shouldRequeue).To(Equal(tt.expectRequeue))
+			if tt.expectRequeue {
+				g.Expect(result.RequeueAfter).To(Equal(tt.expectedRequeueFor))
+			} else {
+				g.Expect(result).To(Equal(ctrl.Result{}))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
Skip Azure ARM VNet/NSG/RG location checks once ValidHostedControlPlaneConfiguration is True for the current generation, and requeue with Retry-After on Azure API errors instead of hard-gating reconciliation during throttling.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/OCPBUGS-99883 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hosted control plane recovery from temporary Azure API errors.
  * Reconciliation now honors Azure retry timing and uses appropriate fallback delays for rate limiting and authorization responses.
  * Avoided repeating Azure resource group location validation when the configuration is already confirmed valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->