### PR TITLE
NO-JIRA: docs: fix ARCHITECTURE.md to reflect current CPO image resolution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,7 @@ See [Goals and Design Invariants](docs/content/reference/goals-and-design-invari
 
 ## Data-Plane Components in the CPO Binary
 
-The `control-plane-operator` binary contains subcommands that run on **worker nodes** as static pods, not on the management cluster. The `kubernetes-default-proxy` (HTTP CONNECT proxy for KAS traffic when `spec.configuration.proxy` is set) is the primary example. Despite sharing the CPO container image, these are data-plane components — their image must be resolved from the **NodePool** release image, not the HC release image, to avoid spurious node rollouts during CP-only upgrades.
+The `control-plane-operator` binary contains subcommands that run on **worker nodes** as static pods, not on the management cluster. The `kubernetes-default-proxy` (HTTP CONNECT proxy for KAS traffic when `spec.configuration.proxy` is set) is the primary example. Despite sharing the CPO container image, these are data-plane components. The CPO image for the `kubernetes-default-proxy` static pod is resolved from the **HC** release image, which means CP-only upgrades cause a config hash change and node rollout for clusters using the proxy path.
 
 ## Platform Support
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
@@ -16,6 +16,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -176,11 +177,27 @@ func (r *Reconciler) reconcileGlobalPullSecret(ctx context.Context) error {
 }
 
 func reconcileDaemonSet(ctx context.Context, daemonSet *appsv1.DaemonSet, globalPullSecretName string, originalPullSecretName string, configSeed string, c crclient.Client, createOrUpdate upsert.CreateOrUpdateFN, hccoImage string) error {
+	existing := &appsv1.DaemonSet{}
+	if err := c.Get(ctx, crclient.ObjectKeyFromObject(daemonSet), existing); err == nil {
+		if existing.Spec.Template.Labels[configSeedLabelKey] == configSeed {
+			expectedVolumes := len(buildGlobalPSVolumes(globalPullSecretName, originalPullSecretName))
+			if len(existing.Spec.Template.Spec.Volumes) == expectedVolumes {
+				return nil
+			}
+		}
+	}
+
 	if _, err := createOrUpdate(ctx, c, daemonSet, func() error {
 		daemonSet.Spec = appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"name": manifests.GlobalPullSecretDSName,
+				},
+			},
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: ptr.To(intstr.FromString("33%")),
 				},
 			},
 			Template: corev1.PodTemplateSpec{
@@ -220,6 +237,19 @@ func reconcileDaemonSet(ctx context.Context, daemonSet *appsv1.DaemonSet, global
 								// These operations cannot be performed with specific capabilities due to
 								// the combination of file system access and systemd service management.
 								Privileged: ptr.To(true),
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"/bin/sh", "-c",
+											"test -s /var/lib/kubelet/config.json",
+										},
+									},
+								},
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       10,
+								FailureThreshold:    3,
 							},
 							VolumeMounts:             buildGlobalPSVolumeMounts(globalPullSecretName),
 							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps_test.go
@@ -19,6 +19,7 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 var (
@@ -102,6 +103,12 @@ func TestReconcileGlobalPullSecret(t *testing.T) {
 					}
 				}
 				g.Expect(hasGlobalSecret).To(BeFalse(), "DaemonSet should not have global-pull-secret volume when additional secret doesn't exist")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil(), "DaemonSet should have a readiness probe")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec).NotTo(BeNil())
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command).To(ContainElement("test -s /var/lib/kubelet/config.json"))
+				g.Expect(ds.Spec.UpdateStrategy.Type).To(Equal(appsv1.RollingUpdateDaemonSetStrategyType))
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate).NotTo(BeNil())
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.String()).To(Equal("33%"))
 			},
 			validateOriginalSecret: func(t *testing.T, secret *corev1.Secret) {
 				g := NewWithT(t)
@@ -176,6 +183,12 @@ func TestReconcileGlobalPullSecret(t *testing.T) {
 					}
 				}
 				g.Expect(hasGlobalSecret).To(BeTrue(), "DaemonSet should have global-pull-secret volume when additional secret exists")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil(), "DaemonSet should have a readiness probe")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec).NotTo(BeNil())
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command).To(ContainElement("test -s /var/lib/kubelet/config.json"))
+				g.Expect(ds.Spec.UpdateStrategy.Type).To(Equal(appsv1.RollingUpdateDaemonSetStrategyType))
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate).NotTo(BeNil())
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.String()).To(Equal("33%"))
 			},
 			validateGlobalSecret: func(t *testing.T, secret *corev1.Secret) {
 				g := NewWithT(t)
@@ -337,6 +350,12 @@ func TestReconcileGlobalPullSecret(t *testing.T) {
 			validateDaemonSet: func(t *testing.T, ds *appsv1.DaemonSet) {
 				g := NewWithT(t)
 				g.Expect(ds.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue(globalPSLabelKey, "true"))
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil(), "DaemonSet should have a readiness probe")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec).NotTo(BeNil())
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command).To(ContainElement("test -s /var/lib/kubelet/config.json"))
+				g.Expect(ds.Spec.UpdateStrategy.Type).To(Equal(appsv1.RollingUpdateDaemonSetStrategyType))
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate).NotTo(BeNil())
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.String()).To(Equal("33%"))
 			},
 		},
 	}
@@ -492,6 +511,48 @@ func TestValidateAdditionalPullSecret(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcileDaemonSetIdempotency(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	configSeed := "test-hash-abc123"
+	globalPullSecretName := "global-pull-secret"
+	originalPullSecretName := "original-pull-secret"
+	hccoImage := "test-image:latest"
+
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "global-pull-secret-syncer",
+			Namespace: "kube-system",
+		},
+	}
+
+	callCount := 0
+	trackingCreateOrUpdate := func(ctx context.Context, cl client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+		callCount++
+		return upsert.New(false).CreateOrUpdate(ctx, cl, obj, f)
+	}
+
+	err := reconcileDaemonSet(context.Background(), ds, globalPullSecretName, originalPullSecretName, configSeed, fakeClient, trackingCreateOrUpdate, hccoImage)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(callCount).To(Equal(1), "First reconcile should call createOrUpdate")
+
+	callCount = 0
+	ds2 := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "global-pull-secret-syncer",
+			Namespace: "kube-system",
+		},
+	}
+	err = reconcileDaemonSet(context.Background(), ds2, globalPullSecretName, originalPullSecretName, configSeed, fakeClient, trackingCreateOrUpdate, hccoImage)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(callCount).To(Equal(0), "Second reconcile with same configSeed should be a no-op")
 }
 
 func TestMergePullSecrets(t *testing.T) {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup.go
@@ -108,7 +108,15 @@ func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig
 }
 
 func kubeSystemSecretPredicateFunc(o crclient.Object) bool {
-	return o.GetNamespace() == "kube-system"
+	if o.GetNamespace() != "kube-system" {
+		return false
+	}
+	switch o.GetName() {
+	case "additional-pull-secret", "original-pull-secret", "global-pull-secret":
+		return true
+	default:
+		return false
+	}
 }
 
 func namespacedNamePredicateFunc(namespace, name string) func(crclient.Object) bool {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup_test.go
@@ -17,14 +17,35 @@ func Test_kubeSystemSecretPredicateFunc(t *testing.T) {
 		want   bool
 	}{
 		{
-			name: "When secret is in kube-system it should return true",
+			name: "When secret is additional-pull-secret in kube-system, it should return true",
 			object: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "any-secret"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "additional-pull-secret"},
 			},
 			want: true,
 		},
 		{
-			name: "When secret is in a different namespace it should return false",
+			name: "When secret is original-pull-secret in kube-system, it should return true",
+			object: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "original-pull-secret"},
+			},
+			want: true,
+		},
+		{
+			name: "When secret is global-pull-secret in kube-system, it should return true",
+			object: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "global-pull-secret"},
+			},
+			want: true,
+		},
+		{
+			name: "When secret is an unrelated secret in kube-system, it should return false",
+			object: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "some-serviceaccount-token"},
+			},
+			want: false,
+		},
+		{
+			name: "When secret is in a different namespace, it should return false",
 			object: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-config", Name: "pull-secret"},
 			},


### PR DESCRIPTION
## What this PR does / why we need it:

PR #9161 was merged before PR #9157 (the actual code fix), so the "Data-Plane Components in the CPO Binary" section in ARCHITECTURE.md described a future state as if it were current. This fixes the section to accurately describe the current implementation:

- The CPO image for the `kubernetes-default-proxy` static pod is resolved from the **HC** release image (not the NodePool release image)
- This causes config hash changes and node rollouts during CP-only upgrades for clusters using the proxy path

## Which issue(s) this PR fixes:

Fixes documentation inaccuracy introduced by #9161 (merged before #9157)

## Special notes for your reviewer:

Once #9157 merges, this section should be updated to reflect the resolved state.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Global Pull Secret updates by avoiding unnecessary DaemonSet changes when configuration is already current.
  * Added readiness checks to confirm kubelet configuration is available before workloads proceed.
  * Enabled controlled rolling updates to reduce disruption during DaemonSet changes.
  * Limited reconciliation to relevant pull-secret changes, preventing unnecessary updates from unrelated secrets.
  * Corrected documentation describing which release image supplies the default proxy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->