### PR TITLE
CNTRLPLANE-3921: fix(globalps): eliminate EnsureGlobalPullSecret e2e flake

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
@@ -16,6 +16,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -176,11 +177,27 @@ func (r *Reconciler) reconcileGlobalPullSecret(ctx context.Context) error {
 }
 
 func reconcileDaemonSet(ctx context.Context, daemonSet *appsv1.DaemonSet, globalPullSecretName string, originalPullSecretName string, configSeed string, c crclient.Client, createOrUpdate upsert.CreateOrUpdateFN, hccoImage string) error {
+	existing := &appsv1.DaemonSet{}
+	if err := c.Get(ctx, crclient.ObjectKeyFromObject(daemonSet), existing); err == nil {
+		if existing.Spec.Template.Labels[configSeedLabelKey] == configSeed {
+			expectedVolumes := len(buildGlobalPSVolumes(globalPullSecretName, originalPullSecretName))
+			if len(existing.Spec.Template.Spec.Volumes) == expectedVolumes {
+				return nil
+			}
+		}
+	}
+
 	if _, err := createOrUpdate(ctx, c, daemonSet, func() error {
 		daemonSet.Spec = appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"name": manifests.GlobalPullSecretDSName,
+				},
+			},
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: ptr.To(intstr.FromString("33%")),
 				},
 			},
 			Template: corev1.PodTemplateSpec{
@@ -220,6 +237,19 @@ func reconcileDaemonSet(ctx context.Context, daemonSet *appsv1.DaemonSet, global
 								// These operations cannot be performed with specific capabilities due to
 								// the combination of file system access and systemd service management.
 								Privileged: ptr.To(true),
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"/bin/sh", "-c",
+											"test -s /var/lib/kubelet/config.json",
+										},
+									},
+								},
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       10,
+								FailureThreshold:    3,
 							},
 							VolumeMounts:             buildGlobalPSVolumeMounts(globalPullSecretName),
 							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps_test.go
@@ -19,6 +19,7 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 var (
@@ -102,6 +103,12 @@ func TestReconcileGlobalPullSecret(t *testing.T) {
 					}
 				}
 				g.Expect(hasGlobalSecret).To(BeFalse(), "DaemonSet should not have global-pull-secret volume when additional secret doesn't exist")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil(), "DaemonSet should have a readiness probe")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec).NotTo(BeNil())
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command).To(ContainElement("test -s /var/lib/kubelet/config.json"))
+				g.Expect(ds.Spec.UpdateStrategy.Type).To(Equal(appsv1.RollingUpdateDaemonSetStrategyType))
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate).NotTo(BeNil())
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.String()).To(Equal("33%"))
 			},
 			validateOriginalSecret: func(t *testing.T, secret *corev1.Secret) {
 				g := NewWithT(t)
@@ -176,6 +183,12 @@ func TestReconcileGlobalPullSecret(t *testing.T) {
 					}
 				}
 				g.Expect(hasGlobalSecret).To(BeTrue(), "DaemonSet should have global-pull-secret volume when additional secret exists")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil(), "DaemonSet should have a readiness probe")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec).NotTo(BeNil())
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command).To(ContainElement("test -s /var/lib/kubelet/config.json"))
+				g.Expect(ds.Spec.UpdateStrategy.Type).To(Equal(appsv1.RollingUpdateDaemonSetStrategyType))
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate).NotTo(BeNil())
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.String()).To(Equal("33%"))
 			},
 			validateGlobalSecret: func(t *testing.T, secret *corev1.Secret) {
 				g := NewWithT(t)
@@ -337,6 +350,12 @@ func TestReconcileGlobalPullSecret(t *testing.T) {
 			validateDaemonSet: func(t *testing.T, ds *appsv1.DaemonSet) {
 				g := NewWithT(t)
 				g.Expect(ds.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue(globalPSLabelKey, "true"))
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil(), "DaemonSet should have a readiness probe")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec).NotTo(BeNil())
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command).To(ContainElement("test -s /var/lib/kubelet/config.json"))
+				g.Expect(ds.Spec.UpdateStrategy.Type).To(Equal(appsv1.RollingUpdateDaemonSetStrategyType))
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate).NotTo(BeNil())
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.String()).To(Equal("33%"))
 			},
 		},
 	}
@@ -492,6 +511,48 @@ func TestValidateAdditionalPullSecret(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcileDaemonSetIdempotency(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	configSeed := "test-hash-abc123"
+	globalPullSecretName := "global-pull-secret"
+	originalPullSecretName := "original-pull-secret"
+	hccoImage := "test-image:latest"
+
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "global-pull-secret-syncer",
+			Namespace: "kube-system",
+		},
+	}
+
+	callCount := 0
+	trackingCreateOrUpdate := func(ctx context.Context, cl client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+		callCount++
+		return upsert.New(false).CreateOrUpdate(ctx, cl, obj, f)
+	}
+
+	err := reconcileDaemonSet(context.Background(), ds, globalPullSecretName, originalPullSecretName, configSeed, fakeClient, trackingCreateOrUpdate, hccoImage)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(callCount).To(Equal(1), "First reconcile should call createOrUpdate")
+
+	callCount = 0
+	ds2 := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "global-pull-secret-syncer",
+			Namespace: "kube-system",
+		},
+	}
+	err = reconcileDaemonSet(context.Background(), ds2, globalPullSecretName, originalPullSecretName, configSeed, fakeClient, trackingCreateOrUpdate, hccoImage)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(callCount).To(Equal(0), "Second reconcile with same configSeed should be a no-op")
 }
 
 func TestMergePullSecrets(t *testing.T) {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup.go
@@ -108,7 +108,15 @@ func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig
 }
 
 func kubeSystemSecretPredicateFunc(o crclient.Object) bool {
-	return o.GetNamespace() == "kube-system"
+	if o.GetNamespace() != "kube-system" {
+		return false
+	}
+	switch o.GetName() {
+	case "additional-pull-secret", "original-pull-secret", "global-pull-secret":
+		return true
+	default:
+		return false
+	}
 }
 
 func namespacedNamePredicateFunc(namespace, name string) func(crclient.Object) bool {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup_test.go
@@ -17,14 +17,35 @@ func Test_kubeSystemSecretPredicateFunc(t *testing.T) {
 		want   bool
 	}{
 		{
-			name: "When secret is in kube-system it should return true",
+			name: "When secret is additional-pull-secret in kube-system, it should return true",
 			object: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "any-secret"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "additional-pull-secret"},
 			},
 			want: true,
 		},
 		{
-			name: "When secret is in a different namespace it should return false",
+			name: "When secret is original-pull-secret in kube-system, it should return true",
+			object: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "original-pull-secret"},
+			},
+			want: true,
+		},
+		{
+			name: "When secret is global-pull-secret in kube-system, it should return true",
+			object: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "global-pull-secret"},
+			},
+			want: true,
+		},
+		{
+			name: "When secret is an unrelated secret in kube-system, it should return false",
+			object: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "some-serviceaccount-token"},
+			},
+			want: false,
+		},
+		{
+			name: "When secret is in a different namespace, it should return false",
 			object: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-config", Name: "pull-secret"},
 			},


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes the `EnsureGlobalPullSecret` e2e test flake by addressing four root causes identified through analysis of 5 failing and 2 passing Prow runs:

1. **Narrow kube-system secret predicate** — The watcher previously matched ALL secrets in `kube-system`, causing reconcile storms from unrelated secret churn (SA tokens, etc.). Now only watches the 3 relevant secrets: `additional-pull-secret`, `original-pull-secret`, `global-pull-secret`.

2. **Idempotent reconcileDaemonSet** — `reconcileDaemonSet` previously overwrote the full DaemonSet spec on every reconcile, bumping `.metadata.generation` and triggering unnecessary rolling updates. Now short-circuits when the existing DaemonSet already has the correct `configSeed` label and expected volume count.

3. **Readiness probe on syncer container** — The syncer container had no readiness probe, so the DaemonSet rollout controller considered pods "ready" before they actually wrote `/var/lib/kubelet/config.json`. Added an exec probe (`test -s /var/lib/kubelet/config.json`) so rollout waits for actual file write completion.

4. **maxUnavailable 33% UpdateStrategy** — The default `maxUnavailable: 1` caused serial pod-by-pod rollouts that took too long on multi-node clusters. Set to `33%` for faster parallel rollout.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3921](https://redhat.atlassian.net/browse/CNTRLPLANE-3921)

## Special notes for your reviewer:

The flake was binary (all-or-nothing across a run) and timing-dependent. Passing runs showed the same stuck DaemonSet pattern but recovered within the test timeout. The fix targets all four contributing factors rather than just one, since they compound.

Key investigation finding: the self-triggering reconcile loop (delete `global-pull-secret` → triggers kube-system watcher → re-reconcile → full spec overwrite → generation bump → rolling update) was the primary amplifier, and the broad predicate was the primary trigger of spurious reconciles.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Global Pull Secret rollout behavior by applying rolling updates with up to 33% of pods unavailable.
  * Added readiness checks to confirm the node configuration is present and non-empty.
  * Prevented unnecessary DaemonSet updates when configuration is unchanged.
  * Limited pull-secret reconciliation to the supported secrets in the `kube-system` namespace.
* **Tests**
  * Expanded coverage for readiness checks, rollout settings, idempotent reconciliation, and secret filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->