### PR TITLE
CNTRLPLANE-3956: Make EnsureGlobalPullSecret e2e test informing

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -123,7 +123,6 @@ func TestCreateCluster(t *testing.T) {
 			e2eutil.EnsureKubeAPIServerAllowedCIDRs(t, ctx, mgtClient, guestConfig, hostedCluster)
 		}
 
-		e2eutil.EnsureGlobalPullSecret(t, ctx, mgtClient, hostedCluster, globalOpts.AdditionalPullSecretFile)
 		e2eutil.EnsureMetricsForwarderWorking(t, ctx, mgtClient, hostedCluster)
 
 		// Verify CPO override image if TEST_CPO_OVERRIDE=1 is set

--- a/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
@@ -44,7 +44,7 @@ func RegisterGlobalPullSecretTests(getTestCtx internal.TestContextGetter) {
 }
 
 func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
-	When("an additional pull secret is created in the hosted cluster", func() {
+	When("an additional pull secret is created in the hosted cluster", Label("Informing"), func() {
 		It("should propagate it through the global pull secret pipeline and clean up on deletion", func() {
 			tc := getTestCtx()
 			if e2eutil.IsLessThan(e2eutil.Version419) {


### PR DESCRIPTION
## Summary
- Mark the v2 `EnsureGlobalPullSecret` test as `Informing` so failures are reported as skips instead of failing the suite
- Remove the v1 `EnsureGlobalPullSecret` call from `create_cluster_test.go` since standard Go testing has no informing mechanism

## Why
The `EnsureGlobalPullSecret` validation is flaky and causing frequent e2e failures across CI runs. This unblocks CI while the root cause is investigated.

## Test plan
- [ ] Verify v2 e2e suite compiles with `go vet -tags e2ev2 ./test/e2e/v2/tests/`
- [ ] Verify v1 e2e suite compiles with `go build ./test/e2e/...`
- [ ] Confirm `EnsureGlobalPullSecret` failures no longer block e2e suite results

Jira: https://redhat.atlassian.net/browse/CNTRLPLANE-3956

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test coverage for cluster creation by removing the global pull secret validation step.
  * Classified the additional pull secret scenario as an informing test for clearer test reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->