### PR TITLE
OCPBUGS-100054: Fix Azure Private clusters without external DNS

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -333,7 +333,7 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 			},
 		}
 	}
-	cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, o.externalDNSDomain != "")
+	cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, o.externalDNSDomain != "", false)
 	if o.externalDNSDomain != "" {
 		for i, svc := range cluster.Spec.Services {
 			switch svc.Service {

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -474,7 +474,8 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 		}
 	}
 
-	cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, o.externalDNSDomain != "")
+	isPrivateOnly := o.EndpointAccess == string(hyperv1.AzureTopologyPrivate)
+	cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, o.externalDNSDomain != "", isPrivateOnly)
 
 	for i, svc := range cluster.Spec.Services {
 		if svc.Service == hyperv1.OAuthServer && o.OAuthPublishingStrategy == "LoadBalancer" {

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_When_endpoint_access_is_Private_with_endpoint_access_private_flags_it_should_render_HostedCluster_with_Private_endpoint_access.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_When_endpoint_access_is_Private_with_endpoint_access_private_flags_it_should_render_HostedCluster_with_Private_endpoint_access.yaml
@@ -132,7 +132,7 @@ spec:
   services:
   - service: APIServer
     servicePublishingStrategy:
-      type: LoadBalancer
+      type: Route
   - service: Ignition
     servicePublishingStrategy:
       type: Route

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -1089,10 +1089,9 @@ func defaultNodePool(opts *CreateOptions) func(platformType hyperv1.PlatformType
 	}
 }
 
-func GetIngressServicePublishingStrategyMapping(netType hyperv1.NetworkType, usesExternalDNS bool) []hyperv1.ServicePublishingStrategyMapping {
-	// TODO (Alberto): Default KAS to Route if endpointAccess is Private.
+func GetIngressServicePublishingStrategyMapping(netType hyperv1.NetworkType, usesExternalDNS bool, isPrivate bool) []hyperv1.ServicePublishingStrategyMapping {
 	apiServiceStrategy := hyperv1.LoadBalancer
-	if usesExternalDNS {
+	if usesExternalDNS || isPrivate {
 		apiServiceStrategy = hyperv1.Route
 	}
 	services := map[hyperv1.ServiceType]hyperv1.PublishingStrategyType{

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -832,12 +832,12 @@ func TestGetServicePublishingStrategyMapping(t *testing.T) {
 	}{
 		{
 			name:            "When GetIngressServicePublishingStrategyMapping is called with OVNKubernetes, it should not include deprecated service types",
-			services:        GetIngressServicePublishingStrategyMapping(hyperv1.OVNKubernetes, false),
+			services:        GetIngressServicePublishingStrategyMapping(hyperv1.OVNKubernetes, false, false),
 			checkDeprecated: true,
 		},
 		{
 			name:            "When GetIngressServicePublishingStrategyMapping is called with Other network type, it should not include deprecated service types",
-			services:        GetIngressServicePublishingStrategyMapping(hyperv1.Other, false),
+			services:        GetIngressServicePublishingStrategyMapping(hyperv1.Other, false, false),
 			checkDeprecated: true,
 		},
 		{
@@ -852,7 +852,7 @@ func TestGetServicePublishingStrategyMapping(t *testing.T) {
 		},
 		{
 			name:          "When GetIngressServicePublishingStrategyMapping is called, it should include all required service types",
-			services:      GetIngressServicePublishingStrategyMapping(hyperv1.Other, false),
+			services:      GetIngressServicePublishingStrategyMapping(hyperv1.Other, false, false),
 			checkRequired: true,
 			requiredTypes: requiredServiceTypes,
 		},
@@ -871,13 +871,19 @@ func TestGetServicePublishingStrategyMapping(t *testing.T) {
 		},
 		{
 			name:             "When GetIngressServicePublishingStrategyMapping is called without external DNS, it should use LoadBalancer for APIServer",
-			services:         GetIngressServicePublishingStrategyMapping(hyperv1.OVNKubernetes, false),
+			services:         GetIngressServicePublishingStrategyMapping(hyperv1.OVNKubernetes, false, false),
 			checkStrategy:    true,
 			expectedStrategy: hyperv1.LoadBalancer,
 		},
 		{
 			name:             "When GetIngressServicePublishingStrategyMapping is called with external DNS, it should use Route for APIServer",
-			services:         GetIngressServicePublishingStrategyMapping(hyperv1.OVNKubernetes, true),
+			services:         GetIngressServicePublishingStrategyMapping(hyperv1.OVNKubernetes, true, false),
+			checkStrategy:    true,
+			expectedStrategy: hyperv1.Route,
+		},
+		{
+			name:             "When GetIngressServicePublishingStrategyMapping is called with isPrivate, it should use Route for APIServer",
+			services:         GetIngressServicePublishingStrategyMapping(hyperv1.OVNKubernetes, false, true),
 			checkStrategy:    true,
 			expectedStrategy: hyperv1.Route,
 		},

--- a/cmd/cluster/gcp/create.go
+++ b/cmd/cluster/gcp/create.go
@@ -306,7 +306,7 @@ func (o *CreateOptions) ApplyPlatformSpecifics(hostedCluster *hyperv1.HostedClus
 		}
 	}
 
-	hostedCluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(hostedCluster.Spec.Networking.NetworkType, o.externalDNSDomain != "")
+	hostedCluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(hostedCluster.Spec.Networking.NetworkType, o.externalDNSDomain != "", false)
 
 	if o.externalDNSDomain != "" {
 		// Only APIServer and OAuthServer need external DNS routes.

--- a/cmd/cluster/kubevirt/create.go
+++ b/cmd/cluster/kubevirt/create.go
@@ -200,7 +200,7 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 	case "NodePort":
 		cluster.Spec.Services = core.GetServicePublishingStrategyMappingByAPIServerAddress(o.APIServerAddress, cluster.Spec.Networking.NetworkType)
 	case "Ingress":
-		cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, o.externalDNSDomain != "")
+		cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, o.externalDNSDomain != "", false)
 	default:
 		panic(fmt.Sprintf("service publishing type %s is not supported", o.ServicePublishingStrategy))
 	}

--- a/cmd/cluster/none/create.go
+++ b/cmd/cluster/none/create.go
@@ -67,7 +67,7 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 	if o.APIServerAddress != "" {
 		cluster.Spec.Services = core.GetServicePublishingStrategyMappingByAPIServerAddress(o.APIServerAddress, cluster.Spec.Networking.NetworkType)
 	} else {
-		cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, false)
+		cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, false, false)
 	}
 	return nil
 }

--- a/cmd/cluster/openstack/create.go
+++ b/cmd/cluster/openstack/create.go
@@ -210,7 +210,7 @@ func (o *RawCreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster
 		}
 	}
 
-	cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, false)
+	cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, false, false)
 
 	// MachineNetwork has no default in Hypershift, but it's convenient to have one for OpenStack:
 	// * To specify the subnet that CAPO will manage.

--- a/cmd/cluster/powervs/create.go
+++ b/cmd/cluster/powervs/create.go
@@ -203,7 +203,7 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 	}
 	cluster.Spec.InfraID = o.infra.ID
 	cluster.Spec.Networking.MachineNetwork = []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR(defaultCIDRBlock)}}
-	cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, o.externalDNSDomain != "")
+	cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, o.externalDNSDomain != "", false)
 	return nil
 }
 

--- a/cmd/infra/azure/destroy.go
+++ b/cmd/infra/azure/destroy.go
@@ -202,7 +202,7 @@ type resourceToDelete struct {
 // deleteClusterResourcesInGroup deletes cluster-specific resources within a resource group
 // while preserving the resource group itself and any non-cluster resources.
 // Resources are identified as cluster-specific if they contain the infraID in their name OR
-// if they match the cluster naming pattern (e.g., {name}-azurecluster.{baseDomain} for DNS zones).
+// if they match the cluster naming pattern (e.g., {name}.{baseDomain} for DNS zones).
 // Resources are deleted in dependency order to avoid conflicts.
 func (o *DestroyInfraOptions) deleteClusterResourcesInGroup(ctx context.Context, logger logr.Logger, resourcesClient *armresources.Client, resourceGroupName string) error {
 	// List all resources in the resource group
@@ -222,8 +222,10 @@ func (o *DestroyInfraOptions) deleteClusterResourcesInGroup(ctx context.Context,
 
 			// Only delete resources that are cluster-specific
 			// Resources are identified as cluster-specific if they contain the InfraID OR
-			// if they match the cluster naming pattern (e.g., {name}-azurecluster.{baseDomain} for DNS zones)
+			// if they match the cluster naming pattern for DNS zones (both current {name}.{baseDomain}
+			// and legacy {name}-azurecluster.{baseDomain} formats)
 			isClusterResource := strings.Contains(*resource.Name, o.InfraID) ||
+				strings.HasPrefix(*resource.Name, o.Name+".") ||
 				strings.HasPrefix(*resource.Name, o.Name+"-azurecluster.")
 
 			if isClusterResource {

--- a/cmd/infra/azure/networking.go
+++ b/cmd/infra/azure/networking.go
@@ -182,7 +182,7 @@ func (n *NetworkManager) CreatePrivateDNSZone(ctx context.Context, resourceGroup
 	privateZoneParams := armprivatedns.PrivateZone{
 		Location: ptr.To("global"),
 	}
-	privateDNSZonePromise, err := privateZoneClient.BeginCreateOrUpdate(ctx, resourceGroupName, name+"-azurecluster."+baseDomain, privateZoneParams, nil)
+	privateDNSZonePromise, err := privateZoneClient.BeginCreateOrUpdate(ctx, resourceGroupName, name+"."+baseDomain, privateZoneParams, nil)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create private DNS zone: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
@@ -247,49 +247,35 @@ func (r *Reconciler) reconcileAPIServerService(ctx context.Context, hcp *hyperv1
 	if serviceStrategy.Type == hyperv1.Route {
 		externalPublicRoute := manifests.KubeAPIServerExternalPublicRoute(hcp.Namespace)
 		externalPrivateRoute := manifests.KubeAPIServerExternalPrivateRoute(hcp.Namespace)
+		hostname := ""
+		if serviceStrategy.Route != nil {
+			hostname = serviceStrategy.Route.Hostname
+		}
 		if netutil.IsPublicHCP(hcp) {
-			// Remove the external private route if it exists
-			err := r.Client.Get(ctx, client.ObjectKeyFromObject(externalPrivateRoute), externalPrivateRoute)
-			if err != nil {
-				if !apierrors.IsNotFound(err) {
-					return fmt.Errorf("failed to check whether apiserver external private route exists: %w", err)
-				}
-			} else {
-				if err := r.Client.Delete(ctx, externalPrivateRoute); err != nil {
-					return fmt.Errorf("failed to delete apiserver external private route: %w", err)
-				}
+			if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, externalPrivateRoute); err != nil {
+				return err
 			}
-			// Reconcile the external public route
 			if _, err := createOrUpdate(ctx, r.Client, externalPublicRoute, func() error {
-				hostname := ""
-				if serviceStrategy.Route != nil {
-					hostname = serviceStrategy.Route.Hostname
-				}
 				return kas.ReconcileExternalPublicRoute(externalPublicRoute, p.OwnerReference, hostname)
 			}); err != nil {
 				return fmt.Errorf("failed to reconcile apiserver external public route %s: %w", externalPublicRoute.Name, err)
 			}
 		} else {
-			// Remove the external public route if it exists
-			err := r.Client.Get(ctx, client.ObjectKeyFromObject(externalPublicRoute), externalPublicRoute)
-			if err != nil {
-				if !apierrors.IsNotFound(err) {
-					return fmt.Errorf("failed to check whether apiserver external public route exists: %w", err)
+			if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, externalPublicRoute); err != nil {
+				return err
+			}
+			// Reconcile the external private route only when a hostname is configured.
+			// Private clusters without external DNS (no hostname) use only the internal route.
+			if hostname != "" {
+				if _, err := createOrUpdate(ctx, r.Client, externalPrivateRoute, func() error {
+					return kas.ReconcileExternalPrivateRoute(externalPrivateRoute, p.OwnerReference, hostname)
+				}); err != nil {
+					return fmt.Errorf("failed to reconcile apiserver external private route %s: %w", externalPrivateRoute.Name, err)
 				}
 			} else {
-				if err := r.Client.Delete(ctx, externalPublicRoute); err != nil {
-					return fmt.Errorf("failed to delete apiserver external public route: %w", err)
+				if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, externalPrivateRoute); err != nil {
+					return err
 				}
-			}
-			// Reconcile the external private route
-			if _, err := createOrUpdate(ctx, r.Client, externalPrivateRoute, func() error {
-				hostname := ""
-				if serviceStrategy.Route != nil {
-					hostname = serviceStrategy.Route.Hostname
-				}
-				return kas.ReconcileExternalPrivateRoute(externalPrivateRoute, p.OwnerReference, hostname)
-			}); err != nil {
-				return fmt.Errorf("failed to reconcile apiserver external private route %s: %w", externalPrivateRoute.Name, err)
 			}
 		}
 		// The private KAS route is always present as it is the default

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
@@ -147,6 +147,43 @@ func allServicesRouteWithHostnames() []hyperv1.ServicePublishingStrategyMapping 
 	}
 }
 
+// allServicesRouteNoKASHostname creates service publishing strategies with all services using Route type,
+// but without a hostname for APIServer (simulates Private cluster without external DNS).
+func allServicesRouteNoKASHostname() []hyperv1.ServicePublishingStrategyMapping {
+	return []hyperv1.ServicePublishingStrategyMapping{
+		{
+			Service: hyperv1.APIServer,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.Route,
+			},
+		},
+		{
+			Service: hyperv1.Konnectivity,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{
+					Hostname: testKonnectivityHost,
+				},
+			},
+		},
+		{
+			Service: hyperv1.OAuthServer,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{
+					Hostname: testOAuthHostname,
+				},
+			},
+		},
+		{
+			Service: hyperv1.Ignition,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.Route,
+			},
+		},
+	}
+}
+
 // kasServiceLoadBalancerOthersRoute creates service publishing strategies with LoadBalancer for APIServer
 // and Route for others (Konnectivity, OAuthServer, Ignition).
 func kasServiceLoadBalancerOthersRoute() []hyperv1.ServicePublishingStrategyMapping {
@@ -462,6 +499,14 @@ func TestReconcileInfrastructure(t *testing.T) {
 			},
 		},
 		// Azure self-managed test cases
+		{
+			name: "When Azure Private cluster has Route strategy without hostname, it should only need an internal router",
+			hcp: withServices(
+				withAzureTopology(baseAzureHCP(), hyperv1.AzureTopologyPrivate),
+				allServicesRouteNoKASHostname(),
+			),
+			expectError: false,
+		},
 		{
 			name: "When Azure self-managed cluster has KAS Route with hostname, it should need an external router",
 			hcp: withServices(
@@ -1355,6 +1400,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 		name                  string
 		endpointAccess        hyperv1.AWSEndpointAccessType
 		apiPublishingStrategy hyperv1.ServicePublishingStrategy
+		existingObjects       []client.Object
 
 		expectedServices []corev1.Service
 		expectedRoutes   []routev1.Route
@@ -1473,6 +1519,28 @@ func TestReconcileAPIServerService(t *testing.T) {
 				kasExternalPrivateRoute,
 			},
 		},
+		{
+			name:           "When Route strategy is private with no hostname, it should delete obsolete routes and create only internal route",
+			endpointAccess: hyperv1.Private,
+			apiPublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.Route,
+			},
+			existingObjects: []client.Object{
+				manifests.KubeAPIServerExternalPublicRoute(targetNamespace),
+				manifests.KubeAPIServerExternalPrivateRoute(targetNamespace),
+			},
+
+			expectedServices: []corev1.Service{
+				kasPublicService(func(s *corev1.Service) {
+					s.Spec.Type = corev1.ServiceTypeClusterIP
+					delete(s.Annotations, "external-dns.alpha.kubernetes.io/hostname")
+					delete(s.Annotations, "service.beta.kubernetes.io/aws-load-balancer-type")
+				}),
+			},
+			expectedRoutes: []routev1.Route{
+				kasInternalRoute,
+			},
+		},
 	}
 	for _, tc := range testsCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1503,7 +1571,11 @@ func TestReconcileAPIServerService(t *testing.T) {
 
 			ctx := context.Background()
 
-			fakeClient := fake.NewClientBuilder().WithScheme(api.Scheme).Build()
+			clientBuilder := fake.NewClientBuilder().WithScheme(api.Scheme)
+			if len(tc.existingObjects) > 0 {
+				clientBuilder = clientBuilder.WithObjects(tc.existingObjects...)
+			}
+			fakeClient := clientBuilder.Build()
 			r := NewReconciler(fakeClient, testIngressDomain)
 
 			if err := r.reconcileAPIServerService(ctx, hcp, controllerutil.CreateOrUpdate); err != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_When_Azure_Private_cluster_has_Route_strategy_without_hostname__it_should_only_need_an_internal_router.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_When_Azure_Private_cluster_has_Route_strategy_without_hostname__it_should_only_need_an_internal_router.yaml
@@ -1,0 +1,262 @@
+routes:
+  items:
+  - metadata:
+      annotations:
+        haproxy.router.openshift.io/balance: roundrobin
+      labels:
+        hypershift.openshift.io/hosted-control-plane: test-namespace
+        hypershift.openshift.io/internal-route: "true"
+      name: konnectivity-server
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      host: konnectivity-server.apps.test-cluster.hypershift.local
+      tls:
+        insecureEdgeTerminationPolicy: None
+        termination: passthrough
+      to:
+        kind: Service
+        name: konnectivity-server
+        weight: null
+    status: {}
+  - metadata:
+      labels:
+        hypershift.openshift.io/hosted-control-plane: test-namespace
+        hypershift.openshift.io/internal-route: "true"
+      name: kube-apiserver-internal
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      host: api.test-cluster.hypershift.local
+      tls:
+        insecureEdgeTerminationPolicy: None
+        termination: passthrough
+      to:
+        kind: Service
+        name: kube-apiserver
+        weight: null
+    status: {}
+  - metadata:
+      labels:
+        hypershift.openshift.io/hosted-control-plane: test-namespace
+        hypershift.openshift.io/internal-route: "true"
+      name: oauth-internal
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      host: oauth.apps.test-cluster.hypershift.local
+      tls:
+        insecureEdgeTerminationPolicy: None
+        termination: passthrough
+      to:
+        kind: Service
+        name: oauth-openshift
+        weight: null
+    status: {}
+  - metadata:
+      labels:
+        hypershift.openshift.io/hosted-control-plane: test-namespace
+        hypershift.openshift.io/internal-route: "true"
+        hypershift.openshift.io/route-visibility: private
+      name: oauth-private
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      host: oauth.test.example.com
+      tls:
+        insecureEdgeTerminationPolicy: None
+        termination: passthrough
+      to:
+        kind: Service
+        name: oauth-openshift
+        weight: null
+    status: {}
+  metadata: {}
+services:
+  items:
+  - metadata:
+      name: konnectivity-server
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      ports:
+      - port: 8091
+        protocol: TCP
+        targetPort: 8091
+      selector:
+        app: kube-apiserver
+        hypershift.openshift.io/control-plane-component: kube-apiserver
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - metadata:
+      labels:
+        app: kube-apiserver
+        hypershift.openshift.io/control-plane-component: kube-apiserver
+      name: kube-apiserver
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      ipFamilyPolicy: PreferDualStack
+      ports:
+      - port: 6443
+        protocol: TCP
+        targetPort: client
+      selector:
+        app: kube-apiserver
+        hypershift.openshift.io/control-plane-component: kube-apiserver
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - metadata:
+      name: oauth-openshift
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      ipFamilyPolicy: PreferDualStack
+      ports:
+      - port: 6443
+        protocol: TCP
+        targetPort: 6443
+      selector:
+        app: oauth-openshift
+        hypershift.openshift.io/control-plane-component: oauth-openshift
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - metadata:
+      labels:
+        app: openshift-apiserver
+        hypershift.openshift.io/control-plane-component: openshift-apiserver
+      name: openshift-apiserver
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      ports:
+      - name: https
+        port: 443
+        protocol: TCP
+        targetPort: 8443
+      selector:
+        app: openshift-apiserver
+        hypershift.openshift.io/control-plane-component: openshift-apiserver
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - metadata:
+      labels:
+        app: openshift-apiserver
+        hypershift.openshift.io/control-plane-component: openshift-apiserver
+      name: openshift-oauth-apiserver
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      ports:
+      - name: https
+        port: 443
+        protocol: TCP
+        targetPort: 8443
+      selector:
+        app: openshift-oauth-apiserver
+        hypershift.openshift.io/control-plane-component: openshift-oauth-apiserver
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - metadata:
+      labels:
+        app: openshift-apiserver
+        hypershift.openshift.io/control-plane-component: openshift-apiserver
+      name: packageserver
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      ports:
+      - name: https
+        port: 443
+        protocol: TCP
+        targetPort: 5443
+      selector:
+        app: packageserver
+        hypershift.openshift.io/control-plane-component: packageserver
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - metadata:
+      annotations:
+        service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+      labels:
+        app: private-router
+      name: private-router
+      namespace: test-namespace
+    spec:
+      ports:
+      - name: https
+        port: 443
+        protocol: TCP
+        targetPort: https
+      selector:
+        app: private-router
+      type: LoadBalancer
+    status:
+      loadBalancer: {}
+  metadata: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -177,7 +177,14 @@ func ReconcileServiceStatus(svc *corev1.Service, strategy *hyperv1.ServicePublis
 		if message, err := k8sutil.CollectLBMessageIfNotProvisioned(svc, messageCollector); err != nil || message != "" {
 			return host, port, message, err
 		}
-		host = strategy.Route.Hostname
+		switch {
+		case strategy.Route != nil && strategy.Route.Hostname != "":
+			host = strategy.Route.Hostname
+		case svc.Status.LoadBalancer.Ingress[0].Hostname != "":
+			host = svc.Status.LoadBalancer.Ingress[0].Hostname
+		case svc.Status.LoadBalancer.Ingress[0].IP != "":
+			host = svc.Status.LoadBalancer.Ingress[0].IP
+		}
 		port = 443
 	}
 	return

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
@@ -64,7 +64,7 @@ func (defaulter *hostedClusterDefaulter) Default(ctx context.Context, hcluster *
 
 		// Default services for any service types that were not configured
 		existingServices := map[hyperv1.ServiceType]bool{}
-		defaults := core.GetIngressServicePublishingStrategyMapping(hcluster.Spec.Networking.NetworkType, false)
+		defaults := core.GetIngressServicePublishingStrategyMapping(hcluster.Spec.Networking.NetworkType, false, false)
 		for _, entry := range hcluster.Spec.Services {
 			existingServices[entry.Service] = true
 		}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
@@ -496,7 +496,7 @@ func TestValidateKVNodePoolUpdate(t *testing.T) {
 // util function used to generate a service map that is different than the defaults
 func customKubeVirtServiceMap() []v1beta1.ServicePublishingStrategyMapping {
 	// use the defaults as a basis
-	defaults := core.GetIngressServicePublishingStrategyMapping(v1beta1.OVNKubernetes, false)
+	defaults := core.GetIngressServicePublishingStrategyMapping(v1beta1.OVNKubernetes, false, false)
 
 	custom := []v1beta1.ServicePublishingStrategyMapping{}
 	for _, cur := range defaults {
@@ -537,7 +537,7 @@ func TestKubevirtClusterServiceDefaulting(t *testing.T) {
 					},
 				},
 			},
-			expectedServices: core.GetIngressServicePublishingStrategyMapping(v1beta1.OVNKubernetes, false),
+			expectedServices: core.GetIngressServicePublishingStrategyMapping(v1beta1.OVNKubernetes, false, false),
 		},
 		{
 			name: "don't default when services already exist",

--- a/support/globalconfig/dns.go
+++ b/support/globalconfig/dns.go
@@ -19,11 +19,7 @@ func DNSConfig() *configv1.DNS {
 }
 
 func ReconcileDNSConfig(dns *configv1.DNS, hcp *hyperv1.HostedControlPlane) {
-	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
-		dns.Spec.BaseDomain = hcp.Spec.DNS.BaseDomain
-	} else {
-		dns.Spec.BaseDomain = BaseDomain(hcp)
-	}
+	dns.Spec.BaseDomain = BaseDomain(hcp)
 	if len(hcp.Spec.DNS.PublicZoneID) > 0 {
 		dns.Spec.PublicZone = &configv1.DNSZone{
 			ID: hcp.Spec.DNS.PublicZoneID,
@@ -34,10 +30,20 @@ func ReconcileDNSConfig(dns *configv1.DNS, hcp *hyperv1.HostedControlPlane) {
 			ID: hcp.Spec.DNS.PrivateZoneID,
 		}
 	}
-	if hcp.Spec.Platform.AWS != nil && hcp.Spec.Platform.AWS.SharedVPC != nil {
-		dns.Spec.Platform.Type = configv1.AWSPlatformType
-		dns.Spec.Platform.AWS = &configv1.AWSDNSSpec{
-			PrivateZoneIAMRole: hcp.Spec.Platform.AWS.SharedVPC.RolesRef.IngressARN,
+	applyPlatformDNSConfig(dns, hcp)
+}
+
+// applyPlatformDNSConfig applies platform-specific DNS configuration overrides.
+func applyPlatformDNSConfig(dns *configv1.DNS, hcp *hyperv1.HostedControlPlane) {
+	switch hcp.Spec.Platform.Type {
+	case hyperv1.IBMCloudPlatform:
+		dns.Spec.BaseDomain = hcp.Spec.DNS.BaseDomain
+	case hyperv1.AWSPlatform:
+		if hcp.Spec.Platform.AWS != nil && hcp.Spec.Platform.AWS.SharedVPC != nil {
+			dns.Spec.Platform.Type = configv1.AWSPlatformType
+			dns.Spec.Platform.AWS = &configv1.AWSDNSSpec{
+				PrivateZoneIAMRole: hcp.Spec.Platform.AWS.SharedVPC.RolesRef.IngressARN,
+			}
 		}
 	}
 }

--- a/support/globalconfig/dns_test.go
+++ b/support/globalconfig/dns_test.go
@@ -126,6 +126,88 @@ func TestReconcileDNSConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:           "When Azure platform topology is Private, it should include both zones",
+			inputDNSConfig: DNSConfig(),
+			inputHCP: &hyperv1.HostedControlPlane{
+				ObjectMeta: v1.ObjectMeta{
+					Name: fakeHCPName,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					DNS: hyperv1.DNSSpec{
+						BaseDomain:    fakeBaseDomain,
+						PublicZoneID:  fakePublicZoneID,
+						PrivateZoneID: fakePrivateZoneID,
+					},
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							Topology: hyperv1.AzureTopologyPrivate,
+						},
+					},
+				},
+			},
+			expectedDNSConfig: &configv1.DNS{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: configv1.DNSSpec{
+					BaseDomain: fmt.Sprintf("%s.%s", fakeHCPName, fakeBaseDomain),
+					PublicZone: &configv1.DNSZone{
+						ID: fakePublicZoneID,
+					},
+					PrivateZone: &configv1.DNSZone{
+						ID: fakePrivateZoneID,
+					},
+				},
+			},
+		},
+		{
+			name:           "When AWS SharedVPC is configured, it should set PrivateZoneIAMRole",
+			inputDNSConfig: DNSConfig(),
+			inputHCP: &hyperv1.HostedControlPlane{
+				ObjectMeta: v1.ObjectMeta{
+					Name: fakeHCPName,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					DNS: hyperv1.DNSSpec{
+						BaseDomain:    fakeBaseDomain,
+						PublicZoneID:  fakePublicZoneID,
+						PrivateZoneID: fakePrivateZoneID,
+					},
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							SharedVPC: &hyperv1.AWSSharedVPC{
+								RolesRef: hyperv1.AWSSharedVPCRolesRef{
+									IngressARN: "arn:aws:iam::123456789012:role/ingress-role",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDNSConfig: &configv1.DNS{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: configv1.DNSSpec{
+					BaseDomain: fmt.Sprintf("%s.%s", fakeHCPName, fakeBaseDomain),
+					PublicZone: &configv1.DNSZone{
+						ID: fakePublicZoneID,
+					},
+					PrivateZone: &configv1.DNSZone{
+						ID: fakePrivateZoneID,
+					},
+					Platform: configv1.DNSPlatformSpec{
+						Type: configv1.AWSPlatformType,
+						AWS: &configv1.AWSDNSSpec{
+							PrivateZoneIAMRole: "arn:aws:iam::123456789012:role/ingress-role",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testsCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What this PR does / why we need it:

Azure Private clusters created without `--external-dns-domain` fail to complete. Several issues compound to prevent the hosted cluster from reaching `Completed`:

1. **`PublicZoneID` leaks into guest DNS config**: The ingress operator tries to manage records in a public DNS zone it has no access to, causing `AuthorizationFailed` errors.

2. **KAS defaults to `NodePort` instead of `Route`**: Without external DNS, the CLI doesn't set `--api-server-address`, so `servicePublishingStrategy` defaults to `NodePort` for KAS. Azure Private clusters need `Route` since there are no public load balancers.

3. **CPO fails reconciling external KAS route**: When the cluster is Private with Route strategy but no external DNS hostname, `reconcileExternalRoute` requires a non-empty hostname and errors out.

4. **Private DNS zone name mismatch**: `create infra azure` creates the private DNS zone as `<name>-azurecluster.<baseDomain>`. The ingress operator's `getARecordName` strips the zone suffix from the FQDN to produce a relative record name — but when the zone name doesn't match the cluster domain (due to `-azurecluster`), stripping is a no-op and the full FQDN becomes the record name. Azure then double-suffixes it, producing an unresolvable DNS entry.

### Fixes

- **CLI guard**: Omit `PublicZoneID` for Private clusters; default KAS to `Route` when Private and no `--api-server-address` is set.
- **GlobalConfig defense-in-depth**: Refactor `ReconcileDNSConfig` to extract platform DNS overrides into `applyPlatformDNSConfig`. For Azure Private topology, clear the public zone even if set on the HCP spec.
- **CPO route handling**: Skip external KAS route when Private with no hostname (matches existing Konnectivity pattern). Clean up stale external route if it exists.
- **DNS zone naming**: Change infra CLI zone name from `<name>-azurecluster.<baseDomain>` to `<name>.<baseDomain>` so the zone matches the cluster domain. Update destroy path to match both current and legacy zone name patterns.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/OCPBUGS-100054

## Special notes for your reviewer:

**Validated end-to-end**: Created a Private Azure self-managed cluster without `--external-dns-domain`. HC completed at `5.0.0-ec.5` with all cluster operators available and zero unhealthy pods — no manual DNS intervention required.

**DNS zone naming context**: The `-azurecluster` suffix was originally added to avoid shadowing `*.apps` when the PLS controller creates a baseDomain zone with only `api`/`oauth` records (see PR #8480). That concern doesn't apply here because the ingress operator populates the `*.apps` wildcard in the infra-created zone, so there's no shadowing. The old `-azurecluster` zone is vestigial — CAPZ marks AzureCluster as externally managed and never uses it.

**Backward compatibility**: `PrivateZoneID` is immutable on the HC API (CEL rule: `oldSelf == "" || self == oldSelf`), so existing clusters keep their `-azurecluster` zone. Only new clusters get the fixed zone name. The destroy path handles both patterns.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.