### PR TITLE
OCPBUGS-99941: replace invalid pip-install input with explicit pip install step

### DIFF
--- a/.github/workflows/docs-build-reusable.yaml
+++ b/.github/workflows/docs-build-reusable.yaml
@@ -18,7 +18,8 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
-          pip-install: '-r docs/requirements.txt'
+      - name: Install documentation dependencies
+        run: pip install -r docs/requirements.txt
         env:
           PIP_CACHE_DIR: ${{ runner.temp }}/.pip-cache
       - name: Build documentation


### PR DESCRIPTION
## What this PR does / why we need it:

The `pip-install` input is no longer a valid input for `actions/setup-python`, causing the "Build Docs" CI job to fail with `mkdocs: command not found` on all PRs. This replaces the invalid input with an explicit `pip install -r docs/requirements.txt` step.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-99941

## Special notes for your reviewer:

This is a repo-wide CI fix — the "Build Docs" job is currently broken for new PRs (e.g., #9132 and #8878). The `pip-install` input was introduced in PR #8386 and worked initially, but `actions/setup-python` has since removed it as a valid input.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the documentation build workflow by adding an explicit documentation dependency installation step.
  * Documentation builds now install requirements from the designated `docs/requirements.txt` file consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->