### PR TITLE
OCPBUGS-100194: fix(cpo): set correct --advertise-client-url for etcd grpc-proxy

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -197,7 +197,6 @@ spec:
         - grpc-proxy
         - start
         - --endpoints=https://localhost:2382
-        - --advertise-client-url=""
         - --key=/etc/etcd/tls/peer/peer.key
         - --key-file=/etc/etcd/tls/server/server.key
         - --cert=/etc/etcd/tls/peer/peer.crt
@@ -206,6 +205,7 @@ spec:
         - --trusted-ca-file=/etc/etcd/tls/etcd-metrics-ca/ca.crt
         - --listen-addr=127.0.0.1:2383
         - --metrics-addr=https://0.0.0.0:2381
+        - --advertise-client-url=
         command:
         - etcd
         image: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -202,7 +202,6 @@ spec:
         - grpc-proxy
         - start
         - --endpoints=https://localhost:2382
-        - --advertise-client-url=""
         - --key=/etc/etcd/tls/peer/peer.key
         - --key-file=/etc/etcd/tls/server/server.key
         - --cert=/etc/etcd/tls/peer/peer.crt
@@ -211,6 +210,7 @@ spec:
         - --trusted-ca-file=/etc/etcd/tls/etcd-metrics-ca/ca.crt
         - --listen-addr=127.0.0.1:2383
         - --metrics-addr=https://0.0.0.0:2381
+        - --advertise-client-url=
         command:
         - etcd
         image: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -197,7 +197,6 @@ spec:
         - grpc-proxy
         - start
         - --endpoints=https://localhost:2382
-        - --advertise-client-url=""
         - --key=/etc/etcd/tls/peer/peer.key
         - --key-file=/etc/etcd/tls/server/server.key
         - --cert=/etc/etcd/tls/peer/peer.crt
@@ -206,6 +205,7 @@ spec:
         - --trusted-ca-file=/etc/etcd/tls/etcd-metrics-ca/ca.crt
         - --listen-addr=127.0.0.1:2383
         - --metrics-addr=https://0.0.0.0:2381
+        - --advertise-client-url=
         command:
         - etcd
         image: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -197,7 +197,6 @@ spec:
         - grpc-proxy
         - start
         - --endpoints=https://localhost:2382
-        - --advertise-client-url=""
         - --key=/etc/etcd/tls/peer/peer.key
         - --key-file=/etc/etcd/tls/server/server.key
         - --cert=/etc/etcd/tls/peer/peer.crt
@@ -206,6 +205,7 @@ spec:
         - --trusted-ca-file=/etc/etcd/tls/etcd-metrics-ca/ca.crt
         - --listen-addr=127.0.0.1:2383
         - --metrics-addr=https://0.0.0.0:2381
+        - --advertise-client-url=
         command:
         - etcd
         image: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -197,7 +197,6 @@ spec:
         - grpc-proxy
         - start
         - --endpoints=https://localhost:2382
-        - --advertise-client-url=""
         - --key=/etc/etcd/tls/peer/peer.key
         - --key-file=/etc/etcd/tls/server/server.key
         - --cert=/etc/etcd/tls/peer/peer.crt
@@ -206,6 +205,7 @@ spec:
         - --trusted-ca-file=/etc/etcd/tls/etcd-metrics-ca/ca.crt
         - --listen-addr=127.0.0.1:2383
         - --metrics-addr=https://0.0.0.0:2381
+        - --advertise-client-url=
         command:
         - etcd
         image: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/statefulset.yaml
@@ -129,7 +129,6 @@ spec:
         - grpc-proxy
         - start
         - --endpoints=https://localhost:2382
-        - --advertise-client-url=""
         - --key=/etc/etcd/tls/peer/peer.key
         - --key-file=/etc/etcd/tls/server/server.key
         - --cert=/etc/etcd/tls/peer/peer.crt

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
@@ -67,6 +67,7 @@ func adaptStatefulSet(cpContext component.WorkloadContext, sts *appsv1.StatefulS
 		c.Args = append(c.Args,
 			fmt.Sprintf("--listen-addr=%s:2383", loInterface),
 			fmt.Sprintf("--metrics-addr=https://%s:2381", allInterfaces),
+			"--advertise-client-url=",
 		)
 	})
 


### PR DESCRIPTION
## Summary
- The etcd-metrics container runs an etcd gRPC proxy configured with `--advertise-client-url=""` in the YAML template. Due to YAML parsing, the value passed to Go is two literal double-quote characters (`""`), not an empty string. Newer etcd versions try to dial this as a network address, causing crash-loops.
- Fix by removing the static flag from the YAML template and instead setting `--advertise-client-url=` (truly empty) dynamically in `statefulset.go`. An empty value causes the grpc-proxy to skip endpoint self-registration, which is correct since this proxy is a local metrics sidecar that doesn't need discovery.

Fixes: https://issues.redhat.com/browse/OCPBUGS-100194

## Test plan
- [x] Updated fixture files via `make api`/generated fixtures
- [ ] CI passes