### PR TITLE
fix(OCPBUGS-54987): Enable platform metrics for IBMCloud

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/configoperator/podmonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/configoperator/podmonitor.go
@@ -1,6 +1,7 @@
 package configoperator
 
 import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/util"
@@ -12,6 +13,14 @@ func adaptPodMonitor(cpContext component.WorkloadContext, podMonitor *prometheus
 	podMonitor.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{MatchNames: []string{cpContext.HCP.Namespace}}
 	podMonitor.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs = metrics.HostedClusterConfigOperatorRelabelConfigs(cpContext.MetricsSet)
 	util.ApplyClusterIDLabelToPodMonitor(&podMonitor.Spec.PodMetricsEndpoints[0], cpContext.HCP.Spec.ClusterID)
+
+	// IBMCloudPlatform
+	if cpContext.HCP.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
+		if podMonitor.Annotations == nil {
+			podMonitor.Annotations = map[string]string{}
+		}
+		podMonitor.Annotations["hypershift.openshift.io/metrics-service"] = "roks-metrics"
+	}
 
 	return nil
 }

--- a/support/globalconfig/infrastructure.go
+++ b/support/globalconfig/infrastructure.go
@@ -88,6 +88,10 @@ func ReconcileInfrastructure(infra *configv1.Infrastructure, hcp *hyperv1.Hosted
 		}
 		infra.Status.PlatformStatus.Azure.CloudName = cloudName
 		infra.Status.PlatformStatus.Azure.ResourceGroupName = hcp.Spec.Platform.Azure.ResourceGroupName
+	case hyperv1.IBMCloudPlatform:
+		infra.Status.PlatformStatus.IBMCloud = &configv1.IBMCloudPlatformStatus{
+			ProviderType: hcp.Spec.Platform.IBMCloud.ProviderType,
+		}
 	case hyperv1.PowerVSPlatform:
 		infra.Status.PlatformStatus.PowerVS = &configv1.PowerVSPlatformStatus{
 			Region:         hcp.Spec.Platform.PowerVS.Region,


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
IBMCloud infrastructure metrics are currently not generated. This change enables the generation of the metrics and for the config-operator, it overwrites the metrics-service default to be "roks-metrics" as was reported in the toolkit for IBMCloud.

## Which issue(s) this PR fixes:
Fixes#OCPBUGS-54987

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IBM Cloud platform support for infrastructure status reporting.
  * Configured hosted control plane monitoring to integrate with the IBM Cloud metrics service.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->