### PR TITLE
OCPBUGS-99638: fix(certs): support non-RSA private keys in PemToPrivateKey

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -5273,7 +5273,7 @@ func (r *HostedClusterReconciler) serviceAccountSigningKeyBytes(ctx context.Cont
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot decode private key in secret %s: %w", signingKeySecret.Name, err)
 	}
-	publicKeyPEMBytes, err := certs.PublicKeyToPem(&privateKey.PublicKey)
+	publicKeyPEMBytes, err := certs.PublicKeyToPem(privateKey.Public())
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot serialize public key from private key %s: %w", signingKeySecret.Name, err)
 	}

--- a/support/certs/tls.go
+++ b/support/certs/tls.go
@@ -2,6 +2,7 @@ package certs
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/md5"
 	"crypto/rand"
 	"crypto/rsa"
@@ -20,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/util/keyutil"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -86,7 +88,7 @@ func GenerateSelfSignedCertificate(cfg *CertCfg) (*rsa.PrivateKey, *x509.Certifi
 }
 
 // GenerateSignedCertificate generate a key and cert defined by CertCfg and signed by CA.
-func GenerateSignedCertificate(caKey *rsa.PrivateKey, caCert *x509.Certificate,
+func GenerateSignedCertificate(caKey crypto.Signer, caCert *x509.Certificate,
 	cfg *CertCfg) (*rsa.PrivateKey, *x509.Certificate, error) {
 
 	// create a private key
@@ -166,7 +168,7 @@ func signedCertificate(
 	csr *x509.CertificateRequest,
 	key *rsa.PrivateKey,
 	caCert *x509.Certificate,
-	caKey *rsa.PrivateKey,
+	caKey crypto.Signer,
 ) (*x509.Certificate, error) {
 	serial, err := rand.Int(Reader(), new(big.Int).SetInt64(math.MaxInt64))
 	if err != nil {
@@ -231,28 +233,33 @@ func CertToPem(cert *x509.Certificate) []byte {
 	return certInPem
 }
 
-// PublicKeyToPem converts a rsa.PublicKey object to pem string
-func PublicKeyToPem(key *rsa.PublicKey) ([]byte, error) {
+// PublicKeyToPem converts a crypto.PublicKey to a PEM-encoded PKIX public key.
+func PublicKeyToPem(key crypto.PublicKey) ([]byte, error) {
 	keyInBytes, err := x509.MarshalPKIXPublicKey(key)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to MarshalPKIXPublicKey")
 	}
 	keyinPem := pem.EncodeToMemory(
 		&pem.Block{
-			Type:  "RSA PUBLIC KEY",
+			Type:  "PUBLIC KEY",
 			Bytes: keyInBytes,
 		},
 	)
 	return keyinPem, nil
 }
 
-// PemToPrivateKey converts a data block to rsa.PrivateKey.
-func PemToPrivateKey(data []byte) (*rsa.PrivateKey, error) {
-	block, _ := pem.Decode(data)
-	if block == nil {
-		return nil, errors.Errorf("could not find a PEM block in the private key")
+// PemToPrivateKey parses a PEM-encoded private key. Supports RSA (PKCS#1),
+// ECDSA (SEC 1), and PKCS#8 encoded keys.
+func PemToPrivateKey(data []byte) (crypto.Signer, error) {
+	key, err := keyutil.ParsePrivateKeyPEM(data)
+	if err != nil {
+		return nil, err
 	}
-	return x509.ParsePKCS1PrivateKey(block.Bytes)
+	signer, ok := key.(crypto.Signer)
+	if !ok {
+		return nil, fmt.Errorf("parsed key type %T does not implement crypto.Signer", key)
+	}
+	return signer, nil
 }
 
 // PemToCertificate converts a data block to x509.Certificate.
@@ -268,7 +275,7 @@ func Base64(data []byte) string {
 	return base64.StdEncoding.EncodeToString(data)
 }
 
-func parsePemKeypair(key, certificate []byte) (*rsa.PrivateKey, *x509.Certificate, error) {
+func parsePemKeypair(key, certificate []byte) (crypto.Signer, *x509.Certificate, error) {
 	privKey, err := PemToPrivateKey(key)
 	if err != nil {
 		return nil, nil, err
@@ -277,13 +284,16 @@ func parsePemKeypair(key, certificate []byte) (*rsa.PrivateKey, *x509.Certificat
 	if err != nil {
 		return nil, nil, err
 	}
-	rsaPublicKey, ok := cert.PublicKey.(*rsa.PublicKey)
-	if !ok {
-		return nil, nil, fmt.Errorf("certificate does not have a RSA public key but a %T, not supported", cert.PublicKey)
-	}
 
-	// https://cs.opensource.google/go/go/+/refs/tags/go1.17.5:src/crypto/tls/tls.go;drc=860704317e02d699e4e4a24103853c4782d746c1;l=310
-	if rsaPublicKey.N.Cmp(privKey.N) != 0 {
+	pubFromKey, err := x509.MarshalPKIXPublicKey(privKey.Public())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal public key from private key: %w", err)
+	}
+	pubFromCert, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal public key from certificate: %w", err)
+	}
+	if !bytes.Equal(pubFromKey, pubFromCert) {
 		return nil, nil, errors.New("private key does not match certificate")
 	}
 
@@ -512,7 +522,7 @@ func annotateWithCA(secret, ca *corev1.Secret, opts *CAOpts) {
 	secret.Annotations[CAHashAnnotation] = computeCAHash(ca, opts)
 }
 
-func decodeCA(ca *corev1.Secret, opts *CAOpts) (*x509.Certificate, *rsa.PrivateKey, error) {
+func decodeCA(ca *corev1.Secret, opts *CAOpts) (*x509.Certificate, crypto.Signer, error) {
 	crt, err := PemToCertificate(ca.Data[opts.CASignerCertMapKey])
 	if err != nil {
 		return nil, nil, err

--- a/support/certs/tls_test.go
+++ b/support/certs/tls_test.go
@@ -2,8 +2,14 @@ package certs_test
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net"
 	"reflect"
 	"strconv"
@@ -223,6 +229,294 @@ func TestReconcileSignedCertWithCustomCAKeys(t *testing.T) {
 	if diff := cmp.Diff(expectedKeys, actualKeys); diff != "" {
 		t.Errorf("unexpected keys in cert secret: %s", diff)
 
+	}
+}
+
+func TestPemToPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+	ecP256Key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate P-256 key: %v", err)
+	}
+	ecP384Key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate P-384 key: %v", err)
+	}
+
+	rsaPKCS1PEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(rsaKey),
+	})
+	ecP256DER, err := x509.MarshalECPrivateKey(ecP256Key)
+	if err != nil {
+		t.Fatalf("failed to marshal P-256 key: %v", err)
+	}
+	ecP256PEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: ecP256DER,
+	})
+	ecP384DER, err := x509.MarshalECPrivateKey(ecP384Key)
+	if err != nil {
+		t.Fatalf("failed to marshal P-384 key: %v", err)
+	}
+	ecP384PEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: ecP384DER,
+	})
+	rsaPKCS8DER, err := x509.MarshalPKCS8PrivateKey(rsaKey)
+	if err != nil {
+		t.Fatalf("failed to marshal RSA PKCS#8 key: %v", err)
+	}
+	rsaPKCS8PEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: rsaPKCS8DER,
+	})
+	ecPKCS8DER, err := x509.MarshalPKCS8PrivateKey(ecP256Key)
+	if err != nil {
+		t.Fatalf("failed to marshal EC PKCS#8 key: %v", err)
+	}
+	ecPKCS8PEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: ecPKCS8DER,
+	})
+
+	ecParamsPreamble := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PARAMETERS",
+		Bytes: []byte{0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07},
+	})
+	ecWithParamsPEM := append(ecParamsPreamble, ecP256PEM...)
+
+	testCases := []struct {
+		name    string
+		pem     []byte
+		wantErr bool
+	}{
+		{
+			name: "When parsing an RSA PKCS#1 key, it should return a signer",
+			pem:  rsaPKCS1PEM,
+		},
+		{
+			name: "When parsing an ECDSA P-256 SEC 1 key, it should return a signer",
+			pem:  ecP256PEM,
+		},
+		{
+			name: "When parsing an ECDSA P-384 SEC 1 key, it should return a signer",
+			pem:  ecP384PEM,
+		},
+		{
+			name: "When parsing an RSA PKCS#8 key, it should return a signer",
+			pem:  rsaPKCS8PEM,
+		},
+		{
+			name: "When parsing an ECDSA PKCS#8 key, it should return a signer",
+			pem:  ecPKCS8PEM,
+		},
+		{
+			name: "When parsing PEM with EC PARAMETERS preamble, it should return a signer",
+			pem:  ecWithParamsPEM,
+		},
+		{
+			name:    "When parsing invalid PEM, it should return an error",
+			pem:     []byte("not a PEM block"),
+			wantErr: true,
+		},
+		{
+			name: "When parsing a certificate PEM, it should return an error",
+			pem: pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: []byte{0x30},
+			}),
+			wantErr: true,
+		},
+		{
+			name:    "When parsing empty input, it should return an error",
+			pem:     []byte{},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			signer, err := certs.PemToPrivateKey(tc.pem)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if signer == nil {
+				t.Fatal("expected non-nil signer")
+			}
+			if signer.Public() == nil {
+				t.Fatal("signer.Public() returned nil")
+			}
+		})
+	}
+}
+
+func TestPemToPrivateKeyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+	rsaPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(rsaKey),
+	})
+
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ECDSA key: %v", err)
+	}
+	ecDER, err := x509.MarshalECPrivateKey(ecKey)
+	if err != nil {
+		t.Fatalf("failed to marshal EC key: %v", err)
+	}
+	ecPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: ecDER,
+	})
+
+	testCases := []struct {
+		name        string
+		pem         []byte
+		originalPub interface{}
+	}{
+		{
+			name:        "When round-tripping an RSA key, it should preserve the public key",
+			pem:         rsaPEM,
+			originalPub: &rsaKey.PublicKey,
+		},
+		{
+			name:        "When round-tripping an ECDSA key, it should preserve the public key",
+			pem:         ecPEM,
+			originalPub: &ecKey.PublicKey,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			signer, err := certs.PemToPrivateKey(tc.pem)
+			if err != nil {
+				t.Fatalf("PemToPrivateKey failed: %v", err)
+			}
+
+			originalBytes, err := x509.MarshalPKIXPublicKey(tc.originalPub)
+			if err != nil {
+				t.Fatalf("failed to marshal original public key: %v", err)
+			}
+			parsedBytes, err := x509.MarshalPKIXPublicKey(signer.Public())
+			if err != nil {
+				t.Fatalf("failed to marshal parsed public key: %v", err)
+			}
+			if !bytes.Equal(originalBytes, parsedBytes) {
+				t.Error("parsed key's public key does not match original")
+			}
+		})
+	}
+}
+
+func TestECDSACASignsCertificate(t *testing.T) {
+	t.Parallel()
+
+	ecCAKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ECDSA CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "ecdsa-ca", OrganizationalUnit: []string{"test"}},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(certs.ValidityOneYear),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &ecCAKey.PublicKey, ecCAKey)
+	if err != nil {
+		t.Fatalf("failed to create ECDSA CA cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caCertDER)
+	if err != nil {
+		t.Fatalf("failed to parse ECDSA CA cert: %v", err)
+	}
+
+	leafCfg := &certs.CertCfg{
+		Subject:      pkix.Name{CommonName: "leaf"},
+		KeyUsages:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		Validity:     certs.ValidityOneDay,
+		DNSNames:     []string{"leaf.example.com"},
+	}
+	leafKey, leafCert, err := certs.GenerateSignedCertificate(ecCAKey, caCert, leafCfg)
+	if err != nil {
+		t.Fatalf("GenerateSignedCertificate with ECDSA CA failed: %v", err)
+	}
+
+	if leafKey == nil || leafCert == nil {
+		t.Fatal("expected non-nil leaf key and cert")
+	}
+
+	roots := x509.NewCertPool()
+	roots.AddCert(caCert)
+	if _, err := leafCert.Verify(x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		t.Fatalf("leaf cert does not verify against ECDSA CA: %v", err)
+	}
+}
+
+func TestPublicKeyToPemAcceptsAllKeyTypes(t *testing.T) {
+	t.Parallel()
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ECDSA key: %v", err)
+	}
+
+	testCases := []struct {
+		name string
+		pub  interface{}
+	}{
+		{
+			name: "When encoding an RSA public key, it should produce valid PEM",
+			pub:  &rsaKey.PublicKey,
+		},
+		{
+			name: "When encoding an ECDSA public key, it should produce valid PEM",
+			pub:  &ecKey.PublicKey,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pemBytes, err := certs.PublicKeyToPem(tc.pub)
+			if err != nil {
+				t.Fatalf("PublicKeyToPem failed: %v", err)
+			}
+			block, _ := pem.Decode(pemBytes)
+			if block == nil {
+				t.Fatal("PublicKeyToPem produced invalid PEM")
+			}
+			if block.Type != "PUBLIC KEY" {
+				t.Errorf("expected PEM type 'PUBLIC KEY', got %q", block.Type)
+			}
+		})
 	}
 }
 

--- a/support/oidc/oidc.go
+++ b/support/oidc/oidc.go
@@ -3,6 +3,8 @@ package oidc
 import (
 	"bytes"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
@@ -26,20 +28,49 @@ type KeyResponse struct {
 
 type OIDCDocumentGeneratorFunc func(params OIDCGeneratorParams) (io.ReadSeeker, error)
 
-func GenerateJWKSDocument(params OIDCGeneratorParams) (io.ReadSeeker, error) {
-	block, _ := pem.Decode(params.PubKey)
-	if block == nil || block.Type != "RSA PUBLIC KEY" {
-		return nil, fmt.Errorf("failed to decode PEM block containing RSA public key")
+func algorithmFromPublicKey(pub crypto.PublicKey) (jose.SignatureAlgorithm, error) {
+	switch pk := pub.(type) {
+	case *rsa.PublicKey:
+		return jose.RS256, nil
+	case *ecdsa.PublicKey:
+		switch pk.Curve {
+		case elliptic.P256():
+			return jose.ES256, nil
+		case elliptic.P384():
+			return jose.ES384, nil
+		case elliptic.P521():
+			return jose.ES512, nil
+		default:
+			return "", fmt.Errorf("unsupported ECDSA curve %v", pk.Curve.Params().Name)
+		}
+	default:
+		return "", fmt.Errorf("unsupported key type %T", pub)
+	}
+}
+
+func parsePublicKeyAndAlgorithm(pemBytes []byte) (crypto.PublicKey, jose.SignatureAlgorithm, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, "", fmt.Errorf("failed to decode PEM block containing public key")
 	}
 	pubKey, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse public key: %w", err)
+		return nil, "", fmt.Errorf("failed to parse public key: %w", err)
 	}
-	rsaPubKey, ok := pubKey.(*rsa.PublicKey)
-	if !ok {
-		return nil, fmt.Errorf("public key is not RSA")
+	alg, err := algorithmFromPublicKey(pubKey)
+	if err != nil {
+		return nil, "", err
+	}
+	return pubKey, alg, nil
+}
+
+func GenerateJWKSDocument(params OIDCGeneratorParams) (io.ReadSeeker, error) {
+	pubKey, alg, err := parsePublicKeyAndAlgorithm(params.PubKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine signing algorithm: %w", err)
 	}
 
+	block, _ := pem.Decode(params.PubKey)
 	hasher := crypto.SHA256.New()
 	hasher.Write(block.Bytes)
 	hash := hasher.Sum(nil)
@@ -47,9 +78,9 @@ func GenerateJWKSDocument(params OIDCGeneratorParams) (io.ReadSeeker, error) {
 
 	var keys []jose.JSONWebKey
 	keys = append(keys, jose.JSONWebKey{
-		Key:       rsaPubKey,
+		Key:       pubKey,
 		KeyID:     kid,
-		Algorithm: string(jose.RS256),
+		Algorithm: string(alg),
 		Use:       "sig",
 	})
 
@@ -73,11 +104,19 @@ const (
 		"public"
 	],
 	"id_token_signing_alg_values_supported": [
-		"RS256"
+		"%s"
 	]
 }`
 )
 
 func GenerateConfigurationDocument(params OIDCGeneratorParams) (io.ReadSeeker, error) {
-	return strings.NewReader(fmt.Sprintf(discoveryTemplate, params.IssuerURL, params.IssuerURL, JWKSURI)), nil
+	alg := "RS256"
+	if len(params.PubKey) > 0 {
+		_, detectedAlg, err := parsePublicKeyAndAlgorithm(params.PubKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine signing algorithm: %w", err)
+		}
+		alg = string(detectedAlg)
+	}
+	return strings.NewReader(fmt.Sprintf(discoveryTemplate, params.IssuerURL, params.IssuerURL, JWKSURI, alg)), nil
 }

--- a/support/oidc/oidc_test.go
+++ b/support/oidc/oidc_test.go
@@ -1,0 +1,314 @@
+package oidc
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"testing"
+
+	"github.com/go-jose/go-jose/v3"
+)
+
+func pemEncodePublicKey(t *testing.T, pub interface{}, blockType string) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("failed to marshal public key: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der})
+}
+
+func TestAlgorithmFromPublicKey(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name    string
+		keyFunc func(t *testing.T) interface{}
+		wantAlg jose.SignatureAlgorithm
+		wantErr bool
+	}{
+		{
+			name: "When given an RSA key, it should return RS256",
+			keyFunc: func(t *testing.T) interface{} {
+				key, err := rsa.GenerateKey(rand.Reader, 2048)
+				if err != nil {
+					t.Fatalf("failed to generate RSA key: %v", err)
+				}
+				return &key.PublicKey
+			},
+			wantAlg: jose.RS256,
+		},
+		{
+			name: "When given an ECDSA P-256 key, it should return ES256",
+			keyFunc: func(t *testing.T) interface{} {
+				key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					t.Fatalf("failed to generate ECDSA key: %v", err)
+				}
+				return &key.PublicKey
+			},
+			wantAlg: jose.ES256,
+		},
+		{
+			name: "When given an ECDSA P-384 key, it should return ES384",
+			keyFunc: func(t *testing.T) interface{} {
+				key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+				if err != nil {
+					t.Fatalf("failed to generate ECDSA key: %v", err)
+				}
+				return &key.PublicKey
+			},
+			wantAlg: jose.ES384,
+		},
+		{
+			name: "When given an ECDSA P-521 key, it should return ES512",
+			keyFunc: func(t *testing.T) interface{} {
+				key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+				if err != nil {
+					t.Fatalf("failed to generate ECDSA key: %v", err)
+				}
+				return &key.PublicKey
+			},
+			wantAlg: jose.ES512,
+		},
+		{
+			name: "When given an unsupported key type, it should return an error",
+			keyFunc: func(t *testing.T) interface{} {
+				pub, _, err := ed25519.GenerateKey(rand.Reader)
+				if err != nil {
+					t.Fatalf("failed to generate Ed25519 key: %v", err)
+				}
+				return pub
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pub := tc.keyFunc(t)
+			alg, err := algorithmFromPublicKey(pub)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if alg != tc.wantAlg {
+				t.Errorf("got algorithm %q, want %q", alg, tc.wantAlg)
+			}
+		})
+	}
+}
+
+func TestGenerateJWKSDocument(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name    string
+		keyFunc func(t *testing.T) []byte
+		wantKty string
+		wantAlg string
+	}{
+		{
+			name: "When given an RSA key, it should produce an RSA JWK with RS256",
+			keyFunc: func(t *testing.T) []byte {
+				key, err := rsa.GenerateKey(rand.Reader, 2048)
+				if err != nil {
+					t.Fatalf("failed to generate RSA key: %v", err)
+				}
+				return pemEncodePublicKey(t, &key.PublicKey, "PUBLIC KEY")
+			},
+			wantKty: "RSA",
+			wantAlg: "RS256",
+		},
+		{
+			name: "When given an ECDSA P-256 key, it should produce an EC JWK with ES256",
+			keyFunc: func(t *testing.T) []byte {
+				key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					t.Fatalf("failed to generate ECDSA key: %v", err)
+				}
+				return pemEncodePublicKey(t, &key.PublicKey, "PUBLIC KEY")
+			},
+			wantKty: "EC",
+			wantAlg: "ES256",
+		},
+		{
+			name: "When given an ECDSA P-384 key, it should produce an EC JWK with ES384",
+			keyFunc: func(t *testing.T) []byte {
+				key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+				if err != nil {
+					t.Fatalf("failed to generate ECDSA key: %v", err)
+				}
+				return pemEncodePublicKey(t, &key.PublicKey, "PUBLIC KEY")
+			},
+			wantKty: "EC",
+			wantAlg: "ES384",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pubKeyPEM := tc.keyFunc(t)
+			params := OIDCGeneratorParams{
+				IssuerURL: "https://example.com",
+				PubKey:    pubKeyPEM,
+			}
+			reader, err := GenerateJWKSDocument(params)
+			if err != nil {
+				t.Fatalf("GenerateJWKSDocument failed: %v", err)
+			}
+			data, err := io.ReadAll(reader)
+			if err != nil {
+				t.Fatalf("failed to read JWKS: %v", err)
+			}
+
+			var resp KeyResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				t.Fatalf("failed to unmarshal JWKS: %v", err)
+			}
+			if len(resp.Keys) != 1 {
+				t.Fatalf("expected 1 key, got %d", len(resp.Keys))
+			}
+			jwk := resp.Keys[0]
+			if jwk.Algorithm != tc.wantAlg {
+				t.Errorf("got algorithm %q, want %q", jwk.Algorithm, tc.wantAlg)
+			}
+			if jwk.Use != "sig" {
+				t.Errorf("got use %q, want %q", jwk.Use, "sig")
+			}
+			if jwk.KeyID == "" {
+				t.Error("expected non-empty key ID")
+			}
+
+			rawJSON, err := json.Marshal(jwk)
+			if err != nil {
+				t.Fatalf("failed to marshal JWK: %v", err)
+			}
+			var fields map[string]interface{}
+			if err := json.Unmarshal(rawJSON, &fields); err != nil {
+				t.Fatalf("failed to unmarshal JWK fields: %v", err)
+			}
+			if got := fields["kty"].(string); got != tc.wantKty {
+				t.Errorf("got kty %q, want %q", got, tc.wantKty)
+			}
+		})
+	}
+}
+
+func TestGenerateJWKSDocumentAcceptsBothPEMHeaders(t *testing.T) {
+	t.Parallel()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	testCases := []struct {
+		name      string
+		blockType string
+	}{
+		{
+			name:      "When given a PUBLIC KEY header, it should accept the key",
+			blockType: "PUBLIC KEY",
+		},
+		{
+			name:      "When given an RSA PUBLIC KEY header, it should accept the key",
+			blockType: "RSA PUBLIC KEY",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pubPEM := pemEncodePublicKey(t, &key.PublicKey, tc.blockType)
+			params := OIDCGeneratorParams{
+				IssuerURL: "https://example.com",
+				PubKey:    pubPEM,
+			}
+			_, err := GenerateJWKSDocument(params)
+			if err != nil {
+				t.Fatalf("GenerateJWKSDocument rejected PEM header %q: %v", tc.blockType, err)
+			}
+		})
+	}
+}
+
+func TestGenerateConfigurationDocument(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name    string
+		keyFunc func(t *testing.T) []byte
+		wantAlg string
+	}{
+		{
+			name: "When given an RSA key, it should advertise RS256",
+			keyFunc: func(t *testing.T) []byte {
+				key, err := rsa.GenerateKey(rand.Reader, 2048)
+				if err != nil {
+					t.Fatalf("failed to generate RSA key: %v", err)
+				}
+				return pemEncodePublicKey(t, &key.PublicKey, "PUBLIC KEY")
+			},
+			wantAlg: "RS256",
+		},
+		{
+			name: "When given an ECDSA P-256 key, it should advertise ES256",
+			keyFunc: func(t *testing.T) []byte {
+				key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					t.Fatalf("failed to generate ECDSA key: %v", err)
+				}
+				return pemEncodePublicKey(t, &key.PublicKey, "PUBLIC KEY")
+			},
+			wantAlg: "ES256",
+		},
+		{
+			name:    "When PubKey is empty, it should default to RS256",
+			keyFunc: func(t *testing.T) []byte { return nil },
+			wantAlg: "RS256",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			params := OIDCGeneratorParams{
+				IssuerURL: "https://example.com",
+				PubKey:    tc.keyFunc(t),
+			}
+			reader, err := GenerateConfigurationDocument(params)
+			if err != nil {
+				t.Fatalf("GenerateConfigurationDocument failed: %v", err)
+			}
+			data, err := io.ReadAll(reader)
+			if err != nil {
+				t.Fatalf("failed to read config: %v", err)
+			}
+
+			var config struct {
+				Issuer  string   `json:"issuer"`
+				JWKSURI string   `json:"jwks_uri"`
+				Algs    []string `json:"id_token_signing_alg_values_supported"`
+			}
+			if err := json.Unmarshal(data, &config); err != nil {
+				t.Fatalf("failed to unmarshal config: %v", err)
+			}
+			if len(config.Algs) != 1 {
+				t.Fatalf("expected 1 algorithm, got %d", len(config.Algs))
+			}
+			if config.Algs[0] != tc.wantAlg {
+				t.Errorf("got algorithm %q, want %q", config.Algs[0], tc.wantAlg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

### `support/certs/tls.go` — flexible key parsing

`PemToPrivateKey` in `support/certs/tls.go` only handles RSA keys via a single `pem.Decode` + `x509.ParsePKCS1PrivateKey` call. This fails on ECDSA and PKCS#8 encoded keys, blocking configurable PKI when non-RSA algorithms are configured.

This PR replaces the RSA-only parser with `keyutil.ParsePrivateKeyPEM` from `k8s.io/client-go/util/keyutil`, which handles RSA (PKCS#1), ECDSA (SEC 1), and PKCS#8 keys, and tolerates `EC PARAMETERS` preamble blocks. The return type changes from `*rsa.PrivateKey` to `crypto.Signer`, propagated through `decodeCA`, `parsePemKeypair`, `GenerateSignedCertificate`, `signedCertificate`, and `PublicKeyToPem`. The RSA-specific modulus comparison in `parsePemKeypair` is replaced with algorithm-agnostic PKIX public key byte comparison.

Same approach as the cluster-network-operator fix in https://github.com/openshift/cluster-network-operator/pull/2958.

### `support/oidc/oidc.go` — key-type-agnostic JWKS generation

`GenerateJWKSDocument` was hardcoded to RSA at four levels:

1. PEM block type check required `"RSA PUBLIC KEY"`
2. Parsed key was type-asserted to `*rsa.PublicKey`
3. JWK algorithm was hardcoded to `jose.RS256`
4. Discovery template hardcoded `"RS256"` in `id_token_signing_alg_values_supported`

This commit adds an `algorithmFromPublicKey` helper following upstream Kubernetes's pattern in `pkg/serviceaccount/openidmetadata.go` (type switch: RSA -> RS256, ECDSA P-256/384/521 -> ES256/384/512) and updates both `GenerateJWKSDocument` and `GenerateConfigurationDocument` to derive the algorithm dynamically from the actual key type. The PEM block type check now accepts any header, maintaining backward compatibility with both the legacy `"RSA PUBLIC KEY"` and the standard `"PUBLIC KEY"` headers.

## History and why this is safe

### The `"RSA PUBLIC KEY"` PEM header

`PublicKeyToPem` has used the PEM header `"RSA PUBLIC KEY"` with `x509.MarshalPKIXPublicKey` encoding since it was first written in openshift/installer in 2018 (PR openshift/installer#89). This is technically a mismatch: `"RSA PUBLIC KEY"` is the conventional header for PKCS#1 encoding, while `"PUBLIC KEY"` is the correct header for PKIX/SPKI encoding. It worked because both the writer (`PublicKeyToPem`) and reader (`GenerateJWKSDocument`) shared the same convention. This PR fixes both sides, and the reader now accepts either header for backward compatibility with existing secrets.

### Why RSA was required

The JWKS generator was hardcoded to RSA because of AWS STS. HyperShift publishes OIDC documents (discovery + JWKS) to an S3 bucket so that AWS STS can validate Kubernetes service account tokens via `AssumeRoleWithWebIdentity` (IRSA). Before November 2024, AWS STS could only verify RSA-signed JWTs. Publishing an ECDSA key in the JWKS would have caused STS to reject every token. AWS [added ECDSA support](https://aws.amazon.com/about-aws/whats-new/2024/11/aws-sts-ecdsa-based-signatures-oidc-tokens/) (ES256, ES384, ES512) for OIDC on November 22, 2024, so the RSA-only constraint is no longer imposed by AWS.

Kubernetes upstream has supported both RSA and ECDSA for service account OIDC since the `algorithmFromPublicKey` type switch was added to `pkg/serviceaccount/openidmetadata.go`.

### The 2022 ECDSA revert

In March 2022, PR #1167 switched HyperShift's entire PKI to generate ECDSA **P-521** keys. It was reverted 6 days later (PR #1195) because the console broke with `ERR_SSL_VERSION_OR_CIPHER_MISMATCH`. The root cause was P-521 specifically: Chrome's BoringSSL dropped P-521 support in 2015 and has never re-enabled it. The breakage would not have occurred with P-256 or P-384, which are universally supported by all browsers. The revert discarded the flexible parsing along with the P-521 key generation.

### Why this PR does not break anything

**No key generation changes.** `PrivateKey()`, `GenerateSelfSignedCertificate`, and all production code paths continue to produce RSA 2048-bit keys. The only `ecdsa.GenerateKey` calls in this PR are in test files. All callers of the OIDC generators (`reconcileAWSOIDCDocuments`, `reconcileGCPOIDCDocuments`, `dr_oidc_iam.go`, `sharedoidc.go`) pass opaque `[]byte` from the `sa-signing-key` secret, which remains RSA-generated. The JWKS and discovery documents will continue to contain `RS256` and RSA JWK fields (`kty: "RSA"`, `n`, `e`) in all existing deployments.

## Forward looking

This is a prerequisite for enabling configurable PKI in HyperShift, which allows operators to select ECDSA key algorithms (P-256, P-384, P-521). It also lays groundwork for eventual post-quantum certificate support (ML-DSA via Go 1.27+), which will require `crypto.Signer` throughout the signing chain.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./support/certs/` passes
- [x] `go test ./support/certs/` passes (9 test cases covering RSA/ECDSA parsing, round-trips, CA signing)
- [x] `go test ./support/oidc/` passes (12 test cases covering algorithm selection, JWKS generation for RSA/ECDSA, PEM header backward compatibility, discovery document algorithm)
- [x] `go test ./test/e2e/util/ -run TestGenerateCustomCertificate` passes
- [ ] CI presubmit jobs

/verified by "existing unit tests cover RSA key round-trip; keyutil.ParsePrivateKeyPEM is vendored and well-tested upstream"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for ECDSA signing keys in certificate generation and OIDC configuration.
  - Added automatic detection of RSA and ECDSA signing algorithms, including ES256, ES384, and ES512.
  - Improved compatibility with multiple private-key and public-key PEM formats.
  - OIDC discovery metadata now reports the detected signing algorithm.

- **Bug Fixes**
  - Improved key validation and clearer errors for unsupported or invalid key data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->