### PR TITLE
NO-JIRA: docs: add hash migration impact guidance and CPO data-plane component docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,5 @@ See [docs/content/how-to/common/global-pull-secret.md](docs/content/how-to/commo
 ## Fleet-Wide Rollout Impact
 
 Changes to config data, secrets, or any value that feeds into a NodePool config hash will trigger a rollout across **all** HostedClusters. Before adding new data to ignition configs, MachineConfigs, or any resource reconciled into the data plane, check whether the change affects the NodePool config hash (search for `hashStruct` / `configHash`). If it does, the PR **must** pass `e2e-aws-upgrade-hypershift-operator` to prove the rollout is safe.
+
+Additionally, consider the **deployment-time migration impact** on existing NodePools: if the hash was previously computed with different inputs (e.g., an image resolved from a different source), deploying the change will cause a one-time hash change and rollout across all affected NodePools — even when HC and NodePool are at the same version. Reviewers must ask: "what happens to clusters that already exist when this operator version is deployed?"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,6 +30,10 @@ See [Concepts and Personas](docs/content/reference/concepts-and-personas.md) for
 
 See [Goals and Design Invariants](docs/content/reference/goals-and-design-invariants.md) for the full set including control plane and data plane ingress separation.
 
+## Data-Plane Components in the CPO Binary
+
+The `control-plane-operator` binary contains subcommands that run on **worker nodes** as static pods, not on the management cluster. The `kubernetes-default-proxy` (HTTP CONNECT proxy for KAS traffic when `spec.configuration.proxy` is set) is the primary example. Despite sharing the CPO container image, these are data-plane components — their image must be resolved from the **NodePool** release image, not the HC release image, to avoid spurious node rollouts during CP-only upgrades.
+
 ## Platform Support
 
 - AWS — self-managed and managed (ROSA HCP)


### PR DESCRIPTION
## What this PR does / why we need it:

Adds two documentation improvements based on a review of PR #9157, where a hash-affecting change to ignition configs was missing deployment-time migration analysis:

1. **ARCHITECTURE.md** — Documents that the CPO binary contains data-plane subcommands (`kubernetes-default-proxy`) that run as static pods on worker nodes. Their images must be resolved from the NodePool release, not the HC release.

2. **AGENTS.md** — Strengthens the "Fleet-Wide Rollout Impact" section to explicitly cover deployment-time migration risks: when hash inputs change source (not just value), existing NodePools will experience a one-time hash delta and rollout even at steady state.

## Which issue(s) this PR fixes:

N/A — documentation improvement to prevent a class of review gaps.

## Special notes for your reviewer:

These additions are motivated by the review of #9157, where multiple review passes (human and automated) missed the deployment-time rollout risk that csrwng caught in a single comment. The goal is to make this review dimension explicit so it's not missed again.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on deployment-time configuration hash changes that may trigger one-time NodePool rollouts.
  * Documented data-plane components running on worker nodes and clarified release-image handling during control-plane upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->