### PR TITLE
CNTRLPLANE-3976: Document management cluster vs hosted cluster feature gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Project documentation is published via MkDocs. The site structure and navigation
 | **Upgrades lifecycle** | [docs/content/how-to/upgrades.md](docs/content/how-to/upgrades.md) |
 | **Contributing and PR workflow** | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | **Agentic SDLC framework** | [docs/content/how-to/agentic-sdlc.md](docs/content/how-to/agentic-sdlc.md) |
+| **Feature gates** | [docs/content/how-to/feature-gates.md](docs/content/how-to/feature-gates.md) — two separate systems: management cluster gates vs hosted cluster gates |
 | **Pre-commit hooks** | [docs/content/contribute/precommit-hook-help.md](docs/content/contribute/precommit-hook-help.md) |
 
 ## Pull Secret Cycling

--- a/docs/content/how-to/configure-ocp-components/index.md
+++ b/docs/content/how-to/configure-ocp-components/index.md
@@ -3,7 +3,7 @@
 ## Overview
 
 In standalone OpenShift, cluster configuration is achieved via cluster-scoped resources in the `config.openshift.io/v1`
-API group. Resources such as APIServer, OAuth, and Proxy allow adding additional named certificates to the Kube APIServer, 
+API group. Resources such as APIServer, OAuth, and Proxy allow adding additional named certificates to the Kube APIServer,
 adding identity providers, configuring the global proxy, etc. In HyperShift, configuration resources that
 impact the control plane need to be specified in the HostedCluster resource instead of inside the guest cluster. The
 resources still exist inside the guest cluster, but their source of truth is the HostedCluster and are continuously
@@ -15,7 +15,7 @@ The configuration resources that should be specified in the HostedCluster are:
 
 * [APIServer](https://docs.openshift.com/container-platform/4.20/rest_api/config_apis/apiserver-config-openshift-io-v1.html) - Provides API server configuration such as certificates and certificate authorities.
 * [Authentication](https://docs.openshift.com/container-platform/4.20/rest_api/config_apis/authentication-config-openshift-io-v1.html) - Controls the identity provider and authentication configuration for the cluster.
-* [FeatureGate](https://docs.openshift.com/container-platform/4.20/rest_api/config_apis/featuregate-config-openshift-io-v1.html) - Enables FeatureGates so that you can use Tech Preview features.
+* [FeatureGate](https://docs.openshift.com/container-platform/4.20/rest_api/config_apis/featuregate-config-openshift-io-v1.html) - Enables FeatureGates so that you can use Tech Preview features. See [Feature Gates](../feature-gates.md) for the distinction between management cluster and hosted cluster feature gates.
 * [Ingress](https://docs.openshift.com/container-platform/4.20/rest_api/config_apis/ingress-config-openshift-io-v1.html) - Configuration details related to routing such as the default domain for routes.
 * [Image](https://docs.openshift.com/container-platform/4.20/rest_api/config_apis/image-config-openshift-io-v1.html) - Configures how specific image registries should be treated (allowed, disallowed, insecure, CA details).
 * [OAuth](https://docs.openshift.com/container-platform/4.20/rest_api/config_apis/oauth-config-openshift-io-v1.html) - Configures identity providers and other behavior related to internal OAuth server flows.

--- a/docs/content/how-to/feature-gates.md
+++ b/docs/content/how-to/feature-gates.md
@@ -1,53 +1,102 @@
 # Feature Gates
 
-Feature gates in OpenShift allows to ensure everything new works together and optimizes for rapid evaluation in CI to promote without ever releasing a public preview.
-There are no guarantees that your fleet continues to be operational long term after you enable a feature gate.
+## :material-information-outline: Overview
 
-In the HCP context, there are multiple non exclusive scenarios where features might need to be gated:
+HyperShift has two separate feature gate systems that serve different purposes. Understanding which system applies is essential for correctly enabling and testing features.
 
-1 - A feature that impacts HO install
-E.g. New CRDs are required for CPOv2 (control plane operator version 2)
+| System | Scope | Set by |
+|--------|-------|--------|
+| **Management cluster feature gates** | CRD schemas, HyperShift Operator, Control Plane Operator | `hypershift install --tech-preview-no-upgrade` |
+| **Hosted Cluster feature gates** | OCP release payload for a single tenant | `spec.configuration.featureGate.featureSet` on the HostedCluster |
 
-2 - A feature that impacts the whole cluster fleet / HO
-E.g. Introduce fleet wide shared ingress to be validated in targeted environments
+!!! warning
 
-3 - A feature that impacts individual clusters
-E.g. Introduce using CPOv2 for some HC to develop feedback
+    These two systems are independent. Enabling a management cluster feature gate does **not** enable OCP feature gates inside hosted clusters, and vice versa.
 
-4 - A feature that impacts API
-E.g. Introduce a new provider like Openstack
-E.g. Introduce a new field/feature like AWS tenancy
+## :material-server-network: Management Cluster Feature Gates
 
-5 - A feature specific for an OCP component
-Components honour existing standalone in-cluster OCP feature gate mechanisim
+Management cluster feature gates govern the HyperShift infrastructure running on the management cluster. There are no guarantees that your fleet continues to be operational long-term after you enable these feature gates.
 
-## Users
-All the feature gates are grouped in a single TechPreviewNoUpgrade feature set. Current implementation exposes this --tech-preview-no-upgrade flag in the CLI at install time
+These gates apply to the following scenarios:
 
-```
-hypershift install --help
-```
-Will show among other flags:
-```
---tech-preview-no-upgrade                        If true, the HyperShift operator runs with TechPreviewNoUpgrade features enabled
+- A feature that impacts HyperShift Operator install (e.g. new CRDs are required for CPOv2)
+- A feature that impacts the whole cluster fleet (e.g. fleet-wide shared ingress to be validated in targeted environments)
+- A feature that impacts individual clusters (e.g. introduce using CPOv2 for some HostedClusters)
+- A feature that impacts the HyperShift API (e.g. introduce a new provider like OpenStack, or a new field like AWS tenancy)
+
+All management cluster feature gates are grouped under a single `TechPreviewNoUpgrade` feature set. To enable them, pass `--tech-preview-no-upgrade` at install time:
+
+```bash
+hypershift install --tech-preview-no-upgrade
 ```
 
-In a follow up we'll consider to introduce support to also signal --tech-preview-no-upgrade at the HC level.
-Eventually support for at least 1, 2, 3 and 4 afromentioned scenarios will most likely converge into a single API.
+This flag determines which CRD variants are installed (Default vs TechPreviewNoUpgrade) and configures the `HYPERSHIFT_FEATURESET` environment variable that both the HyperShift Operator and Control Plane Operator read.
 
-## Devs
+### Adding a Management Cluster Feature Gate
 
-We rely on [openshift/api](https://github.com/openshift/api) tooling for generating CRDs with [openshift markers](https://github.com/openshift/kubernetes-sigs-controller-tools/blob/96a305393cb22f0c69c4ee59be27ad09057cc704/pkg/crd/markers/patch_validation.go#L30-L36). See [this PR](https://github.com/openshift/hypershift/pull/5047) as an example of a adding a field behind a feature gate.
+We rely on [openshift/api](https://github.com/openshift/api) tooling for generating CRDs with [openshift markers](https://github.com/openshift/kubernetes-sigs-controller-tools/blob/96a305393cb22f0c69c4ee59be27ad09057cc704/pkg/crd/markers/patch_validation.go#L30-L36). See [this PR](https://github.com/openshift/hypershift/pull/8675) as an example of adding an API field behind a feature gate.
 
-The currently ongoing implementation of feature gates for the controllers business logic relies on "k8s.io/component-base/featuregate". This enables devs to declare [granular gates for their features](https://github.com/openshift/hypershift/blob/9f5ccaef47cdcf9d2df91134571f1783e99e30fe/hypershift-operator/featuregate/feature.go).
-See [this PR](https://github.com/openshift/hypershift/pull/4980) as an example.
+The controller business logic uses `k8s.io/component-base/featuregate`. This enables devs to declare [granular gates for their features](https://github.com/openshift/hypershift/blob/9f5ccaef47cdcf9d2df91134571f1783e99e30fe/hypershift-operator/featuregate/feature.go). See [this PR](https://github.com/openshift/hypershift/pull/8976) as an example.
 
-### Promoting a feature gated API field and feature to sable
+## :material-cloud-outline: Hosted Cluster Feature Gates
 
-Generally speaking any new field should start by being feature gated.
+Hosted Cluster feature gates control the OCP release payload for a specific hosted cluster. OCP components in the hosted control plane honor the standard in-cluster OCP feature gate mechanism. This applies to:
+
+- A feature specific to an OCP component (e.g. TLSAdherence, DynamicResourceAllocation)
+
+To enable a feature set for a hosted cluster, set it in `spec.configuration.featureGate.featureSet`:
+
+```yaml
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  configuration:
+    featureGate:
+      featureSet: TechPreviewNoUpgrade
+```
+
+!!! warning
+
+    Enabling `TechPreviewNoUpgrade` is irreversible and prevents minor-version upgrades on the hosted cluster. Use this only on test clusters where future upgrades are not required.
+
+The `featuregate-generator` job in the hosted control plane namespace renders the OCP payload's feature gates into a `feature-gate` ConfigMap that OCP components consume.
+
+!!! note
+
+    If you are an OCP component team looking to test a feature gate like `TLSAdherence` or `DynamicResourceAllocation`, this is the mechanism you need — set the feature set on the HostedCluster, not on the management cluster.
+
+### Example: Enabling TLSAdherence
+
+The `TLSAdherence` feature gate is an OCP feature gate that is part of the `TechPreviewNoUpgrade` feature set. To enable it on a hosted cluster:
+
+1. Set `TechPreviewNoUpgrade` as the feature set on the HostedCluster:
+
+    ```yaml
+    spec:
+      configuration:
+        featureGate:
+          featureSet: TechPreviewNoUpgrade
+    ```
+
+2. Verify the feature gate was rendered by checking the ConfigMap in the hosted control plane namespace:
+
+    ```bash
+    oc get configmap feature-gate -n <hcp-namespace> -o yaml
+    ```
+
+    !!! tip
+
+        The hosted control plane namespace is typically `<clusters-namespace>-<hostedcluster-name>`.
+
+## Promoting a Feature Gated API Field
+
+Generally speaking any new field should start by being feature-gated.
 The minimum criteria for promotion is:
 
-- Provide clear context and analysis on the PR about how the field might impact the different GA products. This includes but it is not limited to ROSA, ARO, IBM Cloud and MCE (self hosted).
+- Provide clear context and analysis on the PR about how the field might impact the different GA products. This includes but is not limited to ROSA, ARO, IBM Cloud and MCE (self-hosted).
 
 - Document the field with the expected behaviour for day 1 and day 2 changes.
 
@@ -57,4 +106,4 @@ The minimum criteria for promotion is:
 
 - There is e2e test coverage for day 2 on update UX failure expectations via [this e2e test](https://github.com/openshift/hypershift/blob/d6f79f6cd0a638e07f82b6c57bff6c23a6c8d2c0/test/e2e/util/util.go#L977)
 
-In general we aim to adhere and converge with stand alone principles in [openshift/api](https://github.com/openshift/api)
+In general we aim to adhere and converge with stand-alone principles in [openshift/api](https://github.com/openshift/api)

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -17505,7 +17505,7 @@ The configuration resources that should be specified in the HostedCluster are:
 
 * APIServer - Provides API server configuration such as certificates and certificate authorities.
 * Authentication - Controls the identity provider and authentication configuration for the cluster.
-* FeatureGate - Enables FeatureGates so that you can use Tech Preview features.
+* FeatureGate - Enables FeatureGates so that you can use Tech Preview features. See Feature Gates for the distinction between management cluster and hosted cluster feature gates.
 * Ingress - Configuration details related to routing such as the default domain for routes.
 * Image - Configures how specific image registries should be treated (allowed, disallowed, insecure, CA details).
 * OAuth - Configures identity providers and other behavior related to internal OAuth server flows.
@@ -23216,54 +23216,103 @@ It will install four priority classes in a management cluster with the following
 
 # Feature Gates
 
-Feature gates in OpenShift allows to ensure everything new works together and optimizes for rapid evaluation in CI to promote without ever releasing a public preview.
-There are no guarantees that your fleet continues to be operational long term after you enable a feature gate.
+## :material-information-outline: Overview
 
-In the HCP context, there are multiple non exclusive scenarios where features might need to be gated:
+HyperShift has two separate feature gate systems that serve different purposes. Understanding which system applies is essential for correctly enabling and testing features.
 
-1 - A feature that impacts HO install
-E.g. New CRDs are required for CPOv2 (control plane operator version 2)
+| System | Scope | Set by |
+|--------|-------|--------|
+| **Management cluster feature gates** | CRD schemas, HyperShift Operator, Control Plane Operator | `hypershift install --tech-preview-no-upgrade` |
+| **Hosted Cluster feature gates** | OCP release payload for a single tenant | `spec.configuration.featureGate.featureSet` on the HostedCluster |
 
-2 - A feature that impacts the whole cluster fleet / HO
-E.g. Introduce fleet wide shared ingress to be validated in targeted environments
+!!! warning
 
-3 - A feature that impacts individual clusters
-E.g. Introduce using CPOv2 for some HC to develop feedback
+    These two systems are independent. Enabling a management cluster feature gate does **not** enable OCP feature gates inside hosted clusters, and vice versa.
 
-4 - A feature that impacts API
-E.g. Introduce a new provider like Openstack
-E.g. Introduce a new field/feature like AWS tenancy
+## :material-server-network: Management Cluster Feature Gates
 
-5 - A feature specific for an OCP component
-Components honour existing standalone in-cluster OCP feature gate mechanisim
+Management cluster feature gates govern the HyperShift infrastructure running on the management cluster. There are no guarantees that your fleet continues to be operational long-term after you enable these feature gates.
 
-## Users
-All the feature gates are grouped in a single TechPreviewNoUpgrade feature set. Current implementation exposes this --tech-preview-no-upgrade flag in the CLI at install time
+These gates apply to the following scenarios:
 
-```
-hypershift install --help
-```
-Will show among other flags:
-```
---tech-preview-no-upgrade                        If true, the HyperShift operator runs with TechPreviewNoUpgrade features enabled
+- A feature that impacts HyperShift Operator install (e.g. new CRDs are required for CPOv2)
+- A feature that impacts the whole cluster fleet (e.g. fleet-wide shared ingress to be validated in targeted environments)
+- A feature that impacts individual clusters (e.g. introduce using CPOv2 for some HostedClusters)
+- A feature that impacts the HyperShift API (e.g. introduce a new provider like OpenStack, or a new field like AWS tenancy)
+
+All management cluster feature gates are grouped under a single `TechPreviewNoUpgrade` feature set. To enable them, pass `--tech-preview-no-upgrade` at install time:
+
+```bash
+hypershift install --tech-preview-no-upgrade
 ```
 
-In a follow up we'll consider to introduce support to also signal --tech-preview-no-upgrade at the HC level.
-Eventually support for at least 1, 2, 3 and 4 afromentioned scenarios will most likely converge into a single API.
+This flag determines which CRD variants are installed (Default vs TechPreviewNoUpgrade) and configures the `HYPERSHIFT_FEATURESET` environment variable that both the HyperShift Operator and Control Plane Operator read.
 
-## Devs
+### Adding a Management Cluster Feature Gate
 
-We rely on openshift/api tooling for generating CRDs with openshift markers. See this PR as an example of a adding a field behind a feature gate.
+We rely on openshift/api tooling for generating CRDs with openshift markers. See this PR as an example of adding an API field behind a feature gate.
 
-The currently ongoing implementation of feature gates for the controllers business logic relies on "k8s.io/component-base/featuregate". This enables devs to declare granular gates for their features.
-See this PR as an example.
+The controller business logic uses `k8s.io/component-base/featuregate`. This enables devs to declare granular gates for their features. See this PR as an example.
 
-### Promoting a feature gated API field and feature to sable
+## :material-cloud-outline: Hosted Cluster Feature Gates
 
-Generally speaking any new field should start by being feature gated.
+Hosted Cluster feature gates control the OCP release payload for a specific hosted cluster. OCP components in the hosted control plane honor the standard in-cluster OCP feature gate mechanism. This applies to:
+
+- A feature specific to an OCP component (e.g. TLSAdherence, DynamicResourceAllocation)
+
+To enable a feature set for a hosted cluster, set it in `spec.configuration.featureGate.featureSet`:
+
+```yaml
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  configuration:
+    featureGate:
+      featureSet: TechPreviewNoUpgrade
+```
+
+!!! warning
+
+    Enabling `TechPreviewNoUpgrade` is irreversible and prevents minor-version upgrades on the hosted cluster. Use this only on test clusters where future upgrades are not required.
+
+The `featuregate-generator` job in the hosted control plane namespace renders the OCP payload's feature gates into a `feature-gate` ConfigMap that OCP components consume.
+
+!!! note
+
+    If you are an OCP component team looking to test a feature gate like `TLSAdherence` or `DynamicResourceAllocation`, this is the mechanism you need — set the feature set on the HostedCluster, not on the management cluster.
+
+### Example: Enabling TLSAdherence
+
+The `TLSAdherence` feature gate is an OCP feature gate that is part of the `TechPreviewNoUpgrade` feature set. To enable it on a hosted cluster:
+
+1. Set `TechPreviewNoUpgrade` as the feature set on the HostedCluster:
+
+    ```yaml
+    spec:
+      configuration:
+        featureGate:
+          featureSet: TechPreviewNoUpgrade
+    ```
+
+2. Verify the feature gate was rendered by checking the ConfigMap in the hosted control plane namespace:
+
+    ```bash
+    oc get configmap feature-gate -n <hcp-namespace> -o yaml
+    ```
+
+    !!! tip
+
+        The hosted control plane namespace is typically `<clusters-namespace>-<hostedcluster-name>`.
+
+## Promoting a Feature Gated API Field
+
+Generally speaking any new field should start by being feature-gated.
 The minimum criteria for promotion is:
 
-- Provide clear context and analysis on the PR about how the field might impact the different GA products. This includes but it is not limited to ROSA, ARO, IBM Cloud and MCE (self hosted).
+- Provide clear context and analysis on the PR about how the field might impact the different GA products. This includes but is not limited to ROSA, ARO, IBM Cloud and MCE (self-hosted).
 
 - Document the field with the expected behaviour for day 1 and day 2 changes.
 
@@ -23273,7 +23322,8 @@ The minimum criteria for promotion is:
 
 - There is e2e test coverage for day 2 on update UX failure expectations via this e2e test
 
-In general we aim to adhere and converge with stand alone principles in openshift/api
+In general we aim to adhere and converge with stand-alone principles in openshift/api
+
 
 ---
 


### PR DESCRIPTION
## What this PR does / why we need it:

Restructures the feature gates documentation to clearly distinguish between the two separate feature gate systems in HyperShift:

- **Management cluster feature gates** — set at install time via `--tech-preview-no-upgrade`, govern HO and CPO behavior and CRD schemas
- **Hosted Cluster feature gates** — set per-HostedCluster via `spec.configuration.featureGate.featureSet`, govern the OCP release payload

This distinction was a source of confusion for OCP component teams trying to enable OCP feature gates (e.g. TLSAdherence) on hosted clusters. The updated doc includes a worked example and verification steps.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3976

## Special notes for your reviewer:

This is documentation-only — no code changes. Three files touched:
- `docs/content/how-to/feature-gates.md` — main restructure with two-system distinction, reworked scenarios, TLSAdherence example, configmap verification
- `docs/content/how-to/configure-ocp-components/index.md` — one-line cross-reference to feature gates doc
- `AGENTS.md` — Key References table entry

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Feature gates” how-to to clearly distinguish management-cluster vs hosted-cluster feature-gates, and how each is configured.
  * Added instructions for enabling management feature sets (including `TechPreviewNoUpgrade`) and for setting hosted-cluster `featureSet`.
  * Included clearer YAML examples and verification steps, including checking the hosted control plane’s `feature-gate` ConfigMap and TLS adherence.
  * Refreshed the feature promotion guidance into a clearer checklist with revised criteria language.
  * Improved documentation navigation by adding direct links to the Feature gates guide from the key references table and related pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->