### PR TITLE
OCPBUGS-98983: improve guest cluster state management reliability

### DIFF
--- a/test/e2e/v2/cmd/create-guests/main.go
+++ b/test/e2e/v2/cmd/create-guests/main.go
@@ -132,17 +132,37 @@ func loadEnvConfig() envConfig {
 func run(ctx context.Context, cfg envConfig) error {
 	specs := cfg.platform.ClusterSpecs(cfg.releaseImage, cfg.n1Image)
 
-	// Derive cluster names and build the name map.
+	// Phase 0: The manifest must exist before any infra is provisioned so
+	// destroy-guests can always clean up, even if create-guests fails
+	// before the HostedCluster CR is applied.
+	log.Println("Phase 0: Computing cluster identities and writing manifest")
 	named := make([]namedSpec, len(specs))
-	clusterNames := make(map[string]string) // outputFile -> name
+	clusterNames := make(map[string]string) // variant -> name
+	entries := make([]lifecycle.ClusterEntry, len(specs))
 	for i, spec := range specs {
 		name := lifecycle.DeriveClusterName(cfg.prowJobID, spec.Variant)
 		named[i] = namedSpec{ClusterSpec: spec, name: name}
-		clusterNames[spec.OutputFile] = name
+		clusterNames[spec.Variant] = name
+		entries[i] = lifecycle.ClusterEntry{
+			Variant:   spec.Variant,
+			Name:      name,
+			InfraID:   name,
+			Namespace: cfg.namespace,
+		}
+		log.Printf("Cluster %s: name=%s", spec.Variant, name)
 	}
 
-	// Phase 0: Platform-specific pre-create hooks (e.g., deploy OIDC providers).
-	log.Println("Phase 0: Running platform pre-create hooks")
+	manifest := &lifecycle.ClusterManifest{
+		Clusters: entries,
+	}
+	if err := lifecycle.WriteManifest(cfg.sharedDir, manifest); err != nil {
+		return fmt.Errorf("writing cluster manifest: %w", err)
+	}
+	log.Printf("Wrote cluster manifest to %s/%s", cfg.sharedDir, lifecycle.ManifestFileName)
+
+	// Phase 1: Some platforms need prerequisites deployed before clusters
+	// exist (e.g., OIDC providers that the HC spec references).
+	log.Println("Phase 1: Running platform pre-create hooks")
 	mgmtClientPre, err := newMgmtClient()
 	if err != nil {
 		return fmt.Errorf("creating management cluster client for pre-create: %w", err)
@@ -151,8 +171,9 @@ func run(ctx context.Context, cfg envConfig) error {
 		return fmt.Errorf("platform pre-create hook: %w", err)
 	}
 
-	// Phase 1: Create all clusters in parallel.
-	log.Printf("Phase 1: Creating %d clusters in parallel", len(named))
+	// Phase 2: Clusters are independent; creating them in parallel cuts
+	// wall-clock time proportionally.
+	log.Printf("Phase 2: Creating %d clusters in parallel", len(named))
 	createErrors := createClustersParallel(ctx, cfg, named)
 	for _, ns := range named {
 		if err := createErrors[ns.Variant]; err != nil {
@@ -167,8 +188,9 @@ func run(ctx context.Context, cfg envConfig) error {
 		}
 	}
 
-	// Phase 2: Platform-specific post-create hooks.
-	log.Println("Phase 2: Running platform post-create hooks")
+	// Phase 3: Some platforms need configuration applied after the HC CR
+	// exists but before it becomes Available (e.g., patching OperatorConfiguration).
+	log.Println("Phase 3: Running platform post-create hooks")
 	mgmtClient, err := newMgmtClient()
 	if err != nil {
 		return fmt.Errorf("creating management cluster client: %w", err)
@@ -177,9 +199,9 @@ func run(ctx context.Context, cfg envConfig) error {
 		return fmt.Errorf("platform post-create hook: %w", err)
 	}
 
-	// Phase 3: Watch for Available condition on all clusters.
-	log.Println("Phase 3: Waiting for all clusters to become Available")
-	// Use cfg.waitTimeout (45m) to match the version rollout timeout at line 352.
+	// Phase 4: Control plane components must exist before post-available
+	// hooks can run; Available guarantees that.
+	log.Println("Phase 4: Waiting for all clusters to become Available")
 	availableErrors := waitForClustersAvailable(ctx, mgmtClient, cfg.namespace, named, cfg.waitTimeout)
 	for _, ns := range named {
 		if err := availableErrors[ns.Variant]; err != nil {
@@ -194,15 +216,16 @@ func run(ctx context.Context, cfg envConfig) error {
 		}
 	}
 
-	// Phase 4: Platform-specific post-available hooks (e.g., waiting for
-	// day-2 config transitions now that control plane components exist).
-	log.Println("Phase 4: Running platform post-available hooks")
+	// Phase 5: Some platforms need to wait for day-2 config transitions
+	// that depend on control plane components existing.
+	log.Println("Phase 5: Running platform post-available hooks")
 	if err := cfg.platform.PostAvailable(ctx, mgmtClient, cfg.namespace, clusterNames); err != nil {
 		return fmt.Errorf("platform post-available hook: %w", err)
 	}
 
-	// Phase 5: Watch for version rollout completion on all clusters.
-	log.Println("Phase 5: Waiting for version rollout completion on all clusters")
+	// Phase 6: Tests assume rollout is complete; block until all version
+	// history entries reach CompletedUpdate.
+	log.Println("Phase 6: Waiting for version rollout completion on all clusters")
 	rolloutErrors := waitForVersionRollout(ctx, mgmtClient, cfg, named)
 	anyRolloutFailed := false
 	for _, ns := range named {
@@ -216,21 +239,11 @@ func run(ctx context.Context, cfg envConfig) error {
 		}
 	}
 
-	// Phase 6: Day-2 operations that disrupt ClusterOperators (e.g., External OIDC).
-	// These run after VersionState=Completed so the initial rollout isn't blocked.
-	log.Println("Phase 6: Running platform post-version-rollout hooks (day-2 operations)")
+	// Phase 7: Day-2 operations that disrupt ClusterOperators (e.g., External OIDC)
+	// run after rollout so they don't block the initial version completion.
+	log.Println("Phase 7: Running platform post-version-rollout hooks (day-2 operations)")
 	if err := cfg.platform.PostVersionRollout(ctx, mgmtClient, cfg.namespace, clusterNames); err != nil {
 		return fmt.Errorf("platform post-version-rollout hook: %w", err)
-	}
-
-	// Phase 7: Write cluster names to SHARED_DIR.
-	log.Println("Phase 7: Writing cluster names to SHARED_DIR")
-	for _, ns := range named {
-		outputPath := filepath.Join(cfg.sharedDir, ns.OutputFile)
-		if err := os.WriteFile(outputPath, []byte(ns.name), 0600); err != nil {
-			return fmt.Errorf("writing cluster name to %s: %w", outputPath, err)
-		}
-		log.Printf("Wrote cluster name %q to %s", ns.name, outputPath)
 	}
 
 	if anyRolloutFailed {
@@ -242,16 +255,17 @@ func run(ctx context.Context, cfg envConfig) error {
 }
 
 // buildCreateArgs returns CLI arguments for creating a cluster.
-func buildCreateArgs(cfg envConfig, name string, spec lifecycle.ClusterSpec) []string {
+func buildCreateArgs(cfg envConfig, ns namedSpec) []string {
 	releaseImage := cfg.releaseImage
-	if spec.ReleaseImage != "" {
-		releaseImage = spec.ReleaseImage
+	if ns.ReleaseImage != "" {
+		releaseImage = ns.ReleaseImage
 	}
 
 	args := []string{
 		"create", "cluster", cfg.platform.Name(),
-		"--name=" + name,
+		"--name=" + ns.name,
 		"--namespace=" + cfg.namespace,
+		"--infra-id=" + ns.name,
 		"--node-pool-replicas=" + strconv.Itoa(cfg.nodeCount),
 		"--base-domain=" + cfg.baseDomain,
 		"--pull-secret=" + cfg.pullSecret,
@@ -267,7 +281,7 @@ func buildCreateArgs(cfg envConfig, name string, spec lifecycle.ClusterSpec) []s
 	}
 
 	args = append(args, cfg.platform.CreateArgs()...)
-	args = append(args, spec.ExtraArgs...)
+	args = append(args, ns.ExtraArgs...)
 
 	return args
 }
@@ -286,7 +300,7 @@ func createClustersParallel(ctx context.Context, cfg envConfig, specs []namedSpe
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			args := buildCreateArgs(cfg, ns.name, ns.ClusterSpec)
+			args := buildCreateArgs(cfg, ns)
 			log.Printf("Creating %s cluster %s", ns.Variant, ns.name)
 			log.Printf("Running: %s %v", cfg.hypershiftBinary, args)
 

--- a/test/e2e/v2/cmd/destroy-guests/main.go
+++ b/test/e2e/v2/cmd/destroy-guests/main.go
@@ -15,11 +15,10 @@ limitations under the License.
 */
 
 // destroy-guests destroys all HostedClusters created by the v2 e2e
-// lifecycle tests. Cluster names are re-derived from PROW_JOB_ID
-// using the same sha256 hash logic as the create step. All clusters
-// are destroyed in parallel with best-effort semantics.
-// Platform selection is controlled by the HYPERSHIFT_PLATFORM
-// environment variable (default: "azure").
+// lifecycle tests. Cluster identities are read from the cluster
+// manifest written by create-guests to SHARED_DIR. Platform-specific
+// destroy flags come from PlatformConfig.DestroyArgs().
+// All clusters are destroyed in parallel with best-effort semantics.
 package main
 
 import (
@@ -35,12 +34,15 @@ import (
 const clusterGracePeriod = "40m"
 
 func main() {
-	prowJobID := os.Getenv("PROW_JOB_ID")
-	if prowJobID == "" {
-		log.Fatal("PROW_JOB_ID is required")
+	sharedDir := os.Getenv("SHARED_DIR")
+	if sharedDir == "" {
+		log.Fatal("SHARED_DIR is required")
 	}
 
-	sharedDir := os.Getenv("SHARED_DIR")
+	manifest, err := lifecycle.ReadManifest(sharedDir)
+	if err != nil {
+		log.Fatalf("Failed to read cluster manifest: %v", err)
+	}
 
 	platform, err := lifecycle.NewPlatformConfig(os.Getenv("HYPERSHIFT_PLATFORM"), sharedDir)
 	if err != nil {
@@ -52,14 +54,7 @@ func main() {
 		hypershiftBin = "hypershift"
 	}
 
-	namespace := os.Getenv("HYPERSHIFT_NAMESPACE")
-	if namespace == "" {
-		namespace = "clusters"
-	}
-
-	specs := platform.ClusterSpecs("", "")
-
-	log.Printf("Destroying %d clusters derived from PROW_JOB_ID=%s", len(specs), prowJobID)
+	log.Printf("Destroying %d clusters from manifest", len(manifest.Clusters))
 
 	var (
 		mu     sync.Mutex
@@ -67,14 +62,13 @@ func main() {
 		wg     sync.WaitGroup
 	)
 
-	for _, spec := range specs {
-		clusterName := lifecycle.DeriveClusterName(prowJobID, spec.Variant)
+	for _, entry := range manifest.Clusters {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := destroyCluster(hypershiftBin, clusterName, namespace, spec.Variant, platform); err != nil {
-				log.Printf("WARNING: Failed to destroy cluster %s (%s): %v", clusterName, spec.Variant, err)
-				log.Printf("ACTION REQUIRED: cloud resources for cluster %s may be orphaned and need manual cleanup (resource group, DNS records, etc.)", clusterName)
+			if err := destroyCluster(hypershiftBin, entry, platform); err != nil {
+				log.Printf("WARNING: Failed to destroy cluster %s (%s): %v", entry.Name, entry.Variant, err)
+				log.Printf("ACTION REQUIRED: cloud resources for cluster %s (infraID=%s) may be orphaned and need manual cleanup", entry.Name, entry.InfraID)
 				mu.Lock()
 				failed = true
 				mu.Unlock()
@@ -90,13 +84,14 @@ func main() {
 	log.Printf("All clusters destroyed successfully")
 }
 
-func destroyCluster(hypershiftBin, name, namespace, variant string, platform lifecycle.PlatformConfig) error {
-	log.Printf("Destroying cluster %s (%s)", name, variant)
+func destroyCluster(hypershiftBin string, entry lifecycle.ClusterEntry, platform lifecycle.PlatformConfig) error {
+	log.Printf("Destroying cluster %s (%s, infraID=%s)", entry.Name, entry.Variant, entry.InfraID)
 
 	args := []string{
 		"destroy", "cluster", platform.Name(),
-		"--name=" + name,
-		"--namespace=" + namespace,
+		"--name=" + entry.Name,
+		"--namespace=" + entry.Namespace,
+		"--infra-id=" + entry.InfraID,
 		"--cluster-grace-period=" + clusterGracePeriod,
 	}
 	args = append(args, platform.DestroyArgs()...)
@@ -107,9 +102,9 @@ func destroyCluster(hypershiftBin, name, namespace, variant string, platform lif
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("hypershift destroy cluster %s failed for %s: %w", platform.Name(), name, err)
+		return fmt.Errorf("hypershift destroy cluster %s failed for %s: %w", platform.Name(), entry.Name, err)
 	}
 
-	log.Printf("Finished destroying cluster: %s", name)
+	log.Printf("Finished destroying cluster: %s", entry.Name)
 	return nil
 }

--- a/test/e2e/v2/cmd/dump-guests/main.go
+++ b/test/e2e/v2/cmd/dump-guests/main.go
@@ -15,11 +15,9 @@ limitations under the License.
 */
 
 // dump-guests collects diagnostic artifacts from all v2 e2e
-// HostedClusters in parallel. It shells out to the hypershift CLI
-// for each cluster and always exits 0 so that dump failures never
-// block teardown.
-// Platform selection is controlled by the HYPERSHIFT_PLATFORM
-// environment variable (default: "azure").
+// HostedClusters in parallel. Cluster identities are read from
+// the cluster manifest written by create-guests to SHARED_DIR.
+// It always exits 0 so that dump failures never block teardown.
 package main
 
 import (
@@ -37,36 +35,28 @@ func main() {
 	hypershiftBinary := flag.String("hypershift-binary", "hypershift", "Path to the hypershift CLI binary")
 	flag.Parse()
 
-	prowJobID := os.Getenv("PROW_JOB_ID")
-	if prowJobID == "" {
-		log.Fatal("PROW_JOB_ID environment variable is required")
+	sharedDir := os.Getenv("SHARED_DIR")
+	if sharedDir == "" {
+		log.Fatal("SHARED_DIR environment variable is required")
 	}
 	artifactDir := os.Getenv("ARTIFACT_DIR")
 	if artifactDir == "" {
 		log.Fatal("ARTIFACT_DIR environment variable is required")
 	}
 
-	sharedDir := os.Getenv("SHARED_DIR")
-	platform, err := lifecycle.NewPlatformConfig(os.Getenv("HYPERSHIFT_PLATFORM"), sharedDir)
+	manifest, err := lifecycle.ReadManifest(sharedDir)
 	if err != nil {
-		log.Fatalf("Failed to initialize platform config: %v", err)
+		log.Fatalf("Failed to read cluster manifest: %v", err)
 	}
 
-	namespace := os.Getenv("HYPERSHIFT_NAMESPACE")
-	if namespace == "" {
-		namespace = "clusters"
-	}
-
-	specs := platform.ClusterSpecs("", "")
-	log.Printf("Dumping %d clusters derived from PROW_JOB_ID=%s", len(specs), prowJobID)
+	log.Printf("Dumping %d clusters from manifest", len(manifest.Clusters))
 
 	var wg sync.WaitGroup
-	for _, spec := range specs {
-		clusterName := lifecycle.DeriveClusterName(prowJobID, spec.Variant)
+	for _, entry := range manifest.Clusters {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			dumpCluster(*hypershiftBinary, artifactDir, clusterName, namespace)
+			dumpCluster(*hypershiftBinary, artifactDir, entry.Name, entry.Namespace)
 		}()
 	}
 	wg.Wait()

--- a/test/e2e/v2/cmd/run-tests/main.go
+++ b/test/e2e/v2/cmd/run-tests/main.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/openshift/hypershift/test/e2e/v2/lifecycle"
@@ -19,7 +18,6 @@ import (
 
 const (
 	defaultTestBinary    = "bin/test-e2e-v2"
-	defaultNamespace     = "clusters"
 	defaultVerbose       = "false"
 	defaultGinkgoTimeout = "3h"
 )
@@ -46,16 +44,16 @@ func main() {
 	artifactDir := requireEnv("ARTIFACT_DIR")
 	releaseImage := os.Getenv("RELEASE_IMAGE_LATEST")
 
-	namespace := os.Getenv("HYPERSHIFT_NAMESPACE")
-	if namespace == "" {
-		namespace = defaultNamespace
-	}
-
 	eventuallyVerbose := os.Getenv("EVENTUALLY_VERBOSE")
 	if eventuallyVerbose == "" {
 		eventuallyVerbose = defaultVerbose
 	}
 	os.Setenv("EVENTUALLY_VERBOSE", eventuallyVerbose)
+
+	manifest, err := lifecycle.ReadManifest(sharedDir)
+	if err != nil {
+		log.Fatalf("Failed to read cluster manifest: %v", err)
+	}
 
 	platform, err := lifecycle.NewPlatformConfig(os.Getenv("HYPERSHIFT_PLATFORM"), sharedDir)
 	if err != nil {
@@ -67,6 +65,11 @@ func main() {
 
 	matrix := platform.TestMatrix(releaseImage)
 
+	clustersByVariant, err := matrix.ResolveVariants(manifest)
+	if err != nil {
+		log.Fatalf("Manifest/test matrix mismatch: %v", err)
+	}
+
 	var (
 		mu      sync.Mutex
 		results []testResult
@@ -76,12 +79,12 @@ func main() {
 	// Launch parallel test groups.
 	for _, g := range matrix.Parallel {
 		g := g
+		entry := clustersByVariant[g.Variant]
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			clusterName := readClusterName(sharedDir, g.ClusterFile)
-			log.Printf("Running %s tests against %s...", g.Name, clusterName)
-			err := runTestBinary(testBinary, clusterName, namespace, g.LabelFilter, g.Skip,
+			log.Printf("Running %s tests against %s...", g.Name, entry.Name)
+			err := runTestBinary(testBinary, entry.Name, entry.Namespace, g.LabelFilter, g.Skip,
 				filepath.Join(artifactDir, g.JUnitFile), g.ExtraEnv)
 			mu.Lock()
 			results = append(results, testResult{name: g.Name, err: err})
@@ -102,9 +105,9 @@ func main() {
 		go func() {
 			defer wg.Done()
 			for i, step := range sg.Steps {
-				clusterName := readClusterName(sharedDir, step.ClusterFile)
-				log.Printf("Running %s tests against %s...", step.Name, clusterName)
-				err := runTestBinary(testBinary, clusterName, namespace, step.LabelFilter, step.Skip,
+				entry := clustersByVariant[step.Variant]
+				log.Printf("Running %s tests against %s...", step.Name, entry.Name)
+				err := runTestBinary(testBinary, entry.Name, entry.Namespace, step.LabelFilter, step.Skip,
 					filepath.Join(artifactDir, step.JUnitFile), step.ExtraEnv)
 				mu.Lock()
 				results = append(results, testResult{name: step.Name, err: err})
@@ -167,19 +170,6 @@ func runTestBinary(testBinary, clusterName, namespace, labelFilter, skip, junitP
 	cmd.Env = append(cmd.Env, extraEnv...)
 
 	return cmd.Run()
-}
-
-func readClusterName(sharedDir, filename string) string {
-	path := filepath.Join(sharedDir, filename)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		log.Fatalf("Failed to read cluster name from %s: %v", path, err)
-	}
-	name := strings.TrimSpace(string(data))
-	if name == "" {
-		log.Fatalf("Cluster name file %s is empty", path)
-	}
-	return name
 }
 
 func requireEnv(key string) string {

--- a/test/e2e/v2/lifecycle/aws.go
+++ b/test/e2e/v2/lifecycle/aws.go
@@ -58,9 +58,8 @@ func (a *AWSPlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Cluster
 	}
 	return []ClusterSpec{
 		{
-			Variant:    "public",
-			OutputFile: "cluster-name-public",
-			ExtraArgs:  extraArgs,
+			Variant:   "public",
+			ExtraArgs: extraArgs,
 		},
 	}
 }
@@ -105,7 +104,7 @@ func (a *AWSPlatformConfig) TestMatrix(releaseImage string) TestMatrix {
 		Parallel: []TestGroup{
 			{
 				Name:        "aws-public",
-				ClusterFile: "cluster-name-public",
+				Variant:     "public",
 				LabelFilter: "!lifecycle || hosted-cluster-aws",
 				JUnitFile:   "junit_aws_public.xml",
 			},
@@ -113,10 +112,13 @@ func (a *AWSPlatformConfig) TestMatrix(releaseImage string) TestMatrix {
 	}
 }
 
+
 func (a *AWSPlatformConfig) SetupTestEnv(sharedDir string) {}
 
 func (a *AWSPlatformConfig) DestroyArgs() []string {
+	baseDomain := envOrDefault("HYPERSHIFT_BASE_DOMAIN", a.DefaultBaseDomain())
 	return []string{
 		"--region=" + a.region,
+		"--base-domain=" + baseDomain,
 	}
 }

--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -117,36 +117,30 @@ func (a *AzurePlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Clust
 
 	return []ClusterSpec{
 		{
-			Variant:    "public",
-			OutputFile: "cluster-name-public",
-			ExtraArgs:  publicExtraArgs,
+			Variant:   "public",
+			ExtraArgs: publicExtraArgs,
 		},
 		{
-			Variant:    "private",
-			OutputFile: "cluster-name-private",
+			Variant: "private",
 			ExtraArgs: []string{
 				"--endpoint-access=Private",
 				"--endpoint-access-private-nat-subnet-id=" + a.privateNATSubnetID,
 			},
 		},
 		{
-			Variant:    "oauth-lb",
-			OutputFile: "cluster-name-oauth-lb",
-			ExtraArgs:  []string{"--oauth-publishing-strategy=LoadBalancer"},
+			Variant:   "oauth-lb",
+			ExtraArgs: []string{"--oauth-publishing-strategy=LoadBalancer"},
 		},
 		{
 			Variant:      "upgrade",
-			OutputFile:   "cluster-name-upgrade",
 			ReleaseImage: n1Image,
 			ExtraArgs:    []string{"--control-plane-availability-policy=HighlyAvailable"},
 		},
 		{
-			Variant:    "autoscaling",
-			OutputFile: "cluster-name-autoscaling",
+			Variant: "autoscaling",
 		},
 		{
-			Variant:    "external-oidc",
-			OutputFile: "cluster-name-external-oidc",
+			Variant: "external-oidc",
 		},
 	}
 }
@@ -191,7 +185,7 @@ func (a *AzurePlatformConfig) PreCreate(ctx context.Context, cl crclient.WithWat
 // PostCreate runs variant-specific post-creation hooks for each cluster
 // that was created by the lifecycle orchestrator.
 func (a *AzurePlatformConfig) PostCreate(ctx context.Context, cl crclient.WithWatch, namespace string, clusterNames map[string]string) error {
-	if publicName, ok := clusterNames["cluster-name-public"]; ok {
+	if publicName, ok := clusterNames["public"]; ok {
 		if err := a.postCreatePublic(ctx, cl, namespace, publicName); err != nil {
 			return err
 		}
@@ -211,7 +205,7 @@ func (a *AzurePlatformConfig) PostAvailable(ctx context.Context, cl crclient.Wit
 }
 
 func (a *AzurePlatformConfig) PostVersionRollout(ctx context.Context, cl crclient.WithWatch, namespace string, clusterNames map[string]string) error {
-	if oidcName, ok := clusterNames["cluster-name-external-oidc"]; ok {
+	if oidcName, ok := clusterNames["external-oidc"]; ok {
 		if err := a.postCreateExternalOIDC(ctx, cl, namespace, oidcName); err != nil {
 			return err
 		}
@@ -332,32 +326,32 @@ func (a *AzurePlatformConfig) TestMatrix(releaseImage string) TestMatrix {
 		Parallel: []TestGroup{
 			{
 				Name:        "public",
-				ClusterFile: "cluster-name-public",
+				Variant:     "public",
 				LabelFilter: "self-managed-azure-public || nodepool-lifecycle || secret-encryption || control-plane-workloads || hosted-cluster-security",
 				Skip:        "KAS allowed CIDRs",
 				JUnitFile:   "junit_self_managed_azure_public.xml",
 			},
 			{
 				Name:        "private",
-				ClusterFile: "cluster-name-private",
+				Variant:     "private",
 				LabelFilter: "self-managed-azure-private || hosted-cluster-compliance || nodepool-osimagestream",
 				JUnitFile:   "junit_self_managed_azure_private.xml",
 			},
 			{
 				Name:        "oauth-lb",
-				ClusterFile: "cluster-name-oauth-lb",
+				Variant:     "oauth-lb",
 				LabelFilter: "self-managed-azure-oauth-lb || hosted-cluster-health || hosted-cluster-metrics || hosted-cluster-image-registry",
 				JUnitFile:   "junit_self_managed_azure_oauth_lb.xml",
 			},
 			{
 				Name:        "autoscaling",
-				ClusterFile: "cluster-name-autoscaling",
+				Variant:     "autoscaling",
 				LabelFilter: "nodepool-autoscaling",
 				JUnitFile:   "junit_self_managed_azure_nodepool_autoscaling.xml",
 			},
 			{
 				Name:        "external-oidc",
-				ClusterFile: "cluster-name-external-oidc",
+				Variant:     "external-oidc",
 				LabelFilter: "external-oidc || global-pull-secret",
 				JUnitFile:   "junit_self_managed_azure_external_oidc.xml",
 			},
@@ -368,14 +362,14 @@ func (a *AzurePlatformConfig) TestMatrix(releaseImage string) TestMatrix {
 				Steps: []TestGroup{
 					{
 						Name:        "upgrade",
-						ClusterFile: "cluster-name-upgrade",
+						Variant:     "upgrade",
 						LabelFilter: "control-plane-upgrade",
 						JUnitFile:   "junit_lifecycle_upgrade.xml",
 						ExtraEnv:    []string{fmt.Sprintf("E2E_LATEST_RELEASE_IMAGE=%s", releaseImage)},
 					},
 					{
 						Name:        "etcd-chaos",
-						ClusterFile: "cluster-name-upgrade",
+						Variant:     "upgrade",
 						LabelFilter: "etcd-chaos",
 						JUnitFile:   "junit_lifecycle_etcd_chaos.xml",
 					},
@@ -411,6 +405,7 @@ func (a *AzurePlatformConfig) DestroyArgs() []string {
 		"--dns-zone-rg-name=" + a.dnsZoneRG,
 	}
 }
+
 
 func envOrDefault(key, defaultVal string) string {
 	if val := os.Getenv(key); val != "" {

--- a/test/e2e/v2/lifecycle/manifest.go
+++ b/test/e2e/v2/lifecycle/manifest.go
@@ -1,0 +1,63 @@
+//go:build e2ev2
+
+package lifecycle
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const ManifestFileName = "cluster-manifests.json"
+
+// ClusterManifest captures the identity of all clusters for a CI run.
+// It is written to SHARED_DIR before any infrastructure is provisioned
+// so that destroy-guests can always clean up, even if the HostedCluster
+// CR was never applied to the management cluster.
+type ClusterManifest struct {
+	Clusters []ClusterEntry `json:"clusters"`
+}
+
+// ClusterEntry captures the deterministic identity of a single cluster.
+type ClusterEntry struct {
+	Variant   string `json:"variant"`
+	Name      string `json:"name"`
+	InfraID   string `json:"infraID"`
+	Namespace string `json:"namespace"`
+}
+
+func WriteManifest(dir string, m *ClusterManifest) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling cluster manifest: %w", err)
+	}
+	path := filepath.Join(dir, ManifestFileName)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("writing cluster manifest to %s: %w", path, err)
+	}
+	return nil
+}
+
+func ReadManifest(dir string) (*ClusterManifest, error) {
+	path := filepath.Join(dir, ManifestFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading cluster manifest from %s: %w", path, err)
+	}
+	var m ClusterManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("unmarshaling cluster manifest: %w", err)
+	}
+	return &m, nil
+}
+
+// LookupCluster returns the ClusterEntry for the given variant.
+func (m *ClusterManifest) LookupCluster(variant string) (ClusterEntry, error) {
+	for _, c := range m.Clusters {
+		if c.Variant == variant {
+			return c, nil
+		}
+	}
+	return ClusterEntry{}, fmt.Errorf("no cluster entry for variant %q", variant)
+}

--- a/test/e2e/v2/lifecycle/manifest_test.go
+++ b/test/e2e/v2/lifecycle/manifest_test.go
@@ -1,0 +1,176 @@
+//go:build e2ev2
+
+package lifecycle
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestManifestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		want *ClusterManifest
+	}{
+		{
+			name: "when written with a single cluster should deserialize identically",
+			want: &ClusterManifest{
+				Clusters: []ClusterEntry{
+					{Variant: "public", Name: "public-abc1234567", InfraID: "public-abc1234567", Namespace: "clusters"},
+				},
+			},
+		},
+		{
+			name: "when written with multiple clusters should deserialize identically",
+			want: &ClusterManifest{
+				Clusters: []ClusterEntry{
+					{Variant: "public", Name: "public-abc1234567", InfraID: "public-abc1234567", Namespace: "clusters"},
+					{Variant: "private", Name: "private-abc1234567", InfraID: "private-abc1234567", Namespace: "clusters"},
+					{Variant: "external-oidc", Name: "external-oidc-abc1234567", InfraID: "external-oidc-abc1234567", Namespace: "clusters"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := WriteManifest(dir, tt.want); err != nil {
+				t.Fatalf("WriteManifest: %v", err)
+			}
+			got, err := ReadManifest(dir)
+			if err != nil {
+				t.Fatalf("ReadManifest: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveVariants(t *testing.T) {
+	manifest := &ClusterManifest{
+		Clusters: []ClusterEntry{
+			{Variant: "public", Name: "public-abc", InfraID: "public-abc", Namespace: "clusters"},
+			{Variant: "private", Name: "private-abc", InfraID: "private-abc", Namespace: "clusters"},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		matrix    TestMatrix
+		want      map[string]ClusterEntry
+		wantError bool
+	}{
+		{
+			name: "when all parallel variants exist should return resolved map",
+			matrix: TestMatrix{
+				Parallel: []TestGroup{
+					{Variant: "public"},
+					{Variant: "private"},
+				},
+			},
+			want: map[string]ClusterEntry{
+				"public":  {Variant: "public", Name: "public-abc", InfraID: "public-abc", Namespace: "clusters"},
+				"private": {Variant: "private", Name: "private-abc", InfraID: "private-abc", Namespace: "clusters"},
+			},
+		},
+		{
+			name: "when sequential variants exist should return resolved map",
+			matrix: TestMatrix{
+				Sequential: []SequentialGroup{
+					{Steps: []TestGroup{{Variant: "public"}, {Variant: "private"}}},
+				},
+			},
+			want: map[string]ClusterEntry{
+				"public":  {Variant: "public", Name: "public-abc", InfraID: "public-abc", Namespace: "clusters"},
+				"private": {Variant: "private", Name: "private-abc", InfraID: "private-abc", Namespace: "clusters"},
+			},
+		},
+		{
+			name: "when a parallel variant is missing should return an error",
+			matrix: TestMatrix{
+				Parallel: []TestGroup{
+					{Variant: "public"},
+					{Variant: "nonexistent"},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "when a sequential variant is missing should return an error",
+			matrix: TestMatrix{
+				Sequential: []SequentialGroup{
+					{Steps: []TestGroup{{Variant: "nonexistent"}}},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "when duplicate variants exist across parallel and sequential should deduplicate",
+			matrix: TestMatrix{
+				Parallel:   []TestGroup{{Variant: "public"}},
+				Sequential: []SequentialGroup{{Steps: []TestGroup{{Variant: "public"}}}},
+			},
+			want: map[string]ClusterEntry{
+				"public": {Variant: "public", Name: "public-abc", InfraID: "public-abc", Namespace: "clusters"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.matrix.ResolveVariants(manifest)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLookupCluster(t *testing.T) {
+	m := &ClusterManifest{
+		Clusters: []ClusterEntry{
+			{Variant: "public", Name: "pub-name", InfraID: "pub-name", Namespace: "clusters"},
+			{Variant: "private", Name: "priv-name", InfraID: "priv-name", Namespace: "clusters"},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		variant   string
+		want      ClusterEntry
+		wantError bool
+	}{
+		{"when variant exists should return the entry", "public", ClusterEntry{Variant: "public", Name: "pub-name", InfraID: "pub-name", Namespace: "clusters"}, false},
+		{"when variant does not exist should return an error", "nonexistent", ClusterEntry{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := m.LookupCluster(tt.variant)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/v2/lifecycle/platform.go
+++ b/test/e2e/v2/lifecycle/platform.go
@@ -13,7 +13,6 @@ import (
 // ClusterSpec describes a single cluster to create for lifecycle tests.
 type ClusterSpec struct {
 	Variant      string
-	OutputFile   string // filename under SHARED_DIR
 	ExtraArgs    []string
 	ReleaseImage string // override (empty = use default)
 }
@@ -21,7 +20,7 @@ type ClusterSpec struct {
 // TestGroup describes one logical group of e2e tests to execute.
 type TestGroup struct {
 	Name        string
-	ClusterFile string // filename under SHARED_DIR containing cluster name
+	Variant     string
 	LabelFilter string
 	Skip        string
 	JUnitFile   string
@@ -42,6 +41,40 @@ type SequentialGroup struct {
 type TestMatrix struct {
 	Parallel   []TestGroup
 	Sequential []SequentialGroup
+}
+
+// ResolveVariants validates that every variant referenced by the test
+// matrix exists in the manifest and returns a map from variant to
+// ClusterEntry. Returns an error listing all missing variants.
+func (m TestMatrix) ResolveVariants(manifest *ClusterManifest) (map[string]ClusterEntry, error) {
+	resolved := make(map[string]ClusterEntry)
+	var missing []string
+
+	resolve := func(variant string) {
+		if _, ok := resolved[variant]; ok {
+			return
+		}
+		entry, err := manifest.LookupCluster(variant)
+		if err != nil {
+			missing = append(missing, variant)
+			return
+		}
+		resolved[variant] = entry
+	}
+
+	for _, g := range m.Parallel {
+		resolve(g.Variant)
+	}
+	for _, sg := range m.Sequential {
+		for _, step := range sg.Steps {
+			resolve(step.Variant)
+		}
+	}
+
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("manifest missing variants: %v", missing)
+	}
+	return resolved, nil
 }
 
 // PlatformConfig provides all platform-specific configuration for


### PR DESCRIPTION
Before this commit, only guest cluster names were tracked, and infra IDs were auto generated and not persisted outside the hostedcluster. So, if infra setup fails and the hostedcluster is never persisted, downstream steps can no longer identify the infra for cleanup, causing destroy-guests to fail and infra to be leaked.

This commit solves the problem and also makes the overall design more predictable and flexible by introducing a `ClusterManifest` that captures the identity of a guest cluster before any infra is provisioned, serving as an up-front declaration of intent that downstream steps consume.

This eliminates the old cluster name files entirely and provides a more stable and robust interface for inter-process communication between steps. Guests can now be reliably destroyed in the absence of a hostedcluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared cluster manifest tracking names, variants, namespaces, and infrastructure identifiers.
  * Updated test execution, guest cleanup, and diagnostics to discover clusters through the manifest.
  * Added variant-based resolution for parallel and sequential test suites.
  * Added configurable base-domain support for AWS cluster cleanup.

* **Bug Fixes**
  * Improved lifecycle and cleanup error reporting with cluster metadata.
  * Added validation for missing or unknown cluster variants.

* **Tests**
  * Added coverage for manifest handling, cluster lookup, and variant resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->