### PR TITLE
CNTRLPLANE-3202: add restore, OADP, and limitations docs for self-managed Azure DR

### DIFF
--- a/docs/content/how-to/azure/backup-and-restore-etcd-snapshot.md
+++ b/docs/content/how-to/azure/backup-and-restore-etcd-snapshot.md
@@ -1,4 +1,4 @@
-# Etcd Snapshot Backup for Self-Managed Azure
+# Etcd Snapshot Backup and Restore for Self-Managed Azure
 
 !!! warning "Tech Preview"
 
@@ -262,8 +262,164 @@ az storage account delete \
     --yes
 ```
 
+## Restoring from an Etcd Snapshot
+
+!!! important
+
+    Only same-management-cluster restore is validated for self-managed Azure. Cross-management-cluster restore is not currently supported due to the lack of end-to-end testing coverage for that scenario.
+
+Restore is driven by OADP. The HyperShift OADP plugin orchestrates the full restore lifecycle:
+
+1. OADP recreates the HostedCluster from the Velero backup
+2. The plugin reads the etcd snapshot URL from the backup annotations and injects it into the restored HostedCluster's `spec.etcd.managed.storage.restoreSnapshotURL` field
+3. When the restored control plane boots, the control-plane-operator detects the URL and injects an `etcd-init` init container into the etcd StatefulSet
+4. The init container downloads the snapshot and restores it using `etcdutl snapshot restore`
+5. Once the restore completes, the `EtcdSnapshotRestored` condition is set on the HostedControlPlane
+
+The `restoreSnapshotURL` field is immutable — once set at HostedCluster creation time, it cannot be changed. The OADP plugin handles SAS token generation and URL injection automatically; no manual intervention is needed.
+
+For the full restore architecture and OADP plugin behavior, see [Restore Flow Architecture](../disaster-recovery/etcd-snapshot-backup/restore-flow.md).
+
+### Prerequisites
+
+- OADP 1.5+ installed with the HyperShift plugin (see [OADP Setup](#oadp-setup) below)
+- A completed OADP backup created with `--use-etcd-snapshot` mode
+- The `HCPEtcdBackup` associated with the backup must have `BackupCompleted` condition `True`
+
+### Step 1: Clean Up the Existing HostedCluster
+
+Before restoring, remove the existing HostedCluster resources:
+
+```bash
+# Delete the HostedCluster and NodePools
+kubectl delete hostedcluster my-hosted-cluster -n clusters
+
+# Verify no PVCs remain in the HostedControlPlane namespace
+kubectl get pvc -n clusters-my-hosted-cluster
+```
+
+### Step 2: Restore with the CLI
+
+```bash
+hypershift create oadp-restore \
+    --hc-name my-hosted-cluster \
+    --hc-namespace clusters \
+    --from-backup <backup-name> \
+    --use-etcd-snapshot
+```
+
+The `--use-etcd-snapshot` flag sets `restorePVs: false` in the Velero Restore CR. The HyperShift OADP plugin reads the snapshot URL from the backup annotations and injects it into the restored HostedCluster's `restoreSnapshotURL` field automatically.
+
+### Step 3: Verify the Restore
+
+Monitor the restore process:
+
+```bash
+# Watch the Velero restore status
+watch "oc get restore -n openshift-adp -o jsonpath='{.items[-1].status}' | jq"
+
+# Watch etcd pods for the init container
+kubectl get pods -n <HCP_NAMESPACE> -l app=etcd -w
+
+# Check the EtcdSnapshotRestored condition on the HostedControlPlane
+kubectl get hostedcontrolplane -n <HCP_NAMESPACE> \
+    -o jsonpath='{.items[0].status.conditions[?(@.type=="EtcdSnapshotRestored")]}' | jq
+
+# Verify the hosted cluster API server becomes available
+kubectl get hostedcluster my-hosted-cluster -n clusters \
+    -o jsonpath='{.status.conditions[?(@.type=="Available")]}'
+```
+
+The restore is complete when:
+
+- The Velero Restore reaches `Completed` phase
+- The `etcd-init` init container exits successfully
+- The `EtcdSnapshotRestored` condition is `True` on the HostedControlPlane
+- The HostedCluster reaches `Available` status
+
+### Restore Troubleshooting
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| `etcd-init` container shows XML error output | SAS token expired or invalid URL | Delete the HostedCluster and trigger a new OADP restore |
+| `etcd-init` container shows curl 404 | Wrong blob URL | Verify the `snapshotURL` from the HCPEtcdBackup status; ensure the storage account and container still exist |
+| `etcd-init` logs "not empty, not restoring snapshot" | Existing data in etcd PVC | Delete the PVC and let the restore recreate it |
+| Velero restore stuck | OADP plugin error | Check `oc logs -n openshift-adp -l deploy=velero -f` for details |
+
+## OADP Setup
+
+OADP (OpenShift API for Data Protection) with the HyperShift plugin is required for backup and restore operations on self-managed Azure. The `hypershift create oadp-*` CLI commands auto-detect the Azure platform and include the correct CAPI resources (`azureclusters`, `azuremachinetemplates`, `azuremachines`).
+
+### Prerequisites
+
+- OADP 1.5+ installed on the management cluster
+- DataProtectionApplication (DPA) configured with `hypershift` in `defaultPlugins`
+- Azure Blob Storage credentials configured for the BackupStorageLocation
+
+For DPA configuration details, see the [Azure DPA tab in the OADP 1.5+ guide](../disaster-recovery/backup-and-restore-oadp-1-5.md#sample-dpa-configurations).
+
+### Creating a Backup with the CLI
+
+Two backup modes are available:
+
+```bash
+# Volume snapshot mode (default) — backs up etcd PVs via CSI snapshots
+hypershift create oadp-backup \
+    --hc-name my-hosted-cluster \
+    --hc-namespace clusters
+
+# Etcd snapshot mode (Tech Preview) — uses HCPEtcdBackup CRD instead of PV snapshots
+hypershift create oadp-backup \
+    --hc-name my-hosted-cluster \
+    --hc-namespace clusters \
+    --use-etcd-snapshot
+```
+
+The `--use-etcd-snapshot` mode creates an `HCPEtcdBackup` CR and excludes PV-related resources from the Velero backup. This mode requires the `HCPEtcdBackup` feature gate and Azure Blob Storage configured as described in the [Setup](#setup) section.
+
+### Scheduling Backups
+
+Set up recurring backups using the OADP Schedule CR:
+
+```bash
+hypershift create oadp-schedule \
+    --hc-name my-hosted-cluster \
+    --hc-namespace clusters \
+    --schedule "0 2 * * *" \
+    --ttl 168h \
+    --use-etcd-snapshot
+```
+
+### Verifying OADP Operations
+
+```bash
+# Watch backup status
+watch "oc get backup -n openshift-adp -o jsonpath='{.items[-1].status}' | jq"
+
+# Watch restore status
+watch "oc get restore -n openshift-adp -o jsonpath='{.items[-1].status}' | jq"
+
+# Follow Velero logs
+oc logs -n openshift-adp -l deploy=velero -f
+```
+
+## Known Limitations
+
+| Limitation | Details |
+|-----------|---------|
+| Same-cluster restore only | Cross-management-cluster restore is not currently supported due to the lack of end-to-end testing coverage for that scenario |
+| OADP required for restore | Restore is driven by OADP; there is no standalone manual restore path for self-managed Azure |
+| `restoreSnapshotURL` is immutable | Set by the OADP plugin at HostedCluster creation time; cannot be changed afterward |
+| No in-place restore | Etcd data cannot be restored onto an existing HostedCluster; OADP recreates it from the backup |
+| Worker node reprovisioning | After restore, Azure worker nodes are reprovisioned; node readoption is not supported |
+| Tech Preview | The `HCPEtcdBackup` feature gate is required; this feature is not for production use |
+| Single snapshot per restore | `restoreSnapshotURL` accepts at most 1 entry |
+
 ## See Also
 
 - [Etcd Snapshot Backup Overview](../disaster-recovery/etcd-snapshot-backup/index.md) - Architecture and backup flow
+- [Restore Flow Architecture](../disaster-recovery/etcd-snapshot-backup/restore-flow.md) - Detailed restore sequence and OADP plugin behavior
 - [Managed Services Credentials](../disaster-recovery/etcd-snapshot-backup/managed-services-credentials.md) - Credential auto-detection and formats
+- [OADP 1.5+ Disaster Recovery](../disaster-recovery/backup-and-restore-oadp-1-5.md) - Full OADP DR procedure with Azure DPA configuration
+- [Disaster Recovery CLI](../disaster-recovery/dr-cli.md) - CLI reference for `hypershift create oadp-*` commands
 - [Self-Managed Azure Overview](self-managed-azure-index.md) - Self-managed Azure architecture

--- a/docs/content/how-to/disaster-recovery/backup-and-restore-oadp-1-5.md
+++ b/docs/content/how-to/disaster-recovery/backup-and-restore-oadp-1-5.md
@@ -20,6 +20,7 @@ After installation, create a DataProtectionApplication (DPA) object, which defin
 This guide focuses on the following platforms:
 
 - [AWS](https://docs.openshift.com/container-platform/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html)
+- [Azure](https://docs.openshift.com/container-platform/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.html)
 - [Baremetal](https://docs.openshift.com/container-platform/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.html)
 - [Openstack](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/installing/installing-on-openstack)
 - [KubeVirt](https://docs.openshift.com/container-platform/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.html)
@@ -40,6 +41,26 @@ oc create secret generic cloud-credentials -n openshift-adp --from-file cloud=cr
 !!! note
 
     If using AWS S3, additional AWS resources must be created to enable data backup and restoration. Follow [these instructions](https://docs.openshift.com/container-platform/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#migration-configuring-aws-s3_installing-oadp-aws) to set up the necessary configurations.
+
+For Azure Blob Storage, create the credentials in the following format:
+
+```bash
+cat << EOF > ./credentials-azure
+[default]
+AZURE_SUBSCRIPTION_ID=<subscription-id>
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_CLIENT_SECRET=<client-secret>
+AZURE_RESOURCE_GROUP=<resource-group>
+AZURE_CLOUD_NAME=AzurePublicCloud
+EOF
+
+oc create secret generic cloud-credentials -n openshift-adp --from-file cloud=credentials-azure
+```
+
+!!! note
+
+    For Azure, additional resources (Storage Account, Blob Container) must be created. Follow the [Azure OADP installation guide](https://docs.openshift.com/container-platform/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.html) or the [self-managed Azure etcd backup setup](../azure/backup-and-restore-etcd-snapshot.md#setup) for details.
 
 
 ### Sample DPA Configurations
@@ -183,6 +204,43 @@ Below are some samples of DPA configurations for the mentioned platforms
           defaultPlugins:
             - openshift
             - aws
+            - csi
+            - hypershift
+          resourceTimeout: 2h
+    ```
+
+=== "**Azure**"
+
+    ```yaml
+    ---
+    apiVersion: oadp.openshift.io/v1alpha1
+    kind: DataProtectionApplication
+    metadata:
+      name: dpa-instance
+      namespace: openshift-adp
+    spec:
+      backupLocations:
+        - name: default
+          velero:
+            provider: azure
+            default: true
+            objectStorage:
+              bucket: <blob_container_name>
+              prefix: hcp
+            config:
+              resourceGroup: <resource_group>
+              storageAccount: <storage_account_name>
+            credential:
+              key: cloud
+              name: cloud-credentials
+      configuration:
+        nodeAgent:
+          enable: true
+          uploaderType: kopia
+        velero:
+          defaultPlugins:
+            - openshift
+            - azure
             - csi
             - hypershift
           resourceTimeout: 2h
@@ -698,6 +756,115 @@ Once you create any of these DPA objects, several pods will be instantiated in t
 
     The backup process is considered complete when the `status.phase` is `Completed`.
 
+=== "**Azure**"
+
+    ### Data Plane workloads backup
+
+    !!! Note
+
+        If the workloads in the Data Plane are not crucial for you, it's safe to skip this step.
+
+    If you need to backup the applications running under the HostedCluster, it's advisable to follow [the official documentation for backup and restore of OpenShift applications](https://docs.openshift.com/container-platform/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html)
+
+    The steps are the following:
+
+    - Deploy the OADP operator from OLM.
+      - Create the DPA (Data Protection Application), with a manifest similar to the one provided earlier. It might be beneficial to adjust the `Prefix` or/and `Bucket` fields to keep the ControlPlane and DataPlane backups separated.
+      - Create the backup manifest. This step varies depending on the complexity of the workloads in the Data Plane. It's essential to thoroughly examine how to back up the PersistentVolumes, the backend used, and ensure compatibility with our storage provisioner.
+
+      We recommend checking if your workloads contain Persistent Volumes and if our StorageClass is compatible with CSI Volume Snapshots, which is one of the simplest ways to handle this aspect.
+
+    As a standard approach to maintain consistency in the backup layer for the Hosted Control Plane, we will utilize [`Kopia`](https://docs.openshift.com/container-platform/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-about-kopia.html) as the backend tool for data snapshots, along with [`File System Backup`](https://docs.openshift.com/container-platform/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.html). However, it's possible that your workloads may benefit from a different approach that better aligns with your specific use case.
+
+    !!! Important
+
+        The backup of the workloads residing in the Data Plane falls outside the scope of this documentation. Please refer to the official Openshift-ADP backup documentation for further details. Additional links and information can be found in the [References](#References) section.
+
+    Once we have completed the backup of the Data Plane layer, we can proceed with the backup of the Hosted Control Plane (HCP).
+
+
+    ### Control Plane backup
+
+    Now, we will apply the backup manifest. Here is how it looks like:
+
+    ```yaml
+    ---
+    apiVersion: velero.io/v1
+    kind: Backup
+    metadata:
+      name: hc-clusters-hosted-backup
+      namespace: openshift-adp
+      labels:
+        velero.io/storage-location: default
+        spec:
+      hooks: {}
+      includedNamespaces:
+      - clusters
+      - clusters-hosted
+      includedResources:
+      - sa
+      - role
+      - rolebinding
+      - pod
+      - pvc
+      - pv
+      - configmap
+      - priorityclasses
+      - pdb
+      - hostedcluster
+      - nodepool
+      - secrets
+      - services
+      - deployments
+      - statefulsets
+      - hostedcontrolplane
+      - cluster
+      - azureclusters
+      - azuremachinetemplates
+      - azuremachines
+      - machinedeployment
+      - machineset
+      - machine
+      - route
+      - clusterdeployment
+      excludedResources: []
+      storageLocation: default
+      ttl: 2h30m0s
+      snapshotMoveData: true
+      datamover: "velero"
+      defaultVolumesToFsBackup: false
+      snapshotVolumes: true
+    ```
+
+    We will emphasize the most important fields:
+
+    - These two fields enable the CSI VolumeSnapshots to be automatically uploaded to the remote cloud storage.
+
+    ```yaml
+    snapshotMoveData: true
+    datamover: "velero"
+    ```
+
+    - This field selects the namespaces from which objects will be backed up. They should include namespaces from both the HostedCluster (in the example `clusters`) and the HostedControlPlane (in the example `clusters-hosted`).
+
+    ```yaml
+    includedNamespaces:
+    - clusters
+    - clusters-hosted
+    ```
+
+    - The Azure-specific CAPI resources that must be included:
+
+    ```yaml
+    - azureclusters
+    - azuremachinetemplates
+    - azuremachines
+    ```
+
+    Once you apply the manifest, you can monitor the backup process in two places: the backup object status and the Velero logs. Please refer to the [Watching](#watching) section for more information.
+
+    The backup process is considered complete when the `status.phase` is `Completed`.
+
 
 ## Restore
 
@@ -781,6 +948,12 @@ The restoration process is considered complete once the `status.phase` is `Compl
 
     - Restoration in a separated Management cluster is not supported by this provider
     - Node readoption is not supported in this provider yet, so the worker nodes will be reprovisioned at restoration time
+
+=== "**Azure**"
+
+    - Restoration on the same management cluster only (cross-cluster restore is not currently supported due to the lack of end-to-end testing coverage for that scenario)
+    - Node readoption is not supported in this provider yet, so the worker nodes will be reprovisioned at restoration time
+    - For etcd snapshot backup and restore details specific to self-managed Azure, see [Etcd Snapshot Backup and Restore for Self-Managed Azure](../azure/backup-and-restore-etcd-snapshot.md)
 
 
 ## Schedule

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -10356,7 +10356,7 @@ spec:
 
 ## Source: docs/content/how-to/azure/backup-and-restore-etcd-snapshot.md
 
-# Etcd Snapshot Backup for Self-Managed Azure
+# Etcd Snapshot Backup and Restore for Self-Managed Azure
 
 !!! warning "Tech Preview"
 
@@ -10620,10 +10620,166 @@ az storage account delete \
     --yes
 ```
 
+## Restoring from an Etcd Snapshot
+
+!!! important
+
+    Only same-management-cluster restore is validated for self-managed Azure. Cross-management-cluster restore is not currently supported due to the lack of end-to-end testing coverage for that scenario.
+
+Restore is driven by OADP. The HyperShift OADP plugin orchestrates the full restore lifecycle:
+
+1. OADP recreates the HostedCluster from the Velero backup
+2. The plugin reads the etcd snapshot URL from the backup annotations and injects it into the restored HostedCluster's `spec.etcd.managed.storage.restoreSnapshotURL` field
+3. When the restored control plane boots, the control-plane-operator detects the URL and injects an `etcd-init` init container into the etcd StatefulSet
+4. The init container downloads the snapshot and restores it using `etcdutl snapshot restore`
+5. Once the restore completes, the `EtcdSnapshotRestored` condition is set on the HostedControlPlane
+
+The `restoreSnapshotURL` field is immutable — once set at HostedCluster creation time, it cannot be changed. The OADP plugin handles SAS token generation and URL injection automatically; no manual intervention is needed.
+
+For the full restore architecture and OADP plugin behavior, see Restore Flow Architecture.
+
+### Prerequisites
+
+- OADP 1.5+ installed with the HyperShift plugin (see OADP Setup below)
+- A completed OADP backup created with `--use-etcd-snapshot` mode
+- The `HCPEtcdBackup` associated with the backup must have `BackupCompleted` condition `True`
+
+### Step 1: Clean Up the Existing HostedCluster
+
+Before restoring, remove the existing HostedCluster resources:
+
+```bash
+# Delete the HostedCluster and NodePools
+kubectl delete hostedcluster my-hosted-cluster -n clusters
+
+# Verify no PVCs remain in the HostedControlPlane namespace
+kubectl get pvc -n clusters-my-hosted-cluster
+```
+
+### Step 2: Restore with the CLI
+
+```bash
+hypershift create oadp-restore \
+    --hc-name my-hosted-cluster \
+    --hc-namespace clusters \
+    --from-backup <backup-name> \
+    --use-etcd-snapshot
+```
+
+The `--use-etcd-snapshot` flag sets `restorePVs: false` in the Velero Restore CR. The HyperShift OADP plugin reads the snapshot URL from the backup annotations and injects it into the restored HostedCluster's `restoreSnapshotURL` field automatically.
+
+### Step 3: Verify the Restore
+
+Monitor the restore process:
+
+```bash
+# Watch the Velero restore status
+watch "oc get restore -n openshift-adp -o jsonpath='{.items[-1].status}' | jq"
+
+# Watch etcd pods for the init container
+kubectl get pods -n <HCP_NAMESPACE> -l app=etcd -w
+
+# Check the EtcdSnapshotRestored condition on the HostedControlPlane
+kubectl get hostedcontrolplane -n <HCP_NAMESPACE> \
+    -o jsonpath='{.items[0].status.conditions[?(@.type=="EtcdSnapshotRestored")]}' | jq
+
+# Verify the hosted cluster API server becomes available
+kubectl get hostedcluster my-hosted-cluster -n clusters \
+    -o jsonpath='{.status.conditions[?(@.type=="Available")]}'
+```
+
+The restore is complete when:
+
+- The Velero Restore reaches `Completed` phase
+- The `etcd-init` init container exits successfully
+- The `EtcdSnapshotRestored` condition is `True` on the HostedControlPlane
+- The HostedCluster reaches `Available` status
+
+### Restore Troubleshooting
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| `etcd-init` container shows XML error output | SAS token expired or invalid URL | Delete the HostedCluster and trigger a new OADP restore |
+| `etcd-init` container shows curl 404 | Wrong blob URL | Verify the `snapshotURL` from the HCPEtcdBackup status; ensure the storage account and container still exist |
+| `etcd-init` logs "not empty, not restoring snapshot" | Existing data in etcd PVC | Delete the PVC and let the restore recreate it |
+| Velero restore stuck | OADP plugin error | Check `oc logs -n openshift-adp -l deploy=velero -f` for details |
+
+## OADP Setup
+
+OADP (OpenShift API for Data Protection) with the HyperShift plugin is required for backup and restore operations on self-managed Azure. The `hypershift create oadp-*` CLI commands auto-detect the Azure platform and include the correct CAPI resources (`azureclusters`, `azuremachinetemplates`, `azuremachines`).
+
+### Prerequisites
+
+- OADP 1.5+ installed on the management cluster
+- DataProtectionApplication (DPA) configured with `hypershift` in `defaultPlugins`
+- Azure Blob Storage credentials configured for the BackupStorageLocation
+
+For DPA configuration details, see the Azure DPA tab in the OADP 1.5+ guide.
+
+### Creating a Backup with the CLI
+
+Two backup modes are available:
+
+```bash
+# Volume snapshot mode (default) — backs up etcd PVs via CSI snapshots
+hypershift create oadp-backup \
+    --hc-name my-hosted-cluster \
+    --hc-namespace clusters
+
+# Etcd snapshot mode (Tech Preview) — uses HCPEtcdBackup CRD instead of PV snapshots
+hypershift create oadp-backup \
+    --hc-name my-hosted-cluster \
+    --hc-namespace clusters \
+    --use-etcd-snapshot
+```
+
+The `--use-etcd-snapshot` mode creates an `HCPEtcdBackup` CR and excludes PV-related resources from the Velero backup. This mode requires the `HCPEtcdBackup` feature gate and Azure Blob Storage configured as described in the Setup section.
+
+### Scheduling Backups
+
+Set up recurring backups using the OADP Schedule CR:
+
+```bash
+hypershift create oadp-schedule \
+    --hc-name my-hosted-cluster \
+    --hc-namespace clusters \
+    --schedule "0 2 * * *" \
+    --ttl 168h \
+    --use-etcd-snapshot
+```
+
+### Verifying OADP Operations
+
+```bash
+# Watch backup status
+watch "oc get backup -n openshift-adp -o jsonpath='{.items[-1].status}' | jq"
+
+# Watch restore status
+watch "oc get restore -n openshift-adp -o jsonpath='{.items[-1].status}' | jq"
+
+# Follow Velero logs
+oc logs -n openshift-adp -l deploy=velero -f
+```
+
+## Known Limitations
+
+| Limitation | Details |
+|-----------|---------|
+| Same-cluster restore only | Cross-management-cluster restore is not currently supported due to the lack of end-to-end testing coverage for that scenario |
+| OADP required for restore | Restore is driven by OADP; there is no standalone manual restore path for self-managed Azure |
+| `restoreSnapshotURL` is immutable | Set by the OADP plugin at HostedCluster creation time; cannot be changed afterward |
+| No in-place restore | Etcd data cannot be restored onto an existing HostedCluster; OADP recreates it from the backup |
+| Worker node reprovisioning | After restore, Azure worker nodes are reprovisioned; node readoption is not supported |
+| Tech Preview | The `HCPEtcdBackup` feature gate is required; this feature is not for production use |
+| Single snapshot per restore | `restoreSnapshotURL` accepts at most 1 entry |
+
 ## See Also
 
 - Etcd Snapshot Backup Overview - Architecture and backup flow
+- Restore Flow Architecture - Detailed restore sequence and OADP plugin behavior
 - Managed Services Credentials - Credential auto-detection and formats
+- OADP 1.5+ Disaster Recovery - Full OADP DR procedure with Azure DPA configuration
+- Disaster Recovery CLI - CLI reference for `hypershift create oadp-*` commands
 - Self-Managed Azure Overview - Self-managed Azure architecture
 
 
@@ -17930,6 +18086,7 @@ After installation, create a DataProtectionApplication (DPA) object, which defin
 This guide focuses on the following platforms:
 
 - AWS
+- Azure
 - Baremetal
 - Openstack
 - KubeVirt
@@ -17950,6 +18107,26 @@ oc create secret generic cloud-credentials -n openshift-adp --from-file cloud=cr
 !!! note
 
     If using AWS S3, additional AWS resources must be created to enable data backup and restoration. Follow these instructions to set up the necessary configurations.
+
+For Azure Blob Storage, create the credentials in the following format:
+
+```bash
+cat << EOF > ./credentials-azure
+[default]
+AZURE_SUBSCRIPTION_ID=<subscription-id>
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_CLIENT_SECRET=<client-secret>
+AZURE_RESOURCE_GROUP=<resource-group>
+AZURE_CLOUD_NAME=AzurePublicCloud
+EOF
+
+oc create secret generic cloud-credentials -n openshift-adp --from-file cloud=credentials-azure
+```
+
+!!! note
+
+    For Azure, additional resources (Storage Account, Blob Container) must be created. Follow the Azure OADP installation guide or the self-managed Azure etcd backup setup for details.
 
 
 ### Sample DPA Configurations
@@ -18093,6 +18270,43 @@ Below are some samples of DPA configurations for the mentioned platforms
           defaultPlugins:
             - openshift
             - aws
+            - csi
+            - hypershift
+          resourceTimeout: 2h
+    ```
+
+=== "**Azure**"
+
+    ```yaml
+    ---
+    apiVersion: oadp.openshift.io/v1alpha1
+    kind: DataProtectionApplication
+    metadata:
+      name: dpa-instance
+      namespace: openshift-adp
+    spec:
+      backupLocations:
+        - name: default
+          velero:
+            provider: azure
+            default: true
+            objectStorage:
+              bucket: <blob_container_name>
+              prefix: hcp
+            config:
+              resourceGroup: <resource_group>
+              storageAccount: <storage_account_name>
+            credential:
+              key: cloud
+              name: cloud-credentials
+      configuration:
+        nodeAgent:
+          enable: true
+          uploaderType: kopia
+        velero:
+          defaultPlugins:
+            - openshift
+            - azure
             - csi
             - hypershift
           resourceTimeout: 2h
@@ -18608,6 +18822,115 @@ Once you create any of these DPA objects, several pods will be instantiated in t
 
     The backup process is considered complete when the `status.phase` is `Completed`.
 
+=== "**Azure**"
+
+    ### Data Plane workloads backup
+
+    !!! Note
+
+        If the workloads in the Data Plane are not crucial for you, it's safe to skip this step.
+
+    If you need to backup the applications running under the HostedCluster, it's advisable to follow the official documentation for backup and restore of OpenShift applications
+
+    The steps are the following:
+
+    - Deploy the OADP operator from OLM.
+      - Create the DPA (Data Protection Application), with a manifest similar to the one provided earlier. It might be beneficial to adjust the `Prefix` or/and `Bucket` fields to keep the ControlPlane and DataPlane backups separated.
+      - Create the backup manifest. This step varies depending on the complexity of the workloads in the Data Plane. It's essential to thoroughly examine how to back up the PersistentVolumes, the backend used, and ensure compatibility with our storage provisioner.
+
+      We recommend checking if your workloads contain Persistent Volumes and if our StorageClass is compatible with CSI Volume Snapshots, which is one of the simplest ways to handle this aspect.
+
+    As a standard approach to maintain consistency in the backup layer for the Hosted Control Plane, we will utilize `Kopia` as the backend tool for data snapshots, along with `File System Backup`. However, it's possible that your workloads may benefit from a different approach that better aligns with your specific use case.
+
+    !!! Important
+
+        The backup of the workloads residing in the Data Plane falls outside the scope of this documentation. Please refer to the official Openshift-ADP backup documentation for further details. Additional links and information can be found in the References section.
+
+    Once we have completed the backup of the Data Plane layer, we can proceed with the backup of the Hosted Control Plane (HCP).
+
+
+    ### Control Plane backup
+
+    Now, we will apply the backup manifest. Here is how it looks like:
+
+    ```yaml
+    ---
+    apiVersion: velero.io/v1
+    kind: Backup
+    metadata:
+      name: hc-clusters-hosted-backup
+      namespace: openshift-adp
+      labels:
+        velero.io/storage-location: default
+        spec:
+      hooks: {}
+      includedNamespaces:
+      - clusters
+      - clusters-hosted
+      includedResources:
+      - sa
+      - role
+      - rolebinding
+      - pod
+      - pvc
+      - pv
+      - configmap
+      - priorityclasses
+      - pdb
+      - hostedcluster
+      - nodepool
+      - secrets
+      - services
+      - deployments
+      - statefulsets
+      - hostedcontrolplane
+      - cluster
+      - azureclusters
+      - azuremachinetemplates
+      - azuremachines
+      - machinedeployment
+      - machineset
+      - machine
+      - route
+      - clusterdeployment
+      excludedResources: []
+      storageLocation: default
+      ttl: 2h30m0s
+      snapshotMoveData: true
+      datamover: "velero"
+      defaultVolumesToFsBackup: false
+      snapshotVolumes: true
+    ```
+
+    We will emphasize the most important fields:
+
+    - These two fields enable the CSI VolumeSnapshots to be automatically uploaded to the remote cloud storage.
+
+    ```yaml
+    snapshotMoveData: true
+    datamover: "velero"
+    ```
+
+    - This field selects the namespaces from which objects will be backed up. They should include namespaces from both the HostedCluster (in the example `clusters`) and the HostedControlPlane (in the example `clusters-hosted`).
+
+    ```yaml
+    includedNamespaces:
+    - clusters
+    - clusters-hosted
+    ```
+
+    - The Azure-specific CAPI resources that must be included:
+
+    ```yaml
+    - azureclusters
+    - azuremachinetemplates
+    - azuremachines
+    ```
+
+    Once you apply the manifest, you can monitor the backup process in two places: the backup object status and the Velero logs. Please refer to the Watching section for more information.
+
+    The backup process is considered complete when the `status.phase` is `Completed`.
+
 
 ## Restore
 
@@ -18691,6 +19014,12 @@ The restoration process is considered complete once the `status.phase` is `Compl
 
     - Restoration in a separated Management cluster is not supported by this provider
     - Node readoption is not supported in this provider yet, so the worker nodes will be reprovisioned at restoration time
+
+=== "**Azure**"
+
+    - Restoration on the same management cluster only (cross-cluster restore is not currently supported due to the lack of end-to-end testing coverage for that scenario)
+    - Node readoption is not supported in this provider yet, so the worker nodes will be reprovisioned at restoration time
+    - For etcd snapshot backup and restore details specific to self-managed Azure, see Etcd Snapshot Backup and Restore for Self-Managed Azure
 
 
 ## Schedule


### PR DESCRIPTION
## Summary
- Add same-cluster etcd snapshot restore procedure for self-managed Azure (SAS token generation, `restoreSnapshotURL` usage, verification, troubleshooting)
- Add OADP automated backup/restore section with `hypershift create oadp-*` CLI commands
- Add Azure platform tabs to OADP 1.5+ DR guide (DPA config, credentials, backup manifest, restore notes)
- Add known limitations section documenting current constraints
- Cross-management-cluster restore explicitly documented as unsupported due to lack of e2e testing coverage

Builds on top of #8785 ([CNTRLPLANE-3199](https://redhat.atlassian.net/browse/CNTRLPLANE-3199)) which added the backup infrastructure and docs.

## Test plan
- [ ] Verify mkdocs renders correctly (`mkdocs serve` from `docs/`)
- [ ] Verify all cross-references resolve (Azure doc ↔ OADP 1.5 doc ↔ DR section)
- [ ] Verify Azure tabs render correctly alongside existing platform tabs in OADP 1.5 doc
- [ ] Verify aggregated-docs.md includes updated content

Fixes: https://redhat.atlassian.net/browse/CNTRLPLANE-3202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Azure self-managed etcd snapshot guide with a new restore flow, CLI restore steps, verification checks, troubleshooting, and restored-mode limitations.
  * Updated known limitations and “see also” references for etcd snapshot backup/restore.
  * Added Azure-specific OADP 1.5+ disaster-recovery documentation for hosted control planes, including blob credentials setup, sample DPA configurations, Azure Backup manifests, and restore constraints (same-management-cluster only).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->