### PR TITLE
OCPBUGS-105591: [release-4.22] use in-cluster service for oauth-server

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/pki/oauth.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/oauth.go
@@ -15,7 +15,7 @@ func ReconcileOAuthServerCert(secret, ca *corev1.Secret, ownerRef config.OwnerRe
 	if oauthIP != nil {
 		ips = append(ips, externalOAuthAddress)
 	} else {
-		dnsNames = append(dnsNames, externalOAuthAddress)
+		dnsNames = append(dnsNames, externalOAuthAddress, "oauth-openshift."+secret.GetNamespace()+".svc.cluster.local")
 	}
 	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-oauth", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, ips)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/AROSwift/zz_fixture_TestControlPlaneComponents_oauth_openshift_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/AROSwift/zz_fixture_TestControlPlaneComponents_oauth_openshift_configmap.yaml
@@ -33,7 +33,7 @@ data:
       loginURL: https://:0
       masterCA: /etc/kubernetes/certs/master-ca/ca.crt
       masterPublicURL: https://:0
-      masterURL: https://:0
+      masterURL: https://oauth-openshift.hcp-namespace.svc.cluster.local:6443
       sessionConfig:
         sessionMaxAgeSeconds: 300
         sessionName: ssn

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/AROSwift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/AROSwift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,tmp-dir
-        component.hypershift.openshift.io/config-hash: 19dc307e3b105d444ebc1fdd60b54b1d741638a5a0dd232cbcc341c5
+        component.hypershift.openshift.io/config-hash: 19dc307e3b105d44458a71d460b54b1d741638a5a0dd232cbcc341c5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: oauth-openshift
@@ -95,7 +95,7 @@ spec:
         - name: ALL_PROXY
           value: socks5://127.0.0.1:8090
         - name: NO_PROXY
-          value: kube-apiserver,audit-webhook
+          value: kube-apiserver,audit-webhook,oauth-openshift.hcp-namespace.svc.cluster.local
         image: oauth-server
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/GCP/zz_fixture_TestControlPlaneComponents_oauth_openshift_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/GCP/zz_fixture_TestControlPlaneComponents_oauth_openshift_configmap.yaml
@@ -33,7 +33,7 @@ data:
       loginURL: https://:0
       masterCA: /etc/kubernetes/certs/master-ca/ca.crt
       masterPublicURL: https://:0
-      masterURL: https://:0
+      masterURL: https://oauth-openshift.hcp-namespace.svc.cluster.local:6443
       sessionConfig:
         sessionMaxAgeSeconds: 300
         sessionName: ssn

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/GCP/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/GCP/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,tmp-dir
-        component.hypershift.openshift.io/config-hash: 19dc307e3b105d444ebc1fdd60b54b1d741638a5a0dd232cbcc341c5
+        component.hypershift.openshift.io/config-hash: 19dc307e3b105d44458a71d460b54b1d741638a5a0dd232cbcc341c5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: oauth-openshift
@@ -95,7 +95,7 @@ spec:
         - name: ALL_PROXY
           value: socks5://127.0.0.1:8090
         - name: NO_PROXY
-          value: kube-apiserver,audit-webhook
+          value: kube-apiserver,audit-webhook,oauth-openshift.hcp-namespace.svc.cluster.local
         image: oauth-server
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/IBMCloud/zz_fixture_TestControlPlaneComponents_oauth_openshift_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/IBMCloud/zz_fixture_TestControlPlaneComponents_oauth_openshift_configmap.yaml
@@ -33,7 +33,7 @@ data:
       loginURL: https://:0
       masterCA: /etc/kubernetes/certs/master-ca/ca.crt
       masterPublicURL: https://:0
-      masterURL: https://:0
+      masterURL: https://oauth-openshift.hcp-namespace.svc.cluster.local:6443
       sessionConfig:
         sessionMaxAgeSeconds: 300
         sessionName: ssn

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/IBMCloud/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/IBMCloud/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,tmp-dir
-        component.hypershift.openshift.io/config-hash: 19dc307e3b105d444ebc1fdd60b54b1d741638a5a0dd232cbcc341c5
+        component.hypershift.openshift.io/config-hash: 19dc307e3b105d44458a71d460b54b1d741638a5a0dd232cbcc341c5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: oauth-openshift
@@ -95,7 +95,7 @@ spec:
         - name: ALL_PROXY
           value: socks5://127.0.0.1:8090
         - name: NO_PROXY
-          value: kube-apiserver,audit-webhook,iam.cloud.ibm.com,iam.test.cloud.ibm.com
+          value: kube-apiserver,audit-webhook,oauth-openshift.hcp-namespace.svc.cluster.local,iam.cloud.ibm.com,iam.test.cloud.ibm.com
         image: oauth-server
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_oauth_openshift_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_oauth_openshift_configmap.yaml
@@ -33,7 +33,7 @@ data:
       loginURL: https://:0
       masterCA: /etc/kubernetes/certs/master-ca/ca.crt
       masterPublicURL: https://:0
-      masterURL: https://:0
+      masterURL: https://oauth-openshift.hcp-namespace.svc.cluster.local:6443
       sessionConfig:
         sessionMaxAgeSeconds: 300
         sessionName: ssn

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,tmp-dir
-        component.hypershift.openshift.io/config-hash: 19dc307e3b105d444ebc1fdd60b54b1d741638a5a0dd232cbcc341c5
+        component.hypershift.openshift.io/config-hash: 19dc307e3b105d44458a71d460b54b1d741638a5a0dd232cbcc341c5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: oauth-openshift
@@ -95,7 +95,7 @@ spec:
         - name: ALL_PROXY
           value: socks5://127.0.0.1:8090
         - name: NO_PROXY
-          value: kube-apiserver,audit-webhook
+          value: kube-apiserver,audit-webhook,oauth-openshift.hcp-namespace.svc.cluster.local
         image: oauth-server
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_oauth_openshift_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_oauth_openshift_configmap.yaml
@@ -33,7 +33,7 @@ data:
       loginURL: https://:0
       masterCA: /etc/kubernetes/certs/master-ca/ca.crt
       masterPublicURL: https://:0
-      masterURL: https://:0
+      masterURL: https://oauth-openshift.hcp-namespace.svc.cluster.local:6443
       sessionConfig:
         sessionMaxAgeSeconds: 300
         sessionName: ssn

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,tmp-dir
-        component.hypershift.openshift.io/config-hash: 19dc307e3b105d444ebc1fdd60b54b1d741638a5a0dd232cbcc341c5
+        component.hypershift.openshift.io/config-hash: 19dc307e3b105d44458a71d460b54b1d741638a5a0dd232cbcc341c5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: oauth-openshift
@@ -95,7 +95,7 @@ spec:
         - name: ALL_PROXY
           value: socks5://127.0.0.1:8090
         - name: NO_PROXY
-          value: kube-apiserver,audit-webhook
+          value: kube-apiserver,audit-webhook,oauth-openshift.hcp-namespace.svc.cluster.local
         image: oauth-server
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/oauth-openshift/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/oauth-openshift/deployment.yaml
@@ -33,8 +33,6 @@ spec:
           value: http://127.0.0.1:8092
         - name: ALL_PROXY
           value: socks5://127.0.0.1:8090
-        - name: NO_PROXY
-          value: kube-apiserver,audit-webhook
         image: oauth-server
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
@@ -7,7 +7,6 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/oauth"
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -25,6 +24,7 @@ const (
 	auditPolicyProfileMapKey = "profile"
 
 	defaultAccessTokenMaxAgeSeconds int32 = 86400
+	OAuthServerPort                 int32 = 6443
 )
 
 // ConfigOverride defines the oauth parameters that can be overridden in special use cases. The only supported
@@ -81,7 +81,7 @@ func adaptOAuthConfig(cpContext component.WorkloadContext, cfg *osinv1.OsinServe
 
 	masterUrl := fmt.Sprintf("https://%s:%d", cpContext.InfraStatus.OAuthHost, cpContext.InfraStatus.OAuthPort)
 	controlPlaneEndpoint := cpContext.HCP.Status.ControlPlaneEndpoint
-	cfg.OAuthConfig.MasterURL = fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(cpContext.HCP.Namespace), oauth.OAuthServerPort)
+	cfg.OAuthConfig.MasterURL = fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(cpContext.HCP.Namespace), OAuthServerPort)
 	cfg.OAuthConfig.MasterPublicURL = masterUrl
 	cfg.OAuthConfig.LoginURL = fmt.Sprintf("https://%s:%d", controlPlaneEndpoint.Host, controlPlaneEndpoint.Port)
 	// loginURLOverride can be used to specify an override for the oauth config login url. The need for this arises

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
@@ -7,6 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -79,11 +80,15 @@ func adaptOAuthConfig(cpContext component.WorkloadContext, cfg *osinv1.OsinServe
 	cfg.ServingInfo.MinTLSVersion = config.MinTLSVersion(configuration.GetTLSSecurityProfile())
 	cfg.ServingInfo.CipherSuites = config.CipherSuites(configuration.GetTLSSecurityProfile())
 
-	masterUrl := fmt.Sprintf("https://%s:%d", cpContext.InfraStatus.OAuthHost, cpContext.InfraStatus.OAuthPort)
+	masterUrl := fmt.Sprintf("https://%s:%d", pki.AddBracketsIfIPv6(cpContext.InfraStatus.OAuthHost), cpContext.InfraStatus.OAuthPort)
 	controlPlaneEndpoint := cpContext.HCP.Status.ControlPlaneEndpoint
+	loginURLHost := controlPlaneEndpoint.Host
+	if cpContext.HCP.Spec.KubeAPIServerDNSName != "" {
+		loginURLHost = cpContext.HCP.Spec.KubeAPIServerDNSName
+	}
 	cfg.OAuthConfig.MasterURL = fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(cpContext.HCP.Namespace), OAuthServerPort)
 	cfg.OAuthConfig.MasterPublicURL = masterUrl
-	cfg.OAuthConfig.LoginURL = fmt.Sprintf("https://%s:%d", controlPlaneEndpoint.Host, controlPlaneEndpoint.Port)
+	cfg.OAuthConfig.LoginURL = fmt.Sprintf("https://%s:%d", pki.AddBracketsIfIPv6(loginURLHost), controlPlaneEndpoint.Port)
 	// loginURLOverride can be used to specify an override for the oauth config login url. The need for this arises
 	// when the login a provider uses doesn't conform to the standard login url in hypershift. The only supported use case
 	// for this is IBMCloud Red Hat Openshift

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/oauth"
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -33,6 +35,15 @@ type ConfigOverride struct {
 	URLs      osinv1.OpenIDURLs   `json:"urls,omitempty"`
 	Claims    osinv1.OpenIDClaims `json:"claims,omitempty"`
 	Challenge *bool               `json:"challenge,omitempty"`
+}
+
+// getOAuthServiceDNS returns the internal cluster DNS name for the OAuth service
+// in the given namespace.
+func getOAuthServiceDNS(namespace string) string {
+	if namespace == "" {
+		return ""
+	}
+	return manifests.OauthServerService("").Name + "." + namespace + ".svc.cluster.local"
 }
 
 func adaptAuditConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap) error {
@@ -70,7 +81,7 @@ func adaptOAuthConfig(cpContext component.WorkloadContext, cfg *osinv1.OsinServe
 
 	masterUrl := fmt.Sprintf("https://%s:%d", cpContext.InfraStatus.OAuthHost, cpContext.InfraStatus.OAuthPort)
 	controlPlaneEndpoint := cpContext.HCP.Status.ControlPlaneEndpoint
-	cfg.OAuthConfig.MasterURL = masterUrl
+	cfg.OAuthConfig.MasterURL = fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(cpContext.HCP.Namespace), oauth.OAuthServerPort)
 	cfg.OAuthConfig.MasterPublicURL = masterUrl
 	cfg.OAuthConfig.LoginURL = fmt.Sprintf("https://%s:%d", controlPlaneEndpoint.Host, controlPlaneEndpoint.Port)
 	// loginURLOverride can be used to specify an override for the oauth config login url. The need for this arises

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/infra"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 
 	osinv1 "github.com/openshift/api/osin/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetOAuthServiceDNS(t *testing.T) {
@@ -50,8 +51,7 @@ func TestGetOAuthServiceDNS(t *testing.T) {
 func TestAdaptOAuthConfig(t *testing.T) {
 
 	const (
-		testNamespace           = "test-cluster"
-		testInternalServicePort = int32(6443)
+		testNamespace = "test-cluster"
 	)
 	testCases := []struct {
 		name                    string
@@ -72,7 +72,7 @@ func TestAdaptOAuthConfig(t *testing.T) {
 			cpEndpointHost:          "api.example.com",
 			cpEndpointPort:          6443,
 			expectedLoginURL:        "https://api.example.com:6443",
-			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), testInternalServicePort),
+			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), OAuthServerPort),
 			expectedMasterPublicURL: "https://oauth.example.com:443",
 		},
 		{
@@ -83,7 +83,7 @@ func TestAdaptOAuthConfig(t *testing.T) {
 			cpEndpointPort:          6443,
 			kasDNSName:              "api.custom.example.com",
 			expectedLoginURL:        "https://api.custom.example.com:6443",
-			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), testInternalServicePort),
+			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), OAuthServerPort),
 			expectedMasterPublicURL: "https://oauth.example.com:443",
 		},
 		{
@@ -93,7 +93,7 @@ func TestAdaptOAuthConfig(t *testing.T) {
 			cpEndpointHost:          "10.0.0.1",
 			cpEndpointPort:          6443,
 			expectedLoginURL:        "https://10.0.0.1:6443",
-			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), testInternalServicePort),
+			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), OAuthServerPort),
 			expectedMasterPublicURL: "https://10.0.0.2:443",
 		},
 		{
@@ -105,7 +105,7 @@ func TestAdaptOAuthConfig(t *testing.T) {
 			kasDNSName:              "api.custom.example.com",
 			loginURLOverride:        "https://ibm.override.example.com:6443",
 			expectedLoginURL:        "https://ibm.override.example.com:6443",
-			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), testInternalServicePort),
+			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), OAuthServerPort),
 			expectedMasterPublicURL: "https://oauth.example.com:443",
 		},
 		{
@@ -115,7 +115,7 @@ func TestAdaptOAuthConfig(t *testing.T) {
 			cpEndpointHost:          "2001:db8::1",
 			cpEndpointPort:          6443,
 			expectedLoginURL:        "https://[2001:db8::1]:6443",
-			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), testInternalServicePort),
+			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), OAuthServerPort),
 			expectedMasterPublicURL: "https://oauth.example.com:443",
 		},
 		{
@@ -125,7 +125,7 @@ func TestAdaptOAuthConfig(t *testing.T) {
 			cpEndpointHost:          "api.example.com",
 			cpEndpointPort:          6443,
 			expectedLoginURL:        "https://api.example.com:6443",
-			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), testInternalServicePort),
+			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), OAuthServerPort),
 			expectedMasterPublicURL: "https://[2001:db8::2]:443",
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config_test.go
@@ -1,0 +1,176 @@
+package oauth
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/infra"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	osinv1 "github.com/openshift/api/osin/v1"
+)
+
+func TestGetOAuthServiceDNS(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		namespace string
+		expected  string
+	}{
+		{
+			name:      "When namespace is provided, it should return the correct OAuth service DNS",
+			namespace: "clusters-test-cluster",
+			expected:  "oauth-openshift.clusters-test-cluster.svc.cluster.local",
+		},
+		{
+			name:      "When namespace is empty, it should return empty string",
+			namespace: "",
+			expected:  "",
+		},
+		{
+			name:      "When namespace has special characters, it should include them in the DNS",
+			namespace: "test-ns-123",
+			expected:  "oauth-openshift.test-ns-123.svc.cluster.local",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			result := getOAuthServiceDNS(tt.namespace)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestAdaptOAuthConfig(t *testing.T) {
+
+	const (
+		testNamespace           = "test-cluster"
+		testInternalServicePort = int32(6443)
+	)
+	testCases := []struct {
+		name                    string
+		oauthHost               string
+		oauthPort               int32
+		cpEndpointHost          string
+		cpEndpointPort          int32
+		kasDNSName              string
+		loginURLOverride        string
+		expectedLoginURL        string
+		expectedMasterURL       string
+		expectedMasterPublicURL string
+	}{
+		{
+			name:                    "When no custom DNS is set, it should use the control plane endpoint for LoginURL",
+			oauthHost:               "oauth.example.com",
+			oauthPort:               443,
+			cpEndpointHost:          "api.example.com",
+			cpEndpointPort:          6443,
+			expectedLoginURL:        "https://api.example.com:6443",
+			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), testInternalServicePort),
+			expectedMasterPublicURL: "https://oauth.example.com:443",
+		},
+		{
+			name:                    "When KubeAPIServerDNSName is set, it should use the custom DNS name for LoginURL",
+			oauthHost:               "oauth.example.com",
+			oauthPort:               443,
+			cpEndpointHost:          "10.0.0.1",
+			cpEndpointPort:          6443,
+			kasDNSName:              "api.custom.example.com",
+			expectedLoginURL:        "https://api.custom.example.com:6443",
+			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), testInternalServicePort),
+			expectedMasterPublicURL: "https://oauth.example.com:443",
+		},
+		{
+			name:                    "When control plane endpoint is an IP and no custom DNS is set, it should use the IP for LoginURL",
+			oauthHost:               "10.0.0.2",
+			oauthPort:               443,
+			cpEndpointHost:          "10.0.0.1",
+			cpEndpointPort:          6443,
+			expectedLoginURL:        "https://10.0.0.1:6443",
+			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), testInternalServicePort),
+			expectedMasterPublicURL: "https://10.0.0.2:443",
+		},
+		{
+			name:                    "When login URL override annotation is set, it should take precedence over KubeAPIServerDNSName",
+			oauthHost:               "oauth.example.com",
+			oauthPort:               443,
+			cpEndpointHost:          "10.0.0.1",
+			cpEndpointPort:          6443,
+			kasDNSName:              "api.custom.example.com",
+			loginURLOverride:        "https://ibm.override.example.com:6443",
+			expectedLoginURL:        "https://ibm.override.example.com:6443",
+			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), testInternalServicePort),
+			expectedMasterPublicURL: "https://oauth.example.com:443",
+		},
+		{
+			name:                    "When control plane endpoint is an IPv6 address, it should bracket it in the LoginURL",
+			oauthHost:               "oauth.example.com",
+			oauthPort:               443,
+			cpEndpointHost:          "2001:db8::1",
+			cpEndpointPort:          6443,
+			expectedLoginURL:        "https://[2001:db8::1]:6443",
+			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), testInternalServicePort),
+			expectedMasterPublicURL: "https://oauth.example.com:443",
+		},
+		{
+			name:                    "When OAuth host is an IPv6 address, it should bracket it in the MasterURL",
+			oauthHost:               "2001:db8::2",
+			oauthPort:               443,
+			cpEndpointHost:          "api.example.com",
+			cpEndpointPort:          6443,
+			expectedLoginURL:        "https://api.example.com:6443",
+			expectedMasterURL:       fmt.Sprintf("https://%s:%d", getOAuthServiceDNS(testNamespace), testInternalServicePort),
+			expectedMasterPublicURL: "https://[2001:db8::2]:443",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: testNamespace,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					KubeAPIServerDNSName: tc.kasDNSName,
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					ControlPlaneEndpoint: hyperv1.APIEndpoint{
+						Host: tc.cpEndpointHost,
+						Port: tc.cpEndpointPort,
+					},
+				},
+			}
+			if tc.loginURLOverride != "" {
+				hcp.Annotations = map[string]string{
+					hyperv1.OauthLoginURLOverrideAnnotation: tc.loginURLOverride,
+				}
+			}
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+				InfraStatus: infra.InfrastructureStatus{
+					OAuthHost: tc.oauthHost,
+					OAuthPort: tc.oauthPort,
+				},
+			}
+
+			cfg := &osinv1.OsinServerConfig{}
+			cfg.OAuthConfig = osinv1.OAuthConfig{}
+
+			adaptOAuthConfig(cpContext, cfg)
+
+			g.Expect(cfg.OAuthConfig.LoginURL).To(Equal(tc.expectedLoginURL))
+			g.Expect(cfg.OAuthConfig.MasterURL).To(Equal(tc.expectedMasterURL))
+			g.Expect(cfg.OAuthConfig.MasterPublicURL).To(Equal(tc.expectedMasterPublicURL))
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/deployment.go
@@ -52,8 +52,9 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 				},
 			})
 		}
-
+		noProxy := []string{manifests.KubeAPIServerService("").Name, config.AuditWebhookService, getOAuthServiceDNS(cpContext.HCP.Namespace)}
 		if cpContext.HCP.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
+<<<<<<< HEAD
 			noProxy := []string{
 				manifests.KubeAPIServerService("").Name, config.AuditWebhookService,
 				"iam.cloud.ibm.com", "iam.test.cloud.ibm.com",
@@ -62,7 +63,15 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 				Name:  "NO_PROXY",
 				Value: strings.Join(noProxy, ","),
 			})
+=======
+			noProxy = append(noProxy, "iam.cloud.ibm.com", "iam.test.cloud.ibm.com")
+>>>>>>> 8ef294737 (fix(cpo): use in-cluster URL for oauth-server MasterURL)
 		}
+
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
+			Name:  "NO_PROXY",
+			Value: strings.Join(noProxy, ","),
+		})
 	})
 
 	configuration := cpContext.HCP.Spec.Configuration

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/deployment.go
@@ -54,21 +54,10 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		}
 		noProxy := []string{manifests.KubeAPIServerService("").Name, config.AuditWebhookService, getOAuthServiceDNS(cpContext.HCP.Namespace)}
 		if cpContext.HCP.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
-<<<<<<< HEAD
-			noProxy := []string{
-				manifests.KubeAPIServerService("").Name, config.AuditWebhookService,
-				"iam.cloud.ibm.com", "iam.test.cloud.ibm.com",
-			}
-			util.UpsertEnvVar(c, corev1.EnvVar{
-				Name:  "NO_PROXY",
-				Value: strings.Join(noProxy, ","),
-			})
-=======
 			noProxy = append(noProxy, "iam.cloud.ibm.com", "iam.test.cloud.ibm.com")
->>>>>>> 8ef294737 (fix(cpo): use in-cluster URL for oauth-server MasterURL)
 		}
 
-		podspec.UpsertEnvVar(c, corev1.EnvVar{
+		util.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "NO_PROXY",
 			Value: strings.Join(noProxy, ","),
 		})

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/deployment_test.go
@@ -1,0 +1,118 @@
+package oauth
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
+	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/config"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestAdaptDeployment(t *testing.T) {
+	t.Parallel()
+
+	const testNamespace = "clusters-test"
+
+	tests := []struct {
+		name         string
+		platformType hyperv1.PlatformType
+		wantNoProxy  []string
+	}{
+		{
+			name:         "When platform is AWS, it should set NO_PROXY with kube-apiserver, audit-webhook, and oauth in-cluster DNS",
+			platformType: hyperv1.AWSPlatform,
+			wantNoProxy: []string{
+				manifests.KubeAPIServerService("").Name,
+				config.AuditWebhookService,
+				getOAuthServiceDNS(testNamespace),
+			},
+		},
+		{
+			name:         "When platform is Azure, it should set NO_PROXY with kube-apiserver, audit-webhook, and oauth in-cluster DNS",
+			platformType: hyperv1.AzurePlatform,
+			wantNoProxy: []string{
+				manifests.KubeAPIServerService("").Name,
+				config.AuditWebhookService,
+				getOAuthServiceDNS(testNamespace),
+			},
+		},
+		{
+			name:         "When platform is None, it should set NO_PROXY with kube-apiserver, audit-webhook, and oauth in-cluster DNS",
+			platformType: hyperv1.NonePlatform,
+			wantNoProxy: []string{
+				manifests.KubeAPIServerService("").Name,
+				config.AuditWebhookService,
+				getOAuthServiceDNS(testNamespace),
+			},
+		},
+		{
+			name:         "When platform is IBMCloud, it should also include IAM endpoints in NO_PROXY",
+			platformType: hyperv1.IBMCloudPlatform,
+			wantNoProxy: []string{
+				manifests.KubeAPIServerService("").Name,
+				config.AuditWebhookService,
+				getOAuthServiceDNS(testNamespace),
+				"iam.cloud.ibm.com",
+				"iam.test.cloud.ibm.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: testNamespace,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: tt.platformType,
+					},
+				},
+			}
+
+			deployment, err := assets.LoadDeploymentManifest(ComponentName)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			cpContext := component.WorkloadContext{
+				Client: fake.NewClientBuilder().WithScheme(api.Scheme).Build(),
+				HCP:    hcp,
+			}
+
+			err = adaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+			g.Expect(container).ToNot(BeNil())
+
+			noProxyEnv := podspec.FindEnvVar("NO_PROXY", container.Env)
+			g.Expect(noProxyEnv).ToNot(BeNil())
+
+			noProxyEntries := strings.Split(noProxyEnv.Value, ",")
+			for _, entry := range tt.wantNoProxy {
+				g.Expect(noProxyEntries).To(ContainElement(entry), "expected NO_PROXY to contain %q", entry)
+			}
+
+			// Ensure no unexpected IBM entries for non-IBM platforms
+			if tt.platformType != hyperv1.IBMCloudPlatform {
+				g.Expect(noProxyEnv.Value).ToNot(ContainSubstring("iam.cloud.ibm.com"))
+				g.Expect(noProxyEnv.Value).ToNot(ContainSubstring("iam.test.cloud.ibm.com"))
+			}
+		})
+	}
+}

--- a/support/podspec/containers.go
+++ b/support/podspec/containers.go
@@ -1,0 +1,23 @@
+package podspec
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func FindContainer(name string, containers []corev1.Container) *corev1.Container {
+	for i, c := range containers {
+		if c.Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+func FindEnvVar(name string, envVars []corev1.EnvVar) *corev1.EnvVar {
+	for i := range envVars {
+		if envVars[i].Name == name {
+			return &envVars[i]
+		}
+	}
+	return nil
+}

--- a/support/podspec/containers_test.go
+++ b/support/podspec/containers_test.go
@@ -1,0 +1,66 @@
+package podspec
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestFindContainer(t *testing.T) {
+	t.Parallel()
+	containers := []corev1.Container{
+		{Name: "first"},
+		{Name: "second"},
+		{Name: "third"},
+	}
+
+	t.Run("When the container exists, it should return a pointer to it", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+		result := FindContainer("second", containers)
+		g.Expect(result).ToNot(BeNil())
+		g.Expect(result.Name).To(Equal("second"))
+	})
+
+	t.Run("When the container does not exist, it should return nil", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+		g.Expect(FindContainer("nonexistent", containers)).To(BeNil())
+	})
+
+	t.Run("When the slice is empty, it should return nil", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+		g.Expect(FindContainer("any", nil)).To(BeNil())
+	})
+}
+
+func TestFindEnvVar(t *testing.T) {
+	t.Parallel()
+	envVars := []corev1.EnvVar{
+		{Name: "FOO", Value: "bar"},
+		{Name: "BAZ", Value: "qux"},
+	}
+
+	t.Run("When the env var exists, it should return a pointer to it", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+		result := FindEnvVar("BAZ", envVars)
+		g.Expect(result).ToNot(BeNil())
+		g.Expect(result.Value).To(Equal("qux"))
+	})
+
+	t.Run("When the env var does not exist, it should return nil", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+		g.Expect(FindEnvVar("MISSING", envVars)).To(BeNil())
+	})
+
+	t.Run("When the slice is empty, it should return nil", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+		g.Expect(FindEnvVar("FOO", nil)).To(BeNil())
+	})
+}


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

When a user clicks “Display Token”, the oauth-openshift service attempts to call itself using the cluster’s API endpoint.
This self-call fails depending on whether the oauth-server is configured a public or private service URL as MasterURL.

In case of a public URL and control plane outbound connecitivty is restricted, the call fails.
In case a private URL, it can happen that the DNS is also a private one, and DNS resolution fails.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-88312

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.
