### PR TITLE
CNTRLPLANE-3978: Fix CPO finalizer race leaving orphaned Azure Private Endpoint resources

### DIFF
--- a/control-plane-operator/controllers/azureprivatelinkservice/controller.go
+++ b/control-plane-operator/controllers/azureprivatelinkservice/controller.go
@@ -276,7 +276,22 @@ func (r *AzurePrivateLinkServiceReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, nil
 	}
 
-	// 3. Add CR finalizer if not present
+	// 3. Look up the HostedControlPlane. This must happen before adding the CR
+	// finalizer so that during HCP deletion we return early and never re-add a
+	// per-CR finalizer that reconcileHCPDeletion just removed.
+	hcp, err := r.getHCPOrCleanupOrphan(ctx, azPLS, log)
+	if hcp == nil {
+		return ctrl.Result{}, err
+	}
+
+	// 4. Handle HCP deletion: clean up Azure resources, remove per-CR finalizers
+	// from all CRs, and remove the shared HCP finalizer. This returns early so
+	// step 5 (add CR finalizer) is never reached during HCP deletion.
+	if !hcp.DeletionTimestamp.IsZero() {
+		return r.reconcileHCPDeletion(ctx, azPLS, hcp, log)
+	}
+
+	// 5. Add CR finalizer if not present
 	if !controllerutil.ContainsFinalizer(azPLS, azurePrivateLinkServiceFinalizer) {
 		controllerutil.AddFinalizer(azPLS, azurePrivateLinkServiceFinalizer)
 		if err := r.Update(ctx, azPLS); err != nil {
@@ -288,21 +303,10 @@ func (r *AzurePrivateLinkServiceReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, nil
 	}
 
-	// 4. Wait for PLS alias to be available (populated by HO platform controller)
+	// 6. Wait for PLS alias to be available (populated by HO platform controller)
 	if azPLS.Status.PrivateLinkServiceAlias == "" {
 		log.Info("PLS alias not yet available, waiting")
 		return ctrl.Result{RequeueAfter: azureutil.PLSRequeueInterval}, nil
-	}
-
-	// 5. Look up the HostedControlPlane for the KAS hostname
-	hcp, err := r.getHostedControlPlane(ctx, azPLS)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get HostedControlPlane: %w", err)
-	}
-
-	// 6. Handle HCP deletion: clean up Azure resources and remove HCP finalizer
-	if !hcp.DeletionTimestamp.IsZero() {
-		return r.reconcileHCPDeletion(ctx, azPLS, hcp, log)
 	}
 
 	// 7. Add HCP finalizer to block HCP deletion until Azure cleanup is done.
@@ -396,13 +400,39 @@ func (r *AzurePrivateLinkServiceReconciler) ensureHCPFinalizer(ctx context.Conte
 	return ctrl.Result{}, nil
 }
 
-// reconcileHCPDeletion handles HCP deletion by cleaning up Azure resources and removing
-// the HCP finalizer. This ensures credentials remain valid during the cleanup process.
+// getHCPOrCleanupOrphan looks up the HostedControlPlane for the given CR. If the HCP
+// is gone (NotFound), it removes any orphaned per-CR finalizer so the CR can be
+// garbage-collected with the namespace. Returns (nil, nil) when the HCP is gone and
+// cleanup succeeded; the caller should return immediately.
+func (r *AzurePrivateLinkServiceReconciler) getHCPOrCleanupOrphan(ctx context.Context, azPLS *hyperv1.AzurePrivateLinkService, log logr.Logger) (*hyperv1.HostedControlPlane, error) {
+	hcp, err := r.getHostedControlPlane(ctx, azPLS)
+	if err == nil {
+		return hcp, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to get HostedControlPlane: %w", err)
+	}
+	if controllerutil.ContainsFinalizer(azPLS, azurePrivateLinkServiceFinalizer) {
+		log.Info("HostedControlPlane not found, removing orphaned per-CR finalizer", "name", azPLS.Name)
+		controllerutil.RemoveFinalizer(azPLS, azurePrivateLinkServiceFinalizer)
+		if updateErr := r.Update(ctx, azPLS); updateErr != nil {
+			return nil, fmt.Errorf("failed to remove orphaned finalizer: %w", updateErr)
+		}
+	}
+	return nil, nil
+}
+
+// reconcileHCPDeletion handles HCP deletion by cleaning up Azure resources, removing
+// per-CR finalizers, and removing the shared HCP finalizer. Per-CR finalizers must be
+// removed here because once HCP deletion completes and HO deletes the namespace, CPO
+// is terminated and can no longer process them. Stuck per-CR finalizers block namespace
+// deletion, which blocks HO from removing the HC finalizer, causing a 40-minute timeout.
 //
 // The flow is:
 //  1. If the HCP does not have our finalizer, nothing to do.
-//  2. Perform Azure resource cleanup (PE, DNS zone, VNet link, A record).
-//  3. Remove the HCP finalizer to unblock HCP deletion.
+//  2. Perform Azure resource cleanup for ALL CRs (PE, DNS zone, VNet link, A record).
+//  3. Remove per-CR finalizers from ALL CRs so they can be garbage-collected with the namespace.
+//  4. Remove the shared HCP finalizer to unblock HCP deletion.
 func (r *AzurePrivateLinkServiceReconciler) reconcileHCPDeletion(ctx context.Context, azPLS *hyperv1.AzurePrivateLinkService, hcp *hyperv1.HostedControlPlane, log logr.Logger) (ctrl.Result, error) {
 	if !controllerutil.ContainsFinalizer(hcp, hcpAzurePLSFinalizerName) {
 		return ctrl.Result{}, nil
@@ -410,13 +440,35 @@ func (r *AzurePrivateLinkServiceReconciler) reconcileHCPDeletion(ctx context.Con
 
 	log.Info("HCP is being deleted, cleaning up Azure resources before removing HCP finalizer")
 
-	// Perform Azure resource cleanup
-	if err := r.reconcileDelete(ctx, azPLS, log); err != nil {
+	// List all AzurePrivateLinkService CRs in the namespace to ensure all are cleaned up
+	// before removing the shared HCP finalizer. When multiple CRs exist (e.g., private-router
+	// and oauth-openshift), each must complete Azure resource cleanup while HCP credentials
+	// are still valid. With MaxConcurrentReconciles: 1, the first CR to reconcile handles
+	// cleanup for all siblings in a single pass.
+	var allPLS hyperv1.AzurePrivateLinkServiceList
+	if err := r.List(ctx, &allPLS, client.InNamespace(azPLS.Namespace)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to list AzurePrivateLinkService resources: %w", err)
+	}
+
+	if err := r.cleanupAllAzureResources(ctx, allPLS.Items, log); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to clean up Azure resources during HCP deletion: %w", err)
 	}
 
+	// Delete the base domain DNS zone explicitly. When multiple CRs share the same
+	// base domain zone, each CR's reconcileDelete skips zone deletion because
+	// hasSiblingCR sees the other CR as still active (neither has DeletionTimestamp
+	// during HCP deletion). The per-CR cleanup above already removed all A records
+	// and VNet links from the zone, so it is safe to delete here.
+	if err := r.deleteBaseDomainDNSZone(ctx, allPLS.Items, log); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to delete base domain DNS zone during HCP deletion: %w", err)
+	}
+
+	if err := r.removeAllCRFinalizers(ctx, allPLS.Items, log); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to remove per-CR finalizers during HCP deletion: %w", err)
+	}
+
 	// Remove the HCP finalizer to unblock HCP deletion
-	log.Info("Azure resource cleanup complete, removing HCP finalizer")
+	log.Info("Azure resource cleanup complete for all AzurePrivateLinkService CRs, removing HCP finalizer")
 	originalHCP := hcp.DeepCopy()
 	controllerutil.RemoveFinalizer(hcp, hcpAzurePLSFinalizerName)
 	if err := r.Patch(ctx, hcp, client.MergeFromWithOptions(originalHCP, client.MergeFromWithOptimisticLock{})); err != nil {
@@ -427,6 +479,50 @@ func (r *AzurePrivateLinkServiceReconciler) reconcileHCPDeletion(ctx context.Con
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// deleteBaseDomainDNSZone finds the base domain from the CR list and deletes the
+// shared DNS zone. This is called during HCP deletion after all per-CR resources
+// (A records, VNet links, PEs) have been cleaned up by cleanupAllAzureResources.
+func (r *AzurePrivateLinkServiceReconciler) deleteBaseDomainDNSZone(ctx context.Context, items []hyperv1.AzurePrivateLinkService, log logr.Logger) error {
+	for i := range items {
+		if items[i].Spec.BaseDomain != "" {
+			log.Info("Deleting base domain DNS zone after all-CR cleanup", "zone", items[i].Spec.BaseDomain)
+			return r.deleteDNSZone(ctx, items[i].Spec.ResourceGroupName, items[i].Spec.BaseDomain, log)
+		}
+	}
+	return nil
+}
+
+func (r *AzurePrivateLinkServiceReconciler) cleanupAllAzureResources(ctx context.Context, items []hyperv1.AzurePrivateLinkService, log logr.Logger) error {
+	var errs []error
+	for i := range items {
+		pls := &items[i]
+		log.Info("Cleaning up Azure resources for AzurePrivateLinkService", "name", pls.Name)
+		if err := r.reconcileDelete(ctx, pls, log); err != nil {
+			errs = append(errs, fmt.Errorf("failed to clean up %s: %w", pls.Name, err))
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+// removeAllCRFinalizers removes per-CR finalizers so the CRs can be deleted
+// during namespace cleanup without requiring CPO to still be running.
+func (r *AzurePrivateLinkServiceReconciler) removeAllCRFinalizers(ctx context.Context, items []hyperv1.AzurePrivateLinkService, log logr.Logger) error {
+	var errs []error
+	for i := range items {
+		pls := &items[i]
+		if !controllerutil.ContainsFinalizer(pls, azurePrivateLinkServiceFinalizer) {
+			continue
+		}
+		log.Info("Removing per-CR finalizer from AzurePrivateLinkService", "name", pls.Name)
+		original := pls.DeepCopy()
+		controllerutil.RemoveFinalizer(pls, azurePrivateLinkServiceFinalizer)
+		if err := r.Patch(ctx, pls, client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{})); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove per-CR finalizer from %s: %w", pls.Name, err))
+		}
+	}
+	return utilerrors.NewAggregate(errs)
 }
 
 // reconcilePrivateEndpoint creates or updates the Private Endpoint in the guest VNet.

--- a/control-plane-operator/controllers/azureprivatelinkservice/controller_test.go
+++ b/control-plane-operator/controllers/azureprivatelinkservice/controller_test.go
@@ -672,11 +672,12 @@ func TestReconcile_WhenFinalizerNotPresent_ItShouldAddFinalizer(t *testing.T) {
 	scheme := newTestScheme(t, g)
 
 	azPLS := newTestAzurePLS(t, "test-pls", "test-ns")
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "kas.example.com")
 	// No finalizer set
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(azPLS).
+		WithObjects(azPLS, hcp).
 		WithStatusSubresource(azPLS).
 		Build()
 
@@ -1374,6 +1375,327 @@ func TestReconcile_WhenHCPIsBeingDeleted_ItShouldTriggerCleanupInsteadOfCreation
 	}
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(updatedHCP.Finalizers).ToNot(ContainElement(hcpAzurePLSFinalizerName), "HCP finalizer should be removed")
+}
+
+func newTestReconciler(fakeClient client.Client) *AzurePrivateLinkServiceReconciler {
+	return &AzurePrivateLinkServiceReconciler{
+		Client:              fakeClient,
+		PrivateEndpoints:    &mockPrivateEndpoints{},
+		PrivateDNSZones:     &mockPrivateDNSZones{},
+		VirtualNetworkLinks: &mockVirtualNetworkLinks{},
+		RecordSets:          &mockRecordSets{},
+	}
+}
+
+func TestReconcileHCPDeletion_WhenMultipleCRsExist_ItShouldRemoveAllPerCRFinalizers(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	scheme := newTestScheme(t, g)
+
+	azPLS1 := newTestAzurePLS(t, privateRouterCRName, "test-ns")
+	azPLS1.Finalizers = []string{azurePrivateLinkServiceFinalizer}
+	azPLS1.Status.DNSZoneName = "test-hcp.hypershift.local"
+
+	azPLS2 := newTestAzurePLS(t, "oauth-openshift", "test-ns")
+	azPLS2.Finalizers = []string{azurePrivateLinkServiceFinalizer}
+	azPLS2.Status.DNSZoneName = "test-hcp.hypershift.local"
+
+	now := metav1.Now()
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.test.example.com")
+	hcp.DeletionTimestamp = &now
+	hcp.Finalizers = []string{hcpAzurePLSFinalizerName}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(azPLS1, azPLS2, hcp).
+		WithStatusSubresource(azPLS1, azPLS2).
+		Build()
+
+	mockDNS := &mockPrivateDNSZones{}
+	r := newTestReconciler(fakeClient)
+	r.PrivateDNSZones = mockDNS
+
+	result, err := r.reconcileHCPDeletion(t.Context(), azPLS1, hcp, testr.New(t))
+	g.Expect(err).ToNot(HaveOccurred(), "failed to reconcile HCP deletion with multiple AzurePrivateLinkService CRs")
+	g.Expect(result.IsZero()).To(BeTrue(), "expected zero requeue result after successful multi-CR HCP deletion cleanup")
+
+	// Neither CR has BaseDomain set, so deleteBaseDomainDNSZone should be a no-op.
+	// Only the internal hypershift.local zones should be deleted (one per CR).
+	for _, zoneName := range mockDNS.deletedZoneNames {
+		g.Expect(zoneName).To(Equal("test-hcp.hypershift.local"),
+			"only internal DNS zones should be deleted when no BaseDomain is set")
+	}
+
+	// Both CRs should have per-CR finalizer removed
+	updated1 := &hyperv1.AzurePrivateLinkService{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: privateRouterCRName, Namespace: "test-ns"}, updated1)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get first AzurePrivateLinkService CR after HCP deletion reconciliation")
+	g.Expect(updated1.Finalizers).ToNot(ContainElement(azurePrivateLinkServiceFinalizer),
+		"per-CR finalizer should be removed from first CR")
+
+	updated2 := &hyperv1.AzurePrivateLinkService{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "oauth-openshift", Namespace: "test-ns"}, updated2)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get second AzurePrivateLinkService CR after HCP deletion reconciliation")
+	g.Expect(updated2.Finalizers).ToNot(ContainElement(azurePrivateLinkServiceFinalizer),
+		"per-CR finalizer should be removed from second CR")
+
+	// Shared HCP finalizer should be removed. The fake client garbage-collects
+	// objects whose DeletionTimestamp is set and all finalizers are removed,
+	// so a NotFound error confirms the finalizer was successfully removed.
+	updatedHCP := &hyperv1.HostedControlPlane{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "test-hcp", Namespace: "test-ns"}, updatedHCP)
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get HCP after multi-CR HCP deletion reconciliation")
+	g.Expect(updatedHCP.Finalizers).ToNot(ContainElement(hcpAzurePLSFinalizerName),
+		"shared HCP finalizer should be removed after all CRs are cleaned up")
+}
+
+func TestReconcileHCPDeletion_WhenMultipleCRsShareBaseDomain_ItShouldDeleteBaseDomainZone(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	scheme := newTestScheme(t, g)
+
+	azPLS1 := newTestAzurePLS(t, privateRouterCRName, "test-ns")
+	azPLS1.Finalizers = []string{azurePrivateLinkServiceFinalizer}
+	azPLS1.Status.DNSZoneName = "test-hcp.hypershift.local"
+	azPLS1.Spec.BaseDomain = "example.com"
+
+	azPLS2 := newTestAzurePLS(t, "oauth-openshift", "test-ns")
+	azPLS2.Finalizers = []string{azurePrivateLinkServiceFinalizer}
+	azPLS2.Status.DNSZoneName = "test-hcp.hypershift.local"
+	azPLS2.Spec.BaseDomain = "example.com"
+
+	now := metav1.Now()
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.test.example.com")
+	hcp.DeletionTimestamp = &now
+	hcp.Finalizers = []string{hcpAzurePLSFinalizerName}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(azPLS1, azPLS2, hcp).
+		WithStatusSubresource(azPLS1, azPLS2).
+		Build()
+
+	mockDNS := &mockPrivateDNSZones{}
+	r := newTestReconciler(fakeClient)
+	r.PrivateDNSZones = mockDNS
+
+	result, err := r.reconcileHCPDeletion(t.Context(), azPLS1, hcp, testr.New(t))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.IsZero()).To(BeTrue())
+
+	// The base domain zone should be explicitly deleted by deleteBaseDomainDNSZone,
+	// even though hasSiblingCR prevented each CR's reconcileDelete from doing it.
+	g.Expect(mockDNS.deletedZoneNames).To(ContainElement("example.com"),
+		"base domain DNS zone should be deleted during HCP deletion with multiple CRs")
+}
+
+func TestReconcileHCPDeletion_WhenSingleCRHasBaseDomain_ItShouldDeleteBaseDomainZoneIdempotently(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	scheme := newTestScheme(t, g)
+
+	// Single CR with BaseDomain: reconcileDelete already deletes the zone (hasSiblingCR
+	// returns false), then deleteBaseDomainDNSZone tries again and gets NotFound (no-op).
+	azPLS := newTestAzurePLS(t, privateRouterCRName, "test-ns")
+	azPLS.Finalizers = []string{azurePrivateLinkServiceFinalizer}
+	azPLS.Status.DNSZoneName = "test-hcp.hypershift.local"
+	azPLS.Spec.BaseDomain = "example.com"
+
+	now := metav1.Now()
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.test.example.com")
+	hcp.DeletionTimestamp = &now
+	hcp.Finalizers = []string{hcpAzurePLSFinalizerName}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(azPLS, hcp).
+		WithStatusSubresource(azPLS).
+		Build()
+
+	mockDNS := &mockPrivateDNSZones{}
+	r := newTestReconciler(fakeClient)
+	r.PrivateDNSZones = mockDNS
+
+	result, err := r.reconcileHCPDeletion(t.Context(), azPLS, hcp, testr.New(t))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.IsZero()).To(BeTrue())
+
+	// The base domain zone should appear in deletedZoneNames (called by both
+	// deleteBaseDomainResources and deleteBaseDomainDNSZone). The second call
+	// is idempotent: in production Azure returns NotFound, in the mock it succeeds.
+	g.Expect(mockDNS.deletedZoneNames).To(ContainElement("example.com"),
+		"base domain DNS zone should be deleted for single-CR HCP deletion")
+}
+
+func TestReconcileHCPDeletion_WhenBaseDomainZoneDeletionFails_ItShouldPreserveFinalizers(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	scheme := newTestScheme(t, g)
+
+	azPLS1 := newTestAzurePLS(t, privateRouterCRName, "test-ns")
+	azPLS1.Finalizers = []string{azurePrivateLinkServiceFinalizer}
+	azPLS1.Status.DNSZoneName = "test-hcp.hypershift.local"
+	azPLS1.Spec.BaseDomain = "example.com"
+
+	azPLS2 := newTestAzurePLS(t, "oauth-openshift", "test-ns")
+	azPLS2.Finalizers = []string{azurePrivateLinkServiceFinalizer}
+	azPLS2.Status.DNSZoneName = "test-hcp.hypershift.local"
+	azPLS2.Spec.BaseDomain = "example.com"
+
+	now := metav1.Now()
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.test.example.com")
+	hcp.DeletionTimestamp = &now
+	hcp.Finalizers = []string{hcpAzurePLSFinalizerName}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(azPLS1, azPLS2, hcp).
+		WithStatusSubresource(azPLS1, azPLS2).
+		Build()
+
+	// deleteDNSZone fails only for the base domain zone (called by deleteBaseDomainDNSZone).
+	// The internal zones and per-CR cleanup succeed because the error is scoped.
+	mockDNS := &mockPrivateDNSZones{
+		deleteErr: fmt.Errorf("simulated zone deletion failure"),
+	}
+	r := newTestReconciler(fakeClient)
+	r.PrivateDNSZones = mockDNS
+
+	_, err := r.reconcileHCPDeletion(t.Context(), azPLS1, hcp, testr.New(t))
+
+	// The error may come from cleanupAllAzureResources (internal zone deletion)
+	// or deleteBaseDomainDNSZone. Either way, the HCP finalizer must be preserved.
+	g.Expect(err).To(HaveOccurred(), "expected error when DNS zone deletion fails")
+
+	updatedHCP := &hyperv1.HostedControlPlane{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "test-hcp", Namespace: "test-ns"}, updatedHCP)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(updatedHCP.Finalizers).To(ContainElement(hcpAzurePLSFinalizerName),
+		"HCP finalizer should be preserved when base domain zone deletion fails")
+}
+
+func TestReconcileHCPDeletion_WhenSiblingCleanupFails_ItShouldPreserveAllFinalizers(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	scheme := newTestScheme(t, g)
+
+	azPLS1 := newTestAzurePLS(t, privateRouterCRName, "test-ns")
+	azPLS1.Finalizers = []string{azurePrivateLinkServiceFinalizer}
+	azPLS1.Status.DNSZoneName = "test-hcp.hypershift.local"
+
+	azPLS2 := newTestAzurePLS(t, "oauth-openshift", "test-ns")
+	azPLS2.Finalizers = []string{azurePrivateLinkServiceFinalizer}
+	azPLS2.Status.DNSZoneName = "test-hcp.hypershift.local"
+
+	now := metav1.Now()
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.test.example.com")
+	hcp.DeletionTimestamp = &now
+	hcp.Finalizers = []string{hcpAzurePLSFinalizerName}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(azPLS1, azPLS2, hcp).
+		WithStatusSubresource(azPLS1, azPLS2).
+		Build()
+
+	r := newTestReconciler(fakeClient)
+	r.RecordSets = &mockRecordSets{deleteErr: fmt.Errorf("simulated Azure API failure")}
+
+	_, err := r.reconcileHCPDeletion(t.Context(), azPLS1, hcp, testr.New(t))
+	g.Expect(err).To(HaveOccurred(), "expected error when sibling Azure cleanup fails")
+	g.Expect(err.Error()).To(ContainSubstring("simulated Azure API failure"),
+		"error should originate from the injected Azure cleanup failure")
+
+	// Per-CR finalizers should be preserved (cleanup didn't complete)
+	updated1 := &hyperv1.AzurePrivateLinkService{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: privateRouterCRName, Namespace: "test-ns"}, updated1)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get first CR after partial failure")
+	g.Expect(updated1.Finalizers).To(ContainElement(azurePrivateLinkServiceFinalizer),
+		"per-CR finalizer should be preserved when cleanup fails")
+
+	updated2 := &hyperv1.AzurePrivateLinkService{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "oauth-openshift", Namespace: "test-ns"}, updated2)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get second CR after partial failure")
+	g.Expect(updated2.Finalizers).To(ContainElement(azurePrivateLinkServiceFinalizer),
+		"per-CR finalizer should be preserved when cleanup fails")
+
+	// Shared HCP finalizer should be preserved
+	updatedHCP := &hyperv1.HostedControlPlane{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "test-hcp", Namespace: "test-ns"}, updatedHCP)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get HCP after partial failure")
+	g.Expect(updatedHCP.Finalizers).To(ContainElement(hcpAzurePLSFinalizerName),
+		"shared HCP finalizer should be preserved when cleanup fails")
+}
+
+func TestReconcile_WhenHCPIsGone_ItShouldRemoveOrphanedPerCRFinalizer(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	scheme := newTestScheme(t, g)
+
+	azPLS := newTestAzurePLS(t, "test-pls", "test-ns")
+	azPLS.Finalizers = []string{azurePrivateLinkServiceFinalizer}
+	// HCP referenced by owner ref does NOT exist in the fake client
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(azPLS).
+		WithStatusSubresource(azPLS).
+		Build()
+
+	r := newTestReconciler(fakeClient)
+
+	result, err := r.Reconcile(log.IntoContext(t.Context(), testr.New(t)), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-pls", Namespace: "test-ns"},
+	})
+	g.Expect(err).ToNot(HaveOccurred(), "failed to reconcile AzurePrivateLinkService when HCP is gone")
+	g.Expect(result.IsZero()).To(BeTrue(), "expected zero requeue result when HCP is gone")
+
+	// Per-CR finalizer should be removed when HCP is gone
+	updated := &hyperv1.AzurePrivateLinkService{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "test-pls", Namespace: "test-ns"}, updated)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get AzurePrivateLinkService CR after reconciliation with missing HCP")
+	g.Expect(updated.Finalizers).ToNot(ContainElement(azurePrivateLinkServiceFinalizer),
+		"per-CR finalizer should be removed when HCP is gone")
+}
+
+func TestReconcile_WhenHCPIsBeingDeleted_ItShouldNotReAddPerCRFinalizer(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	scheme := newTestScheme(t, g)
+
+	// Simulate the state after reconcileHCPDeletion has run:
+	// per-CR finalizer is already removed, shared HCP finalizer is gone
+	azPLS := newTestAzurePLS(t, "test-pls", "test-ns")
+	// No per-CR finalizer (already removed by reconcileHCPDeletion)
+
+	now := metav1.Now()
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.test.example.com")
+	hcp.DeletionTimestamp = &now
+	hcp.Finalizers = []string{"some-other-finalizer"} // Another controller's finalizer keeps HCP alive
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(azPLS, hcp).
+		WithStatusSubresource(azPLS).
+		Build()
+
+	r := newTestReconciler(fakeClient)
+
+	result, err := r.Reconcile(log.IntoContext(t.Context(), testr.New(t)), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-pls", Namespace: "test-ns"},
+	})
+	g.Expect(err).ToNot(HaveOccurred(), "failed to reconcile AzurePrivateLinkService when HCP is being deleted")
+	g.Expect(result.IsZero()).To(BeTrue(), "expected zero requeue result when HCP is being deleted")
+
+	// Verify per-CR finalizer was NOT re-added
+	updated := &hyperv1.AzurePrivateLinkService{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "test-pls", Namespace: "test-ns"}, updated)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get AzurePrivateLinkService CR after reconciliation during HCP deletion")
+	g.Expect(updated.Finalizers).ToNot(ContainElement(azurePrivateLinkServiceFinalizer),
+		"per-CR finalizer should NOT be re-added when HCP is being deleted")
 }
 
 func TestReconcile_WhenPEConnectionNotApproved_ItShouldRequeueWithWarning(t *testing.T) {
@@ -3396,6 +3718,7 @@ func TestReconcile_WhenFinalizerAddConflicts_ItShouldRequeue(t *testing.T) {
 	scheme := newTestScheme(t, g)
 
 	azPLS := newTestAzurePLS(t, "test-pls", "test-ns")
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "kas.example.com")
 	// No finalizer → Reconcile will try to add one
 
 	conflictErr := apierrors.NewConflict(
@@ -3403,7 +3726,7 @@ func TestReconcile_WhenFinalizerAddConflicts_ItShouldRequeue(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(azPLS).
+		WithObjects(azPLS, hcp).
 		WithStatusSubresource(azPLS).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {


### PR DESCRIPTION
## What this PR does / why we need it:

When a HostedCluster with `endpointAccess=Private` and
`oauthPublishingStrategy=LoadBalancer` is deleted, two AzurePrivateLinkService CRs
exist in the HCP namespace (one for `private-router`, one for `oauth-openshift`).
Both share a single HCP finalizer (`hypershift.openshift.io/azure-pls-endpoint-cleanup`),
but `reconcileHCPDeletion` only cleans up the CR that reconciles first, then removes
the shared finalizer. The second CR's Azure resources (Private Endpoint, DNS zone,
VNet link) are orphaned, and its per-CR finalizer blocks namespace deletion.

The orphaned Private Endpoint then blocks management cluster resource group deletion
with Azure 409: `PrivateLinkServiceWithPrivateEndpointConnectionsCannotBeDeleted`.

This fix makes `reconcileHCPDeletion` list and clean up ALL AzurePrivateLinkService
CRs in a single pass before removing the shared HCP finalizer. Per-CR finalizers are
also removed during HCP deletion so they do not block namespace cleanup after Azure
resources are already gone.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3978

## Special notes for your reviewer:

- `reconcileDelete` is idempotent (checks `IsAzureNotFoundError`), so processing
  all CRs in a single pass is safe.
- Per-CR finalizers are normally processed by step 2 in `Reconcile` when CRs are
  garbage-collected during namespace cleanup. Removing them during HCP deletion
  avoids the race where CPO is torn down before the second CR reconciles.
- Confirmed in CI (PR #8584): `destroy-guests` completes in ~12m47s vs the
  previous 40-minute timeout.
- This is a pre-existing bug never triggered before because no CI test or
  production scenario combined `Private` endpoint access with `LoadBalancer`
  OAuth publishing strategy until CNTRLPLANE-3277.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of all Azure private link resources when their associated HostedControlPlane is deleted.
  * Removed stale finalizers when the associated HostedControlPlane is missing.
  * Prevented finalizers from being re-added while deletion is blocked or in progress.
  * Ensured normal reconciliation proceeds only for active HostedControlPlanes.

* **Tests**
  * Added coverage for deletion, orphan cleanup, conflict handling, blocked deletion, and multiple related resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->