### PR TITLE
NO-JIRA: docs: fix ARCHITECTURE.md to reflect current CPO image resolution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,7 @@ See [Goals and Design Invariants](docs/content/reference/goals-and-design-invari
 
 ## Data-Plane Components in the CPO Binary
 
-The `control-plane-operator` binary contains subcommands that run on **worker nodes** as static pods, not on the management cluster. The `kubernetes-default-proxy` (HTTP CONNECT proxy for KAS traffic when `spec.configuration.proxy` is set) is the primary example. Despite sharing the CPO container image, these are data-plane components — their image must be resolved from the **NodePool** release image, not the HC release image, to avoid spurious node rollouts during CP-only upgrades.
+The `control-plane-operator` binary contains subcommands that run on **worker nodes** as static pods, not on the management cluster. The `kubernetes-default-proxy` (HTTP CONNECT proxy for KAS traffic when `spec.configuration.proxy` is set) is the primary example. Despite sharing the CPO container image, these are data-plane components. The CPO image for the `kubernetes-default-proxy` static pod is resolved from the **HC** release image, which means CP-only upgrades cause a config hash change and node rollout for clusters using the proxy path.
 
 ## Platform Support
 


### PR DESCRIPTION
## What this PR does / why we need it:

PR #9161 was merged before PR #9157 (the actual code fix), so the "Data-Plane Components in the CPO Binary" section in ARCHITECTURE.md described a future state as if it were current. This fixes the section to accurately describe the current implementation:

- The CPO image for the `kubernetes-default-proxy` static pod is resolved from the **HC** release image (not the NodePool release image)
- This causes config hash changes and node rollouts during CP-only upgrades for clusters using the proxy path

## Which issue(s) this PR fixes:

Fixes documentation inaccuracy introduced by #9161 (merged before #9157)

## Special notes for your reviewer:

Once #9157 merges, this section should be updated to reflect the resolved state.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to clarify that the default proxy static pod image is sourced from the HC release image.
  * Documented that control-plane-only upgrades can trigger configuration changes and node rollouts when using the proxy path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->