### PR TITLE
OCPBUGS-100087: Replace exponential backoff with fixed-interval requeue in CRR controller

### DIFF
--- a/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller.go
+++ b/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller.go
@@ -48,6 +48,20 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// requeueInterval is the fixed polling interval used instead of SyntheticRequeueError.
+// SyntheticRequeueError feeds into DefaultControllerRateLimiter (5ms → 1000s exponential
+// backoff), which causes 11+ minute stalls when polling for KAS trust bundle reloads that
+// take ~1–2 minutes. Returning nil + AddAfter bypasses the rate limiter entirely, and
+// returning nil causes the framework to call Forget(key), resetting the failure counter.
+const requeueInterval = 10 * time.Second
+
+// revocationVerificationTimeout bounds how long step 6 (ensureOldSignerCertificateRevoked)
+// polls before surfacing a real error. Without this, the fixed-interval requeue would poll
+// every 10s indefinitely if KAS never reloads the trust bundle.
+const revocationVerificationTimeout = 10 * time.Minute
+
+const revocationVerificationTimeoutReason = "RevocationVerificationTimeout"
+
 type CertificateRevocationController struct {
 	kubeClient       kubernetes.Interface
 	hypershiftClient hypershiftclient.Interface
@@ -60,6 +74,7 @@ type CertificateRevocationController struct {
 	listPods     func(namespace string, selector labels.Selector) ([]*corev1.Pod, error)
 
 	// for unit testing only
+	clock              func() time.Time
 	skipKASConnections bool
 	// overrideVerifyCertAgainstKASPods, when non-nil, replaces verifyCertificateAgainstAllKASPods
 	// for unit testing. This allows tests to control per-pod verification behavior without
@@ -309,16 +324,10 @@ func (c *CertificateRevocationController) syncCertificateRevocationRequest(ctx c
 		return err
 	}
 
-	action, requeue, err := c.processCertificateRevocationRequest(ctx, namespace, name, nil)
-	if err != nil {
-		return err
-	}
-	if requeue {
-		return factory.SyntheticRequeueError
-	}
+	action, requeue, err := c.processCertificateRevocationRequest(ctx, namespace, name, c.clock)
 	if action != nil {
-		if err := action.validate(); err != nil {
-			panic(err)
+		if validateErr := action.validate(); validateErr != nil {
+			panic(validateErr)
 		}
 		if action.event != nil {
 			syncContext.Recorder().Eventf(action.event.reason, action.event.messageFmt, action.event.args...)
@@ -327,17 +336,26 @@ func (c *CertificateRevocationController) syncCertificateRevocationRequest(ctx c
 		// TODO: using force on secrets & CM since we're a different field manager - maybe collapse?
 		switch {
 		case action.crr != nil:
-			_, err := c.hypershiftClient.CertificatesV1alpha1().CertificateRevocationRequests(*action.crr.Namespace).ApplyStatus(ctx, action.crr, metav1.ApplyOptions{FieldManager: c.fieldManager})
-			return err
+			if _, applyErr := c.hypershiftClient.CertificatesV1alpha1().CertificateRevocationRequests(*action.crr.Namespace).ApplyStatus(ctx, action.crr, metav1.ApplyOptions{FieldManager: c.fieldManager}); applyErr != nil {
+				return fmt.Errorf("apply CertificateRevocationRequest status: %w", applyErr)
+			}
 		case action.secret != nil:
-			_, err := c.kubeClient.CoreV1().Secrets(*action.secret.Namespace).Apply(ctx, action.secret, metav1.ApplyOptions{FieldManager: c.fieldManager, Force: true})
-			return err
+			if _, applyErr := c.kubeClient.CoreV1().Secrets(*action.secret.Namespace).Apply(ctx, action.secret, metav1.ApplyOptions{FieldManager: c.fieldManager, Force: true}); applyErr != nil {
+				return fmt.Errorf("apply Secret: %w", applyErr)
+			}
 		case action.cm != nil:
-			_, err := c.kubeClient.CoreV1().ConfigMaps(*action.cm.Namespace).Apply(ctx, action.cm, metav1.ApplyOptions{FieldManager: c.fieldManager, Force: true})
-			return err
+			if _, applyErr := c.kubeClient.CoreV1().ConfigMaps(*action.cm.Namespace).Apply(ctx, action.cm, metav1.ApplyOptions{FieldManager: c.fieldManager, Force: true}); applyErr != nil {
+				return fmt.Errorf("apply ConfigMap: %w", applyErr)
+			}
 		}
 	}
-
+	if err != nil {
+		return err
+	}
+	if requeue {
+		syncContext.Queue().AddAfter(syncContext.QueueKey(), requeueInterval)
+		return nil
+	}
 	return nil
 }
 
@@ -714,6 +732,7 @@ func (c *CertificateRevocationController) ensureNewSignerCertificatePropagated(c
 		return true, nil, false, err
 	}
 	if totalClientTrustBundle == nil {
+		klog.V(2).Infof("CRR %s/%s step 3: total-client-ca trust bundle ConfigMap not yet available, requeueing", namespace, name)
 		return true, nil, true, nil
 	}
 
@@ -733,6 +752,7 @@ func (c *CertificateRevocationController) ensureNewSignerCertificatePropagated(c
 	// that, though, and it's always valid to first check that our certificates have propagated as far
 	// as we can tell in the system before asking the KAS, since that's expensive
 	if len(trustedCertificates(totalClientTrustBundle, []*certificateSecret{{cert: signers[0]}}, now)) == 0 {
+		klog.V(2).Infof("CRR %s/%s step 3: new signer certificate not yet present in total-client-ca trust bundle, requeueing", namespace, name)
 		return true, nil, true, nil
 	}
 
@@ -758,7 +778,8 @@ func (c *CertificateRevocationController) ensureNewSignerCertificatePropagated(c
 			return true, nil, false, err
 		}
 		if !allTrusted {
-			return true, nil, true, nil // pod transitions trigger reconciliation, but synthetic re-queue is still needed for KAS trust bundle reloads
+			klog.V(2).Infof("CRR %s/%s step 3: KAS pods have not yet accepted new signer certificate, requeueing", namespace, name)
+			return true, nil, true, nil
 		}
 
 		// Cross-check: verify the previous signer is also still trusted.
@@ -777,7 +798,7 @@ func (c *CertificateRevocationController) ensureNewSignerCertificatePropagated(c
 					return true, nil, false, err
 				}
 				if !oldTrusted {
-					klog.V(4).Infof("KAS pods accepted new cert but rejected old signer cert for %s/%s; likely mid-reload, requeueing", namespace, name)
+					klog.V(2).Infof("CRR %s/%s step 3: KAS pods accepted new cert but rejected old signer cert; likely mid-reload, requeueing", namespace, name)
 					return true, nil, true, nil
 				}
 			}
@@ -985,6 +1006,27 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 		return false, nil, false, nil
 	}
 
+	for _, condition := range crr.Status.Conditions {
+		if condition.Type == certificatesv1alpha1.LeafCertificatesRegeneratedType && condition.Status == metav1.ConditionTrue {
+			if now().Sub(condition.LastTransitionTime.Time) > revocationVerificationTimeout {
+				cfg := certificatesv1alpha1applyconfigurations.CertificateRevocationRequest(name, namespace)
+				cfg.Status = certificatesv1alpha1applyconfigurations.CertificateRevocationRequestStatus().
+					WithRevocationTimestamp(*crr.Status.RevocationTimestamp).
+					WithPreviousSigner(*crr.Status.PreviousSigner).
+					WithConditions(conditions(crr.Status.Conditions, metav1applyconfigurations.Condition().
+						WithType(certificatesv1alpha1.PreviousCertificatesRevokedType).
+						WithStatus(metav1.ConditionFalse).
+						WithLastTransitionTime(metav1.NewTime(now())).
+						WithReason(revocationVerificationTimeoutReason).
+						WithMessage(fmt.Sprintf("Timed out after %v waiting for KAS to reject old signer certificate.", revocationVerificationTimeout)),
+					)...)
+				e := event("CertificateRevocationStalled", "Revocation verification for %q signer timed out after %v.", crr.Spec.SignerClass, revocationVerificationTimeout)
+				return true, &actions{event: e, crr: cfg}, false, fmt.Errorf("step 6 timed out after %v waiting for KAS to reject old signer certificate", revocationVerificationTimeout)
+			}
+			break
+		}
+	}
+
 	oldCertSecret, err := c.getSecret(namespace, crr.Status.PreviousSigner.Name)
 	if err != nil {
 		return true, nil, false, err
@@ -1008,6 +1050,7 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 	// Load the current (new) signer cert/key for cross-checking during per-pod verification.
 	signer, ok := secretForSignerClass(namespace, certificates.SignerClass(crr.Spec.SignerClass))
 	if !ok {
+		klog.V(2).Infof("CRR %s/%s step 6: signer secret for class not yet available, requeueing", namespace, name)
 		return true, nil, true, nil
 	}
 	signerSecret, _, err := c.loadCertificateSecret(signer.Namespace, signer.Name)
@@ -1015,6 +1058,7 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 		return true, nil, false, err
 	}
 	if signerSecret == nil {
+		klog.V(2).Infof("CRR %s/%s step 6: signer secret not yet available, requeueing", namespace, name)
 		return true, nil, true, nil
 	}
 	currentCertPEM := signerSecret.Data[corev1.TLSCertKey]
@@ -1026,6 +1070,7 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 		return true, nil, false, err
 	}
 	if totalClientTrustBundle == nil {
+		klog.V(2).Infof("CRR %s/%s step 6: total-client-ca trust bundle ConfigMap not yet available, requeueing", namespace, name)
 		return true, nil, true, nil
 	}
 	// the real gate for this phase is that KAS has loaded the updated trust bundle and no longer
@@ -1033,6 +1078,7 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 	// that, though, and it's always valid to first check that our certificates have propagated as far
 	// as we can tell in the system before asking the KAS, since that's expensive
 	if len(trustedCertificates(totalClientTrustBundle, []*certificateSecret{{cert: oldCerts[0]}}, now)) != 0 {
+		klog.V(2).Infof("CRR %s/%s step 6: old signer certificate still present in total-client-ca trust bundle, requeueing", namespace, name)
 		return true, nil, true, nil
 	}
 
@@ -1058,7 +1104,8 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 			return true, nil, false, err
 		}
 		if !allRevoked {
-			return true, nil, true, nil // pod transitions trigger reconciliation, but synthetic re-queue is still needed for KAS trust bundle reloads
+			klog.V(2).Infof("CRR %s/%s step 6: KAS pods have not yet rejected old signer certificate, requeueing", namespace, name)
+			return true, nil, true, nil
 		}
 
 		// Cross-check: verify the current signer is still trusted by all pods.
@@ -1070,7 +1117,7 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 			return true, nil, false, err
 		}
 		if !allTrusted {
-			klog.V(4).Infof("KAS pods rejected old cert but also rejected current signer cert for %s/%s; likely mid-reload, requeueing", namespace, name)
+			klog.V(2).Infof("CRR %s/%s step 6: KAS pods rejected old cert but also rejected current signer cert; likely mid-reload, requeueing", namespace, name)
 			return true, nil, true, nil
 		}
 	}

--- a/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller_test.go
+++ b/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller_test.go
@@ -16,12 +16,14 @@ import (
 	certificatesv1alpha1 "github.com/openshift/hypershift/api/certificates/v1alpha1"
 	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	certificatesv1alpha1applyconfigurations "github.com/openshift/hypershift/client/applyconfiguration/certificates/v1alpha1"
+	hypershiftfake "github.com/openshift/hypershift/client/clientset/clientset/fake"
 	hcpmanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-pki-operator/certificates"
 	"github.com/openshift/hypershift/control-plane-pki-operator/manifests"
 
 	librarygocrypto "github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/certrotation"
+	"github.com/openshift/library-go/pkg/operator/events"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/workqueue"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 
@@ -2108,6 +2111,360 @@ func TestEnsureOldSignerCertificateRevoked_KASVerification(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(done).To(BeTrue())
 			g.Expect(requeue).To(BeTrue())
+		})
+	}
+}
+
+// spyQueue wraps a RateLimitingInterface to record AddAfter calls.
+type spyQueue struct {
+	workqueue.RateLimitingInterface //nolint:staticcheck
+	addAfterCalls                   []struct {
+		item     any
+		duration time.Duration
+	}
+}
+
+func (s *spyQueue) AddAfter(item any, d time.Duration) {
+	s.addAfterCalls = append(s.addAfterCalls, struct {
+		item     any
+		duration time.Duration
+	}{item, d})
+	s.RateLimitingInterface.AddAfter(item, d)
+}
+
+// fakeSyncContext implements factory.SyncContext for sync-level testing.
+type fakeSyncContext struct {
+	queue    workqueue.RateLimitingInterface //nolint:staticcheck
+	queueKey string
+	recorder events.Recorder
+}
+
+func (f *fakeSyncContext) Queue() workqueue.RateLimitingInterface { return f.queue } //nolint:staticcheck
+func (f *fakeSyncContext) QueueKey() string                       { return f.queueKey }
+func (f *fakeSyncContext) Recorder() events.Recorder              { return f.recorder }
+
+func TestSyncCertificateRevocationRequest_RequeueBehavior(t *testing.T) {
+	revocationTime, err := time.Parse(time.RFC3339Nano, "2006-01-02T15:04:05.999999999Z")
+	if err != nil {
+		t.Fatalf("could not parse time: %v", err)
+	}
+	postRevocationClock := testingclock.NewFakeClock(revocationTime.Add(revocationOffset + 1*time.Hour))
+
+	data := pki(t, revocationTime)
+
+	for _, testCase := range []struct {
+		name    string
+		now     func() time.Time
+		crr     *certificatesv1alpha1.CertificateRevocationRequest
+		secrets []*corev1.Secret
+		cms     []*corev1.ConfigMap
+
+		expectAddAfter bool
+		expectErr      bool
+	}{
+		{
+			name: "When the request is non-terminal, it should requeue via AddAfter",
+			crr: &certificatesv1alpha1.CertificateRevocationRequest{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "crr-name"},
+				Spec:       certificatesv1alpha1.CertificateRevocationRequestSpec{SignerClass: string(certificates.CustomerBreakGlassSigner)},
+				Status: certificatesv1alpha1.CertificateRevocationRequestStatus{
+					RevocationTimestamp: ptr.To(metav1.NewTime(revocationTime)),
+					PreviousSigner:      &corev1.LocalObjectReference{Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+					Conditions: []metav1.Condition{{
+						Type:               certificatesv1alpha1.LeafCertificatesRegeneratedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "All leaf certificates are re-generated.",
+					}, {
+						Type:               certificatesv1alpha1.RootCertificatesRegeneratedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "Signer certificate crr-ns/customer-system-admin-signer regenerated.",
+					}, {
+						Type:               certificatesv1alpha1.NewCertificatesTrustedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "New signer certificate crr-ns/customer-system-admin-signer trusted.",
+					}},
+				},
+			},
+			secrets: []*corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "crr-ns",
+					Name:        manifests.CustomerSystemAdminSigner("").Name,
+					Annotations: map[string]string{certrotation.CertificateIssuer: "crr-ns_customer-break-glass-signer@1234"},
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.future.raw.signerCert,
+					corev1.TLSPrivateKeyKey: data.future.raw.signerKey,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.original.raw.signerCert,
+					corev1.TLSPrivateKeyKey: data.original.raw.signerKey,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "crr-ns",
+					Name:        manifests.CustomerSystemAdminClientCertSecret("").Name,
+					Annotations: map[string]string{certrotation.CertificateIssuer: "crr-ns_customer-break-glass-signer@1234"},
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.future.raw.signedCert,
+					corev1.TLSPrivateKeyKey: data.future.raw.clientKey,
+				},
+			}},
+			cms: []*corev1.ConfigMap{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: manifests.CustomerSystemAdminSignerCA("").Name},
+				Data: map[string]string{
+					"ca-bundle.crt": string(data.future.raw.signerCert),
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: manifests.TotalKASClientCABundle("").Name},
+				Data: map[string]string{
+					"ca-bundle.crt": string(data.original.raw.signerCert) + string(data.future.raw.signerCert),
+				},
+			}},
+			expectAddAfter: true,
+		},
+		{
+			name: "When the request has reached a terminal state, it should not touch the queue",
+			crr: &certificatesv1alpha1.CertificateRevocationRequest{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "crr-name"},
+				Spec:       certificatesv1alpha1.CertificateRevocationRequestSpec{SignerClass: string(certificates.CustomerBreakGlassSigner)},
+				Status: certificatesv1alpha1.CertificateRevocationRequestStatus{
+					RevocationTimestamp: ptr.To(metav1.NewTime(revocationTime)),
+					PreviousSigner:      &corev1.LocalObjectReference{Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+					Conditions: []metav1.Condition{{
+						Type:               certificatesv1alpha1.PreviousCertificatesRevokedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "Previous signer certificate revoked.",
+					}, {
+						Type:               certificatesv1alpha1.LeafCertificatesRegeneratedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "All leaf certificates are re-generated.",
+					}, {
+						Type:               certificatesv1alpha1.RootCertificatesRegeneratedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "Signer certificate crr-ns/customer-system-admin-signer regenerated.",
+					}, {
+						Type:               certificatesv1alpha1.NewCertificatesTrustedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "New signer certificate crr-ns/customer-system-admin-signer trusted.",
+					}},
+				},
+			},
+			secrets: []*corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "crr-ns",
+					Name:        manifests.CustomerSystemAdminSigner("").Name,
+					Annotations: map[string]string{certrotation.CertificateIssuer: "crr-ns_customer-break-glass-signer@1234"},
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.future.raw.signerCert,
+					corev1.TLSPrivateKeyKey: data.future.raw.signerKey,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.original.raw.signerCert,
+					corev1.TLSPrivateKeyKey: data.original.raw.signerKey,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "crr-ns",
+					Name:        manifests.CustomerSystemAdminClientCertSecret("").Name,
+					Annotations: map[string]string{certrotation.CertificateIssuer: "crr-ns_customer-break-glass-signer@1234"},
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.future.raw.signedCert,
+					corev1.TLSPrivateKeyKey: data.future.raw.clientKey,
+				},
+			}},
+			cms: []*corev1.ConfigMap{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: manifests.CustomerSystemAdminSignerCA("").Name},
+				Data: map[string]string{
+					"ca-bundle.crt": string(data.future.raw.signerCert),
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: manifests.TotalKASClientCABundle("").Name},
+				Data: map[string]string{
+					"ca-bundle.crt": string(data.future.raw.signerCert),
+				},
+			}},
+			expectAddAfter: false,
+		},
+		{
+			name: "When old-signer verification exceeds the timeout, it should patch status and return an error",
+			now: func() time.Time {
+				return postRevocationClock.Now().Add(11 * time.Minute)
+			},
+			crr: &certificatesv1alpha1.CertificateRevocationRequest{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "crr-name"},
+				Spec:       certificatesv1alpha1.CertificateRevocationRequestSpec{SignerClass: string(certificates.CustomerBreakGlassSigner)},
+				Status: certificatesv1alpha1.CertificateRevocationRequestStatus{
+					RevocationTimestamp: ptr.To(metav1.NewTime(revocationTime)),
+					PreviousSigner:      &corev1.LocalObjectReference{Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+					Conditions: []metav1.Condition{{
+						Type:               certificatesv1alpha1.LeafCertificatesRegeneratedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "All leaf certificates are re-generated.",
+					}, {
+						Type:               certificatesv1alpha1.RootCertificatesRegeneratedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "Signer certificate crr-ns/customer-system-admin-signer regenerated.",
+					}, {
+						Type:               certificatesv1alpha1.NewCertificatesTrustedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "New signer certificate crr-ns/customer-system-admin-signer trusted.",
+					}},
+				},
+			},
+			secrets: []*corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "crr-ns",
+					Name:        manifests.CustomerSystemAdminSigner("").Name,
+					Annotations: map[string]string{certrotation.CertificateIssuer: "crr-ns_customer-break-glass-signer@1234"},
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.future.raw.signerCert,
+					corev1.TLSPrivateKeyKey: data.future.raw.signerKey,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.original.raw.signerCert,
+					corev1.TLSPrivateKeyKey: data.original.raw.signerKey,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "crr-ns",
+					Name:        manifests.CustomerSystemAdminClientCertSecret("").Name,
+					Annotations: map[string]string{certrotation.CertificateIssuer: "crr-ns_customer-break-glass-signer@1234"},
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.future.raw.signedCert,
+					corev1.TLSPrivateKeyKey: data.future.raw.clientKey,
+				},
+			}},
+			cms: []*corev1.ConfigMap{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: manifests.CustomerSystemAdminSignerCA("").Name},
+				Data: map[string]string{
+					"ca-bundle.crt": string(data.future.raw.signerCert),
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: manifests.TotalKASClientCABundle("").Name},
+				Data: map[string]string{
+					"ca-bundle.crt": string(data.original.raw.signerCert) + string(data.future.raw.signerCert),
+				},
+			}},
+			expectAddAfter: false,
+			expectErr:      true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			spy := &spyQueue{
+				RateLimitingInterface: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()), //nolint:staticcheck
+			}
+			defer spy.ShutDown()
+
+			syncCtx := &fakeSyncContext{
+				queue:    spy,
+				queueKey: "crr-ns/crr-name",
+				recorder: events.NewInMemoryRecorder("test", postRevocationClock),
+			}
+
+			nowFunc := testCase.now
+			if nowFunc == nil {
+				nowFunc = postRevocationClock.Now
+			}
+
+			fakeHypershiftClient := hypershiftfake.NewSimpleClientset()
+			c := &CertificateRevocationController{
+				clock:            nowFunc,
+				hypershiftClient: fakeHypershiftClient,
+				fieldManager:     "test",
+				getCRR: func(namespace, name string) (*certificatesv1alpha1.CertificateRevocationRequest, error) {
+					if namespace == testCase.crr.Namespace && name == testCase.crr.Name {
+						return testCase.crr, nil
+					}
+					return nil, apierrors.NewNotFound(hypershiftv1beta1.SchemeGroupVersion.WithResource("certificaterevocationrequest").GroupResource(), name)
+				},
+				getSecret: func(namespace, name string) (*corev1.Secret, error) {
+					for _, secret := range testCase.secrets {
+						if secret.Namespace == namespace && secret.Name == name {
+							return secret, nil
+						}
+					}
+					return nil, apierrors.NewNotFound(corev1.SchemeGroupVersion.WithResource("secrets").GroupResource(), name)
+				},
+				listSecrets: func(namespace string) ([]*corev1.Secret, error) {
+					return testCase.secrets, nil
+				},
+				getConfigMap: func(namespace, name string) (*corev1.ConfigMap, error) {
+					for _, cm := range testCase.cms {
+						if cm.Namespace == namespace && cm.Name == name {
+							return cm, nil
+						}
+					}
+					return nil, apierrors.NewNotFound(corev1.SchemeGroupVersion.WithResource("configmaps").GroupResource(), name)
+				},
+				listPods: func(namespace string, selector labels.Selector) ([]*corev1.Pod, error) {
+					return nil, nil
+				},
+				skipKASConnections: true,
+			}
+
+			err := c.syncCertificateRevocationRequest(t.Context(), syncCtx)
+
+			if testCase.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				// When timeout fires, verify the status patch contains PreviousCertificatesRevoked=False with the timeout reason
+				actions := fakeHypershiftClient.Actions()
+				var foundPatch bool
+				for _, a := range actions {
+					if a.GetVerb() == "patch" && a.GetResource().Resource == "certificaterevocationrequests" && a.GetSubresource() == "status" {
+						patchAction, ok := a.(k8stesting.PatchAction)
+						g.Expect(ok).To(BeTrue(), "expected PatchAction type")
+						patchBody := string(patchAction.GetPatch())
+						g.Expect(patchBody).To(ContainSubstring(certificatesv1alpha1.PreviousCertificatesRevokedType))
+						g.Expect(patchBody).To(ContainSubstring(string(metav1.ConditionFalse)))
+						g.Expect(patchBody).To(ContainSubstring(revocationVerificationTimeoutReason))
+						foundPatch = true
+					}
+				}
+				g.Expect(foundPatch).To(BeTrue(), "timeout should apply PreviousCertificatesRevoked=False status condition before returning error")
+			} else {
+				g.Expect(err).ToNot(HaveOccurred(), "syncCertificateRevocationRequest should return nil, not SyntheticRequeueError")
+			}
+
+			if testCase.expectAddAfter {
+				g.Expect(spy.addAfterCalls).To(HaveLen(1), "expected exactly one AddAfter call")
+				g.Expect(spy.addAfterCalls[0].item).To(Equal("crr-ns/crr-name"))
+				g.Expect(spy.addAfterCalls[0].duration).To(Equal(requeueInterval))
+			} else {
+				g.Expect(spy.addAfterCalls).To(BeEmpty(), "expected no AddAfter calls for terminal state")
+			}
 		})
 	}
 }

--- a/test/integration/control_plane_pki_operator.go
+++ b/test/integration/control_plane_pki_operator.go
@@ -266,6 +266,7 @@ func validateRevocation(t *testing.T, ctx context.Context, hostedCluster *hypers
 		t.Fatalf("failed to create CRR: %v", err)
 	}
 
+	start := time.Now()
 	util.EventuallyObject(
 		t, ctx, fmt.Sprintf("CRR %s/%s to complete", hostedControlPlaneNamespace, crrName),
 		func(ctx context.Context) (*certificatesv1alpha1.CertificateRevocationRequest, error) {
@@ -278,6 +279,7 @@ func validateRevocation(t *testing.T, ctx context.Context, hostedCluster *hypers
 			}),
 		},
 	)
+	t.Logf("CRR revocation completed in %v", time.Since(start))
 
 	// Poll the SSR through the service LB until we get Unauthorized.
 	// The controller already verified per-pod that all KAS instances rejected


### PR DESCRIPTION
## What this PR does / why we need it:

The CertificateRevocationController's `syncCertificateRevocationRequest` returned `factory.SyntheticRequeueError` when polling for KAS trust bundle reloads during step 6 (revocation verification). This fed into `DefaultControllerRateLimiter` (5ms → 1000s exponential backoff), causing 11+ minute stalls when KAS needs only ~1-2 minutes to reload its trust bundle. This manifested as CertificateRevocationRequest timing out after 10 minutes in HA break-glass credential tests.

### Changes:

- **Replace SyntheticRequeueError with fixed 10-second `AddAfter` requeue.** Returning `nil` causes the library-go framework to call `Forget(key)`, resetting the backoff counter. `AddAfter` bypasses the rate limiter entirely via `DelayingInterface`. Revocation now completes in ~1-2 minutes instead of 11+.

- **Add 10-minute step-level timeout** for `ensureOldSignerCertificateRevoked` (step 6). Compares elapsed time against `LeafCertificatesRegeneratedType` condition timestamp. Sets `PreviousCertificatesRevoked=False` with reason `RevocationVerificationTimeout` if exceeded, preventing indefinite polling.

- **Add V(2) observability logging** at ~10 silent requeue points across steps 3 and 6, making polling progress visible (previously only detectable by absence of logs).

- **Fix action-before-error ordering** in `syncCertificateRevocationRequest`. Previously, the error check ran before action application, silently dropping timeout status condition updates. Now actions are applied first.

- **Add timing instrumentation** to integration test `validateRevocation` to measure actual revocation completion time.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/OCPBUGS-100087

## Special notes for your reviewer:

The root cause is that `SyntheticRequeueError` is unsuitable for polling patterns. The library-go controller framework (`base_controller.go`) calls `AddRateLimited(key)` on error, feeding into exponential backoff. After 12-13 rapid retries during the ~1-2 minute KAS trust bundle reload window, the backoff gap reaches 20-40s, pushing total time past 11 minutes.

The fix pattern (`syncContext.Queue().AddAfter(key, interval)` + `return nil`) is the idiomatic way to implement fixed-interval polling in library-go controllers. Returning `nil` triggers `Forget(key)` which resets the rate limiter state, and `AddAfter` schedules the next sync at a fixed delay.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent indefinite certificate revocation retries by enforcing a bounded verification timeout.
  * When revocation verification times out, the Certificate Revocation Request now updates status with a timeout-specific reason.
  * Requeue behavior is now consistent and fixed-delay for eligible (non-terminal) requests, with fail-fast handling of apply issues.
* **Operational Improvements**
  * Expanded requeue and progress logging for signer trust and revocation checks across reload/mid-reload scenarios.
* **Tests**
  * Added coverage for fixed-delay requeue scheduling and timeout-driven status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->