### PR TITLE
OCPBUGS-100087: fix CRR exponential backoff causing 11+ minute polling stalls

### DIFF
--- a/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller.go
+++ b/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller.go
@@ -48,6 +48,20 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// requeueInterval is the fixed polling interval used instead of SyntheticRequeueError.
+// SyntheticRequeueError feeds into DefaultControllerRateLimiter (5ms → 1000s exponential
+// backoff), which causes 11+ minute stalls when polling for KAS trust bundle reloads that
+// take ~1–2 minutes. Returning nil + AddAfter bypasses the rate limiter entirely, and
+// returning nil causes the framework to call Forget(key), resetting the failure counter.
+const requeueInterval = 10 * time.Second
+
+// revocationVerificationTimeout bounds how long step 6 (ensureOldSignerCertificateRevoked)
+// polls before surfacing a real error. Without this, the fixed-interval requeue would poll
+// every 10s indefinitely if KAS never reloads the trust bundle.
+const revocationVerificationTimeout = 10 * time.Minute
+
+const revocationVerificationTimeoutReason = "RevocationVerificationTimeout"
+
 type CertificateRevocationController struct {
 	kubeClient       kubernetes.Interface
 	hypershiftClient hypershiftclient.Interface
@@ -60,6 +74,7 @@ type CertificateRevocationController struct {
 	listPods     func(namespace string, selector labels.Selector) ([]*corev1.Pod, error)
 
 	// for unit testing only
+	now                func() time.Time
 	skipKASConnections bool
 	// overrideVerifyCertAgainstKASPods, when non-nil, replaces verifyCertificateAgainstAllKASPods
 	// for unit testing. This allows tests to control per-pod verification behavior without
@@ -309,12 +324,13 @@ func (c *CertificateRevocationController) syncCertificateRevocationRequest(ctx c
 		return err
 	}
 
-	action, requeue, err := c.processCertificateRevocationRequest(ctx, namespace, name, nil)
+	action, requeue, err := c.processCertificateRevocationRequest(ctx, namespace, name, c.now)
 	if err != nil {
 		return err
 	}
 	if requeue {
-		return factory.SyntheticRequeueError
+		syncContext.Queue().AddAfter(syncContext.QueueKey(), requeueInterval)
+		return nil
 	}
 	if action != nil {
 		if err := action.validate(); err != nil {
@@ -733,6 +749,7 @@ func (c *CertificateRevocationController) ensureNewSignerCertificatePropagated(c
 	// that, though, and it's always valid to first check that our certificates have propagated as far
 	// as we can tell in the system before asking the KAS, since that's expensive
 	if len(trustedCertificates(totalClientTrustBundle, []*certificateSecret{{cert: signers[0]}}, now)) == 0 {
+		klog.V(2).Infof("New signer certificate not yet in total-client-ca bundle for %s/%s, requeueing", namespace, name)
 		return true, nil, true, nil
 	}
 
@@ -758,7 +775,8 @@ func (c *CertificateRevocationController) ensureNewSignerCertificatePropagated(c
 			return true, nil, false, err
 		}
 		if !allTrusted {
-			return true, nil, true, nil // pod transitions trigger reconciliation, but synthetic re-queue is still needed for KAS trust bundle reloads
+			klog.V(2).Infof("Not all KAS pods trust new signer certificate for %s/%s, requeueing", namespace, name)
+			return true, nil, true, nil
 		}
 
 		// Cross-check: verify the previous signer is also still trusted.
@@ -777,7 +795,7 @@ func (c *CertificateRevocationController) ensureNewSignerCertificatePropagated(c
 					return true, nil, false, err
 				}
 				if !oldTrusted {
-					klog.V(4).Infof("KAS pods accepted new cert but rejected old signer cert for %s/%s; likely mid-reload, requeueing", namespace, name)
+					klog.V(2).Infof("KAS pods accepted new cert but rejected old signer cert for %s/%s; likely mid-reload, requeueing", namespace, name)
 					return true, nil, true, nil
 				}
 			}
@@ -985,6 +1003,28 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 		return false, nil, false, nil
 	}
 
+	for _, condition := range crr.Status.Conditions {
+		if condition.Type == certificatesv1alpha1.NewCertificatesTrustedType && condition.Status == metav1.ConditionTrue {
+			if elapsed := now().Sub(condition.LastTransitionTime.Time); elapsed > revocationVerificationTimeout {
+				klog.Errorf("Revocation verification for %s/%s timed out after %v (since NewCertificatesTrusted)", namespace, name, elapsed)
+				cfg := certificatesv1alpha1applyconfigurations.CertificateRevocationRequest(name, namespace)
+				cfg.Status = certificatesv1alpha1applyconfigurations.CertificateRevocationRequestStatus().
+					WithRevocationTimestamp(*crr.Status.RevocationTimestamp).
+					WithPreviousSigner(*crr.Status.PreviousSigner).
+					WithConditions(conditions(crr.Status.Conditions, metav1applyconfigurations.Condition().
+						WithType(certificatesv1alpha1.PreviousCertificatesRevokedType).
+						WithStatus(metav1.ConditionFalse).
+						WithLastTransitionTime(metav1.NewTime(now())).
+						WithReason(revocationVerificationTimeoutReason).
+						WithMessage(fmt.Sprintf("Revocation verification timed out after %v waiting for KAS to reload trust bundle.", elapsed.Truncate(time.Second))),
+					)...)
+				e := event("CertificateRevocationStalled", "Revocation verification for %q signer timed out after %v.", crr.Spec.SignerClass, elapsed.Truncate(time.Second))
+				return true, &actions{event: e, crr: cfg}, false, fmt.Errorf("revocation verification timed out after %v", elapsed.Truncate(time.Second))
+			}
+			break
+		}
+	}
+
 	oldCertSecret, err := c.getSecret(namespace, crr.Status.PreviousSigner.Name)
 	if err != nil {
 		return true, nil, false, err
@@ -1033,6 +1073,7 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 	// that, though, and it's always valid to first check that our certificates have propagated as far
 	// as we can tell in the system before asking the KAS, since that's expensive
 	if len(trustedCertificates(totalClientTrustBundle, []*certificateSecret{{cert: oldCerts[0]}}, now)) != 0 {
+		klog.V(2).Infof("Old signer certificate still present in total-client-ca bundle for %s/%s, requeueing", namespace, name)
 		return true, nil, true, nil
 	}
 
@@ -1058,7 +1099,8 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 			return true, nil, false, err
 		}
 		if !allRevoked {
-			return true, nil, true, nil // pod transitions trigger reconciliation, but synthetic re-queue is still needed for KAS trust bundle reloads
+			klog.V(2).Infof("Not all KAS pods have rejected old signer certificate for %s/%s, requeueing", namespace, name)
+			return true, nil, true, nil
 		}
 
 		// Cross-check: verify the current signer is still trusted by all pods.
@@ -1070,7 +1112,7 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 			return true, nil, false, err
 		}
 		if !allTrusted {
-			klog.V(4).Infof("KAS pods rejected old cert but also rejected current signer cert for %s/%s; likely mid-reload, requeueing", namespace, name)
+			klog.V(2).Infof("KAS pods rejected old cert but also rejected current signer cert for %s/%s; likely mid-reload, requeueing", namespace, name)
 			return true, nil, true, nil
 		}
 	}

--- a/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller_test.go
+++ b/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller_test.go
@@ -22,6 +22,7 @@ import (
 
 	librarygocrypto "github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/certrotation"
+	"github.com/openshift/library-go/pkg/operator/events"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/workqueue"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 
@@ -2108,6 +2110,342 @@ func TestEnsureOldSignerCertificateRevoked_KASVerification(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(done).To(BeTrue())
 			g.Expect(requeue).To(BeTrue())
+		})
+	}
+}
+
+// spyQueue wraps a RateLimitingInterface to record AddAfter calls.
+type spyQueue struct {
+	workqueue.RateLimitingInterface //nolint:staticcheck
+	addAfterCalls                   []struct {
+		item     any
+		duration time.Duration
+	}
+}
+
+func (s *spyQueue) AddAfter(item any, d time.Duration) {
+	s.addAfterCalls = append(s.addAfterCalls, struct {
+		item     any
+		duration time.Duration
+	}{item, d})
+	s.RateLimitingInterface.AddAfter(item, d)
+}
+
+// fakeSyncContext implements factory.SyncContext for sync-level testing.
+type fakeSyncContext struct {
+	queue    workqueue.RateLimitingInterface //nolint:staticcheck
+	queueKey string
+	recorder events.Recorder
+}
+
+func (f *fakeSyncContext) Queue() workqueue.RateLimitingInterface { return f.queue } //nolint:staticcheck
+func (f *fakeSyncContext) QueueKey() string                       { return f.queueKey }
+func (f *fakeSyncContext) Recorder() events.Recorder              { return f.recorder }
+
+func TestSyncCertificateRevocationRequest_RequeueBehavior(t *testing.T) {
+	revocationTime, err := time.Parse(time.RFC3339Nano, "2006-01-02T15:04:05.999999999Z")
+	if err != nil {
+		t.Fatalf("could not parse time: %v", err)
+	}
+	postRevocationClock := testingclock.NewFakeClock(revocationTime.Add(revocationOffset + 1*time.Hour))
+
+	data := pki(t, revocationTime)
+
+	for _, testCase := range []struct {
+		name    string
+		now     func() time.Time
+		crr     *certificatesv1alpha1.CertificateRevocationRequest
+		secrets []*corev1.Secret
+		cms     []*corev1.ConfigMap
+
+		expectAddAfter bool
+		expectErr      bool
+	}{
+		{
+			name: "requeue path uses AddAfter instead of SyntheticRequeueError",
+			crr: &certificatesv1alpha1.CertificateRevocationRequest{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "crr-name"},
+				Spec:       certificatesv1alpha1.CertificateRevocationRequestSpec{SignerClass: string(certificates.CustomerBreakGlassSigner)},
+				Status: certificatesv1alpha1.CertificateRevocationRequestStatus{
+					RevocationTimestamp: ptr.To(metav1.NewTime(revocationTime)),
+					PreviousSigner:      &corev1.LocalObjectReference{Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+					Conditions: []metav1.Condition{{
+						Type:               certificatesv1alpha1.LeafCertificatesRegeneratedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "All leaf certificates are re-generated.",
+					}, {
+						Type:               certificatesv1alpha1.RootCertificatesRegeneratedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "Signer certificate crr-ns/customer-system-admin-signer regenerated.",
+					}, {
+						Type:               certificatesv1alpha1.NewCertificatesTrustedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "New signer certificate crr-ns/customer-system-admin-signer trusted.",
+					}},
+				},
+			},
+			secrets: []*corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "crr-ns",
+					Name:        manifests.CustomerSystemAdminSigner("").Name,
+					Annotations: map[string]string{certrotation.CertificateIssuer: "crr-ns_customer-break-glass-signer@1234"},
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.future.raw.signerCert,
+					corev1.TLSPrivateKeyKey: data.future.raw.signerKey,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.original.raw.signerCert,
+					corev1.TLSPrivateKeyKey: data.original.raw.signerKey,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "crr-ns",
+					Name:        manifests.CustomerSystemAdminClientCertSecret("").Name,
+					Annotations: map[string]string{certrotation.CertificateIssuer: "crr-ns_customer-break-glass-signer@1234"},
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.future.raw.signedCert,
+					corev1.TLSPrivateKeyKey: data.future.raw.clientKey,
+				},
+			}},
+			cms: []*corev1.ConfigMap{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: manifests.CustomerSystemAdminSignerCA("").Name},
+				Data: map[string]string{
+					"ca-bundle.crt": string(data.future.raw.signerCert),
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: manifests.TotalKASClientCABundle("").Name},
+				Data: map[string]string{
+					"ca-bundle.crt": string(data.original.raw.signerCert) + string(data.future.raw.signerCert),
+				},
+			}},
+			expectAddAfter: true,
+		},
+		{
+			name: "terminal state does not manipulate queue",
+			crr: &certificatesv1alpha1.CertificateRevocationRequest{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "crr-name"},
+				Spec:       certificatesv1alpha1.CertificateRevocationRequestSpec{SignerClass: string(certificates.CustomerBreakGlassSigner)},
+				Status: certificatesv1alpha1.CertificateRevocationRequestStatus{
+					RevocationTimestamp: ptr.To(metav1.NewTime(revocationTime)),
+					PreviousSigner:      &corev1.LocalObjectReference{Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+					Conditions: []metav1.Condition{{
+						Type:               certificatesv1alpha1.PreviousCertificatesRevokedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "Previous signer certificate revoked.",
+					}, {
+						Type:               certificatesv1alpha1.LeafCertificatesRegeneratedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "All leaf certificates are re-generated.",
+					}, {
+						Type:               certificatesv1alpha1.RootCertificatesRegeneratedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "Signer certificate crr-ns/customer-system-admin-signer regenerated.",
+					}, {
+						Type:               certificatesv1alpha1.NewCertificatesTrustedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "New signer certificate crr-ns/customer-system-admin-signer trusted.",
+					}},
+				},
+			},
+			secrets: []*corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "crr-ns",
+					Name:        manifests.CustomerSystemAdminSigner("").Name,
+					Annotations: map[string]string{certrotation.CertificateIssuer: "crr-ns_customer-break-glass-signer@1234"},
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.future.raw.signerCert,
+					corev1.TLSPrivateKeyKey: data.future.raw.signerKey,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.original.raw.signerCert,
+					corev1.TLSPrivateKeyKey: data.original.raw.signerKey,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "crr-ns",
+					Name:        manifests.CustomerSystemAdminClientCertSecret("").Name,
+					Annotations: map[string]string{certrotation.CertificateIssuer: "crr-ns_customer-break-glass-signer@1234"},
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.future.raw.signedCert,
+					corev1.TLSPrivateKeyKey: data.future.raw.clientKey,
+				},
+			}},
+			cms: []*corev1.ConfigMap{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: manifests.CustomerSystemAdminSignerCA("").Name},
+				Data: map[string]string{
+					"ca-bundle.crt": string(data.future.raw.signerCert),
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: manifests.TotalKASClientCABundle("").Name},
+				Data: map[string]string{
+					"ca-bundle.crt": string(data.future.raw.signerCert),
+				},
+			}},
+			expectAddAfter: false,
+		},
+		{
+			name: "step-level timeout returns error after 10 minutes",
+			now: func() time.Time {
+				return postRevocationClock.Now().Add(11 * time.Minute)
+			},
+			crr: &certificatesv1alpha1.CertificateRevocationRequest{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "crr-name"},
+				Spec:       certificatesv1alpha1.CertificateRevocationRequestSpec{SignerClass: string(certificates.CustomerBreakGlassSigner)},
+				Status: certificatesv1alpha1.CertificateRevocationRequestStatus{
+					RevocationTimestamp: ptr.To(metav1.NewTime(revocationTime)),
+					PreviousSigner:      &corev1.LocalObjectReference{Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+					Conditions: []metav1.Condition{{
+						Type:               certificatesv1alpha1.LeafCertificatesRegeneratedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "All leaf certificates are re-generated.",
+					}, {
+						Type:               certificatesv1alpha1.RootCertificatesRegeneratedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "Signer certificate crr-ns/customer-system-admin-signer regenerated.",
+					}, {
+						Type:               certificatesv1alpha1.NewCertificatesTrustedType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(postRevocationClock.Now()),
+						Reason:             hypershiftv1beta1.AsExpectedReason,
+						Message:            "New signer certificate crr-ns/customer-system-admin-signer trusted.",
+					}},
+				},
+			},
+			secrets: []*corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "crr-ns",
+					Name:        manifests.CustomerSystemAdminSigner("").Name,
+					Annotations: map[string]string{certrotation.CertificateIssuer: "crr-ns_customer-break-glass-signer@1234"},
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.future.raw.signerCert,
+					corev1.TLSPrivateKeyKey: data.future.raw.signerKey,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: "1pfcydcz358pa1glirkmc72sdkf5zw21uam4jbnj03pw"},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.original.raw.signerCert,
+					corev1.TLSPrivateKeyKey: data.original.raw.signerKey,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "crr-ns",
+					Name:        manifests.CustomerSystemAdminClientCertSecret("").Name,
+					Annotations: map[string]string{certrotation.CertificateIssuer: "crr-ns_customer-break-glass-signer@1234"},
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       data.future.raw.signedCert,
+					corev1.TLSPrivateKeyKey: data.future.raw.clientKey,
+				},
+			}},
+			cms: []*corev1.ConfigMap{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: manifests.CustomerSystemAdminSignerCA("").Name},
+				Data: map[string]string{
+					"ca-bundle.crt": string(data.future.raw.signerCert),
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "crr-ns", Name: manifests.TotalKASClientCABundle("").Name},
+				Data: map[string]string{
+					"ca-bundle.crt": string(data.original.raw.signerCert) + string(data.future.raw.signerCert),
+				},
+			}},
+			expectAddAfter: false,
+			expectErr:      true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			spy := &spyQueue{
+				RateLimitingInterface: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()), //nolint:staticcheck
+			}
+			defer spy.ShutDown()
+
+			syncCtx := &fakeSyncContext{
+				queue:    spy,
+				queueKey: "crr-ns/crr-name",
+				recorder: events.NewInMemoryRecorder("test", postRevocationClock),
+			}
+
+			nowFunc := testCase.now
+			if nowFunc == nil {
+				nowFunc = postRevocationClock.Now
+			}
+
+			c := &CertificateRevocationController{
+				now: nowFunc,
+				getCRR: func(namespace, name string) (*certificatesv1alpha1.CertificateRevocationRequest, error) {
+					if namespace == testCase.crr.Namespace && name == testCase.crr.Name {
+						return testCase.crr, nil
+					}
+					return nil, apierrors.NewNotFound(hypershiftv1beta1.SchemeGroupVersion.WithResource("certificaterevocationrequest").GroupResource(), name)
+				},
+				getSecret: func(namespace, name string) (*corev1.Secret, error) {
+					for _, secret := range testCase.secrets {
+						if secret.Namespace == namespace && secret.Name == name {
+							return secret, nil
+						}
+					}
+					return nil, apierrors.NewNotFound(corev1.SchemeGroupVersion.WithResource("secrets").GroupResource(), name)
+				},
+				listSecrets: func(namespace string) ([]*corev1.Secret, error) {
+					return testCase.secrets, nil
+				},
+				getConfigMap: func(namespace, name string) (*corev1.ConfigMap, error) {
+					for _, cm := range testCase.cms {
+						if cm.Namespace == namespace && cm.Name == name {
+							return cm, nil
+						}
+					}
+					return nil, apierrors.NewNotFound(corev1.SchemeGroupVersion.WithResource("configmaps").GroupResource(), name)
+				},
+				listPods: func(namespace string, selector labels.Selector) ([]*corev1.Pod, error) {
+					return nil, nil
+				},
+				skipKASConnections: true,
+			}
+
+			err := c.syncCertificateRevocationRequest(t.Context(), syncCtx)
+
+			if testCase.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred(), "syncCertificateRevocationRequest should return nil, not SyntheticRequeueError")
+			}
+
+			if testCase.expectAddAfter {
+				g.Expect(spy.addAfterCalls).To(HaveLen(1), "expected exactly one AddAfter call")
+				g.Expect(spy.addAfterCalls[0].item).To(Equal("crr-ns/crr-name"))
+				g.Expect(spy.addAfterCalls[0].duration).To(Equal(requeueInterval))
+			} else {
+				g.Expect(spy.addAfterCalls).To(BeEmpty(), "expected no AddAfter calls for terminal state")
+			}
 		})
 	}
 }

--- a/test/integration/control_plane_pki_operator.go
+++ b/test/integration/control_plane_pki_operator.go
@@ -266,6 +266,7 @@ func validateRevocation(t *testing.T, ctx context.Context, hostedCluster *hypers
 		t.Fatalf("failed to create CRR: %v", err)
 	}
 
+	revocationStart := time.Now()
 	util.EventuallyObject(
 		t, ctx, fmt.Sprintf("CRR %s/%s to complete", hostedControlPlaneNamespace, crrName),
 		func(ctx context.Context) (*certificatesv1alpha1.CertificateRevocationRequest, error) {
@@ -278,6 +279,7 @@ func validateRevocation(t *testing.T, ctx context.Context, hostedCluster *hypers
 			}),
 		},
 	)
+	t.Logf("CRR %s/%s revocation completed in %v", hostedControlPlaneNamespace, crrName, time.Since(revocationStart))
 
 	// Poll the SSR through the service LB until we get Unauthorized.
 	// The controller already verified per-pod that all KAS instances rejected


### PR DESCRIPTION
## What this PR does / why we need it:

The CertificateRevocationRequest (CRR) controller uses `factory.SyntheticRequeueError` for polling steps (steps 3 and 6), which feeds into the `DefaultControllerRateLimiter`'s exponential backoff (5ms → 1000s cap). During KAS trust bundle reloads (~1–2 minutes), the backoff escalates past the reload window, causing 11+ minute stalls. This exceeds the 10-minute e2e test timeout, blocking 5.0 CI payloads.

This PR:

1. **Fixed-interval requeue**: Replaces `return factory.SyntheticRequeueError` with `syncContext.Queue().AddAfter(key, 10s)` + `return nil`. Returning `nil` causes the framework to call `Forget(key)`, resetting the failure counter. This gives ~6–12 polling cycles during the 1–2 minute KAS reload window.

2. **Step-level timeout**: Adds a 10-minute timeout for revocation verification (step 6). If KAS never reloads the trust bundle, the controller surfaces a `PreviousCertificatesRevoked=False` condition with reason `RevocationVerificationTimeout` instead of polling indefinitely.

3. **Logging**: Adds `klog.V(2).Infof` at all 6 silent requeue points so operators can observe polling progress.

4. **Unit tests**: Adds 3 sync-level test cases covering:
   - Requeue path uses `AddAfter` instead of `SyntheticRequeueError`
   - Terminal state does not manipulate queue
   - Step-level timeout fires after 10 minutes

5. **E2E timing instrumentation**: Adds `time.Since` logging around `validateRevocation` in the integration test to track actual revocation duration.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/OCPBUGS-100087

## Special notes for your reviewer:

- The `revocationVerificationTimeoutReason` constant is defined in the controller package rather than `api/certificates/v1alpha1/` because the `api-lint-fix` pre-commit hook aggressively auto-fixes pre-existing violations across all API files when any `api/` file is touched, producing breaking changes (field renames, pointer type changes). The constant is only used by the controller.
- The `//nolint:staticcheck` annotations on `workqueue.RateLimitingInterface` are required because the `factory.SyncContext` interface from library-go uses the deprecated type.
- All 36 existing + 3 new tests pass.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate revocation progress during KAS trust-bundle polling by using consistent retry scheduling.
  * Added a timeout for stalled certificate revocation verification and reports the operation as stalled when exceeded.
  * Updated retry handling and diagnostics for KAS certificate trust transitions.

* **Tests**
  * Added coverage for retry scheduling, terminal states, and verification timeouts.
  * Added timing logs for certificate revocation completion in integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->