### PR TITLE
CNTRLPLANE-3959: wire apiserver config through ignition server

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
@@ -24,6 +24,7 @@ type MCSParams struct {
 	Network           *configv1.Network
 	Proxy             *configv1.Proxy
 	Image             *configv1.Image
+	APIServer         *configv1.APIServer
 	InstallConfig     *globalconfig.InstallConfig
 	ConfigurationHash string
 }
@@ -47,6 +48,11 @@ func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, pullSecret *corev1.Se
 	image := globalconfig.ImageConfig()
 	globalconfig.ReconcileImageConfig(image, hcp)
 
+	apiServer := globalconfig.APIServerConfiguration()
+	if err := globalconfig.ReconcileAPIServerConfiguration(apiServer, hcp.Spec.Configuration); err != nil {
+		return &MCSParams{}, fmt.Errorf("failed to reconcile apiserver config: %w", err)
+	}
+
 	// Some fields in the ClusterConfiguration have changes that are not backwards compatible with older versions of the CPO.
 	hcConfigurationHash, err := backwardcompat.GetBackwardCompatibleConfigHash(hcp.Spec.Configuration)
 	if err != nil {
@@ -64,6 +70,7 @@ func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, pullSecret *corev1.Se
 		Network:           network,
 		Proxy:             proxy,
 		Image:             image,
+		APIServer:         apiServer,
 		InstallConfig:     globalconfig.NewInstallConfig(hcp),
 		ConfigurationHash: hcConfigurationHash,
 	}, nil

--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
@@ -1,6 +1,8 @@
 package mcs
 
 import (
+	"fmt"
+
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/k8sutil"
@@ -37,6 +39,10 @@ func ReconcileMachineConfigServerConfig(cm *corev1.ConfigMap, p *MCSParams) erro
 	if err != nil {
 		return err
 	}
+	serializedAPIServer, err := serialize(p.APIServer)
+	if err != nil {
+		return fmt.Errorf("failed to serialize apiserver config: %w", err)
+	}
 	serializedMasterConfigPool, err := serializeConfigPool(masterConfigPool())
 	if err != nil {
 		return err
@@ -61,6 +67,7 @@ func ReconcileMachineConfigServerConfig(cm *corev1.ConfigMap, p *MCSParams) erro
 	cm.Data["cluster-network-02-config.yaml"] = serializedNetwork
 	cm.Data["cluster-proxy-01-config.yaml"] = serializedProxy
 	cm.Data["image-config.yaml"] = serializedImage
+	cm.Data["cluster-apiserver-config.yaml"] = serializedAPIServer
 	cm.Data["install-config.yaml"] = p.InstallConfig.String()
 	cm.Data["master.machineconfigpool.yaml"] = serializedMasterConfigPool
 	cm.Data["worker.machineconfigpool.yaml"] = serializedWorkerConfigPool

--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile_test.go
@@ -5,8 +5,164 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/globalconfig"
+
+	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestNewMCSParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		hcp    *hyperv1.HostedControlPlane
+		verify func(g Gomega, params *MCSParams, err error)
+	}{
+		{
+			name: "When HCP has no configuration, it should return empty APIServer spec",
+			hcp:  &hyperv1.HostedControlPlane{},
+			verify: func(g Gomega, params *MCSParams, err error) {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(params.APIServer).ToNot(BeNil())
+				g.Expect(params.APIServer.Spec).To(Equal(configv1.APIServerSpec{}))
+			},
+		},
+		{
+			name: "When HCP has APIServer configuration, it should propagate the spec",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Audit: configv1.Audit{
+								Profile: configv1.WriteRequestBodiesAuditProfileType,
+							},
+							TLSSecurityProfile: &configv1.TLSSecurityProfile{
+								Type: configv1.TLSProfileIntermediateType,
+							},
+						},
+					},
+				},
+			},
+			verify: func(g Gomega, params *MCSParams, err error) {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(params.APIServer).ToNot(BeNil())
+				g.Expect(params.APIServer.Spec.Audit.Profile).To(Equal(configv1.WriteRequestBodiesAuditProfileType))
+				g.Expect(params.APIServer.Spec.TLSSecurityProfile).ToNot(BeNil())
+				g.Expect(params.APIServer.Spec.TLSSecurityProfile.Type).To(Equal(configv1.TLSProfileIntermediateType))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			params, err := NewMCSParams(tt.hcp, &corev1.Secret{}, &corev1.Secret{}, &corev1.ConfigMap{}, &corev1.ConfigMap{})
+			tt.verify(g, params, err)
+		})
+	}
+}
+
+func TestReconcileMachineConfigServerConfig(t *testing.T) {
+	t.Parallel()
+
+	baseParams := func() *MCSParams {
+		return &MCSParams{
+			OwnerRef:        config.OwnerRef{},
+			RootCA:          &corev1.Secret{},
+			KubeletClientCA: &corev1.ConfigMap{},
+			PullSecret:      &corev1.Secret{},
+			DNS:             &configv1.DNS{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+			Infrastructure:  &configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+			Network:         &configv1.Network{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+			Proxy:           &configv1.Proxy{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+			Image:           &configv1.Image{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+			APIServer:       &configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+			InstallConfig:   &globalconfig.InstallConfig{},
+		}
+	}
+
+	deserializeAPIServer := func(g Gomega, data string) *configv1.APIServer {
+		obj, _, err := api.YamlSerializer.Decode([]byte(data), nil, &configv1.APIServer{})
+		g.Expect(err).ToNot(HaveOccurred())
+		apiServer, ok := obj.(*configv1.APIServer)
+		g.Expect(ok).To(BeTrue())
+		return apiServer
+	}
+
+	tests := []struct {
+		name   string
+		params *MCSParams
+		verify func(g Gomega, cm *corev1.ConfigMap)
+	}{
+		{
+			name:   "When APIServer has no spec, it should set an empty apiserver config",
+			params: baseParams(),
+			verify: func(g Gomega, cm *corev1.ConfigMap) {
+				g.Expect(cm.Data).To(HaveKey("cluster-apiserver-config.yaml"))
+				apiServer := deserializeAPIServer(g, cm.Data["cluster-apiserver-config.yaml"])
+				g.Expect(apiServer.Spec).To(Equal(configv1.APIServerSpec{}))
+			},
+		},
+		{
+			name: "When APIServer has audit profile, it should serialize it into the configmap",
+			params: func() *MCSParams {
+				p := baseParams()
+				p.APIServer.Spec.Audit.Profile = configv1.WriteRequestBodiesAuditProfileType
+				return p
+			}(),
+			verify: func(g Gomega, cm *corev1.ConfigMap) {
+				g.Expect(cm.Data).To(HaveKey("cluster-apiserver-config.yaml"))
+				apiServer := deserializeAPIServer(g, cm.Data["cluster-apiserver-config.yaml"])
+				g.Expect(apiServer.Spec.Audit.Profile).To(Equal(configv1.WriteRequestBodiesAuditProfileType))
+			},
+		},
+		{
+			name: "When APIServer has TLS and named certs, it should serialize them into the configmap",
+			params: func() *MCSParams {
+				p := baseParams()
+				p.APIServer.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileIntermediateType,
+				}
+				p.APIServer.Spec.ServingCerts = configv1.APIServerServingCerts{
+					NamedCertificates: []configv1.APIServerNamedServingCert{
+						{
+							Names:              []string{"api.example.com"},
+							ServingCertificate: configv1.SecretNameReference{Name: "api-cert"},
+						},
+					},
+				}
+				return p
+			}(),
+			verify: func(g Gomega, cm *corev1.ConfigMap) {
+				g.Expect(cm.Data).To(HaveKey("cluster-apiserver-config.yaml"))
+				apiServer := deserializeAPIServer(g, cm.Data["cluster-apiserver-config.yaml"])
+				g.Expect(apiServer.Spec.TLSSecurityProfile).ToNot(BeNil())
+				g.Expect(apiServer.Spec.TLSSecurityProfile.Type).To(Equal(configv1.TLSProfileIntermediateType))
+				g.Expect(apiServer.Spec.ServingCerts.NamedCertificates).To(HaveLen(1))
+				g.Expect(apiServer.Spec.ServingCerts.NamedCertificates[0].Names).To(ContainElement("api.example.com"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			cm := &corev1.ConfigMap{}
+			err := ReconcileMachineConfigServerConfig(cm, tt.params)
+			g.Expect(err).ToNot(HaveOccurred())
+			tt.verify(g, cm)
+		})
+	}
+}
 
 func TestMasterConfigPool(t *testing.T) {
 	t.Parallel()

--- a/hypershift-operator/controllers/nodepool/config.go
+++ b/hypershift-operator/controllers/nodepool/config.go
@@ -91,7 +91,7 @@ func NewConfigGenerator(ctx context.Context, client client.Client, hostedCluster
 		return nil, fmt.Errorf("release image can't be nil")
 	}
 
-	globalConfig, err := globalConfigString(hostedCluster)
+	globalConfig, err := globalConfigString(hostedCluster, releaseImage)
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +367,7 @@ func (cg *ConfigGenerator) defaultAndValidateConfigManifest(manifest []byte) ([]
 	return manifest, err
 }
 
-func globalConfigString(hcluster *hyperv1.HostedCluster) (string, error) {
+func globalConfigString(hcluster *hyperv1.HostedCluster, releaseImage *releaseinfo.ReleaseImage) (string, error) {
 	// 1. - Reconcile conditions according to current state of the world.
 	proxy := globalconfig.ProxyConfig()
 	globalconfig.ReconcileProxyConfigWithStatusFromHostedCluster(proxy, hcluster)
@@ -393,10 +393,45 @@ func globalConfigString(hcluster *hyperv1.HostedCluster) (string, error) {
 	}
 	globalConfigBytes.Write(imageBytes)
 
+	if err := conditionallyAddToGlobalConfigString(globalConfigBytes, hcluster, releaseImage); err != nil {
+		return "", fmt.Errorf("failed to encode apiserver global config: %w", err)
+	}
+
 	rawConfig := globalConfigBytes.String()
 
 	// Some fields in the ClusterConfiguration have changes that are not backwards compatible with older versions of the CPO.
 	return backwardcompat.GetBackwardCompatibleConfigString(rawConfig), nil
+}
+
+// conditionallyAddToGlobalConfigString exists so we can add things to the
+// global config string based on the release image version. Every time this
+// global config changes the node pool controller trigger a node pool
+// rollout, this allows us a more fine grained control over the process.
+func conditionallyAddToGlobalConfigString(
+	globalConfigBytes *bytes.Buffer,
+	hcluster *hyperv1.HostedCluster,
+	releaseImage *releaseinfo.ReleaseImage,
+) error {
+	version, err := semver.Parse(releaseImage.Version())
+	if err != nil {
+		return fmt.Errorf("failed to parse release image version: %w", err)
+	}
+
+	// Starting on v4.23.0 we support TLS Profile configuration. The
+	// expected TLS Profile is part of the HostedCluster config.
+	if version.GTE(semver.MustParse("4.23.0")) {
+		apiServer := globalconfig.APIServerConfiguration()
+		if err := globalconfig.ReconcileAPIServerConfiguration(apiServer, hcluster.Spec.Configuration); err != nil {
+			return fmt.Errorf("failed to reconcile apiserver global config: %w", err)
+		}
+		apiServerBytes, err := api.CompatibleJSONEncode(apiServer)
+		if err != nil {
+			return fmt.Errorf("failed to encode apiserver global config: %w", err)
+		}
+		globalConfigBytes.Write(apiServerBytes)
+	}
+
+	return nil
 }
 
 // GetCloudConfigHash returns a hash of the platform-specific cloud config ConfigMap content.

--- a/hypershift-operator/controllers/nodepool/config_test.go
+++ b/hypershift-operator/controllers/nodepool/config_test.go
@@ -126,6 +126,9 @@ spec:
 	expectedGlobalConfigString := `{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"trustedCA":{"name":""}},"status":{}}
 {"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"additionalTrustedCA":{"name":""},"registrySources":{}},"status":{}}
 `
+	// For release versions >= 4.23.0, the apiserver config is additionally included.
+	expectedGlobalConfigStringWithAPIServer := expectedGlobalConfigString + `{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"servingCerts":{},"clientCA":{"name":""},"encryption":{},"audit":{}},"status":{}}
+`
 
 	hostedCluster := &hyperv1.HostedCluster{
 		TypeMeta: metav1.TypeMeta{},
@@ -148,6 +151,7 @@ spec:
 		hostedCluster              *hyperv1.HostedCluster
 		config                     []crclient.Object
 		expectedMCORawConfig       string
+		expectedGlobalConfig       string
 		client                     bool
 		expectedHash               string
 		expectedHashWithoutVersion string
@@ -157,6 +161,7 @@ spec:
 			name:                       "When all input is given it should not return an error",
 			expectedHash:               "83935368",
 			expectedHashWithoutVersion: "0db5756d",
+			expectedGlobalConfig:       expectedGlobalConfigString,
 			nodePool:                   &hyperv1.NodePool{},
 			releaseImage: &releaseinfo.ReleaseImage{
 				ImageStream: &imageapi.ImageStream{
@@ -189,6 +194,7 @@ spec:
 			name:                       "When nodepool has configs it should populate mcoRawConfig ",
 			expectedHash:               "af67f27c",
 			expectedHashWithoutVersion: "fef02451",
+			expectedGlobalConfig:       expectedGlobalConfigString,
 			nodePool: &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
@@ -254,6 +260,7 @@ spec:
 			name:                       "When release version is 4.18.0 with no osImageStream it should produce baseline hash",
 			expectedHash:               "83935368",
 			expectedHashWithoutVersion: "0db5756d",
+			expectedGlobalConfig:       expectedGlobalConfigString,
 			nodePool:                   &hyperv1.NodePool{},
 			releaseImage: &releaseinfo.ReleaseImage{
 				ImageStream: &imageapi.ImageStream{
@@ -270,6 +277,7 @@ spec:
 			name:                       "When osImageStream is set to version-derived default it should produce the same hash as no stream",
 			expectedHash:               "83935368",
 			expectedHashWithoutVersion: "0db5756d",
+			expectedGlobalConfig:       expectedGlobalConfigString,
 			nodePool: &hyperv1.NodePool{
 				Spec: hyperv1.NodePoolSpec{
 					OSImageStream: hyperv1.OSImageStreamReference{Name: "rhel-9"},
@@ -288,8 +296,9 @@ spec:
 		},
 		{
 			name:                       "When osImageStream is set to non-default it should produce a different hash",
-			expectedHash:               "ccd46cc1",
+			expectedHash:               "4ecbeb73",
 			expectedHashWithoutVersion: "3a158178",
+			expectedGlobalConfig:       expectedGlobalConfigStringWithAPIServer,
 			nodePool: &hyperv1.NodePool{
 				Spec: hyperv1.NodePoolSpec{
 					OSImageStream: hyperv1.OSImageStreamReference{Name: "rhel-9"},
@@ -308,8 +317,9 @@ spec:
 		},
 		{
 			name:                       "When release version is 5.0.0 with no osImageStream it should normalize rhelStream to empty",
-			expectedHash:               "ff80e2c8",
+			expectedHash:               "2d564196",
 			expectedHashWithoutVersion: "0db5756d",
+			expectedGlobalConfig:       expectedGlobalConfigStringWithAPIServer,
 			nodePool:                   &hyperv1.NodePool{},
 			releaseImage: &releaseinfo.ReleaseImage{
 				ImageStream: &imageapi.ImageStream{
@@ -324,8 +334,9 @@ spec:
 		},
 		{
 			name:                       "When osImageStream is rhel-10 on 5.0.0 it should normalize to empty and match unset hash",
-			expectedHash:               "ff80e2c8",
+			expectedHash:               "2d564196",
 			expectedHashWithoutVersion: "0db5756d",
+			expectedGlobalConfig:       expectedGlobalConfigStringWithAPIServer,
 			nodePool: &hyperv1.NodePool{
 				Spec: hyperv1.NodePoolSpec{
 					OSImageStream: hyperv1.OSImageStreamReference{Name: "rhel-10"},
@@ -344,8 +355,9 @@ spec:
 		},
 		{
 			name:                       "When runc ContainerRuntimeConfig on 5.0.0 with explicit rhel-9, it should normalize rhelStream to empty",
-			expectedHash:               "72ea1773",
+			expectedHash:               "8dc0d4f5",
 			expectedHashWithoutVersion: "6d5a7b66",
+			expectedGlobalConfig:       expectedGlobalConfigStringWithAPIServer,
 			nodePool: &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
@@ -373,8 +385,9 @@ spec:
 		},
 		{
 			name:                       "When runc ContainerRuntimeConfig on 5.0.0 with no osImageStream, it should match explicit rhel-9 hash",
-			expectedHash:               "72ea1773",
+			expectedHash:               "8dc0d4f5",
 			expectedHashWithoutVersion: "6d5a7b66",
+			expectedGlobalConfig:       expectedGlobalConfigStringWithAPIServer,
 			nodePool: &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
@@ -488,7 +501,7 @@ spec:
 			}
 
 			if tc.hostedCluster.Spec.Configuration != nil {
-				if diff := cmp.Diff(cg.globalConfig, expectedGlobalConfigString); diff != "" {
+				if diff := cmp.Diff(cg.globalConfig, tc.expectedGlobalConfig); diff != "" {
 					t.Errorf("actual config differs from expected: %s", diff)
 				}
 			}
@@ -1935,10 +1948,15 @@ func TestGlobalConfigString(t *testing.T) {
 	expectedGlobalConfigStringWithValues := `{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"httpProxy":"proxy","noProxy":"noProxy","trustedCA":{"name":""}},"status":{"httpProxy":"proxy","noProxy":".cluster.local,.local,.svc,127.0.0.1,localhost,noProxy"}}
 {"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"externalRegistryHostnames":["external registry"],"additionalTrustedCA":{"name":""},"registrySources":{}},"status":{}}
 `
+	expectedGlobalConfigStringWithAPIServer := `{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"trustedCA":{"name":""}},"status":{}}
+{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"additionalTrustedCA":{"name":""},"registrySources":{}},"status":{}}
+{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"servingCerts":{},"clientCA":{"name":""},"encryption":{},"audit":{}},"status":{}}
+`
 
 	testCases := []struct {
 		name           string
 		globalConfig   *hyperv1.ClusterConfiguration
+		releaseImage   *releaseinfo.ReleaseImage
 		expectedOutput string
 	}{
 		// Expected behavior for backward compatibility for empty values is:
@@ -1946,6 +1964,7 @@ func TestGlobalConfigString(t *testing.T) {
 		{
 			name:           "When Empty GlobalConfig it should return serialized string honoring backward compatibility expectation (see code comment)",
 			globalConfig:   &hyperv1.ClusterConfiguration{},
+			releaseImage:   &releaseinfo.ReleaseImage{ImageStream: &imageapi.ImageStream{ObjectMeta: metav1.ObjectMeta{Name: "4.18.0"}}},
 			expectedOutput: expectedGlobalConfigStringWhenEmpty,
 		},
 		{
@@ -1957,6 +1976,7 @@ func TestGlobalConfigString(t *testing.T) {
 				Image:          &configv1.ImageSpec{},
 				Proxy:          &configv1.ProxySpec{},
 			},
+			releaseImage:   &releaseinfo.ReleaseImage{ImageStream: &imageapi.ImageStream{ObjectMeta: metav1.ObjectMeta{Name: "4.18.0"}}},
 			expectedOutput: expectedGlobalConfigStringWhenEmpty,
 		},
 		{
@@ -1979,7 +1999,14 @@ func TestGlobalConfigString(t *testing.T) {
 					TrustedCA:          configv1.ConfigMapNameReference{},
 				},
 			},
+			releaseImage:   &releaseinfo.ReleaseImage{ImageStream: &imageapi.ImageStream{ObjectMeta: metav1.ObjectMeta{Name: "4.18.0"}}},
 			expectedOutput: expectedGlobalConfigStringWithValues,
+		},
+		{
+			name:           "When release image is >= 4.23 the apiserver is included in the global config string",
+			globalConfig:   &hyperv1.ClusterConfiguration{},
+			releaseImage:   &releaseinfo.ReleaseImage{ImageStream: &imageapi.ImageStream{ObjectMeta: metav1.ObjectMeta{Name: "4.23.0"}}},
+			expectedOutput: expectedGlobalConfigStringWithAPIServer,
 		},
 	}
 
@@ -1992,7 +2019,7 @@ func TestGlobalConfigString(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			output, err := globalConfigString(hcluster)
+			output, err := globalConfigString(hcluster, tc.releaseImage)
 			g.Expect(err).ToNot(HaveOccurred())
 			if diff := cmp.Diff(output, tc.expectedOutput); diff != "" {
 				t.Errorf("actual config differs from expected: %s", diff)

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -558,13 +558,22 @@ func (p *LocalIgnitionProvider) copyMCOOutputToMCC(destDir, mccDir, configDir st
 	return nil
 }
 
+func copyMCCConfigInputs(configDir, mccDir string) error {
+	if err := copyFile(filepath.Join(configDir, "cluster-apiserver-config.yaml"), filepath.Join(mccDir, "cluster-apiserver-config.yaml")); err != nil {
+		return fmt.Errorf("failed to copy cluster-apiserver-config.yaml: %w", err)
+	}
+	if err := copyFile(filepath.Join(configDir, "image-config.yaml"), filepath.Join(mccDir, "image-config.yaml")); err != nil {
+		return fmt.Errorf("failed to copy image-config.yaml: %w", err)
+	}
+	return nil
+}
+
 func (p *LocalIgnitionProvider) runMCC(ctx context.Context, dirs *payloadDirs, imageProvider *imageprovider.SimpleReleaseImageProvider, payloadVersion semver.Version) error {
 	log := ctrl.Log.WithName("get-payload")
 	start := time.Now()
 
-	// copy the image config out of the configDir and into the mccBaseDir
-	if err := copyFile(filepath.Join(dirs.configDir, "image-config.yaml"), filepath.Join(dirs.mccDir, "image-config.yaml")); err != nil {
-		return fmt.Errorf("failed to copy image-config.yaml: %w", err)
+	if err := copyMCCConfigInputs(dirs.configDir, dirs.mccDir); err != nil {
+		return err
 	}
 
 	// args contains the base args that have not changed over time.

--- a/ignition-server/controllers/local_ignitionprovider_test.go
+++ b/ignition-server/controllers/local_ignitionprovider_test.go
@@ -711,6 +711,70 @@ func TestCopyMCOOutputToMCC(t *testing.T) {
 	}
 }
 
+func Test_copyMCCConfigInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		setupDirs   func(t *testing.T, configDir string)
+		expectFiles []string
+		expectError bool
+	}{
+		{
+			name: "When config directory has both config files, it should copy them to mcc",
+			setupDirs: func(t *testing.T, configDir string) {
+				g := NewWithT(t)
+				g.Expect(os.WriteFile(filepath.Join(configDir, "cluster-apiserver-config.yaml"), []byte("apiserver-config"), 0644)).To(Succeed())
+				g.Expect(os.WriteFile(filepath.Join(configDir, "image-config.yaml"), []byte("image-config"), 0644)).To(Succeed())
+			},
+			expectFiles: []string{"cluster-apiserver-config.yaml", "image-config.yaml"},
+		},
+		{
+			name: "When cluster-apiserver-config.yaml is missing, it should return an error",
+			setupDirs: func(t *testing.T, configDir string) {
+				g := NewWithT(t)
+				g.Expect(os.WriteFile(filepath.Join(configDir, "image-config.yaml"), []byte("image-config"), 0644)).To(Succeed())
+			},
+			expectError: true,
+		},
+		{
+			name: "When image-config.yaml is missing, it should return an error",
+			setupDirs: func(t *testing.T, configDir string) {
+				g := NewWithT(t)
+				g.Expect(os.WriteFile(filepath.Join(configDir, "cluster-apiserver-config.yaml"), []byte("apiserver-config"), 0644)).To(Succeed())
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			tmpDir := t.TempDir()
+			configDir := filepath.Join(tmpDir, "config")
+			mccDir := filepath.Join(tmpDir, "mcc")
+			g.Expect(os.MkdirAll(configDir, 0755)).To(Succeed())
+			g.Expect(os.MkdirAll(mccDir, 0755)).To(Succeed())
+
+			tt.setupDirs(t, configDir)
+
+			err := copyMCCConfigInputs(configDir, mccDir)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			for _, f := range tt.expectFiles {
+				_, err := os.Stat(filepath.Join(mccDir, f))
+				g.Expect(err).NotTo(HaveOccurred(), "expected file %s to exist in mccDir", f)
+			}
+		})
+	}
+}
+
 func TestInvokeFeatureGateRenderScript(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What this PR does / why we need it:

Ignition server needs to know what is the `HostedCluster` API Server configuration in order to properly set kubelet and cri-o TLS settings (as per PQC compliance requirement). This PR wires the missing config through the `machine-config-server` ConfigMap.

>[!IMPORTANT]
>  **For versions >= 4.23.0**: We are adding the `APIServer` config to the `globalConfigString`. This will, in turn, trigger a rollout across all NodePools on upgrade even if no `APIServer` config is set (the resulting hash will be different). 


## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Hosted control plane machine configuration now includes API server configuration, serialized into the generated ConfigMap.
  - NodePool global configuration generation now incorporates API server configuration.

- **Bug Fixes**
  - Fail fast and surface errors when API server configuration reconciliation/serialization fails during config generation.
  - Ensure generated ignition/provisioning inputs copy the full set of required API server and image configuration files.

- **Tests**
  - Added unit tests for API server parameter creation and ConfigMap reconciliation.
  - Updated configuration serialization/hash expectations to include API server fields.
  - Added a new unit test for copying Machine Config inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->