### PR TITLE
CNTRLPLANE-3564: test(awsprivatelink): add unit test for NoSuchHostedZone handling dur…

### DIFF
--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
@@ -563,6 +563,32 @@ func TestReconcileDeletion(t *testing.T) {
 			expectRequeue:   true,
 			expectFinalizer: true,
 		},
+		{
+			name: "When Route53 hosted zone is already deleted externally it should treat deletion as successful",
+			awsEndpointSvc: &hyperv1.AWSEndpointService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "private-router",
+					Namespace:         "clusters-test",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{finalizer},
+				},
+				Status: hyperv1.AWSEndpointServiceStatus{
+					DNSNames:  []string{"api.example.com"},
+					DNSZoneID: "Z1234567890",
+				},
+			},
+			setupMocks: func(mockCtrl *gomock.Controller) *MockawsClientProvider {
+				mockBuilder := NewMockawsClientProvider(mockCtrl)
+				mockEC2 := awsapi.NewMockEC2API(mockCtrl)
+				mockRoute53 := awsapi.NewMockROUTE53API(mockCtrl)
+				mockRoute53.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any()).Return(
+					nil, &route53types.NoSuchHostedZone{Message: aws.String("Hosted zone Z1234567890 not found")})
+				mockBuilder.EXPECT().getClients(gomock.Any()).Return(mockEC2, mockRoute53, nil)
+				return mockBuilder
+			},
+			expectError:     false,
+			expectFinalizer: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
…ing deletion

## What this PR does / why we need it:

Cover the code path where FindRecord() returns a NoSuchHostedZone error because the Route53 hosted zone was already deleted externally. The controller correctly treats this as successful deletion and removes the finalizer.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3564

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup handling when an AWS Route 53 hosted zone has already been deleted.
  - Endpoint service deletion now completes successfully and removes its finalizer instead of reporting an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->