### PR TITLE
CNTRLPLANE-3901: Add product-cli unit tests for IAM-Infra (Azure)

### DIFF
--- a/product-cli/cmd/iam/azure/create_test.go
+++ b/product-cli/cmd/iam/azure/create_test.go
@@ -1,0 +1,127 @@
+package azure
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/config"
+
+	"github.com/spf13/cobra"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "When IAM create command is created, it should have 'azure' as use",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+				g.Expect(cmd.Use).To(Equal("azure"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should mark name as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should mark infra-id as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("infra-id")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should mark azure-creds as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("azure-creds")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should mark resource-group-name as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("resource-group-name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should mark oidc-issuer-url as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("oidc-issuer-url")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should mark output-file as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("output-file")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should set location to default",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("location")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureLocation))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should set cloud to default",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("cloud")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureCloud))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.test(t)
+		})
+	}
+}

--- a/product-cli/cmd/iam/azure/create_test.go
+++ b/product-cli/cmd/iam/azure/create_test.go
@@ -1,0 +1,147 @@
+package azure
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/config"
+
+	"github.com/spf13/cobra"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test func(t *testing.T, cmd *cobra.Command)
+	}{
+		{
+			name: "When IAM create command is created, it should have 'azure' as use",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.Use).To(Equal("azure"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should silence usage and wire RunE",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.SilenceUsage).To(BeTrue())
+				g.Expect(cmd.RunE).ToNot(BeNil())
+			},
+		},
+		{
+			name: "When IAM create command is created, it should mark name as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should mark infra-id as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("infra-id")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should mark azure-creds as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("azure-creds")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should mark resource-group-name as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("resource-group-name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should mark oidc-issuer-url as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("oidc-issuer-url")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should mark output-file as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("output-file")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should set location to default",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("location")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureLocation))
+			},
+		},
+		{
+			name: "When IAM create command is created, it should set cloud to default",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("cloud")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureCloud))
+			},
+		},
+		{
+			name: "When RunE runs with missing required options, it should return a validation error",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				err := cmd.RunE(cmd, nil)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("name is required"))
+			},
+		},
+		{
+			name: "When RunE runs past validation with an unreadable azure-creds file, it should return an error from Run",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.Flags().Set("name", "test-cluster")).To(Succeed())
+				g.Expect(cmd.Flags().Set("infra-id", "test-infra")).To(Succeed())
+				g.Expect(cmd.Flags().Set("azure-creds", "/nonexistent/azure-creds")).To(Succeed())
+				g.Expect(cmd.Flags().Set("resource-group-name", "test-rg")).To(Succeed())
+				g.Expect(cmd.Flags().Set("oidc-issuer-url", "https://example.com/oidc")).To(Succeed())
+				g.Expect(cmd.Flags().Set("output-file", "/dev/null")).To(Succeed())
+
+				err := cmd.RunE(cmd, nil)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("failed to setup Azure credentials"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := NewCreateCommand()
+			tt.test(t, cmd)
+		})
+	}
+}

--- a/product-cli/cmd/iam/azure/destroy_test.go
+++ b/product-cli/cmd/iam/azure/destroy_test.go
@@ -1,0 +1,104 @@
+package azure
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/config"
+
+	"github.com/spf13/cobra"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "When IAM destroy command is created, it should have 'azure' as use",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+				g.Expect(cmd.Use).To(Equal("azure"))
+			},
+		},
+		{
+			name: "When IAM destroy command is created, it should mark name as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+
+				flag := cmd.Flag("name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM destroy command is created, it should mark infra-id as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+
+				flag := cmd.Flag("infra-id")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM destroy command is created, it should mark workload-identities-file as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+
+				flag := cmd.Flag("workload-identities-file")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM destroy command is created, it should mark azure-creds as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+
+				flag := cmd.Flag("azure-creds")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM destroy command is created, it should mark resource-group-name as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+
+				flag := cmd.Flag("resource-group-name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM destroy command is created, it should set cloud to default",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+
+				flag := cmd.Flag("cloud")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureCloud))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.test(t)
+		})
+	}
+}

--- a/product-cli/cmd/iam/azure/destroy_test.go
+++ b/product-cli/cmd/iam/azure/destroy_test.go
@@ -1,0 +1,128 @@
+package azure
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/config"
+
+	"github.com/spf13/cobra"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test func(t *testing.T, cmd *cobra.Command)
+	}{
+		{
+			name: "When IAM destroy command is created, it should have 'azure' as use",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.Use).To(Equal("azure"))
+			},
+		},
+		{
+			name: "When IAM destroy command is created, it should silence usage and wire RunE",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.SilenceUsage).To(BeTrue())
+				g.Expect(cmd.RunE).ToNot(BeNil())
+			},
+		},
+		{
+			name: "When IAM destroy command is created, it should mark name as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM destroy command is created, it should mark infra-id as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("infra-id")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM destroy command is created, it should mark workload-identities-file as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("workload-identities-file")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM destroy command is created, it should mark azure-creds as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("azure-creds")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM destroy command is created, it should mark resource-group-name as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("resource-group-name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When IAM destroy command is created, it should set cloud to default",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("cloud")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureCloud))
+			},
+		},
+		{
+			name: "When RunE runs with missing required options, it should return a validation error",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				err := cmd.RunE(cmd, nil)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("workload-identities-file is required"))
+			},
+		},
+		{
+			name: "When RunE runs past validation with an unreadable workload-identities file, it should return an error from Run",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.Flags().Set("name", "test-cluster")).To(Succeed())
+				g.Expect(cmd.Flags().Set("infra-id", "test-infra")).To(Succeed())
+				g.Expect(cmd.Flags().Set("workload-identities-file", "/nonexistent/workload-identities")).To(Succeed())
+				g.Expect(cmd.Flags().Set("azure-creds", "/nonexistent/azure-creds")).To(Succeed())
+				g.Expect(cmd.Flags().Set("resource-group-name", "test-rg")).To(Succeed())
+				g.Expect(cmd.Flags().Set("dns-zone-rg-name", "test-dns-rg")).To(Succeed())
+
+				err := cmd.RunE(cmd, nil)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("failed to read workload identities file"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := NewDestroyCommand()
+			tt.test(t, cmd)
+		})
+	}
+}

--- a/product-cli/cmd/infra/azure/create_test.go
+++ b/product-cli/cmd/infra/azure/create_test.go
@@ -1,0 +1,108 @@
+package azure
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/config"
+
+	"github.com/spf13/cobra"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "When infra create command is created, it should have 'azure' as use",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+				g.Expect(cmd.Use).To(Equal("azure"))
+			},
+		},
+		{
+			name: "When infra create command is created, it should mark infra-id as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("infra-id")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When infra create command is created, it should mark azure-creds as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("azure-creds")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When infra create command is created, it should mark name as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When infra create command is created, it should set location to default",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("location")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureLocation))
+			},
+		},
+		{
+			name: "When infra create command is created, it should set cloud to default",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("cloud")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureCloud))
+			},
+		},
+		{
+			name: "When infra create command is created, it should register product-specific flags",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				g.Expect(cmd.Flag("base-domain")).ToNot(BeNil())
+				g.Expect(cmd.Flag("resource-group-name")).ToNot(BeNil())
+				g.Expect(cmd.Flag("resource-group-tags")).ToNot(BeNil())
+				g.Expect(cmd.Flag("vnet-id")).ToNot(BeNil())
+				g.Expect(cmd.Flag("subnet-id")).ToNot(BeNil())
+				g.Expect(cmd.Flag("network-security-group-id")).ToNot(BeNil())
+				g.Expect(cmd.Flag("workload-identities-file")).ToNot(BeNil())
+				g.Expect(cmd.Flag("assign-identity-roles")).ToNot(BeNil())
+				g.Expect(cmd.Flag("output-file")).ToNot(BeNil())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.test(t)
+		})
+	}
+}

--- a/product-cli/cmd/infra/azure/create_test.go
+++ b/product-cli/cmd/infra/azure/create_test.go
@@ -1,0 +1,133 @@
+package azure
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/config"
+
+	"github.com/spf13/cobra"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test func(t *testing.T, cmd *cobra.Command)
+	}{
+		{
+			name: "When infra create command is created, it should have 'azure' as use",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.Use).To(Equal("azure"))
+			},
+		},
+		{
+			name: "When infra create command is created, it should silence usage and wire RunE",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.SilenceUsage).To(BeTrue())
+				g.Expect(cmd.RunE).ToNot(BeNil())
+			},
+		},
+		{
+			name: "When infra create command is created, it should mark infra-id as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("infra-id")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When infra create command is created, it should mark azure-creds as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("azure-creds")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When infra create command is created, it should mark name as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When infra create command is created, it should set location to default",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("location")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureLocation))
+			},
+		},
+		{
+			name: "When infra create command is created, it should set cloud to default",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("cloud")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureCloud))
+			},
+		},
+		{
+			name: "When infra create command is created, it should register product-specific flags",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.Flag("base-domain")).ToNot(BeNil())
+				g.Expect(cmd.Flag("resource-group-name")).ToNot(BeNil())
+				g.Expect(cmd.Flag("resource-group-tags")).ToNot(BeNil())
+				g.Expect(cmd.Flag("vnet-id")).ToNot(BeNil())
+				g.Expect(cmd.Flag("subnet-id")).ToNot(BeNil())
+				g.Expect(cmd.Flag("network-security-group-id")).ToNot(BeNil())
+				g.Expect(cmd.Flag("workload-identities-file")).ToNot(BeNil())
+				g.Expect(cmd.Flag("assign-identity-roles")).ToNot(BeNil())
+				g.Expect(cmd.Flag("output-file")).ToNot(BeNil())
+			},
+		},
+		{
+			name: "When RunE runs with missing required options, it should return a validation error",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				err := cmd.RunE(cmd, nil)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("base-domain is required"))
+			},
+		},
+		{
+			name: "When RunE runs past validation with an unreadable azure-creds file, it should return an error from Run",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.Flags().Set("name", "test-cluster")).To(Succeed())
+				g.Expect(cmd.Flags().Set("infra-id", "test-infra")).To(Succeed())
+				g.Expect(cmd.Flags().Set("azure-creds", "/nonexistent/azure-creds")).To(Succeed())
+				g.Expect(cmd.Flags().Set("base-domain", "example.com")).To(Succeed())
+				// An identity config is required to pass the deployment-model check in Run;
+				// the file is not read before credential setup, so a non-existent path is fine.
+				g.Expect(cmd.Flags().Set("workload-identities-file", "/nonexistent/workload-identities")).To(Succeed())
+
+				err := cmd.RunE(cmd, nil)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("failed to setup Azure credentials"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := NewCreateCommand()
+			tt.test(t, cmd)
+		})
+	}
+}

--- a/product-cli/cmd/infra/azure/destroy_test.go
+++ b/product-cli/cmd/infra/azure/destroy_test.go
@@ -1,0 +1,102 @@
+package azure
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/config"
+
+	"github.com/spf13/cobra"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "When infra destroy command is created, it should have 'azure' as use",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+				g.Expect(cmd.Use).To(Equal("azure"))
+			},
+		},
+		{
+			name: "When infra destroy command is created, it should mark infra-id as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+
+				flag := cmd.Flag("infra-id")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When infra destroy command is created, it should mark azure-creds as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+
+				flag := cmd.Flag("azure-creds")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When infra destroy command is created, it should mark name as required",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+
+				flag := cmd.Flag("name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When infra destroy command is created, it should set location to default",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+
+				flag := cmd.Flag("location")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureLocation))
+			},
+		},
+		{
+			name: "When infra destroy command is created, it should set cloud to default",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+
+				flag := cmd.Flag("cloud")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureCloud))
+			},
+		},
+		{
+			name: "When infra destroy command is created, it should default preserve-resource-group to false",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewDestroyCommand()
+
+				flag := cmd.Flag("preserve-resource-group")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal("false"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.test(t)
+		})
+	}
+}

--- a/product-cli/cmd/infra/azure/destroy_test.go
+++ b/product-cli/cmd/infra/azure/destroy_test.go
@@ -1,0 +1,123 @@
+package azure
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/config"
+
+	"github.com/spf13/cobra"
+)
+
+func TestNewDestroyCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test func(t *testing.T, cmd *cobra.Command)
+	}{
+		{
+			name: "When infra destroy command is created, it should have 'azure' as use",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.Use).To(Equal("azure"))
+			},
+		},
+		{
+			name: "When infra destroy command is created, it should silence usage and wire RunE",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.SilenceUsage).To(BeTrue())
+				g.Expect(cmd.RunE).ToNot(BeNil())
+			},
+		},
+		{
+			name: "When infra destroy command is created, it should mark infra-id as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("infra-id")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When infra destroy command is created, it should mark azure-creds as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("azure-creds")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When infra destroy command is created, it should mark name as required",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.Annotations).To(HaveKey(cobra.BashCompOneRequiredFlag))
+				g.Expect(flag.Annotations[cobra.BashCompOneRequiredFlag]).To(ContainElement("true"))
+			},
+		},
+		{
+			name: "When infra destroy command is created, it should set location to default",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("location")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureLocation))
+			},
+		},
+		{
+			name: "When infra destroy command is created, it should set cloud to default",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("cloud")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal(config.DefaultAzureCloud))
+			},
+		},
+		{
+			name: "When infra destroy command is created, it should default preserve-resource-group to false",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				flag := cmd.Flag("preserve-resource-group")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal("false"))
+			},
+		},
+		{
+			name: "When RunE runs with missing required options, it should return a validation error",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				err := cmd.RunE(cmd, nil)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("name is required"))
+			},
+		},
+		{
+			name: "When RunE runs past validation with an unreadable azure-creds file, it should return an error from Run",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.Flags().Set("name", "test-cluster")).To(Succeed())
+				g.Expect(cmd.Flags().Set("infra-id", "test-infra")).To(Succeed())
+				g.Expect(cmd.Flags().Set("azure-creds", "/nonexistent/azure-creds")).To(Succeed())
+
+				err := cmd.RunE(cmd, nil)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("failed to setup Azure credentials"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := NewDestroyCommand()
+			tt.test(t, cmd)
+		})
+	}
+}


### PR DESCRIPTION
These subcommands have shared cmd/infra/azure/ tests but zero product-cli wiring tests.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

4 new product-cli test files:

1. `product-cli/cmd/iam/azure/create_test.go` — 9 tests: Use field, 6 required flags (name, infra-id, azure-creds, resource-group-name, oidc-issuer-url, output-file), location default (eastus), cloud default (AzurePublicCloud)

2. `product-cli/cmd/iam/azure/destroy_test.go`— 7 tests: Use field, 5 required flags (name, infra-id, workload-identities-file, azure-creds, resource-group-name), cloud default

3. `product-cli/cmd/infra/azure/create_test.go` — 7 tests: Use field, 3 required flags (infra-id, azure-creds, name), location/cloud defaults, product-specific flag registration (base-domain, vnet-id, subnet-id, etc.)

4. `product-cli/cmd/infra/azure/destroy_test.go` — 7 tests: Use field, 3 required flags (infra-id, azure-creds, name), location/cloud defaults, preserve-resource-group default (false)

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3901

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for Azure IAM create and destroy commands.
  * Added automated coverage for Azure infrastructure create and destroy commands.
  * Verified command metadata, required options, command execution wiring, and default Azure settings.
  * Added checks for validation failures and errors caused by unreadable Azure credential files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->