### PR TITLE
CNTRLPLANE-3900: Add shared cmd/ unit tests for destroy cluster

### DIFF
--- a/cmd/cluster/agent/destroy_test.go
+++ b/cmd/cluster/agent/destroy_test.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	tests := map[string]struct {
+		expectedUse   string
+		expectedShort string
+	}{
+		"When command is created it should have correct use and short description": {
+			expectedUse:   "agent",
+			expectedShort: "Destroys a HostedCluster and its associated infrastructure on Agent",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(tt *testing.T) {
+			g := NewGomegaWithT(tt)
+			opts := &core.DestroyOptions{}
+			cmd := NewDestroyCommand(opts)
+			g.Expect(cmd.Use).To(Equal(test.expectedUse))
+			g.Expect(cmd.Short).To(Equal(test.expectedShort))
+			g.Expect(cmd.SilenceUsage).To(BeTrue())
+		})
+	}
+}
+
+func TestDestroyOptions(t *testing.T) {
+	t.Run("When DestroyOptions is created it should have correct zero values", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		opts := &DestroyOptions{}
+		g.Expect(opts.Namespace).To(BeEmpty())
+		g.Expect(opts.Name).To(BeEmpty())
+		g.Expect(opts.ClusterGracePeriod).To(Equal(time.Duration(0)))
+	})
+
+	t.Run("When DestroyOptions fields are set it should retain the values", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		opts := &DestroyOptions{
+			Namespace:          "clusters",
+			Name:               "test-cluster",
+			ClusterGracePeriod: 10 * time.Minute,
+		}
+		g.Expect(opts.Namespace).To(Equal("clusters"))
+		g.Expect(opts.Name).To(Equal("test-cluster"))
+		g.Expect(opts.ClusterGracePeriod).To(Equal(10 * time.Minute))
+	})
+}

--- a/cmd/cluster/agent/destroy_test.go
+++ b/cmd/cluster/agent/destroy_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/log"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When command is created it should have correct use, short description and wire RunE", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+		opts := &core.DestroyOptions{}
+		cmd := NewDestroyCommand(opts)
+		g.Expect(cmd.Use).To(Equal("agent"))
+		g.Expect(cmd.Short).To(Equal("Destroys a HostedCluster and its associated infrastructure on Agent"))
+		g.Expect(cmd.SilenceUsage).To(BeTrue())
+		g.Expect(cmd.RunE).ToNot(BeNil())
+	})
+
+	t.Run("When RunE runs without a reachable cluster it should return an error", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+		opts := &core.DestroyOptions{
+			Name:       "test-cluster",
+			Namespace:  "clusters",
+			Kubeconfig: "/nonexistent/kubeconfig/path",
+			Log:        log.Log,
+		}
+		cmd := NewDestroyCommand(opts)
+		err := cmd.RunE(cmd, nil)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unable to get kubernetes config"))
+	})
+}
+
+func TestDestroyOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When DestroyOptions is created it should have correct zero values", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+		opts := &DestroyOptions{}
+		g.Expect(opts.Namespace).To(BeEmpty())
+		g.Expect(opts.Name).To(BeEmpty())
+		g.Expect(opts.ClusterGracePeriod).To(Equal(time.Duration(0)))
+	})
+
+	t.Run("When DestroyOptions fields are set it should retain the values", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+		opts := &DestroyOptions{
+			Namespace:          "clusters",
+			Name:               "test-cluster",
+			ClusterGracePeriod: 10 * time.Minute,
+		}
+		g.Expect(opts.Namespace).To(Equal("clusters"))
+		g.Expect(opts.Name).To(Equal("test-cluster"))
+		g.Expect(opts.ClusterGracePeriod).To(Equal(10 * time.Minute))
+	})
+}

--- a/cmd/cluster/kubevirt/destroy_test.go
+++ b/cmd/cluster/kubevirt/destroy_test.go
@@ -1,0 +1,32 @@
+package kubevirt
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	tests := map[string]struct {
+		expectedUse   string
+		expectedShort string
+	}{
+		"When command is created it should have correct use and short description": {
+			expectedUse:   "kubevirt",
+			expectedShort: "Destroys a HostedCluster and its associated infrastructure on Kubevirt platform",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(tt *testing.T) {
+			g := NewGomegaWithT(tt)
+			opts := &core.DestroyOptions{}
+			cmd := NewDestroyCommand(opts)
+			g.Expect(cmd.Use).To(Equal(test.expectedUse))
+			g.Expect(cmd.Short).To(Equal(test.expectedShort))
+			g.Expect(cmd.SilenceUsage).To(BeTrue())
+		})
+	}
+}

--- a/cmd/cluster/kubevirt/destroy_test.go
+++ b/cmd/cluster/kubevirt/destroy_test.go
@@ -1,0 +1,40 @@
+package kubevirt
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/log"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When command is created it should have correct use, short description and wire RunE", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+		opts := &core.DestroyOptions{}
+		cmd := NewDestroyCommand(opts)
+		g.Expect(cmd.Use).To(Equal("kubevirt"))
+		g.Expect(cmd.Short).To(Equal("Destroys a HostedCluster and its associated infrastructure on Kubevirt platform"))
+		g.Expect(cmd.SilenceUsage).To(BeTrue())
+		g.Expect(cmd.RunE).ToNot(BeNil())
+	})
+
+	t.Run("When RunE runs without a reachable cluster it should return an error", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+		opts := &core.DestroyOptions{
+			Name:       "test-cluster",
+			Namespace:  "clusters",
+			Kubeconfig: "/nonexistent/kubeconfig/path",
+			Log:        log.Log,
+		}
+		cmd := NewDestroyCommand(opts)
+		err := cmd.RunE(cmd, nil)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unable to get kubernetes config"))
+	})
+}

--- a/cmd/cluster/openstack/destroy_test.go
+++ b/cmd/cluster/openstack/destroy_test.go
@@ -1,0 +1,46 @@
+package openstack
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	tests := map[string]struct {
+		expectedUse   string
+		expectedShort string
+	}{
+		"When command is created it should have correct use and short description": {
+			expectedUse:   "openstack",
+			expectedShort: "Destroys a HostedCluster and its associated infrastructure on OpenStack",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(tt *testing.T) {
+			g := NewGomegaWithT(tt)
+			opts := &core.DestroyOptions{}
+			cmd := NewDestroyCommand(opts)
+			g.Expect(cmd.Use).To(Equal(test.expectedUse))
+			g.Expect(cmd.Short).To(Equal(test.expectedShort))
+			g.Expect(cmd.SilenceUsage).To(BeTrue())
+		})
+	}
+}
+
+func TestDestroyPlatformSpecifics(t *testing.T) {
+	t.Run("When called it should be a no-op and return nil", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		opts := &core.DestroyOptions{
+			Name:      "test-cluster",
+			Namespace: "clusters",
+			InfraID:   "test-infra",
+		}
+		err := destroyPlatformSpecifics(context.Background(), opts)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}

--- a/cmd/cluster/openstack/destroy_test.go
+++ b/cmd/cluster/openstack/destroy_test.go
@@ -1,0 +1,65 @@
+package openstack
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/log"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When command is created it should have correct use, short description and wire Run", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+		opts := &core.DestroyOptions{}
+		cmd := NewDestroyCommand(opts)
+		g.Expect(cmd.Use).To(Equal("openstack"))
+		g.Expect(cmd.Short).To(Equal("Destroys a HostedCluster and its associated infrastructure on OpenStack"))
+		g.Expect(cmd.SilenceUsage).To(BeTrue())
+		// OpenStack wires Run (not RunE) because it installs a SIGINT handler and
+		// calls os.Exit on failure, so we assert on Run here.
+		g.Expect(cmd.Run).ToNot(BeNil())
+	})
+}
+
+func TestDestroyCluster(t *testing.T) {
+	t.Parallel()
+
+	// The command's Run handler calls os.Exit on failure, so it cannot be invoked
+	// directly from a test. DestroyCluster is the function it delegates to, so we
+	// exercise the failure path here instead.
+	t.Run("When called without a reachable cluster it should return an error", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+		opts := &core.DestroyOptions{
+			Name:       "test-cluster",
+			Namespace:  "clusters",
+			Kubeconfig: "/nonexistent/kubeconfig/path",
+			Log:        log.Log,
+		}
+		err := DestroyCluster(context.Background(), opts)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unable to get kubernetes config"))
+	})
+}
+
+func TestDestroyPlatformSpecifics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When called it should be a no-op and return nil", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+		opts := &core.DestroyOptions{
+			Name:      "test-cluster",
+			Namespace: "clusters",
+			InfraID:   "test-infra",
+		}
+		err := destroyPlatformSpecifics(context.Background(), opts)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}


### PR DESCRIPTION
Three platforms - KubeVirt, OpenStack, and Agent  have zero shared unit test coverage for cluster destroy

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

3 new test files for zero-coverage destroy paths:

1. cmd/cluster/kubevirt/destroy_test.go — Tests `NewDestroyCommand` wiring (Use, Short, SilenceUsage). KubeVirt's destroy is a thin delegate to `none.DestroyCluster` with no platform-specific logic.

2. cmd/cluster/openstack/destroy_test.go — Tests `NewDestroyCommand` wiring + `destroyPlatformSpecifics` (verifies it's a no-op returning nil). OpenStack has its own `DestroyCluster` with InfraID validation, but the full flow can't be tested via FAKE_CLIENT because the fake client's scheme doesn't include `hyperv1.HostedCluster`.

3. cmd/cluster/agent/destroy_test.go — Tests `NewDestroyCommand` wiring + the `DestroyOptions` struct (zero values and field retention). Agent's `DestroyCluster` is a direct delegation to `none.DestroyCluster`.

Verification: `go test` passes for all three packages, `make lint-fix` reports 0 issues, `go vet` is clean.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3900

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for cluster destruction commands across agent, KubeVirt, and OpenStack environments.
  * Verified command metadata, usage-silencing behavior, default and configured options, error handling for unreachable clusters, and platform-specific destroy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->