### PR TITLE
OCPBUGS-100301: fix(hostedcluster): handle Unknown status in ClusterVersionFailing inversion

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -752,14 +752,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			// So consumers e.g. UI can categorize as good (True) / bad (False).
 			if conditionType == hyperv1.ClusterVersionSucceeding {
 				hcCVOCondition.Type = string(hyperv1.ClusterVersionSucceeding)
-				var status metav1.ConditionStatus
-				switch hcpCVOConditions[conditionType].Status {
-				case metav1.ConditionTrue:
-					status = metav1.ConditionFalse
-				case metav1.ConditionFalse:
-					status = metav1.ConditionTrue
-				}
-				hcCVOCondition.Status = status
+				hcCVOCondition.Status = invertConditionStatus(hcpCVOConditions[conditionType].Status)
 			}
 		}
 
@@ -3316,6 +3309,17 @@ func reconcileCAPIManagerClusterRoleBinding(binding *rbacv1.ClusterRoleBinding, 
 		},
 	}
 	return nil
+}
+
+func invertConditionStatus(s metav1.ConditionStatus) metav1.ConditionStatus {
+	switch s {
+	case metav1.ConditionTrue:
+		return metav1.ConditionFalse
+	case metav1.ConditionFalse:
+		return metav1.ConditionTrue
+	default:
+		return metav1.ConditionUnknown
+	}
 }
 
 // computeClusterVersionStatus determines the ClusterVersionStatus of the

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -3995,6 +3995,47 @@ func TestIsProgressing(t *testing.T) {
 	}
 }
 
+func TestInvertConditionStatus(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		input          metav1.ConditionStatus
+		expectedStatus metav1.ConditionStatus
+	}{
+		{
+			name:           "When status is True it should invert to False",
+			input:          metav1.ConditionTrue,
+			expectedStatus: metav1.ConditionFalse,
+		},
+		{
+			name:           "When status is False it should invert to True",
+			input:          metav1.ConditionFalse,
+			expectedStatus: metav1.ConditionTrue,
+		},
+		{
+			name:           "When status is Unknown it should produce Unknown",
+			input:          metav1.ConditionUnknown,
+			expectedStatus: metav1.ConditionUnknown,
+		},
+		{
+			name:           "When status is empty string it should produce Unknown",
+			input:          metav1.ConditionStatus(""),
+			expectedStatus: metav1.ConditionUnknown,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			result := invertConditionStatus(tc.input)
+			g.Expect(result).To(Equal(tc.expectedStatus))
+			g.Expect(result).ToNot(BeEmpty(), "Status must not be empty string — API server rejects it")
+		})
+	}
+}
+
 func TestComputeAWSDefaultSGDeletedCondition(t *testing.T) {
 	t.Parallel()
 

--- a/hypershift-operator/controllers/hostedcluster/reconcile_legacy.go
+++ b/hypershift-operator/controllers/hostedcluster/reconcile_legacy.go
@@ -434,14 +434,7 @@ func (r *HostedClusterReconciler) reconcileLegacy(ctx context.Context, req ctrl.
 			// So consumers e.g. UI can categorize as good (True) / bad (False).
 			if conditionType == hyperv1.ClusterVersionSucceeding {
 				hcCVOCondition.Type = string(hyperv1.ClusterVersionSucceeding)
-				var status metav1.ConditionStatus
-				switch hcpCVOConditions[conditionType].Status {
-				case metav1.ConditionTrue:
-					status = metav1.ConditionFalse
-				case metav1.ConditionFalse:
-					status = metav1.ConditionTrue
-				}
-				hcCVOCondition.Status = status
+				hcCVOCondition.Status = invertConditionStatus(hcpCVOConditions[conditionType].Status)
 			}
 		}
 


### PR DESCRIPTION
## What this PR does / why we need it:

The ClusterVersionFailing → ClusterVersionSucceeding condition inversion switch (hostedcluster_controller.go:755-762) only handled True and False. When ClusterVersionFailing had Status: Unknown (common during control plane disruptions like cluster-size-override), the switch fell through and set ClusterVersionSucceeding.Status to "" (zero value). The API server permanently rejects this on Status().Update, blocking the entire reconcile loop before Phase 7 (CoreHCPChain). This prevented HC-to-HCP annotation sync, causing request-serving pods to schedule with stale node affinity and remain Pending indefinitely.

This fix adds a default case that maps Unknown (and any other unexpected status) to ConditionUnknown. Applied to both reconcile and reconcileLegacy paths.

## Which issue(s) this PR fixes:

Fixes [OCPBUGS-100301](https://redhat.atlassian.net/browse/OCPBUGS-100301)

## Special notes for your reviewer:

Two production incidents: 105 min and 44 hours downtime ([ROSAENG-62684](https://redhat.atlassian.net/browse/ROSAENG-62684)).

Root cause confirmed by operator logs showing `status.conditions[4].status: Unsupported value: ""` and HCP showing `ClusterVersionFailing: Unknown`.

**Bug reproduced on staging cluster** by stripping ClusterVersion conditions from the guest cluster:
```
oc patch clusterversion version --type=json -p '[{"op":"remove","path":"/status/conditions"}]' --subresource=status
```
This caused the HCCO to set `ClusterVersionFailing: Unknown` on the HCP, which immediately triggered the same error loop observed in production:
```
{"level":"error","msg":"Reconciler error","controller":"hostedcluster","error":"[failed to update status: HostedCluster is invalid: [status.conditions[4].status: Unsupported value: \"\": supported values: \"True\", \"False\", \"Unknown\"..."}
```

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.