### PR TITLE
CNTRLPLANE-3943: feat(destroy): add --force flag to strip finalizers on grace period expiry

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -64,6 +64,7 @@ func NewDestroyCommands() *cobra.Command {
 	cmd.PersistentFlags().DurationVar(&opts.ClusterGracePeriod, "cluster-grace-period", opts.ClusterGracePeriod, "How long to wait for the cluster to be deleted before forcibly destroying its infra")
 	cmd.PersistentFlags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Infrastructure ID; inferred from the hosted cluster by default")
 	cmd.PersistentFlags().BoolVar(&opts.DestroyCloudResources, "destroy-cloud-resources", opts.DestroyCloudResources, "If true, cloud resources such as load balancers and persistent storage disks created by the cluster during its lifetime are removed")
+	cmd.PersistentFlags().BoolVar(&opts.ForceDestroy, "force", opts.ForceDestroy, "Dev/CI only: when the grace period expires, force-remove all finalizers from child resources and continue with best-effort infrastructure cleanup")
 
 	_ = cmd.MarkPersistentFlagRequired("name")
 

--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -9,16 +10,25 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	"github.com/openshift/hypershift/cmd/util"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 
+	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
+	capaaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	capzv1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -34,6 +44,7 @@ type DestroyPlatformSpecifics = func(ctx context.Context, options *DestroyOption
 
 type DestroyOptions struct {
 	ClusterGracePeriod    time.Duration
+	ForceDestroy          bool
 	Kubeconfig            string
 	Name                  string
 	Namespace             string
@@ -149,15 +160,23 @@ func DestroyCluster(ctx context.Context, hostedCluster *hyperv1.HostedCluster, o
 
 		if shouldDestroyPlatformSpecifics {
 			if err = waitForRestOfFinalizers(ctx, hostedCluster, o, c); err != nil {
-				return err
+				if !o.ForceDestroy {
+					return err
+				}
+				o.Log.Info("Grace period expired and --force is set, force-removing finalizers from all child resources",
+					"namespace", o.Namespace, "name", o.Name)
+				if forceErr := forceRemoveAllFinalizers(ctx, hostedCluster, o, c); forceErr != nil {
+					o.Log.Error(forceErr, "Errors during force finalizer removal, continuing with platform cleanup")
+				}
 			}
 		}
 	}
 
 	if shouldDestroyPlatformSpecifics {
-		// Destroy additional resources which are specific to the current platform
 		if err = destroyPlatformSpecifics(ctx, o); err != nil {
-			return err
+			if err := returnOrForceLog(o, err, "Platform-specific cleanup failed with --force, continuing"); err != nil {
+				return err
+			}
 		}
 	} else if err = waitForClusterDeletion(ctx, hostedCluster, o, c); err != nil {
 		return err
@@ -170,7 +189,9 @@ func DestroyCluster(ctx context.Context, hostedCluster *hyperv1.HostedCluster, o
 
 	if shouldDestroyPlatformSpecifics && hostedClusterExists {
 		if err = removeFinalizer(ctx, hostedCluster, o, c); err != nil {
-			return err
+			if err := returnOrForceLog(o, err, "Failed to remove destroy finalizer with --force, continuing"); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -218,6 +239,157 @@ func removeFinalizer(ctx context.Context, hostedCluster *hyperv1.HostedCluster, 
 	}); err != nil {
 		return err
 	}
+	return nil
+}
+
+// returnOrForceLog returns err when --force is not set; otherwise logs the
+// error and returns nil so that the caller can continue best-effort cleanup.
+func returnOrForceLog(o *DestroyOptions, err error, msg string) error {
+	if !o.ForceDestroy {
+		return err
+	}
+	o.Log.Error(err, msg)
+	return nil
+}
+
+// stripFinalizers removes all finalizers from a single object via a merge patch.
+func stripFinalizers(ctx context.Context, c client.Client, obj client.Object, log logr.Logger) error {
+	if len(obj.GetFinalizers()) == 0 {
+		return nil
+	}
+	original := obj.DeepCopyObject().(client.Object)
+	obj.SetFinalizers(nil)
+	if err := c.Patch(ctx, obj, client.MergeFrom(original)); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to strip finalizers from %T %s/%s: %w",
+			obj, obj.GetNamespace(), obj.GetName(), err)
+	}
+	log.Info("Stripped finalizers", "kind", fmt.Sprintf("%T", obj), "namespace", obj.GetNamespace(), "name", obj.GetName())
+	return nil
+}
+
+// stripFinalizersFromList lists objects of the given type in a namespace and strips all finalizers.
+// CRD-not-found errors are silently ignored so this works on clusters without the CRD installed.
+func stripFinalizersFromList(ctx context.Context, c client.Client, list client.ObjectList, namespace string, log logr.Logger) []error {
+	if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		if !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+			return []error{fmt.Errorf("failed to list %T: %w", list, err)}
+		}
+		return nil
+	}
+	var errs []error
+	var count int
+	if err := meta.EachListItem(list, func(obj runtime.Object) error {
+		count++
+		if co, ok := obj.(client.Object); ok {
+			if err := stripFinalizers(ctx, c, co, log); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		return nil
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to iterate %T: %w", list, err))
+	}
+	log.Info("Processed resources", "type", fmt.Sprintf("%T", list), "namespace", namespace, "count", count)
+	return errs
+}
+
+// forceRemoveAllFinalizers strips finalizers from all child resources in the
+// control plane namespace and NodePools in the HC namespace, then from the
+// HostedCluster itself (preserving the destroy finalizer for the normal
+// removal path). Resources are processed bottom-up so that Kubernetes garbage
+// collection can proceed as each layer is unblocked.
+func forceRemoveAllFinalizers(ctx context.Context, hostedCluster *hyperv1.HostedCluster, o *DestroyOptions, c client.Client) error {
+	cpNamespace := manifests.HostedControlPlaneNamespace(o.Namespace, o.Name)
+	var errs []error
+
+	// Bottom-up: infra machines → CAPI machines → clusters → HCP → deployments.
+	// All provider-specific types are listed; stripFinalizersFromList silently
+	// skips CRDs that are not installed on the current cluster.
+	cpResources := []client.ObjectList{
+		&capaaws.AWSMachineList{},
+		&capaaws.AWSClusterList{},
+		&capzv1.AzureMachineList{},
+		&capzv1.AzureClusterList{},
+		&agentv1.AgentMachineList{},
+		&agentv1.AgentClusterList{},
+		&capikubevirt.KubevirtMachineList{},
+		&capikubevirt.KubevirtClusterList{},
+		&capiv1.MachineList{},
+		&capiv1.MachineSetList{},
+		&capiv1.MachineDeploymentList{},
+		&capiv1.ClusterList{},
+		&hyperv1.HostedControlPlaneList{},
+		&appsv1.DeploymentList{},
+	}
+	for _, list := range cpResources {
+		errs = append(errs, stripFinalizersFromList(ctx, c, list, cpNamespace, o.Log)...)
+	}
+
+	// NodePools live in the HC namespace, not the CP namespace
+	errs = append(errs, stripFinalizersFromList(ctx, c, &hyperv1.NodePoolList{}, o.Namespace, o.Log)...)
+
+	// Strip all HostedCluster finalizers except the destroy finalizer, which
+	// is removed by the normal removeFinalizer path after platform cleanup.
+	if err := c.Get(ctx, client.ObjectKeyFromObject(hostedCluster), hostedCluster); err != nil {
+		if !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("failed to refresh HostedCluster: %w", err))
+		}
+	} else if len(hostedCluster.Finalizers) > 0 {
+		original := hostedCluster.DeepCopy()
+		var kept []string
+		for _, f := range hostedCluster.Finalizers {
+			if f == destroyFinalizer {
+				kept = append(kept, f)
+			}
+		}
+		hostedCluster.SetFinalizers(kept)
+		if err := c.Patch(ctx, hostedCluster, client.MergeFrom(original)); err != nil {
+			if !apierrors.IsNotFound(err) {
+				errs = append(errs, fmt.Errorf("failed to strip non-destroy finalizers from HostedCluster: %w", err))
+			}
+		} else {
+			o.Log.Info("Stripped non-destroy finalizers from HostedCluster", "namespace", o.Namespace, "name", o.Name)
+		}
+	}
+
+	// Strip both metadata.finalizers and spec.finalizers from the control
+	// plane namespace, then delete it. spec.finalizers require the finalize
+	// subresource; a Terminating namespace stays stuck until both are empty.
+	ns := &v1.Namespace{}
+	if err := c.Get(ctx, types.NamespacedName{Name: cpNamespace}, ns); err != nil {
+		if !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("failed to get namespace %s: %w", cpNamespace, err))
+		}
+	} else {
+		if err := stripFinalizers(ctx, c, ns, o.Log); err != nil {
+			errs = append(errs, err)
+		}
+		if len(ns.Spec.Finalizers) > 0 {
+			ns.Spec.Finalizers = nil
+			if err := c.SubResource("finalize").Update(ctx, ns); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errs = append(errs, fmt.Errorf("failed to clear spec.finalizers on namespace %s: %w", cpNamespace, err))
+				}
+			} else {
+				o.Log.Info("Cleared spec.finalizers on namespace", "namespace", cpNamespace)
+			}
+		}
+		if err := c.Delete(ctx, ns); err != nil {
+			if !apierrors.IsNotFound(err) {
+				errs = append(errs, fmt.Errorf("failed to delete namespace %s: %w", cpNamespace, err))
+			}
+		} else {
+			o.Log.Info("Deleted control plane namespace", "namespace", cpNamespace)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("force removal encountered %d error(s): %w", len(errs), errors.Join(errs...))
+	}
+	o.Log.Info("Force removal of all finalizers complete", "namespace", o.Namespace, "name", o.Name)
 	return nil
 }
 

--- a/cmd/cluster/core/destroy_test.go
+++ b/cmd/cluster/core/destroy_test.go
@@ -2,12 +2,27 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/cmd/log"
+	hyperapi "github.com/openshift/hypershift/support/api"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	capzv1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestDestroyCluster(t *testing.T) {
@@ -65,6 +80,289 @@ func TestDestroyCluster(t *testing.T) {
 		err := DestroyCluster(context.Background(), nil, opts, mockPlatformSpecifics)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(platformSpecificsCalled).To(BeTrue())
+	})
+}
+
+func TestForceRemoveAllFinalizers(t *testing.T) {
+	t.Run("When all child resources have finalizers, it should strip them and preserve destroy finalizer on HC", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctx := context.Background()
+		cpNamespace := "clusters-test-cluster"
+
+		hc := &hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-cluster",
+				Namespace:  "clusters",
+				Finalizers: []string{destroyFinalizer, "hypershift.openshift.io/finalizer"},
+			},
+		}
+
+		nodePool := &hyperv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-cluster-np1",
+				Namespace:  "clusters",
+				Finalizers: []string{"hypershift.openshift.io/finalizer"},
+			},
+		}
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-cluster",
+				Namespace:  cpNamespace,
+				Finalizers: []string{"hypershift.openshift.io/finalizer"},
+			},
+		}
+
+		azureMachine := &capzv1.AzureMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-machine-azure-0",
+				Namespace:  cpNamespace,
+				Finalizers: []string{"azuremachine.infrastructure.cluster.x-k8s.io"},
+			},
+		}
+
+		capiCluster := &capiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-cluster",
+				Namespace:  cpNamespace,
+				Finalizers: []string{"cluster.cluster.x-k8s.io"},
+			},
+		}
+
+		capiMachine := &capiv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-machine-0",
+				Namespace:  cpNamespace,
+				Finalizers: []string{"machine.cluster.x-k8s.io"},
+			},
+		}
+
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "capi-provider",
+				Namespace:  cpNamespace,
+				Finalizers: []string{"hypershift.openshift.io/component-finalizer"},
+			},
+		}
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: cpNamespace,
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(hyperapi.Scheme).
+			WithObjects(hc, nodePool, hcp, azureMachine, capiCluster, capiMachine, deployment, ns).
+			Build()
+
+		opts := &DestroyOptions{
+			Name:      "test-cluster",
+			Namespace: "clusters",
+			InfraID:   "test-infra",
+			Log:       log.Log,
+		}
+
+		err := forceRemoveAllFinalizers(ctx, hc, opts, c)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Verify HC retains only the destroy finalizer
+		updatedHC := &hyperv1.HostedCluster{}
+		err = c.Get(ctx, types.NamespacedName{Namespace: "clusters", Name: "test-cluster"}, updatedHC)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updatedHC.Finalizers).To(Equal([]string{destroyFinalizer}))
+
+		// Verify NodePool finalizers are gone
+		updatedNP := &hyperv1.NodePool{}
+		err = c.Get(ctx, types.NamespacedName{Namespace: "clusters", Name: "test-cluster-np1"}, updatedNP)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updatedNP.Finalizers).To(BeEmpty())
+
+		// Verify HCP finalizers are gone
+		updatedHCP := &hyperv1.HostedControlPlane{}
+		err = c.Get(ctx, types.NamespacedName{Namespace: cpNamespace, Name: "test-cluster"}, updatedHCP)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updatedHCP.Finalizers).To(BeEmpty())
+
+		// Verify AzureMachine finalizers are gone
+		updatedAzMachine := &capzv1.AzureMachine{}
+		err = c.Get(ctx, types.NamespacedName{Namespace: cpNamespace, Name: "test-machine-azure-0"}, updatedAzMachine)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updatedAzMachine.Finalizers).To(BeEmpty())
+
+		// Verify CAPI Cluster finalizers are gone
+		updatedCluster := &capiv1.Cluster{}
+		err = c.Get(ctx, types.NamespacedName{Namespace: cpNamespace, Name: "test-cluster"}, updatedCluster)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updatedCluster.Finalizers).To(BeEmpty())
+
+		// Verify CAPI Machine finalizers are gone
+		updatedMachine := &capiv1.Machine{}
+		err = c.Get(ctx, types.NamespacedName{Namespace: cpNamespace, Name: "test-machine-0"}, updatedMachine)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updatedMachine.Finalizers).To(BeEmpty())
+
+		// Verify Deployment finalizers are gone
+		updatedDeploy := &appsv1.Deployment{}
+		err = c.Get(ctx, types.NamespacedName{Namespace: cpNamespace, Name: "capi-provider"}, updatedDeploy)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updatedDeploy.Finalizers).To(BeEmpty())
+	})
+
+	t.Run("When the control plane namespace is empty, it should succeed without errors", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctx := context.Background()
+
+		hc := &hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "empty-cluster",
+				Namespace:  "clusters",
+				Finalizers: []string{destroyFinalizer},
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(hyperapi.Scheme).
+			WithObjects(hc).
+			Build()
+
+		opts := &DestroyOptions{
+			Name:      "empty-cluster",
+			Namespace: "clusters",
+			Log:       log.Log,
+		}
+
+		err := forceRemoveAllFinalizers(ctx, hc, opts, c)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		updatedHC := &hyperv1.HostedCluster{}
+		err = c.Get(ctx, types.NamespacedName{Namespace: "clusters", Name: "empty-cluster"}, updatedHC)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updatedHC.Finalizers).To(Equal([]string{destroyFinalizer}))
+	})
+}
+
+func TestStripFinalizers(t *testing.T) {
+	t.Run("When an object has finalizers, it should remove all of them", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctx := context.Background()
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test",
+				Namespace:  "test-ns",
+				Finalizers: []string{"fin1", "fin2", "fin3"},
+			},
+		}
+
+		c := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(hcp).Build()
+
+		err := stripFinalizers(ctx, c, hcp, log.Log)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		updated := &hyperv1.HostedControlPlane{}
+		err = c.Get(ctx, client.ObjectKeyFromObject(hcp), updated)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updated.Finalizers).To(BeEmpty())
+	})
+
+	t.Run("When an object has no finalizers, it should succeed without errors", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctx := context.Background()
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test-ns",
+			},
+		}
+
+		c := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(hcp).Build()
+
+		err := stripFinalizers(ctx, c, hcp, log.Log)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("When the patch fails, it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctx := context.Background()
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test",
+				Namespace:  "test-ns",
+				Finalizers: []string{"fin1"},
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(hyperapi.Scheme).
+			WithObjects(hcp).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+					return fmt.Errorf("API server unavailable")
+				},
+			}).
+			Build()
+
+		err := stripFinalizers(ctx, c, hcp, log.Log)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("API server unavailable"))
+	})
+}
+
+func TestStripFinalizersFromList(t *testing.T) {
+	t.Run("When the CRD is not installed, it should succeed without errors", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctx := context.Background()
+
+		c := fake.NewClientBuilder().
+			WithScheme(hyperapi.Scheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+					return &apimeta.NoKindMatchError{GroupKind: capzv1.GroupVersion.WithKind("AzureMachine").GroupKind()}
+				},
+			}).
+			Build()
+
+		errs := stripFinalizersFromList(ctx, c, &capzv1.AzureMachineList{}, "test-ns", log.Log)
+		g.Expect(errs).To(BeEmpty())
+	})
+}
+
+func TestForceRemoveAllFinalizersErrors(t *testing.T) {
+	t.Run("When client operations fail, it should return an aggregated error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctx := context.Background()
+
+		hc := &hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-cluster",
+				Namespace:  "clusters",
+				Finalizers: []string{destroyFinalizer, "hypershift.openshift.io/finalizer"},
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(hyperapi.Scheme).
+			WithObjects(hc).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+					return fmt.Errorf("API server unavailable")
+				},
+			}).
+			Build()
+
+		opts := &DestroyOptions{
+			Name:      "test-cluster",
+			Namespace: "clusters",
+			Log:       log.Log,
+		}
+
+		err := forceRemoveAllFinalizers(ctx, hc, opts, c)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("force removal encountered"))
+		g.Expect(err.Error()).To(ContainSubstring("API server unavailable"))
 	})
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a `--force` flag to `hypershift destroy cluster` that, when the grace period expires, force-removes all finalizers from child resources and continues with best-effort infrastructure cleanup. This fixes the Azure CI deprovisioner which fails to clean up stuck HostedClusters when the 7-layer finalizer chain gets blocked by Azure API failures.

Without this fix, orphaned HCs accumulate on the CI cluster (37 were found stuck with `deletionTimestamp` set but finalizers never removed), consuming cluster resources until manual intervention.

**Key behaviors:**
- When `--force` is set and the grace period expires, finalizers are stripped bottom-up: AzureMachines → AzureClusters → CAPI Machines → CAPI Clusters → HostedControlPlane → Deployments → NodePools → HostedCluster (preserving the destroy finalizer) → Namespace
- Platform-specific cleanup errors are logged but don't abort the destroy
- CRDs not installed on the cluster (e.g., CAPZ types on non-Azure clusters) are handled gracefully via `meta.IsNoMatchError`
- The destroy finalizer is preserved on the HC so `removeFinalizer()` can run after platform cleanup

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3943](https://redhat.atlassian.net/browse/CNTRLPLANE-3943)

## Special notes for your reviewer:

- The `returnOrForceLog` helper reduces the repeated `if !o.ForceDestroy { return err }` pattern across `DestroyCluster`
- `forceRemoveAllFinalizers` currently hardcodes Azure CAPZ types — this is intentional since the feature targets the Azure CI deprovisioner. Other platform types can be added later if needed.
- Namespace finalizers are stripped before deletion to handle terminating namespaces with stuck finalizers

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--force` option to cluster destruction, enabling best-effort finalizer removal after the grace period.
* **Bug Fixes**
  * Cluster deletion now continues in force mode even if finalizer stripping or platform cleanup partially fails, with aggregated error reporting.
  * Global pull-secret DaemonSet reconciliation is more idempotent and uses a `33%` rolling update strategy with an added readiness probe.
  * Secret filtering for kube-system pull secrets is now more precise.
* **Tests**
  * Expanded unit tests for forced finalizer behavior, CRD-missing list tolerance, error aggregation, and DaemonSet idempotency/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->