### PR TITLE
OCPBUGS-100332: fix(konnectivity): conditionally prefer IPv4 based on HCP network config [release-4.22]

### DIFF
--- a/konnectivity-https-proxy/cmd.go
+++ b/konnectivity-https-proxy/cmd.go
@@ -65,6 +65,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&noProxy, "no-proxy", "", "URLs that should not use the provided http-proxy and https-proxy")
 
 	cmd.Flags().BoolVar(&opts.ConnectDirectlyToCloudAPIs, "connect-directly-to-cloud-apis", false, "If true, bypass konnectivity to connect to cloud APIs while still honoring management proxy config")
+	cmd.Flags().BoolVar(&opts.PreferIPv4, "prefer-ipv4", false, "Prefer IPv4 addresses when resolving DNS names")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		l.Info("Starting proxy", "version", supportedversion.String())

--- a/konnectivity-socks5-proxy/main.go
+++ b/konnectivity-socks5-proxy/main.go
@@ -44,6 +44,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.ResolveFromGuestClusterDNS, "resolve-from-guest-cluster-dns", false, "If DNS resolving should use the guest clusters cluster-dns")
 	cmd.Flags().BoolVar(&opts.ResolveFromManagementClusterDNS, "resolve-from-management-cluster-dns", false, "If guest cluster's dns fails, fallback to the management cluster's dns")
 	cmd.Flags().BoolVar(&opts.DisableResolver, "disable-resolver", false, "If true, DNS resolving is disabled. Takes precedence over resolve-from-guest-cluster-dns and resolve-from-management-cluster-dns")
+	cmd.Flags().BoolVar(&opts.PreferIPv4, "prefer-ipv4", false, "Prefer IPv4 addresses when resolving DNS names")
 
 	cmd.Flags().StringVar(&opts.CAFile, "ca-cert-path", "/etc/konnectivity/proxy-ca/ca.crt", "The path to the konnectivity client's ca-cert.")
 	cmd.Flags().StringVar(&opts.ClientCertFile, "tls-cert-path", "/etc/konnectivity/proxy-client/tls.crt", "The path to the konnectivity client's tls certificate.")

--- a/support/controlplane-component/konnectivity-container.go
+++ b/support/controlplane-component/konnectivity-container.go
@@ -47,6 +47,8 @@ type HTTPSOptions struct {
 	// before worker nodes are present in the cluster.
 	// See https://github.com/openshift/hypershift/pull/1601
 	ConnectDirectlyToCloudAPIs *bool
+	// PreferIPv4 filters DNS results to IPv4 for single-stack IPv4 data planes.
+	PreferIPv4 *bool
 }
 
 type Socks5Options struct {
@@ -74,6 +76,8 @@ type Socks5Options struct {
 	// DisableResolver disables any name resolution by the resolver. This is used by the CNO.
 	// See https://github.com/openshift/hypershift/pull/3986
 	DisableResolver *bool
+	// PreferIPv4 filters DNS results to IPv4 for single-stack IPv4 data planes.
+	PreferIPv4 *bool
 }
 
 func (opts KonnectivityContainerOptions) injectKonnectivityContainer(cpContext ControlPlaneContext, podSpec *corev1.PodSpec) {
@@ -83,6 +87,13 @@ func (opts KonnectivityContainerOptions) injectKonnectivityContainer(cpContext C
 	}
 
 	hcp := cpContext.HCP
+
+	// Single-stack IPv4 HCPs need IPv4-preferred DNS on dual-stack management clusters.
+	// This overrides any caller-set PreferIPv4 value — single-stack IPv4 always needs IPv4.
+	if isSingleStackIPv4(hcp) {
+		opts.HTTPSOptions.PreferIPv4 = ptr.To(true)
+		opts.Socks5Options.PreferIPv4 = ptr.To(true)
+	}
 	var proxyAdditionalCAs []corev1.VolumeProjection
 	if hcp.Spec.AdditionalTrustBundle != nil {
 		proxyAdditionalCAs = append(proxyAdditionalCAs, corev1.VolumeProjection{
@@ -150,6 +161,9 @@ func (opts KonnectivityContainerOptions) buildContainer(hcp *hyperv1.HostedContr
 		if value := opts.HTTPSOptions.ConnectDirectlyToCloudAPIs; value != nil {
 			args = append(args, fmt.Sprintf("--connect-directly-to-cloud-apis=%t", *value))
 		}
+		if value := opts.HTTPSOptions.PreferIPv4; value != nil {
+			args = append(args, fmt.Sprintf("--prefer-ipv4=%t", *value))
+		}
 	case Socks5:
 		command = append(command, "konnectivity-socks5-proxy")
 		if host := opts.Socks5Options.KonnectivityHost; host != "" {
@@ -172,6 +186,9 @@ func (opts KonnectivityContainerOptions) buildContainer(hcp *hyperv1.HostedContr
 		}
 		if value := opts.Socks5Options.DisableResolver; value != nil {
 			args = append(args, fmt.Sprintf("--disable-resolver=%t", *value))
+		}
+		if value := opts.Socks5Options.PreferIPv4; value != nil {
+			args = append(args, fmt.Sprintf("--prefer-ipv4=%t", *value))
 		}
 	}
 
@@ -281,4 +298,16 @@ func (opts KonnectivityContainerOptions) buildVolumes(proxyAdditionalCAs []corev
 	}
 
 	return volumes
+}
+
+// isSingleStackIPv4 returns true when all HCP ServiceNetwork CIDRs are IPv4.
+// ServiceNetwork determines the IP family of ClusterIPs, which is what konnectivity resolves to.
+func isSingleStackIPv4(hcp *hyperv1.HostedControlPlane) bool {
+	for _, sn := range hcp.Spec.Networking.ServiceNetwork {
+		ipv4, err := util.IsIPv4CIDR(sn.CIDR.String())
+		if err != nil || !ipv4 {
+			return false
+		}
+	}
+	return len(hcp.Spec.Networking.ServiceNetwork) > 0
 }

--- a/support/controlplane-component/konnectivity-container_test.go
+++ b/support/controlplane-component/konnectivity-container_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/api/util/ipnet"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
@@ -171,4 +172,110 @@ func TestBuildContainerDualMode(t *testing.T) {
 		"Socks5 container should not have HTTP_PROXY because ConnectDirectlyToCloudAPIs is not set on Socks5Options")
 	g.Expect(findEnvVar(socks5Container.Env, "HTTPS_PROXY")).To(BeNil(),
 		"Socks5 container should not have HTTPS_PROXY")
+}
+
+func TestBuildContainerPreferIPv4(t *testing.T) {
+	hcp := &hyperv1.HostedControlPlane{}
+
+	tests := []struct {
+		name      string
+		opts      KonnectivityContainerOptions
+		expectArg bool
+	}{
+		{
+			name: "When PreferIPv4 is true for HTTPS mode, it should include --prefer-ipv4=true arg",
+			opts: KonnectivityContainerOptions{
+				Mode: HTTPS,
+				HTTPSOptions: HTTPSOptions{
+					PreferIPv4: ptr.To(true),
+				},
+			},
+			expectArg: true,
+		},
+		{
+			name: "When PreferIPv4 is true for Socks5 mode, it should include --prefer-ipv4=true arg",
+			opts: KonnectivityContainerOptions{
+				Mode: Socks5,
+				Socks5Options: Socks5Options{
+					PreferIPv4: ptr.To(true),
+				},
+			},
+			expectArg: true,
+		},
+		{
+			name: "When PreferIPv4 is not set for HTTPS mode, it should not include --prefer-ipv4 arg",
+			opts: KonnectivityContainerOptions{
+				Mode: HTTPS,
+			},
+			expectArg: false,
+		},
+		{
+			name: "When PreferIPv4 is not set for Socks5 mode, it should not include --prefer-ipv4 arg",
+			opts: KonnectivityContainerOptions{
+				Mode: Socks5,
+			},
+			expectArg: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			container := tt.opts.buildContainer(hcp, "test-image:latest", nil)
+
+			if tt.expectArg {
+				g.Expect(container.Args).To(ContainElement("--prefer-ipv4=true"))
+			} else {
+				for _, arg := range container.Args {
+					g.Expect(arg).NotTo(HavePrefix("--prefer-ipv4"), "should not include --prefer-ipv4 arg")
+				}
+			}
+		})
+	}
+}
+
+func TestIsSingleStackIPv4(t *testing.T) {
+	tests := []struct {
+		name     string
+		networks []string
+		expected bool
+	}{
+		{
+			name:     "When ServiceNetwork has a single IPv4 CIDR, it should return true",
+			networks: []string{"172.31.0.0/16"},
+			expected: true,
+		},
+		{
+			name:     "When ServiceNetwork has a single IPv6 CIDR, it should return false",
+			networks: []string{"fd02::/112"},
+			expected: false,
+		},
+		{
+			name:     "When ServiceNetwork is dual-stack, it should return false",
+			networks: []string{"172.31.0.0/16", "fd02::/112"},
+			expected: false,
+		},
+		{
+			name:     "When ServiceNetwork is empty, it should return false",
+			networks: []string{},
+			expected: false,
+		},
+		{
+			name:     "When ServiceNetwork has multiple IPv4 CIDRs, it should return true",
+			networks: []string{"172.31.0.0/16", "10.96.0.0/16"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			hcp := &hyperv1.HostedControlPlane{}
+			for _, cidr := range tt.networks {
+				hcp.Spec.Networking.ServiceNetwork = append(hcp.Spec.Networking.ServiceNetwork,
+					hyperv1.ServiceNetworkEntry{CIDR: *ipnet.MustParseCIDR(cidr)})
+			}
+			g.Expect(isSingleStackIPv4(hcp)).To(Equal(tt.expected))
+		})
+	}
 }

--- a/support/konnectivityproxy/dialer.go
+++ b/support/konnectivityproxy/dialer.go
@@ -95,6 +95,9 @@ type Options struct {
 	// See https://github.com/openshift/hypershift/pull/3986
 	DisableResolver bool
 
+	// PreferIPv4 filters DNS results to IPv4 when the data plane is single-stack IPv4.
+	PreferIPv4 bool
+
 	// Client for the hosted cluster. This is used by the resolver to resolve names either via
 	// service name or via coredns. REQUIRED (unless DisableResolver is specified)
 	Client client.Client
@@ -191,6 +194,7 @@ func NewKonnectivityDialer(opts Options) (ProxyDialer, error) {
 		resolveFromGuestCluster:      opts.ResolveFromGuestClusterDNS,
 		resolveFromManagementCluster: opts.ResolveFromManagementClusterDNS,
 		mustResolve:                  opts.ResolveBeforeDial,
+		preferIPv4:                   opts.PreferIPv4,
 		konnectivityHealth:           newKonnectivityHealth(),
 		log:                          opts.Log,
 		isCloudAPI:                   proxy.IsCloudAPI,
@@ -198,6 +202,7 @@ func NewKonnectivityDialer(opts Options) (ProxyDialer, error) {
 	proxy.proxyResolver.guestClusterResolver = &guestClusterResolver{
 		client:               opts.Client,
 		konnectivityDialFunc: proxy.DialContext,
+		preferIPv4:           opts.PreferIPv4,
 		log:                  opts.Log,
 	}
 	return proxy, nil

--- a/support/konnectivityproxy/resolver.go
+++ b/support/konnectivityproxy/resolver.go
@@ -26,6 +26,7 @@ type guestClusterResolver struct {
 	log                  logr.Logger
 	client               client.Client
 	konnectivityDialFunc func(ctx context.Context, network string, addr string) (net.Conn, error)
+	preferIPv4           bool
 	resolver             *net.Resolver
 	resolverLock         sync.Mutex
 }
@@ -68,6 +69,15 @@ func (gr *guestClusterResolver) resolve(ctx context.Context, name string) (net.I
 	if len(addresses) == 0 {
 		return nil, errors.New("no addresses found")
 	}
+
+	// On single-stack IPv4 data planes, filter to IPv4 so the konnectivity-agent
+	// doesn't try to connect to unreachable IPv6 endpoints.
+	if gr.preferIPv4 {
+		if filtered := filterIPv4(addresses); len(filtered) > 0 {
+			addresses = filtered
+		}
+	}
+
 	address := net.ParseIP(addresses[0])
 	if address == nil {
 		return nil, fmt.Errorf("failed to parse address %q as IP", addresses[0])
@@ -86,6 +96,7 @@ type proxyResolver struct {
 	resolveFromGuestCluster      bool
 	resolveFromManagementCluster bool
 	mustResolve                  bool
+	preferIPv4                   bool
 	konnectivityHealth           *konnectivityHealth
 	guestClusterResolver         *guestClusterResolver
 	log                          logr.Logger
@@ -102,6 +113,9 @@ func (d proxyResolver) Resolve(ctx context.Context, name string) (context.Contex
 	if err != nil {
 		l.Info("failed to resolve address from Kubernetes service", "err", err.Error())
 		if !d.resolveFromGuestCluster {
+			if d.preferIPv4 {
+				return resolvePreferIPv4(ctx, name)
+			}
 			return socks5.DNSResolver{}.Resolve(ctx, name)
 		}
 
@@ -127,9 +141,16 @@ func (d proxyResolver) Resolve(ctx context.Context, name string) (context.Contex
 			if d.resolveFromManagementCluster {
 				l.Info("Attempting management cluster resolution to determine if konnectivity is down")
 
-				// Use the standard DNS resolver to actually resolve the name via management cluster DNS
-				// We can't use defaultResolve because it returns nil,nil for SOCKS5 proxy
-				mgmtCtx, mgmtIP, mgmtErr := socks5.DNSResolver{}.Resolve(ctx, name)
+				// Use the standard DNS resolver to actually resolve the name via management cluster DNS.
+				// We can't use defaultResolve because it returns nil,nil for SOCKS5 proxy.
+				var mgmtCtx context.Context
+				var mgmtIP net.IP
+				var mgmtErr error
+				if d.preferIPv4 {
+					mgmtCtx, mgmtIP, mgmtErr = resolvePreferIPv4(ctx, name)
+				} else {
+					mgmtCtx, mgmtIP, mgmtErr = socks5.DNSResolver{}.Resolve(ctx, name)
+				}
 
 				// Only mark konnectivity as unhealthy if management cluster resolution succeeds
 				// If management cluster also fails, it's likely a legitimate DNS failure (name doesn't exist)
@@ -170,6 +191,9 @@ func (d proxyResolver) defaultResolve(ctx context.Context, name string) (context
 	// d.mustResolve will be set to true if the dialer needs to resolve names before
 	// dialing (which is the case of the https proxy)
 	if d.mustResolve {
+		if d.preferIPv4 {
+			return resolvePreferIPv4(ctx, name)
+		}
 		return socks5.DNSResolver{}.Resolve(ctx, name)
 	}
 	return ctx, nil, nil
@@ -200,4 +224,45 @@ func (d proxyResolver) ResolveK8sService(ctx context.Context, l logr.Logger, nam
 	l.Info("resolved address from Kubernetes service", "ip", ip.String())
 
 	return ctx, ip, nil
+}
+
+// resolvePreferIPv4 wraps DNS resolution to prefer IPv4 addresses so
+// the konnectivity-agent on single-stack data planes can reach the target.
+// Uses net.DefaultResolver.LookupIPAddr to honor context cancellation/deadlines.
+func resolvePreferIPv4(ctx context.Context, name string) (context.Context, net.IP, error) {
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, name)
+	if err != nil {
+		// Don't fall through to uncancelable socks5.DNSResolver if context is done.
+		if ctx.Err() != nil {
+			return ctx, nil, ctx.Err()
+		}
+		// Fallback intentionally does not filter for IPv4 — resolving something is better than failing.
+		return socks5.DNSResolver{}.Resolve(ctx, name)
+	}
+	// Return the first IPv4 address if available, otherwise the first address.
+	for _, a := range addrs {
+		if a.IP.To4() != nil {
+			return ctx, a.IP, nil
+		}
+	}
+	if len(addrs) > 0 {
+		return ctx, addrs[0].IP, nil
+	}
+	// Don't fall through to uncancelable socks5.DNSResolver if context is done.
+	if ctx.Err() != nil {
+		return ctx, nil, ctx.Err()
+	}
+	// Fallback intentionally does not filter for IPv4 — resolving something is better than failing.
+	return socks5.DNSResolver{}.Resolve(ctx, name)
+}
+
+// filterIPv4 returns only IPv4 addresses from the input slice.
+func filterIPv4(addresses []string) []string {
+	var filtered []string
+	for _, addr := range addresses {
+		if ip := net.ParseIP(addr); ip != nil && ip.To4() != nil {
+			filtered = append(filtered, addr)
+		}
+	}
+	return filtered
 }

--- a/support/konnectivityproxy/resolver_test.go
+++ b/support/konnectivityproxy/resolver_test.go
@@ -1,0 +1,72 @@
+package konnectivityproxy
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestFilterIPv4(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "When mixed IPv4 and IPv6, it should return only IPv4",
+			input:    []string{"2001:db8::1", "192.168.1.1", "fd00::2", "10.0.0.1"},
+			expected: []string{"192.168.1.1", "10.0.0.1"},
+		},
+		{
+			name:     "When only IPv4, it should return all",
+			input:    []string{"192.168.1.1", "10.0.0.1"},
+			expected: []string{"192.168.1.1", "10.0.0.1"},
+		},
+		{
+			name:     "When only IPv6, it should return empty",
+			input:    []string{"2001:db8::1", "fd00::2"},
+			expected: nil,
+		},
+		{
+			name:     "When empty, it should return empty",
+			input:    []string{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(filterIPv4(tt.input)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestResolvePreferIPv4(t *testing.T) {
+	t.Run("When resolving localhost, it should return an IPv4 address", func(t *testing.T) {
+		g := NewWithT(t)
+		_, ip, err := resolvePreferIPv4(context.Background(), "localhost")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ip).ToNot(BeNil())
+		g.Expect(ip.To4()).ToNot(BeNil(), "expected IPv4 address for localhost")
+	})
+
+	t.Run("When resolving an IPv6 literal, it should return an IPv6 address", func(t *testing.T) {
+		g := NewWithT(t)
+		_, ip, err := resolvePreferIPv4(context.Background(), "::1")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ip).ToNot(BeNil())
+		g.Expect(ip.To4()).To(BeNil(), "expected IPv6 address when no IPv4 is available")
+	})
+
+	t.Run("When context is canceled, it should return context error", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		cancel()
+		_, _, err := resolvePreferIPv4(ctx, "localhost")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err).To(MatchError(context.Canceled))
+	})
+}


### PR DESCRIPTION
## Summary

Backport of #9140 to release-4.22.

- Adds `--prefer-ipv4` flag to konnectivity HTTPS and SOCKS5 proxy containers
- Automatically enables IPv4 preference for single-stack IPv4 HCPs on dual-stack management clusters
- Prevents DNS resolution from returning IPv6 addresses that single-stack IPv4 data planes cannot reach

### Conflict resolution

`support/netutil` package doesn't exist on release-4.22. Changed `netutil.IsIPv4CIDR` to `util.IsIPv4CIDR` which provides the same function on this branch.

## Test plan

- [x] `go build` passes for affected packages
- [x] `go vet` clean
- [x] 46 unit tests pass in `support/konnectivityproxy`