### PR TITLE
CNTRLPLANE-3604: Add CAPI migration flag placeholder

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -165,6 +165,7 @@ type Options struct {
 	RenderSensitive                           bool
 	HCPEgressBlockCIDRs                       []string
 	InstallScope                              string
+	DisableCAPIMigration                      bool
 }
 
 func (o *Options) Complete() error {
@@ -445,6 +446,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.EnableValidatingWebhook, "enable-validating-webhook", opts.EnableValidatingWebhook, "Enable webhook for validating hypershift API types")
 	cmd.PersistentFlags().BoolVar(&opts.EnableConversionWebhook, "enable-conversion-webhook", opts.EnableConversionWebhook, "Enable webhook for converting hypershift API types")
 	cmd.PersistentFlags().BoolVar(&opts.DisableCAPIConversionWebhook, "disable-capi-conversion-webhook", opts.DisableCAPIConversionWebhook, "Disable conversion webhook for CAPI CRDs during v1beta1/v1beta2 transition")
+	cmd.PersistentFlags().BoolVar(&opts.DisableCAPIMigration, "disable-capi-migration", opts.DisableCAPIMigration, "Placeholder flag for upcoming feature: Disable automatic CAPI CRD storage version migration from v1beta1 to v1beta2")
 	cmd.PersistentFlags().BoolVar(&opts.ExcludeEtcdManifests, "exclude-etcd", opts.ExcludeEtcdManifests, "Leave out etcd manifests")
 	cmd.PersistentFlags().Var(&opts.PlatformMonitoring, "platform-monitoring", "Select an option for enabling platform cluster monitoring. Valid values are: None, OperatorOnly, All")
 	cmd.PersistentFlags().BoolVar(&opts.EnableCIDebugOutput, "enable-ci-debug-output", opts.EnableCIDebugOutput, "If extra CI debug output should be enabled")


### PR DESCRIPTION
## What this PR does / why we need it:
#8938 introduces the CAPI storage version migration including an opt-out flag. To introduce the feature safely, we need to add the opt-out flag in order to enable the opt-out in relevant places before the migration feature is merged.

This avoids accidental migrations on our envs.

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--disable-capi-migration` option to the install command.
  * The option is currently reserved for future functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->