### PR TITLE
OCPBUGS-100302: fix(metrics): only report limited support when label …

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -423,7 +423,7 @@ func collectUpgradingDurationMetric(ch chan<- prometheus.Metric, clk clock.Clock
 
 func collectLimitedSupportMetric(ch chan<- prometheus.Metric, hcluster *hyperv1.HostedCluster, hclusterLabelValues []string) {
 	limitedSupportValue := 0.0
-	if _, ok := hcluster.Labels[hyperv1.LimitedSupportLabel]; ok {
+	if v, ok := hcluster.Labels[hyperv1.LimitedSupportLabel]; ok && v == "true" {
 		limitedSupportValue = 1.0
 	}
 	ch <- prometheus.MustNewConstMetric(

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -383,9 +383,19 @@ func TestReportLimitedSuportEnabled(t *testing.T) {
 		expected *dto.MetricFamily
 	}{
 		{
-			name:     "When limited support label is set, metric is reported as one",
+			name:     "When limited support label is set to true, metric is reported as one",
 			labels:   map[string]string{hyperv1.LimitedSupportLabel: "true"},
 			expected: wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:     "When limited support label is set to false, metric is reported as zero",
+			labels:   map[string]string{hyperv1.LimitedSupportLabel: "false"},
+			expected: wrapExpectedValueAsMetric(0),
+		},
+		{
+			name:     "When limited support label is set to anything unsupported, metric is reported as zero",
+			labels:   map[string]string{hyperv1.LimitedSupportLabel: "foo"},
+			expected: wrapExpectedValueAsMetric(0),
 		},
 		{
 			name:     "When limited support label is not set, metric is reported as zero",


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

The `hypershift_cluster_limited_support_enabled` metric currently reports `1` if the `api.openshift.com/limited-support` label is present, no matter the value.

[clusters-service intentionally sets the label](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/blob/master/pkg/osd/limited_support_reason_service.go?ref_type=heads#L449) as `false` rather than deleting it when a cluster exists limited support, because the HC-to-HCP label sync is additive-only (OCPBUGS-85584).

This means clusters that enter limited support continue reporting `hypershift_cluster_limited_support_enabled = 1` even when they exit limited support. This affects our ability to correctly silence alerts.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes OCPBUGS-100302

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected limited-support metrics to activate only when the corresponding label is explicitly set to `true`.
  * Prevented incorrectly reporting limited support when the label is present with another value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->