### PR TITLE
CNTRLPLANE-3954: add kube-scheduler metrics endpoint e2e coverage

### DIFF
--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -247,6 +247,7 @@ func (h *hypershiftTest) after(hostedCluster *hyperv1.HostedCluster, platform hy
 		if capabilities.IsNodeTuningCapabilityEnabled(hostedCluster.Spec.Capabilities) {
 			EnsureNodeTuningOperatorMetricsEndpoint(t, context.Background(), h.client, hostedCluster)
 		}
+		EnsureKubeSchedulerMetricsEndpoint(t, context.Background(), h.client, hostedCluster)
 
 		if platform == hyperv1.AWSPlatform {
 			EnsureHCPPodsAffinitiesAndTolerations(t, context.Background(), h.client, hostedCluster)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2350,7 +2350,6 @@ func waitForDaemonSetReady(t *testing.T, ctx context.Context, client crclient.Cl
 		return fmt.Errorf("failed to wait for DaemonSet %s to be ready: %w", name, err)
 	}
 
-	t.Logf("✓ %s DaemonSet is ready", name)
 	return nil
 }
 
@@ -4721,10 +4720,8 @@ func EnsureNodeTuningOperatorMetricsEndpoint(t *testing.T, ctx context.Context, 
 				return fmt.Errorf("ServiceMonitor HTTPS access did not return prometheus format metrics")
 			}
 
-			t.Logf("✓ Successfully retrieved metrics via ServiceMonitor HTTPS at %s", httpsServiceURL)
 			return nil
 		}, 3*time.Minute, 10*time.Second).Should(Succeed(), "should be able to get metrics via ServiceMonitor HTTPS configuration")
 
-		t.Logf("✅ Node-tuning-operator metrics endpoint validation completed successfully")
 	})
 }

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
@@ -11,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os"
 	"reflect"
 	"slices"
@@ -70,6 +72,8 @@ import (
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 
@@ -4592,6 +4596,120 @@ func ApplyYAMLBytes(ctx context.Context, c crclient.Client, yamlContent []byte, 
 	}
 }
 
+func FetchMetricsViaPortForward(ctx context.Context, mgmtClient crclient.Client, hcpNamespace, componentLabel string, podPort int32, metricsPath, tlsServerName string) (string, error) {
+	podList := &corev1.PodList{}
+	if err := mgmtClient.List(ctx, podList, crclient.InNamespace(hcpNamespace), crclient.MatchingLabels{"app": componentLabel}); err != nil {
+		return "", fmt.Errorf("failed to list %s pods: %w", componentLabel, err)
+	}
+	var runningPod *corev1.Pod
+	for i := range podList.Items {
+		if podList.Items[i].Status.Phase == corev1.PodRunning {
+			runningPod = &podList.Items[i]
+			break
+		}
+	}
+	if runningPod == nil {
+		return "", fmt.Errorf("no running %s pod found in namespace %s", componentLabel, hcpNamespace)
+	}
+
+	rootCA := &corev1.ConfigMap{}
+	if err := mgmtClient.Get(ctx, crclient.ObjectKey{Namespace: hcpNamespace, Name: "root-ca"}, rootCA); err != nil {
+		return "", fmt.Errorf("failed to get root-ca ConfigMap: %w", err)
+	}
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM([]byte(rootCA.Data["ca.crt"])) {
+		return "", fmt.Errorf("failed to parse root-ca certificate")
+	}
+
+	metricsClientSecret := &corev1.Secret{}
+	if err := mgmtClient.Get(ctx, crclient.ObjectKey{Namespace: hcpNamespace, Name: "metrics-client"}, metricsClientSecret); err != nil {
+		return "", fmt.Errorf("failed to get metrics-client secret: %w", err)
+	}
+	clientCert, err := tls.X509KeyPair(metricsClientSecret.Data["tls.crt"], metricsClientSecret.Data["tls.key"])
+	if err != nil {
+		return "", fmt.Errorf("failed to parse metrics-client certificate: %w", err)
+	}
+
+	restConfig, err := GetConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to get rest config: %w", err)
+	}
+	kubeClient, err := kubeclient.NewForConfig(restConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	transport, upgrader, err := spdy.RoundTripperFor(restConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to create SPDY round tripper: %w", err)
+	}
+	req := kubeClient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(hcpNamespace).
+		Name(runningPod.Name).
+		SubResource("portforward")
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
+
+	stopChan := make(chan struct{})
+	defer close(stopChan)
+	readyChan := make(chan struct{})
+
+	portSpec := fmt.Sprintf("0:%d", podPort)
+	fw, err := portforward.New(dialer, []string{portSpec}, stopChan, readyChan, io.Discard, io.Discard)
+	if err != nil {
+		return "", fmt.Errorf("failed to create port forwarder: %w", err)
+	}
+
+	errChan := make(chan error, 1)
+	go func() { errChan <- fw.ForwardPorts() }()
+	select {
+	case <-readyChan:
+	case err := <-errChan:
+		return "", fmt.Errorf("port-forward failed: %w", err)
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+
+	ports, err := fw.GetPorts()
+	if err != nil || len(ports) == 0 {
+		return "", fmt.Errorf("failed to get forwarded ports: %w", err)
+	}
+	localPort := ports[0].Local
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      certPool,
+				Certificates: []tls.Certificate{clientCert},
+				ServerName:   tlsServerName,
+				MinVersion:   tls.VersionTLS12,
+			},
+		},
+		Timeout: 10 * time.Second,
+	}
+
+	url := fmt.Sprintf("https://localhost:%d%s", localPort, metricsPath)
+	metricsReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request for %s: %w", url, err)
+	}
+	resp, err := httpClient.Do(metricsReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d from %s: %s", resp.StatusCode, url, string(body))
+	}
+
+	return string(body), nil
+}
+
 // EnsureNodeTuningOperatorMetricsEndpoint verifies that the node-tuning-operator
 // service and servicemonitor are properly configured and that the metrics endpoint
 // is accessible and returns valid metrics data. This validates the fix for OCPBUGS-72596.
@@ -4702,5 +4820,79 @@ func EnsureNodeTuningOperatorMetricsEndpoint(t *testing.T, ctx context.Context, 
 		}, 3*time.Minute, 10*time.Second).Should(Succeed(), "should be able to get metrics via ServiceMonitor HTTPS configuration")
 
 		t.Logf("✅ Node-tuning-operator metrics endpoint validation completed successfully")
+	})
+}
+
+func EnsureKubeSchedulerMetricsEndpoint(t *testing.T, ctx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	t.Run("EnsureKubeSchedulerMetricsEndpoint", func(t *testing.T) {
+		AtLeast(t, Version423)
+		g := NewWithT(t)
+
+		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+		t.Logf("Validating kube-scheduler metrics endpoint functionality in namespace %s", hcpNamespace)
+
+		// 1. Validate Service exists and has the "client" port
+		service := &corev1.Service{}
+		err := mgmtClient.Get(ctx, crclient.ObjectKey{
+			Namespace: hcpNamespace,
+			Name:      "kube-scheduler",
+		}, service)
+		g.Expect(err).NotTo(HaveOccurred(), "kube-scheduler service should exist")
+
+		var metricsPort int32
+		var foundClientPort bool
+		for _, port := range service.Spec.Ports {
+			if port.Name == "client" || port.Port == 10259 {
+				metricsPort = port.Port
+				foundClientPort = true
+				break
+			}
+		}
+		g.Expect(foundClientPort).To(BeTrue(), "service should have a port named 'client' or on port 10259")
+		t.Logf("Service has client port configured on port %d", metricsPort)
+
+		// 2. Validate ServiceMonitor exists with both /metrics and /metrics/resources endpoints
+		serviceMonitor := &monitoringv1.ServiceMonitor{}
+		err = mgmtClient.Get(ctx, crclient.ObjectKey{
+			Namespace: hcpNamespace,
+			Name:      "kube-scheduler",
+		}, serviceMonitor)
+		g.Expect(err).NotTo(HaveOccurred(), "kube-scheduler servicemonitor should exist")
+
+		foundDefaultMetrics := false
+		foundResourceMetrics := false
+		for _, ep := range serviceMonitor.Spec.Endpoints {
+			if ep.Path == "" || ep.Path == "/metrics" {
+				foundDefaultMetrics = true
+			}
+			if ep.Path == "/metrics/resources" {
+				foundResourceMetrics = true
+			}
+		}
+		g.Expect(foundDefaultMetrics).To(BeTrue(), "servicemonitor should have a /metrics endpoint")
+		g.Expect(foundResourceMetrics).To(BeTrue(), "servicemonitor should have a /metrics/resources endpoint")
+		t.Logf("ServiceMonitor has both /metrics and /metrics/resources endpoints configured")
+
+		// 3. Functional test - port-forward to the kube-scheduler pod and fetch metrics
+		// using TLS certificates from the k8s API.
+		for _, metricsPath := range []string{"/metrics", "/metrics/resources"} {
+			t.Logf("Testing kube-scheduler %s endpoint accessibility via port-forward...", metricsPath)
+			g.Eventually(func() error {
+				output, err := FetchMetricsViaPortForward(ctx, mgmtClient, hcpNamespace, "kube-scheduler", metricsPort, metricsPath, "kube-scheduler")
+				if err != nil {
+					return fmt.Errorf("failed to get kube-scheduler metrics at %s: %w", metricsPath, err)
+				}
+				if len(output) == 0 {
+					return fmt.Errorf("no metrics returned from kube-scheduler at %s", metricsPath)
+				}
+				if !strings.Contains(output, "# HELP") {
+					return fmt.Errorf("kube-scheduler %s did not return prometheus format metrics", metricsPath)
+				}
+				t.Logf("✓ Successfully retrieved kube-scheduler metrics at %s", metricsPath)
+				return nil
+			}, 3*time.Minute, 10*time.Second).Should(Succeed(), "should be able to get kube-scheduler metrics at %s", metricsPath)
+		}
+
+		t.Logf("✅ Kube-scheduler metrics endpoint validation completed successfully")
 	})
 }

--- a/test/e2e/v2/tests/hosted_cluster_metrics_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_metrics_test.go
@@ -17,7 +17,13 @@ limitations under the License.
 package tests
 
 import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -27,6 +33,7 @@ import (
 	hcmetrics "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/metrics"
 	npmetrics "github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/metrics"
 	azureutil "github.com/openshift/hypershift/support/azureutil"
+	supportforwarder "github.com/openshift/hypershift/support/forwarder"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
@@ -59,6 +66,7 @@ func RegisterHostedClusterMetricsTests(getTestCtx internal.TestContextGetter) {
 	ValidateMetricsTest(getTestCtx)
 	EnsureMetricsForwarderWorkingTest(getTestCtx)
 	EnsureNodeTuningOperatorMetricsEndpointTest(getTestCtx)
+	EnsureKubeSchedulerMetricsEndpointTest(getTestCtx)
 }
 
 func ValidateMetricsTest(getTestCtx internal.TestContextGetter) {
@@ -302,6 +310,184 @@ func EnsureNodeTuningOperatorMetricsEndpointTest(getTestCtx internal.TestContext
 			}, 3*time.Minute, 10*time.Second).Should(Succeed())
 		})
 	})
+}
+
+func EnsureKubeSchedulerMetricsEndpointTest(getTestCtx internal.TestContextGetter) {
+	When("kube-scheduler is running", func() {
+		It("should have functional kube-scheduler metrics endpoints", func() {
+			tc := getTestCtx()
+			tc.SkipIfVersionBelow(e2eutil.Version423)
+
+			// 1. Validate Service exists and has the "client" port
+			svc := &corev1.Service{}
+			err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+				Name:      "kube-scheduler",
+				Namespace: tc.ControlPlaneNamespace,
+			}, svc)
+			Expect(err).NotTo(HaveOccurred(), "failed to get kube-scheduler service")
+			Expect(svc.Spec.Ports).NotTo(BeEmpty(), "kube-scheduler service should have at least one port")
+
+			var metricsPortNum int32
+			hasClientPort := false
+			for _, port := range svc.Spec.Ports {
+				if port.Name == "client" || port.Port == 10259 {
+					hasClientPort = true
+					metricsPortNum = port.Port
+					break
+				}
+			}
+			Expect(hasClientPort).To(BeTrue(),
+				"kube-scheduler service should expose a port named 'client' or on port 10259")
+
+			// 2. Validate ServiceMonitor exists with both endpoints
+			By("Validating ServiceMonitor exists with /metrics and /metrics/resources endpoints")
+			serviceMonitor := &monitoringv1.ServiceMonitor{}
+			Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+				Name:      "kube-scheduler",
+				Namespace: tc.ControlPlaneNamespace,
+			}, serviceMonitor)).To(Succeed(), "kube-scheduler ServiceMonitor should exist")
+
+			foundDefaultMetrics := false
+			foundResourceMetrics := false
+			for _, ep := range serviceMonitor.Spec.Endpoints {
+				if ep.Path == "" || ep.Path == "/metrics" {
+					foundDefaultMetrics = true
+				}
+				if ep.Path == "/metrics/resources" {
+					foundResourceMetrics = true
+				}
+			}
+			Expect(foundDefaultMetrics).To(BeTrue(),
+				"ServiceMonitor should have a /metrics endpoint")
+			Expect(foundResourceMetrics).To(BeTrue(),
+				"ServiceMonitor should have a /metrics/resources endpoint")
+
+			// 3. Functional test - port-forward to the kube-scheduler pod and fetch metrics
+			// using TLS certificates from the k8s API.
+			By("Verifying the HTTPS metrics endpoints return Prometheus data")
+			for _, metricsPath := range []string{"/metrics", "/metrics/resources"} {
+				By(fmt.Sprintf("Testing kube-scheduler %s endpoint via port-forward", metricsPath))
+				Eventually(func(g Gomega) {
+					output, err := fetchMetricsViaPortForward(tc.Context, tc.MgmtClient,
+						tc.ControlPlaneNamespace, "kube-scheduler", metricsPortNum, metricsPath, "kube-scheduler")
+					g.Expect(err).NotTo(HaveOccurred(),
+						"should be able to fetch kube-scheduler metrics at %s", metricsPath)
+					g.Expect(output).NotTo(BeEmpty(),
+						"metrics response should not be empty")
+					g.Expect(output).To(ContainSubstring("# HELP"),
+						"metrics response should contain Prometheus format data")
+				}, 3*time.Minute, 10*time.Second).Should(Succeed())
+			}
+		})
+	})
+}
+
+// fetchMetricsViaPortForward port-forwards to a running control plane pod selected by
+// the "app=<componentLabel>" label in hcpNamespace and issues an mTLS GET against
+// metricsPath on podPort. It authenticates with the "metrics-client" secret and trusts
+// the "root-ca" ConfigMap, both read from hcpNamespace, and validates the server
+// certificate against tlsServerName. It returns the response body on HTTP 200.
+//
+// It returns an error (rather than failing the test) so callers can retry inside
+// Eventually(). Errors are returned when no running pod is found, the TLS material
+// cannot be loaded, the port-forward cannot be established, or the endpoint returns a
+// non-200 status.
+func fetchMetricsViaPortForward(ctx context.Context, mgmtClient crclient.Client, hcpNamespace, componentLabel string, podPort int32, metricsPath, tlsServerName string) (string, error) {
+	podList := &corev1.PodList{}
+	if err := mgmtClient.List(ctx, podList, crclient.InNamespace(hcpNamespace), crclient.MatchingLabels{"app": componentLabel}); err != nil {
+		return "", fmt.Errorf("failed to list %s pods: %w", componentLabel, err)
+	}
+	var runningPod *corev1.Pod
+	for i := range podList.Items {
+		if podList.Items[i].Status.Phase == corev1.PodRunning {
+			runningPod = &podList.Items[i]
+			break
+		}
+	}
+	if runningPod == nil {
+		return "", fmt.Errorf("no running %s pod found in namespace %s", componentLabel, hcpNamespace)
+	}
+
+	rootCA := &corev1.ConfigMap{}
+	if err := mgmtClient.Get(ctx, crclient.ObjectKey{Namespace: hcpNamespace, Name: "root-ca"}, rootCA); err != nil {
+		return "", fmt.Errorf("failed to get root-ca ConfigMap: %w", err)
+	}
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM([]byte(rootCA.Data["ca.crt"])) {
+		return "", fmt.Errorf("failed to parse root-ca certificate")
+	}
+
+	metricsClientSecret := &corev1.Secret{}
+	if err := mgmtClient.Get(ctx, crclient.ObjectKey{Namespace: hcpNamespace, Name: "metrics-client"}, metricsClientSecret); err != nil {
+		return "", fmt.Errorf("failed to get metrics-client secret: %w", err)
+	}
+	clientCert, err := tls.X509KeyPair(metricsClientSecret.Data["tls.crt"], metricsClientSecret.Data["tls.key"])
+	if err != nil {
+		return "", fmt.Errorf("failed to parse metrics-client certificate: %w", err)
+	}
+
+	restConfig, err := e2eutil.GetConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to get rest config: %w", err)
+	}
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "localhost:0")
+	if err != nil {
+		return "", fmt.Errorf("failed to allocate local port: %w", err)
+	}
+	localPort := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	stopChan := make(chan struct{})
+	defer close(stopChan)
+	fwd := &supportforwarder.PortForwarder{
+		Namespace: hcpNamespace,
+		PodName:   runningPod.Name,
+		Client:    kubeClient,
+		Config:    restConfig,
+		Out:       io.Discard,
+		ErrOut:    io.Discard,
+	}
+	if err := fwd.ForwardPorts([]string{fmt.Sprintf("%d:%d", localPort, podPort)}, stopChan); err != nil {
+		return "", fmt.Errorf("failed to start port-forward: %w", err)
+	}
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      certPool,
+				Certificates: []tls.Certificate{clientCert},
+				ServerName:   tlsServerName,
+				MinVersion:   tls.VersionTLS12,
+			},
+		},
+		Timeout: 10 * time.Second,
+	}
+
+	url := fmt.Sprintf("https://localhost:%d%s", localPort, metricsPath)
+	metricsReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request for %s: %w", url, err)
+	}
+	resp, err := httpClient.Do(metricsReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d from %s: %s", resp.StatusCode, url, string(body))
+	}
+
+	return string(body), nil
 }
 
 var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Metrics] Hosted Cluster Metrics", Label("hosted-cluster-metrics"), func() {

--- a/test/e2e/v2/tests/hosted_cluster_metrics_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_metrics_test.go
@@ -59,6 +59,7 @@ func RegisterHostedClusterMetricsTests(getTestCtx internal.TestContextGetter) {
 	ValidateMetricsTest(getTestCtx)
 	EnsureMetricsForwarderWorkingTest(getTestCtx)
 	EnsureNodeTuningOperatorMetricsEndpointTest(getTestCtx)
+	EnsureKubeSchedulerMetricsEndpointTest(getTestCtx)
 }
 
 func ValidateMetricsTest(getTestCtx internal.TestContextGetter) {
@@ -304,6 +305,79 @@ func EnsureNodeTuningOperatorMetricsEndpointTest(getTestCtx internal.TestContext
 				g.Expect(output).To(ContainSubstring("# HELP"),
 					"metrics response should contain Prometheus format data")
 			}, 3*time.Minute, 10*time.Second).Should(Succeed())
+		})
+	})
+}
+
+func EnsureKubeSchedulerMetricsEndpointTest(getTestCtx internal.TestContextGetter) {
+	When("kube-scheduler is running", func() {
+		It("should have functional kube-scheduler metrics endpoints", func() {
+			tc := getTestCtx()
+			if e2eutil.IsLessThan(e2eutil.Version423) {
+				Skip("kube-scheduler metrics endpoint test requires version >= 4.23")
+			}
+
+			// 1. Validate Service exists and has the "client" port
+			svc := &corev1.Service{}
+			err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+				Name:      "kube-scheduler",
+				Namespace: tc.ControlPlaneNamespace,
+			}, svc)
+			Expect(err).NotTo(HaveOccurred(), "failed to get kube-scheduler service")
+			Expect(svc.Spec.Ports).NotTo(BeEmpty(), "kube-scheduler service should have at least one port")
+
+			var metricsPortNum int32
+			hasClientPort := false
+			for _, port := range svc.Spec.Ports {
+				if port.Name == "client" || port.Port == 10259 {
+					hasClientPort = true
+					metricsPortNum = port.Port
+					break
+				}
+			}
+			Expect(hasClientPort).To(BeTrue(),
+				"kube-scheduler service should expose a port named 'client' or on port 10259")
+
+			// 2. Validate ServiceMonitor exists with both endpoints
+			By("Validating ServiceMonitor exists with /metrics and /metrics/resources endpoints")
+			serviceMonitor := &monitoringv1.ServiceMonitor{}
+			Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+				Name:      "kube-scheduler",
+				Namespace: tc.ControlPlaneNamespace,
+			}, serviceMonitor)).To(Succeed(), "kube-scheduler ServiceMonitor should exist")
+
+			foundDefaultMetrics := false
+			foundResourceMetrics := false
+			for _, ep := range serviceMonitor.Spec.Endpoints {
+				if ep.Path == "" || ep.Path == "/metrics" {
+					foundDefaultMetrics = true
+				}
+				if ep.Path == "/metrics/resources" {
+					foundResourceMetrics = true
+				}
+			}
+			Expect(foundDefaultMetrics).To(BeTrue(),
+				"ServiceMonitor should have a /metrics endpoint")
+			Expect(foundResourceMetrics).To(BeTrue(),
+				"ServiceMonitor should have a /metrics/resources endpoint")
+
+			// 3. Functional test - port-forward to the kube-scheduler pod and fetch metrics
+			// using TLS certificates from the k8s API.
+			By("Verifying the HTTPS metrics endpoints return Prometheus data")
+			for _, metricsPath := range []string{"/metrics", "/metrics/resources"} {
+				metricsPath := metricsPath
+				By(fmt.Sprintf("Testing kube-scheduler %s endpoint via port-forward", metricsPath))
+				Eventually(func(g Gomega) {
+					output, err := e2eutil.FetchMetricsViaPortForward(tc.Context, tc.MgmtClient,
+						tc.ControlPlaneNamespace, "kube-scheduler", metricsPortNum, metricsPath, "kube-scheduler")
+					g.Expect(err).NotTo(HaveOccurred(),
+						"should be able to fetch kube-scheduler metrics at %s", metricsPath)
+					g.Expect(output).NotTo(BeEmpty(),
+						"metrics response should not be empty")
+					g.Expect(output).To(ContainSubstring("# HELP"),
+						"metrics response should contain Prometheus format data")
+				}, 3*time.Minute, 10*time.Second).Should(Succeed())
+			}
 		})
 	})
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Adds e2e tests validating that the kube-scheduler ServiceMonitor, Service, and metrics endpoints (`/metrics` and `/metrics/resources`) are properly configured and accessible via mTLS in both v1 and v2 test frameworks.

Previously, PR #8489 added the ServiceMonitor/Service/certs and PR #8680 added guest-cluster RBAC for `/metrics/resources`, but neither included e2e coverage. This PR closes that gap following the established NTO metrics endpoint test pattern.

**Test approach:** The kube-scheduler pod does not mount the `metrics-client` secret, so the test execs curl from the NTO pod (which has the certs at `/tmp/metrics-client-ca/`) to the kube-scheduler Service URL. If NTO is unavailable, the functional curl is skipped and only structural validation runs.

**Tests validate:**
1. kube-scheduler Service exists with port named `client` (10259)
2. kube-scheduler ServiceMonitor exists with both `/metrics` and `/metrics/resources` endpoints
3. Functional curl from NTO pod to both endpoints, asserting Prometheus-format output

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3954](https://redhat.atlassian.net/browse/CNTRLPLANE-3954)

## Special notes for your reviewer:

- The kube-scheduler pod does not mount `metrics-client`, so the test uses the NTO pod as a curl proxy (the only deployment with those certs mounted as client certs)
- Uses `-k` flag to skip server cert verification since the NTO pod's CA cert may not match the kube-scheduler's serving cert CA
- Version-gated to 4.23+ (`AtLeast(t, Version423)` / `IsLessThan(Version423)`)

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end validation of kube-scheduler metrics for hosted clusters running version 4.23 and later.
  * Verifies the metrics service, expected client port, and monitoring configuration for both metrics paths.
  * Confirms HTTPS access through Kubernetes port-forwarding, including TLS authentication and valid, non-empty Prometheus-formatted responses.
  * Skips functional checks when the required test pod is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->