### PR TITLE
CNTRLPLANE-4025: feat(azure): support managed HSM for KMS encryption

### DIFF
--- a/api/hypershift/v1beta1/azure.go
+++ b/api/hypershift/v1beta1/azure.go
@@ -365,9 +365,9 @@ type AzureNodePoolOSDisk struct {
 // +kubebuilder:validation:XValidation:rule="has(self.topology) && (self.topology == 'Private' || self.topology == 'PublicAndPrivate') ? has(self.private) : !has(self.private)",message="private is required when topology is Private or PublicAndPrivate, and forbidden otherwise"
 // +kubebuilder:validation:XValidation:rule="!has(self.private) || self.private.type != 'PrivateLink' || self.azureAuthenticationConfig.azureAuthenticationConfigType != 'WorkloadIdentities' || has(self.azureAuthenticationConfig.workloadIdentities.controlPlaneOperator)",message="workloadIdentities.controlPlaneOperator is required when Private Link is configured with WorkloadIdentities authentication"
 type AzurePlatformSpec struct {
-	// cloud is the cloud environment identifier, valid values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33
+	// cloud is the Azure cloud environment identifier.
 	//
-	// +kubebuilder:validation:Enum=AzurePublicCloud;AzureUSGovernmentCloud;AzureChinaCloud;AzureGermanCloud;AzureStackCloud
+	// +kubebuilder:validation:Enum=AzurePublicCloud;AzureUSGovernmentCloud;AzureChinaCloud;AzureGermanCloud;AzureBleuCloud;AzureStackCloud
 	// +kubebuilder:default="AzurePublicCloud"
 	// +optional
 	Cloud string `json:"cloud,omitempty"`
@@ -914,9 +914,10 @@ const (
 	AzureKeyVaultPrivate AzureKeyVaultAccessType = "Private"
 )
 
-// AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure key vault
+// AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure Key Vault or Managed HSM.
 //
 // +kubebuilder:validation:XValidation:rule="!has(self.backupKey) || self.backupKey.keyVaultName == self.activeKey.keyVaultName",message="backupKey.keyVaultName must match activeKey.keyVaultName; both keys must reside in the same Key Vault"
+// +kubebuilder:validation:XValidation:rule="(has(self.keyVaultType) ? self.keyVaultType : 'KeyVault') == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType : 'KeyVault')",message="keyVaultType is immutable"
 // +kubebuilder:validation:XValidation:rule="!(has(self.kms) && has(self.workloadIdentity))",message="kms and workloadIdentity are mutually exclusive"
 // +kubebuilder:validation:XValidation:rule="has(self.kms) || has(self.workloadIdentity)",message="one of kms or workloadIdentity must be set"
 // +kubebuilder:validation:XValidation:rule="has(self.kms) == has(oldSelf.kms)",message="the KMS authentication mode is immutable once set"
@@ -948,6 +949,15 @@ type AzureKMSSpec struct {
 	// +optional
 	WorkloadIdentity WorkloadIdentity `json:"workloadIdentity,omitzero"`
 
+	// keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+	// Valid values are "KeyVault" and "ManagedHSM".
+	// When set to "KeyVault", both keys are hosted by Azure Key Vault.
+	// When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+	// The type is immutable; key rotation must remain within the same service.
+	// When omitted, the keys are treated as Key Vault keys.
+	// +optional
+	KeyVaultType AzureKMSKeyVaultType `json:"keyVaultType,omitempty"`
+
 	// keyVaultAccess specifies how the Key Vault should be accessed.
 	// When set to "Private", the control plane routes Key Vault traffic through
 	// the private router to reach the Key Vault's private endpoint in the customer VNet.
@@ -957,16 +967,28 @@ type AzureKMSSpec struct {
 	KeyVaultAccess AzureKeyVaultAccessType `json:"keyVaultAccess,omitempty"`
 }
 
+// AzureKMSKeyVaultType specifies the Azure service that hosts a KMS key.
+// +kubebuilder:validation:Enum=KeyVault;ManagedHSM
+type AzureKMSKeyVaultType string
+
+const (
+	// AzureKMSKeyVaultTypeKeyVault indicates that the key is hosted by Azure Key Vault.
+	AzureKMSKeyVaultTypeKeyVault AzureKMSKeyVaultType = "KeyVault"
+	// AzureKMSKeyVaultTypeManagedHSM indicates that the key is hosted by Azure Managed HSM.
+	AzureKMSKeyVaultTypeManagedHSM AzureKMSKeyVaultType = "ManagedHSM"
+)
+
+// AzureKMSKey defines an Azure Key Vault or Managed HSM key used for KMS encryption.
 type AzureKMSKey struct {
-	// keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-	// Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+	// keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+	// Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
 	// `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=255
 	// +required
 	KeyVaultName string `json:"keyVaultName,omitempty"`
 
-	// keyName is the name of the keyvault key used for encrypt/decrypt
+	// keyName is the name of the key used for encrypt/decrypt.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=255
 	// +required

--- a/api/hypershift/v1beta1/azure.go
+++ b/api/hypershift/v1beta1/azure.go
@@ -914,9 +914,11 @@ const (
 	AzureKeyVaultPrivate AzureKeyVaultAccessType = "Private"
 )
 
-// AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure key vault
+// AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure Key Vault or Managed HSM.
 //
 // +kubebuilder:validation:XValidation:rule="!has(self.backupKey) || self.backupKey.keyVaultName == self.activeKey.keyVaultName",message="backupKey.keyVaultName must match activeKey.keyVaultName; both keys must reside in the same Key Vault"
+// +kubebuilder:validation:XValidation:rule="!has(self.backupKey) || (has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType : 'KeyVault') == (has(self.backupKey.keyVaultType) ? self.backupKey.keyVaultType : 'KeyVault')",message="backupKey.keyVaultType must match activeKey.keyVaultType"
+// +kubebuilder:validation:XValidation:rule="(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType : 'KeyVault') == (has(oldSelf.activeKey.keyVaultType) ? oldSelf.activeKey.keyVaultType : 'KeyVault')",message="activeKey.keyVaultType is immutable"
 // +kubebuilder:validation:XValidation:rule="!(has(self.kms) && has(self.workloadIdentity))",message="kms and workloadIdentity are mutually exclusive"
 // +kubebuilder:validation:XValidation:rule="has(self.kms) || has(self.workloadIdentity)",message="one of kms or workloadIdentity must be set"
 // +kubebuilder:validation:XValidation:rule="has(self.kms) == has(oldSelf.kms)",message="the KMS authentication mode is immutable once set"
@@ -957,16 +959,28 @@ type AzureKMSSpec struct {
 	KeyVaultAccess AzureKeyVaultAccessType `json:"keyVaultAccess,omitempty"`
 }
 
+// AzureKMSKeyVaultType specifies the Azure service that hosts a KMS key.
+// +kubebuilder:validation:Enum=KeyVault;ManagedHSM
+type AzureKMSKeyVaultType string
+
+const (
+	// AzureKMSKeyVaultTypeKeyVault indicates that the key is hosted by Azure Key Vault.
+	AzureKMSKeyVaultTypeKeyVault AzureKMSKeyVaultType = "KeyVault"
+	// AzureKMSKeyVaultTypeManagedHSM indicates that the key is hosted by Azure Managed HSM.
+	AzureKMSKeyVaultTypeManagedHSM AzureKMSKeyVaultType = "ManagedHSM"
+)
+
+// AzureKMSKey defines an Azure Key Vault or Managed HSM key used for KMS encryption.
 type AzureKMSKey struct {
-	// keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-	// Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+	// keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+	// Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
 	// `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=255
 	// +required
 	KeyVaultName string `json:"keyVaultName,omitempty"`
 
-	// keyName is the name of the keyvault key used for encrypt/decrypt
+	// keyName is the name of the key used for encrypt/decrypt.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=255
 	// +required
@@ -977,6 +991,13 @@ type AzureKMSKey struct {
 	// +kubebuilder:validation:MaxLength=255
 	// +required
 	KeyVersion string `json:"keyVersion,omitempty"`
+
+	// keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+	// The type is immutable; key rotation must remain within the same service.
+	// When omitted, the type defaults to KeyVault.
+	// +optional
+	// +default="KeyVault"
+	KeyVaultType AzureKMSKeyVaultType `json:"keyVaultType,omitempty"`
 }
 
 // AzureAuthenticationType is a discriminated union type that contains the Azure authentication configuration for an

--- a/api/hypershift/v1beta1/azure_test.go
+++ b/api/hypershift/v1beta1/azure_test.go
@@ -1,0 +1,80 @@
+package v1beta1
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type azureKMSKeyNMinus1 struct {
+	// keyVaultName is the name of the Key Vault.
+	// +required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=255
+	KeyVaultName string `json:"keyVaultName,omitempty"`
+	// keyName is the name of the key.
+	// +required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=255
+	KeyName string `json:"keyName,omitempty"`
+	// keyVersion is the key version.
+	// +required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=255
+	KeyVersion string `json:"keyVersion,omitempty"`
+}
+
+func TestAzureKMSKeySerializationCompatibility(t *testing.T) {
+	tests := []struct {
+		name    string
+		current AzureKMSKey
+	}{
+		{
+			name: "When keyVaultType is omitted it should remain compatible with the previous API",
+			current: AzureKMSKey{
+				KeyVaultName: "test-vault",
+				KeyName:      "test-key",
+				KeyVersion:   "1",
+			},
+		},
+		{
+			name: "When keyVaultType is ManagedHSM it should be ignored by the previous API",
+			current: AzureKMSKey{
+				KeyVaultName: "test-hsm",
+				KeyName:      "test-key",
+				KeyVersion:   "1",
+				KeyVaultType: AzureKMSKeyVaultTypeManagedHSM,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.current)
+			if err != nil {
+				t.Fatalf("failed to marshal current AzureKMSKey: %v", err)
+			}
+
+			var previous azureKMSKeyNMinus1
+			if err := json.Unmarshal(data, &previous); err != nil {
+				t.Fatalf("previous API failed to unmarshal current AzureKMSKey: %v", err)
+			}
+			if previous.KeyVaultName != tt.current.KeyVaultName ||
+				previous.KeyName != tt.current.KeyName ||
+				previous.KeyVersion != tt.current.KeyVersion {
+				t.Fatalf("previous API key fields differ: got %+v, want %+v", previous, tt.current)
+			}
+
+			previousData, err := json.Marshal(previous)
+			if err != nil {
+				t.Fatalf("failed to marshal previous AzureKMSKey: %v", err)
+			}
+			var current AzureKMSKey
+			if err := json.Unmarshal(previousData, &current); err != nil {
+				t.Fatalf("current API failed to unmarshal previous AzureKMSKey: %v", err)
+			}
+			if current.KeyVaultType != "" {
+				t.Fatalf("expected keyVaultType to be omitted after previous API round trip, got %q", current.KeyVaultType)
+			}
+		})
+	}
+}

--- a/api/hypershift/v1beta1/etcdbackup_types.go
+++ b/api/hypershift/v1beta1/etcdbackup_types.go
@@ -178,14 +178,15 @@ type HCPEtcdBackupAzureBlob struct {
 	// +required
 	Credentials SecretReference `json:"credentials,omitzero"`
 
-	// encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-	// Must be a valid Azure Key Vault key URL in the format
-	// "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+	// encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+	// Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+	// Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+	// Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 	// This field is immutable once set and cannot be removed.
 	// +optional
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=210
-	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.vault\\\\.azure\\\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.(vault\\\\.(azure\\\\.net|usgovcloudapi\\\\.net|azure\\\\.cn|microsoftazure\\\\.de|sovcloud-api\\\\.fr)|managedhsm\\\\.(azure\\\\.net|usgovcloudapi\\\\.net|azure\\\\.cn|microsoftazure\\\\.de|sovcloud-api\\\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="encryptionKeyURL is immutable"
 	EncryptionKeyURL string `json:"encryptionKeyURL,omitempty"`
 }
@@ -249,13 +250,14 @@ type HCPEtcdBackupEncryptionMetadataAWS struct {
 // HCPEtcdBackupEncryptionMetadataAzure contains Azure-specific encryption metadata.
 // The values here reflect the encryption settings from the HCPEtcdBackupConfig input.
 type HCPEtcdBackupEncryptionMetadataAzure struct {
-	// encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-	// Must be a valid Azure Key Vault key URL in the format
-	// "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+	// encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+	// Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+	// Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+	// Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=210
-	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.vault\\\\.azure\\\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.(vault\\\\.(azure\\\\.net|usgovcloudapi\\\\.net|azure\\\\.cn|microsoftazure\\\\.de|sovcloud-api\\\\.fr)|managedhsm\\\\.(azure\\\\.net|usgovcloudapi\\\\.net|azure\\\\.cn|microsoftazure\\\\.de|sovcloud-api\\\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 	EncryptionKeyURL string `json:"encryptionKeyURL,omitempty"`
 }
 
@@ -349,12 +351,13 @@ type HCPEtcdBackupConfigAWS struct {
 
 // HCPEtcdBackupConfigAzure defines Azure-specific encryption settings for etcd backups.
 type HCPEtcdBackupConfigAzure struct {
-	// encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-	// Must be a valid Azure Key Vault key URL in the format
-	// "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+	// encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+	// Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+	// Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+	// Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=210
-	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.vault\\\\.azure\\\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.(vault\\\\.(azure\\\\.net|usgovcloudapi\\\\.net|azure\\\\.cn|microsoftazure\\\\.de|sovcloud-api\\\\.fr)|managedhsm\\\\.(azure\\\\.net|usgovcloudapi\\\\.net|azure\\\\.cn|microsoftazure\\\\.de|sovcloud-api\\\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 	EncryptionKeyURL string `json:"encryptionKeyURL,omitempty"`
 }

--- a/api/hypershift/v1beta1/etcdbackup_types.go
+++ b/api/hypershift/v1beta1/etcdbackup_types.go
@@ -178,14 +178,14 @@ type HCPEtcdBackupAzureBlob struct {
 	// +required
 	Credentials SecretReference `json:"credentials,omitzero"`
 
-	// encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-	// Must be a valid Azure Key Vault key URL in the format
-	// "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+	// encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+	// Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+	// Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 	// This field is immutable once set and cannot be removed.
 	// +optional
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=210
-	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.vault\\\\.azure\\\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.(vault\\\\.azure\\\\.net|managedhsm\\\\.(azure\\\\.net|usgovcloudapi\\\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="encryptionKeyURL is immutable"
 	EncryptionKeyURL string `json:"encryptionKeyURL,omitempty"`
 }
@@ -249,13 +249,13 @@ type HCPEtcdBackupEncryptionMetadataAWS struct {
 // HCPEtcdBackupEncryptionMetadataAzure contains Azure-specific encryption metadata.
 // The values here reflect the encryption settings from the HCPEtcdBackupConfig input.
 type HCPEtcdBackupEncryptionMetadataAzure struct {
-	// encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-	// Must be a valid Azure Key Vault key URL in the format
-	// "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+	// encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+	// Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+	// Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=210
-	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.vault\\\\.azure\\\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.(vault\\\\.azure\\\\.net|managedhsm\\\\.(azure\\\\.net|usgovcloudapi\\\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 	EncryptionKeyURL string `json:"encryptionKeyURL,omitempty"`
 }
 
@@ -349,12 +349,12 @@ type HCPEtcdBackupConfigAWS struct {
 
 // HCPEtcdBackupConfigAzure defines Azure-specific encryption settings for etcd backups.
 type HCPEtcdBackupConfigAzure struct {
-	// encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-	// Must be a valid Azure Key Vault key URL in the format
-	// "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+	// encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+	// Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+	// Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=210
-	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.vault\\\\.azure\\\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.(vault\\\\.azure\\\\.net|managedhsm\\\\.(azure\\\\.net|usgovcloudapi\\\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 	EncryptionKeyURL string `json:"encryptionKeyURL,omitempty"`
 }

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hcpetcdbackups.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hcpetcdbackups.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -101,17 +101,18 @@ spec:
                         type: object
                       encryptionKeyURL:
                         description: |-
-                          encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-                          Must be a valid Azure Key Vault key URL in the format
-                          "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                          encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+                          Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+                          Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+                          Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                           This field is immutable once set and cannot be removed.
                         maxLength: 210
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
                         - message: encryptionKeyURL must be a valid Azure Key Vault
-                            HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                            or Managed HSM HTTPS URL
+                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr)|managedhsm\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                         - message: encryptionKeyURL is immutable
                           rule: self == oldSelf
                       keyPrefix:
@@ -372,16 +373,17 @@ spec:
                     properties:
                       encryptionKeyURL:
                         description: |-
-                          encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-                          Must be a valid Azure Key Vault key URL in the format
-                          "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                          encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+                          Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+                          Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+                          Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                         maxLength: 210
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
                         - message: encryptionKeyURL must be a valid Azure Key Vault
-                            HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                            or Managed HSM HTTPS URL
+                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr)|managedhsm\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                     required:
                     - encryptionKeyURL
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hcpetcdbackups.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hcpetcdbackups.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -101,17 +101,17 @@ spec:
                         type: object
                       encryptionKeyURL:
                         description: |-
-                          encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-                          Must be a valid Azure Key Vault key URL in the format
-                          "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                          encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+                          Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+                          Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                           This field is immutable once set and cannot be removed.
                         maxLength: 210
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
                         - message: encryptionKeyURL must be a valid Azure Key Vault
-                            HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                            or Managed HSM HTTPS URL
+                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.azure\\.net|managedhsm\\.(azure\\.net|usgovcloudapi\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                         - message: encryptionKeyURL is immutable
                           rule: self == oldSelf
                       keyPrefix:
@@ -372,16 +372,16 @@ spec:
                     properties:
                       encryptionKeyURL:
                         description: |-
-                          encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-                          Must be a valid Azure Key Vault key URL in the format
-                          "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                          encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+                          Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+                          Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                         maxLength: 210
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
                         - message: encryptionKeyURL must be a valid Azure Key Vault
-                            HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                            or Managed HSM HTTPS URL
+                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.azure\\.net|managedhsm\\.(azure\\.net|usgovcloudapi\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                     required:
                     - encryptionKeyURL
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -5430,13 +5430,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6403,15 +6403,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6436,15 +6436,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6470,6 +6470,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6554,6 +6566,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7380,15 +7396,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7615,15 +7630,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -6403,18 +6403,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6436,18 +6446,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6554,6 +6574,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7380,18 +7408,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7615,18 +7652,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -5421,13 +5421,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6386,15 +6386,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6419,15 +6419,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6453,6 +6453,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6537,6 +6549,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7363,15 +7379,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7598,15 +7613,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -6386,18 +6386,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6419,18 +6429,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6537,6 +6557,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7363,18 +7391,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7598,18 +7635,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -6406,18 +6406,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6439,18 +6449,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6557,6 +6577,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7383,18 +7411,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7618,18 +7655,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -5441,13 +5441,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6406,15 +6406,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6439,15 +6439,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6473,6 +6473,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6557,6 +6569,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7383,15 +7399,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7618,15 +7633,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
@@ -5892,13 +5892,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6857,15 +6857,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6890,15 +6890,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6924,6 +6924,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -7008,6 +7020,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7834,15 +7850,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -8069,15 +8084,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
@@ -6857,18 +6857,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6890,18 +6900,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -7008,6 +7028,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7834,18 +7862,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -8069,18 +8106,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -6718,18 +6718,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6751,18 +6761,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6869,6 +6889,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7860,18 +7888,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -8095,18 +8132,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -5753,13 +5753,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6718,15 +6718,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6751,15 +6751,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6785,6 +6785,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6869,6 +6881,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7860,15 +7876,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -8095,15 +8110,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
@@ -7140,18 +7140,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -7173,18 +7183,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -7291,6 +7311,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -8117,18 +8145,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -8352,18 +8389,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
@@ -6175,13 +6175,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -7140,15 +7140,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -7173,15 +7173,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -7207,6 +7207,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -7291,6 +7303,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -8117,15 +8133,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -8352,15 +8367,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -6858,18 +6858,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6891,18 +6901,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -7009,6 +7029,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -8000,18 +8028,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -8235,18 +8272,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -5893,13 +5893,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6858,15 +6858,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6891,15 +6891,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6925,6 +6925,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -7009,6 +7021,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -8000,15 +8016,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -8235,15 +8250,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -5884,13 +5884,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6849,15 +6849,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6882,15 +6882,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6916,6 +6916,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -7000,6 +7012,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7826,15 +7842,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -8061,15 +8076,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -6849,18 +6849,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6882,18 +6892,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -7000,6 +7020,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7826,18 +7854,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -8061,18 +8098,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -6832,18 +6832,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6865,18 +6875,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6983,6 +7003,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7809,18 +7837,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -8044,18 +8081,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -5421,13 +5421,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6832,15 +6832,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6865,15 +6865,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6899,6 +6899,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6983,6 +6995,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7809,15 +7825,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -8044,15 +8059,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -2704,16 +2704,17 @@ spec:
                             properties:
                               encryptionKeyURL:
                                 description: |-
-                                  encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-                                  Must be a valid Azure Key Vault key URL in the format
-                                  "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                                  encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+                                  Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+                                  Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+                                  Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                                 maxLength: 210
                                 minLength: 1
                                 type: string
                                 x-kubernetes-validations:
                                 - message: encryptionKeyURL must be a valid Azure
-                                    Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                                    Key Vault or Managed HSM HTTPS URL
+                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr)|managedhsm\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                             required:
                             - encryptionKeyURL
                             type: object
@@ -5486,13 +5487,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6451,15 +6452,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6484,15 +6485,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6518,6 +6519,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6602,6 +6615,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7440,15 +7457,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7675,15 +7691,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -2704,16 +2704,16 @@ spec:
                             properties:
                               encryptionKeyURL:
                                 description: |-
-                                  encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-                                  Must be a valid Azure Key Vault key URL in the format
-                                  "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                                  encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+                                  Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+                                  Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                                 maxLength: 210
                                 minLength: 1
                                 type: string
                                 x-kubernetes-validations:
                                 - message: encryptionKeyURL must be a valid Azure
-                                    Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                                    Key Vault or Managed HSM HTTPS URL
+                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.azure\\.net|managedhsm\\.(azure\\.net|usgovcloudapi\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                             required:
                             - encryptionKeyURL
                             type: object
@@ -6451,18 +6451,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6484,18 +6494,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6602,6 +6622,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7440,18 +7468,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7675,18 +7712,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -5443,13 +5443,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6408,15 +6408,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6441,15 +6441,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6475,6 +6475,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6559,6 +6571,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7385,15 +7401,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7620,15 +7635,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -6408,18 +6408,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6441,18 +6451,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6559,6 +6579,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7385,18 +7413,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7620,18 +7657,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -5439,13 +5439,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6404,15 +6404,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6437,15 +6437,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6471,6 +6471,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6555,6 +6567,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7392,15 +7408,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7627,15 +7642,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -6404,18 +6404,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6437,18 +6447,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6555,6 +6575,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7392,18 +7420,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7627,18 +7664,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/IngressComponentRouteLabels.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/IngressComponentRouteLabels.yaml
@@ -5477,13 +5477,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6442,15 +6442,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6475,15 +6475,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6509,6 +6509,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6593,6 +6605,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7419,15 +7435,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7654,15 +7669,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/IngressComponentRouteLabels.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/IngressComponentRouteLabels.yaml
@@ -6436,18 +6436,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6469,18 +6479,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6587,6 +6607,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7413,18 +7441,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7648,18 +7685,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryption.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryption.yaml
@@ -6678,18 +6678,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6711,18 +6721,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6829,6 +6849,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7655,18 +7683,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7890,18 +7927,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryption.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryption.yaml
@@ -5734,13 +5734,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6699,15 +6699,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6732,15 +6732,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6766,6 +6766,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6850,6 +6862,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7676,15 +7692,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7911,15 +7926,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkObservabilityInstall.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkObservabilityInstall.yaml
@@ -5443,13 +5443,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6408,15 +6408,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6441,15 +6441,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6475,6 +6475,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6559,6 +6571,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7385,15 +7401,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7620,15 +7635,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkObservabilityInstall.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkObservabilityInstall.yaml
@@ -6408,18 +6408,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6441,18 +6451,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6559,6 +6579,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7385,18 +7413,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7620,18 +7657,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -6937,18 +6937,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6970,18 +6980,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -7088,6 +7108,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7914,18 +7942,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -8149,18 +8186,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -5421,13 +5421,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6937,15 +6937,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6970,15 +6970,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -7004,6 +7004,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -7088,6 +7100,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7914,15 +7930,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -8149,15 +8164,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
@@ -6426,18 +6426,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6459,18 +6469,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6577,6 +6597,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7403,18 +7431,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7638,18 +7675,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
@@ -5461,13 +5461,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6426,15 +6426,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6459,15 +6459,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6493,6 +6493,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6577,6 +6589,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7403,15 +7419,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7638,15 +7653,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSGroupPreferences.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSGroupPreferences.yaml
@@ -6426,18 +6426,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6459,18 +6469,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6577,6 +6597,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7403,18 +7431,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7638,18 +7675,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSGroupPreferences.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSGroupPreferences.yaml
@@ -5461,13 +5461,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6426,15 +6426,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6459,15 +6459,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6493,6 +6493,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6577,6 +6589,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7403,15 +7419,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7638,15 +7653,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -6256,18 +6256,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6289,18 +6299,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6407,6 +6427,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7210,18 +7238,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7445,18 +7482,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -5308,13 +5308,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6256,15 +6256,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6289,15 +6289,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6323,6 +6323,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6407,6 +6419,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7210,15 +7226,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7445,15 +7460,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -6239,18 +6239,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6272,18 +6282,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6390,6 +6410,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7193,18 +7221,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7428,18 +7465,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -5299,13 +5299,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6239,15 +6239,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6272,15 +6272,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6306,6 +6306,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6390,6 +6402,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7193,15 +7209,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7428,15 +7443,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -6259,18 +6259,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6292,18 +6302,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6410,6 +6430,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7213,18 +7241,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7448,18 +7485,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -5319,13 +5319,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6259,15 +6259,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6292,15 +6292,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6326,6 +6326,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6410,6 +6422,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7213,15 +7229,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7448,15 +7463,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
@@ -5770,13 +5770,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6710,15 +6710,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6743,15 +6743,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6777,6 +6777,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6861,6 +6873,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7664,15 +7680,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7899,15 +7914,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
@@ -6710,18 +6710,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6743,18 +6753,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6861,6 +6881,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7664,18 +7692,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7899,18 +7936,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -5631,13 +5631,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6571,15 +6571,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6604,15 +6604,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6638,6 +6638,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6722,6 +6734,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7690,15 +7706,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7925,15 +7940,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -6571,18 +6571,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6604,18 +6614,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6722,6 +6742,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7690,18 +7718,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7925,18 +7962,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
@@ -6053,13 +6053,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6993,15 +6993,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -7026,15 +7026,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -7060,6 +7060,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -7144,6 +7156,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7947,15 +7963,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -8182,15 +8197,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
@@ -6993,18 +6993,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -7026,18 +7036,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -7144,6 +7164,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7947,18 +7975,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -8182,18 +8219,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -6711,18 +6711,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6744,18 +6754,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6862,6 +6882,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7830,18 +7858,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -8065,18 +8102,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -5771,13 +5771,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6711,15 +6711,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6744,15 +6744,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6778,6 +6778,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6862,6 +6874,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7830,15 +7846,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -8065,15 +8080,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -6702,18 +6702,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6735,18 +6745,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6853,6 +6873,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7656,18 +7684,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7891,18 +7928,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -5762,13 +5762,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6702,15 +6702,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6735,15 +6735,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6769,6 +6769,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6853,6 +6865,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7656,15 +7672,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7891,15 +7906,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -6685,18 +6685,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6718,18 +6728,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6836,6 +6856,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7639,18 +7667,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7874,18 +7911,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -5299,13 +5299,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6685,15 +6685,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6718,15 +6718,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6752,6 +6752,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6836,6 +6848,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7639,15 +7655,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7874,15 +7889,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -2623,16 +2623,16 @@ spec:
                             properties:
                               encryptionKeyURL:
                                 description: |-
-                                  encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-                                  Must be a valid Azure Key Vault key URL in the format
-                                  "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                                  encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+                                  Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+                                  Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                                 maxLength: 210
                                 minLength: 1
                                 type: string
                                 x-kubernetes-validations:
                                 - message: encryptionKeyURL must be a valid Azure
-                                    Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                                    Key Vault or Managed HSM HTTPS URL
+                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.azure\\.net|managedhsm\\.(azure\\.net|usgovcloudapi\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                             required:
                             - encryptionKeyURL
                             type: object
@@ -6304,18 +6304,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6337,18 +6347,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6455,6 +6475,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7258,18 +7286,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7493,18 +7530,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -2623,16 +2623,17 @@ spec:
                             properties:
                               encryptionKeyURL:
                                 description: |-
-                                  encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-                                  Must be a valid Azure Key Vault key URL in the format
-                                  "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                                  encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+                                  Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+                                  Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+                                  Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                                 maxLength: 210
                                 minLength: 1
                                 type: string
                                 x-kubernetes-validations:
                                 - message: encryptionKeyURL must be a valid Azure
-                                    Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                                    Key Vault or Managed HSM HTTPS URL
+                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr)|managedhsm\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                             required:
                             - encryptionKeyURL
                             type: object
@@ -5364,13 +5365,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6304,15 +6305,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6337,15 +6338,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6371,6 +6372,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6455,6 +6468,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7258,15 +7275,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7493,15 +7509,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -6261,18 +6261,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6294,18 +6304,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6412,6 +6432,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7215,18 +7243,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7450,18 +7487,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -5321,13 +5321,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6261,15 +6261,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6294,15 +6294,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6328,6 +6328,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6412,6 +6424,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7215,15 +7231,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7450,15 +7465,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -5317,13 +5317,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6257,15 +6257,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6290,15 +6290,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6324,6 +6324,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6408,6 +6420,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7222,15 +7238,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7457,15 +7472,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -6257,18 +6257,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6290,18 +6300,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6408,6 +6428,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7222,18 +7250,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7457,18 +7494,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/IngressComponentRouteLabels.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/IngressComponentRouteLabels.yaml
@@ -6289,18 +6289,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6322,18 +6332,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6440,6 +6460,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7243,18 +7271,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7478,18 +7515,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/IngressComponentRouteLabels.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/IngressComponentRouteLabels.yaml
@@ -5355,13 +5355,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6295,15 +6295,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6328,15 +6328,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6362,6 +6362,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6446,6 +6458,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7249,15 +7265,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7484,15 +7499,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryption.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryption.yaml
@@ -6531,18 +6531,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6564,18 +6574,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6682,6 +6702,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7485,18 +7513,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7720,18 +7757,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryption.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryption.yaml
@@ -5612,13 +5612,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6552,15 +6552,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6585,15 +6585,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6619,6 +6619,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6703,6 +6715,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7506,15 +7522,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7741,15 +7756,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkObservabilityInstall.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkObservabilityInstall.yaml
@@ -6261,18 +6261,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6294,18 +6304,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6412,6 +6432,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7215,18 +7243,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7450,18 +7487,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkObservabilityInstall.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkObservabilityInstall.yaml
@@ -5321,13 +5321,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6261,15 +6261,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6294,15 +6294,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6328,6 +6328,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6412,6 +6424,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7215,15 +7231,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7450,15 +7465,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -6790,18 +6790,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6823,18 +6833,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6941,6 +6961,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7744,18 +7772,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7979,18 +8016,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -5299,13 +5299,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6790,15 +6790,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6823,15 +6823,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6857,6 +6857,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6941,6 +6953,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7744,15 +7760,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7979,15 +7994,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
@@ -5339,13 +5339,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6279,15 +6279,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6312,15 +6312,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6346,6 +6346,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6430,6 +6442,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7233,15 +7249,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7468,15 +7483,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
@@ -6279,18 +6279,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6312,18 +6322,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6430,6 +6450,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7233,18 +7261,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7468,18 +7505,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSGroupPreferences.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSGroupPreferences.yaml
@@ -5339,13 +5339,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6279,15 +6279,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6312,15 +6312,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6346,6 +6346,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -6430,6 +6442,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7233,15 +7249,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -7468,15 +7483,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSGroupPreferences.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSGroupPreferences.yaml
@@ -6279,18 +6279,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6312,18 +6322,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6430,6 +6450,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7233,18 +7261,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -7468,18 +7505,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/client/applyconfiguration/hypershift/v1beta1/azurekmskey.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azurekmskey.go
@@ -17,12 +17,17 @@ limitations under the License.
 
 package v1beta1
 
+import (
+	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
 // AzureKMSKeyApplyConfiguration represents a declarative configuration of the AzureKMSKey type for use
 // with apply.
 type AzureKMSKeyApplyConfiguration struct {
-	KeyVaultName *string `json:"keyVaultName,omitempty"`
-	KeyName      *string `json:"keyName,omitempty"`
-	KeyVersion   *string `json:"keyVersion,omitempty"`
+	KeyVaultName *string                                 `json:"keyVaultName,omitempty"`
+	KeyName      *string                                 `json:"keyName,omitempty"`
+	KeyVersion   *string                                 `json:"keyVersion,omitempty"`
+	KeyVaultType *hypershiftv1beta1.AzureKMSKeyVaultType `json:"keyVaultType,omitempty"`
 }
 
 // AzureKMSKeyApplyConfiguration constructs a declarative configuration of the AzureKMSKey type for use with
@@ -52,5 +57,13 @@ func (b *AzureKMSKeyApplyConfiguration) WithKeyName(value string) *AzureKMSKeyAp
 // If called multiple times, the KeyVersion field is set to the value of the last call.
 func (b *AzureKMSKeyApplyConfiguration) WithKeyVersion(value string) *AzureKMSKeyApplyConfiguration {
 	b.KeyVersion = &value
+	return b
+}
+
+// WithKeyVaultType sets the KeyVaultType field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the KeyVaultType field is set to the value of the last call.
+func (b *AzureKMSKeyApplyConfiguration) WithKeyVaultType(value hypershiftv1beta1.AzureKMSKeyVaultType) *AzureKMSKeyApplyConfiguration {
+	b.KeyVaultType = &value
 	return b
 }

--- a/client/applyconfiguration/hypershift/v1beta1/azurekmsspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azurekmsspec.go
@@ -28,6 +28,7 @@ type AzureKMSSpecApplyConfiguration struct {
 	BackupKey        *AzureKMSKeyApplyConfiguration             `json:"backupKey,omitempty"`
 	KMS              *ManagedIdentityApplyConfiguration         `json:"kms,omitempty"`
 	WorkloadIdentity *WorkloadIdentityApplyConfiguration        `json:"workloadIdentity,omitempty"`
+	KeyVaultType     *hypershiftv1beta1.AzureKMSKeyVaultType    `json:"keyVaultType,omitempty"`
 	KeyVaultAccess   *hypershiftv1beta1.AzureKeyVaultAccessType `json:"keyVaultAccess,omitempty"`
 }
 
@@ -66,6 +67,14 @@ func (b *AzureKMSSpecApplyConfiguration) WithKMS(value *ManagedIdentityApplyConf
 // If called multiple times, the WorkloadIdentity field is set to the value of the last call.
 func (b *AzureKMSSpecApplyConfiguration) WithWorkloadIdentity(value *WorkloadIdentityApplyConfiguration) *AzureKMSSpecApplyConfiguration {
 	b.WorkloadIdentity = value
+	return b
+}
+
+// WithKeyVaultType sets the KeyVaultType field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the KeyVaultType field is set to the value of the last call.
+func (b *AzureKMSSpecApplyConfiguration) WithKeyVaultType(value hypershiftv1beta1.AzureKMSKeyVaultType) *AzureKMSSpecApplyConfiguration {
+	b.KeyVaultType = &value
 	return b
 }
 

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -448,6 +448,7 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 				KeyName:      o.encryptionKey.KeyName,
 				KeyVersion:   o.encryptionKey.KeyVersion,
 			},
+			KeyVaultType: o.encryptionKey.KeyVaultType,
 		}
 
 		if o.infra.WorkloadIdentities != nil {

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -447,6 +447,7 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 				KeyVaultName: o.encryptionKey.KeyVaultName,
 				KeyName:      o.encryptionKey.KeyName,
 				KeyVersion:   o.encryptionKey.KeyVersion,
+				KeyVaultType: o.encryptionKey.KeyVaultType,
 			},
 		}
 

--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -42,7 +42,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Cluster ID(required)")
 	cmd.Flags().StringVar(&opts.CredentialsFile, "azure-creds", opts.CredentialsFile, "Path to a credentials file (required). This file is used to create credentials used to create the necessary Azure resources for the HostedCluster.")
 	cmd.Flags().StringVar(&opts.Location, "location", opts.Location, "Azure location where HostedCluster infrastructure should be created")
-	cmd.Flags().StringVar(&opts.Cloud, "cloud", opts.Cloud, "Azure cloud environment (AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud)")
+	cmd.Flags().StringVar(&opts.Cloud, "cloud", opts.Cloud, "Azure cloud environment (AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud, AzureBleuCloud)")
 	cmd.Flags().StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "The ingress base domain for the HostedCluster")
 	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "A name for the HostedCluster")
 	cmd.Flags().StringVar(&opts.ResourceGroupName, "resource-group-name", opts.ResourceGroupName, "A resource group name to create the HostedCluster infrastructure resources under. If not provided, a new resource group will be created.")
@@ -99,7 +99,7 @@ func BindProductFlags(opts *CreateInfraOptions, flags *pflag.FlagSet) {
 
 	// Location and cloud
 	flags.StringVar(&opts.Location, "location", opts.Location, util.LocationDescription)
-	flags.StringVar(&opts.Cloud, "cloud", opts.Cloud, "Azure cloud environment (AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud)")
+	flags.StringVar(&opts.Cloud, "cloud", opts.Cloud, "Azure cloud environment (AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud, AzureBleuCloud)")
 	flags.StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, util.BaseDomainInfraDescription)
 
 	// Resource group and tags

--- a/cmd/infra/azure/destroy.go
+++ b/cmd/infra/azure/destroy.go
@@ -46,7 +46,7 @@ func NewDestroyCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Cluster ID(required)")
 	cmd.Flags().StringVar(&opts.CredentialsFile, "azure-creds", opts.CredentialsFile, "Path to a credentials file (required)")
 	cmd.Flags().StringVar(&opts.Location, "location", opts.Location, "Location where cluster infra should be created")
-	cmd.Flags().StringVar(&opts.Cloud, "cloud", opts.Cloud, "Azure cloud environment (AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud)")
+	cmd.Flags().StringVar(&opts.Cloud, "cloud", opts.Cloud, "Azure cloud environment (AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud, AzureBleuCloud)")
 	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "A name for the cluster")
 	cmd.Flags().StringVar(&opts.ResourceGroupName, "resource-group-name", opts.ResourceGroupName, "The name of the resource group containing the HostedCluster infrastructure resources that need to be destroyed.")
 	cmd.Flags().BoolVar(&opts.PreserveResourceGroup, "preserve-resource-group", opts.PreserveResourceGroup, "When true, the managed/main resource group will not be deleted during cluster destroy. Only cluster-specific resources within the resource group will be cleaned up.")
@@ -87,7 +87,7 @@ func BindDestroyProductFlags(opts *DestroyInfraOptions, flags *pflag.FlagSet) {
 
 	// Location and cloud
 	flags.StringVar(&opts.Location, "location", opts.Location, util.LocationDescription)
-	flags.StringVar(&opts.Cloud, "cloud", opts.Cloud, "Azure cloud environment (AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud)")
+	flags.StringVar(&opts.Cloud, "cloud", opts.Cloud, "Azure cloud environment (AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud, AzureBleuCloud)")
 
 	// Resource group
 	flags.StringVar(&opts.ResourceGroupName, "resource-group-name", opts.ResourceGroupName, util.ResourceGroupNameDescription)

--- a/cmd/install/assets/crds/hypershift-operator/tests/hcpetcdbackups.hypershift.openshift.io/techpreview.hcpetcdbackups.status.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hcpetcdbackups.hypershift.openshift.io/techpreview.hcpetcdbackups.status.testsuite.yaml
@@ -342,6 +342,64 @@ tests:
             encryptionKeyURL: "https://my-vault.vault.azure.net/keys/my-key/abc123"
 
   # --- encryptionMetadata field format validation ---
+  - name: When encryptionMetadata uses a US Government Managed HSM encryptionKeyURL it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+      status:
+        conditions:
+        - type: BackupCompleted
+          status: "True"
+          reason: BackupSucceeded
+          message: Backup completed
+          lastTransitionTime: "2024-01-01T00:00:00Z"
+        encryptionMetadata:
+          azure:
+            encryptionKeyURL: "https://my-hsm.managedhsm.usgovcloudapi.net/keys/my-key/abc123"
+    expected: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+      status:
+        conditions:
+        - type: BackupCompleted
+          status: "True"
+          reason: BackupSucceeded
+          message: Backup completed
+          lastTransitionTime: "2024-01-01T00:00:00Z"
+        encryptionMetadata:
+          azure:
+            encryptionKeyURL: "https://my-hsm.managedhsm.usgovcloudapi.net/keys/my-key/abc123"
+
   - name: When encryptionMetadata aws kmsKeyARN has invalid format it should fail
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1
@@ -414,4 +472,4 @@ tests:
         encryptionMetadata:
           azure:
             encryptionKeyURL: "not-a-valid-url"
-    expectedStatusError: "encryptionKeyURL must be a valid Azure Key Vault HTTPS URL"
+    expectedStatusError: "encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"

--- a/cmd/install/assets/crds/hypershift-operator/tests/hcpetcdbackups.hypershift.openshift.io/techpreview.hcpetcdbackups.validation.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hcpetcdbackups.hypershift.openshift.io/techpreview.hcpetcdbackups.validation.testsuite.yaml
@@ -65,6 +65,157 @@ tests:
               name: azure-credentials
             encryptionKeyURL: "https://my-vault.vault.azure.net/keys/my-key/abc123"
 
+  - name: When an AzureBlob backup uses a US Government Key Vault encryptionKeyURL it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-vault.vault.usgovcloudapi.net/keys/my-key/abc123"
+
+  - name: When an AzureBlob backup uses a China Key Vault encryptionKeyURL it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-vault.vault.azure.cn/keys/my-key/abc123"
+
+  - name: When an AzureBlob backup uses a German Key Vault encryptionKeyURL it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-vault.vault.microsoftazure.de/keys/my-key/abc123"
+
+  - name: When an AzureBlob backup uses a Bleu Key Vault encryptionKeyURL it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-vault.vault.sovcloud-api.fr/keys/my-key/abc123"
+
+  - name: When an AzureBlob backup uses a Managed HSM encryptionKeyURL it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-hsm.managedhsm.azure.net/keys/my-key/abc123"
+
+  - name: When an AzureBlob backup uses a US Government Managed HSM encryptionKeyURL it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-hsm.managedhsm.usgovcloudapi.net/keys/my-key/abc123"
+
+  - name: When an AzureBlob backup uses a China Managed HSM encryptionKeyURL it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-hsm.managedhsm.azure.cn/keys/my-key/abc123"
+
+  - name: When an AzureBlob backup uses a German Managed HSM encryptionKeyURL it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-hsm.managedhsm.microsoftazure.de/keys/my-key/abc123"
+
+  - name: When an AzureBlob backup uses a Bleu Managed HSM encryptionKeyURL it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-hsm.managedhsm.sovcloud-api.fr/keys/my-key/abc123"
+
+  - name: When an AzureBlob backup uses an unsupported Managed HSM encryptionKeyURL it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-hsm.managedhsm.invalid.example/keys/my-key/abc123"
+    expectedError: "encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
+
   # --- Storage type union discrimination ---
   - name: When storageType is S3 but azureBlob is provided it should fail
     initial: |
@@ -389,7 +540,7 @@ tests:
             credentials:
               name: azure-credentials
             encryptionKeyURL: "not-a-valid-url"
-    expectedError: "encryptionKeyURL must be a valid Azure Key Vault HTTPS URL"
+    expectedError: "encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 
   # --- SecretReference name validation ---
   - name: When S3 credentials name has invalid characters it should fail

--- a/cmd/install/assets/crds/hypershift-operator/tests/hcpetcdbackups.hypershift.openshift.io/techpreview.hcpetcdbackups.validation.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hcpetcdbackups.hypershift.openshift.io/techpreview.hcpetcdbackups.validation.testsuite.yaml
@@ -65,6 +65,52 @@ tests:
               name: azure-credentials
             encryptionKeyURL: "https://my-vault.vault.azure.net/keys/my-key/abc123"
 
+  - name: When an AzureBlob backup uses a Managed HSM encryptionKeyURL it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-hsm.managedhsm.azure.net/keys/my-key/abc123"
+
+  - name: When an AzureBlob backup uses a US Government Managed HSM encryptionKeyURL it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-hsm.managedhsm.usgovcloudapi.net/keys/my-key/abc123"
+
+  - name: When an AzureBlob backup uses an unsupported Managed HSM encryptionKeyURL it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-hsm.managedhsm.azure.cn/keys/my-key/abc123"
+    expectedError: "encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
+
   # --- Storage type union discrimination ---
   - name: When storageType is S3 but azureBlob is provided it should fail
     initial: |
@@ -389,7 +435,7 @@ tests:
             credentials:
               name: azure-credentials
             encryptionKeyURL: "not-a-valid-url"
-    expectedError: "encryptionKeyURL must be a valid Azure Key Vault HTTPS URL"
+    expectedError: "encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 
   # --- SecretReference name validation ---
   - name: When S3 credentials name has invalid characters it should fail

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/featuregated.hostedclusters.etcdbackup.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/featuregated.hostedclusters.etcdbackup.testsuite.yaml
@@ -5,6 +5,54 @@ featureGates:
   - HCPEtcdBackup
 version: v1beta1
 tests:
+  onCreate:
+  - name: When Azure backup encryption uses a US Government Managed HSM URL, it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        etcd:
+          managementType: Managed
+          managed:
+            storage:
+              type: PersistentVolume
+              persistentVolume:
+                size: 8Gi
+            backup:
+              platform: Azure
+              azure:
+                encryptionKeyURL: "https://my-hsm.managedhsm.usgovcloudapi.net/keys/my-key/abc123"
+        platform:
+          type: AWS
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
   onUpdate:
   - name: When lastSuccessfulEtcdBackupURL has invalid scheme it should fail
     initial: |

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.azure.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.azure.testsuite.yaml
@@ -5,6 +5,130 @@ version: v1beta1
 tests:
   onCreate:
   # --- Azure authentication configuration validation ---
+  - name: Azure German cloud should be selectable
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            cloud: AzureGermanCloud
+            location: germanywestcentral
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                ingress:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                file:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                disk:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                nodePoolManagement:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                cloudProvider:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                network:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  - name: Azure Bleu cloud should be selectable
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            cloud: AzureBleuCloud
+            location: bleufrancecentral
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                ingress:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                file:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                disk:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                nodePoolManagement:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                cloudProvider:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                network:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
   - name: When azureAuthenticationConfigType is ManagedIdentities but managedIdentities field is missing it should fail
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.kms.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.kms.testsuite.yaml
@@ -209,7 +209,628 @@ tests:
             type: Route
             route: {}
 
+  - name: When both active and backup keys omit keyVaultType it should succeed
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                ingress:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                file:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                disk:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                nodePoolManagement:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                cloudProvider:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                network:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.22.0-x86_64
+        secretEncryption:
+          type: kms
+          kms:
+            provider: Azure
+            azure:
+              activeKey:
+                keyVaultName: test-vault
+                keyName: test-key
+                keyVersion: "1"
+              backupKey:
+                keyVaultName: test-vault
+                keyName: backup-key
+                keyVersion: "1"
+              kms:
+                credentialsSecretName: kms-creds
+                objectEncoding: utf-8
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  - name: When keyVaultType is ManagedHSM it should succeed
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                ingress:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                file:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                disk:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                nodePoolManagement:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                cloudProvider:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                network:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.22.0-x86_64
+        secretEncryption:
+          type: kms
+          kms:
+            provider: Azure
+            azure:
+              keyVaultType: ManagedHSM
+              activeKey:
+                keyVaultName: test-hsm
+                keyName: test-key
+                keyVersion: "1"
+              backupKey:
+                keyVaultName: test-hsm
+                keyName: backup-key
+                keyVersion: "1"
+              kms:
+                credentialsSecretName: kms-creds
+                objectEncoding: utf-8
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  - name: When keyVaultType is explicit KeyVault it should succeed
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                ingress:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                file:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                disk:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                nodePoolManagement:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                cloudProvider:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                network:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.22.0-x86_64
+        secretEncryption:
+          type: kms
+          kms:
+            provider: Azure
+            azure:
+              keyVaultType: KeyVault
+              activeKey:
+                keyVaultName: test-vault
+                keyName: test-key
+                keyVersion: "1"
+              backupKey:
+                keyVaultName: test-vault
+                keyName: backup-key
+                keyVersion: "1"
+              kms:
+                credentialsSecretName: kms-creds
+                objectEncoding: utf-8
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
   onUpdate:
+  - name: When keyVaultType changes it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                ingress:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                file:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                disk:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                nodePoolManagement:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                cloudProvider:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                network:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.22.0-x86_64
+        secretEncryption:
+          type: kms
+          kms:
+            provider: Azure
+            azure:
+              keyVaultType: KeyVault
+              activeKey:
+                keyVaultName: test-vault
+                keyName: test-key
+                keyVersion: "1"
+              workloadIdentity:
+                clientID: "22222222-2222-2222-2222-222222222222"
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                ingress:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                file:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                disk:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                nodePoolManagement:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                cloudProvider:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                network:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.22.0-x86_64
+        secretEncryption:
+          type: kms
+          kms:
+            provider: Azure
+            azure:
+              keyVaultType: ManagedHSM
+              activeKey:
+                keyVaultName: test-vault
+                keyName: test-key
+                keyVersion: "2"
+              workloadIdentity:
+                clientID: "22222222-2222-2222-2222-222222222222"
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "keyVaultType is immutable"
+
+  - name: When ManagedHSM keyVaultType is omitted it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                ingress:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                file:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                disk:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                nodePoolManagement:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                cloudProvider:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                network:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.22.0-x86_64
+        secretEncryption:
+          type: kms
+          kms:
+            provider: Azure
+            azure:
+              keyVaultType: ManagedHSM
+              activeKey:
+                keyVaultName: test-vault
+                keyName: test-key
+                keyVersion: "1"
+              workloadIdentity:
+                clientID: "22222222-2222-2222-2222-222222222222"
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                ingress:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                file:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                disk:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                nodePoolManagement:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                cloudProvider:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                network:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.22.0-x86_64
+        secretEncryption:
+          type: kms
+          kms:
+            provider: Azure
+            azure:
+              activeKey:
+                keyVaultName: test-vault
+                keyName: test-key
+                keyVersion: "2"
+              workloadIdentity:
+                clientID: "22222222-2222-2222-2222-222222222222"
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "keyVaultType is immutable"
+
+  - name: When an omitted keyVaultType is updated to ManagedHSM it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                ingress:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                file:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                disk:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                nodePoolManagement:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                cloudProvider:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                network:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.22.0-x86_64
+        secretEncryption:
+          type: kms
+          kms:
+            provider: Azure
+            azure:
+              activeKey:
+                keyVaultName: test-vault
+                keyName: test-key
+                keyVersion: "1"
+              workloadIdentity:
+                clientID: "22222222-2222-2222-2222-222222222222"
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                ingress:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                file:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                disk:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                nodePoolManagement:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                cloudProvider:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                network:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.22.0-x86_64
+        secretEncryption:
+          type: kms
+          kms:
+            provider: Azure
+            azure:
+              keyVaultType: ManagedHSM
+              activeKey:
+                keyVaultName: test-vault
+                keyName: test-key
+                keyVersion: "2"
+              workloadIdentity:
+                clientID: "22222222-2222-2222-2222-222222222222"
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "keyVaultType is immutable"
+
   - name: When switching from kms to workloadIdentity it should fail
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1
@@ -478,7 +1099,7 @@ tests:
             route: {}
     expectedError: "the KMS authentication mode is immutable once set"
 
-  - name: When only workloadIdentity is set and key version is updated it should succeed
+  - name: When an omitted keyVaultType is updated to explicit KeyVault it should succeed
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1
       kind: HostedCluster
@@ -586,6 +1207,7 @@ tests:
           kms:
             provider: Azure
             azure:
+              keyVaultType: KeyVault
               activeKey:
                 keyVaultName: test-vault
                 keyName: test-key
@@ -672,6 +1294,7 @@ tests:
                 keyName: test-key
                 keyVaultName: test-vault
                 keyVersion: '2'
+              keyVaultType: KeyVault
               workloadIdentity:
                 clientID: 22222222-2222-2222-2222-222222222222
             provider: Azure

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.kms.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.kms.testsuite.yaml
@@ -209,7 +209,217 @@ tests:
             type: Route
             route: {}
 
+  - name: When active and backup keys use different vault types it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                ingress:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                file:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                disk:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                nodePoolManagement:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                cloudProvider:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                network:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.22.0-x86_64
+        secretEncryption:
+          type: kms
+          kms:
+            provider: Azure
+            azure:
+              activeKey:
+                keyVaultName: test-vault
+                keyName: test-key
+                keyVersion: "1"
+                keyVaultType: KeyVault
+              backupKey:
+                keyVaultName: test-vault
+                keyName: backup-key
+                keyVersion: "1"
+                keyVaultType: ManagedHSM
+              kms:
+                credentialsSecretName: kms-creds
+                objectEncoding: utf-8
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "backupKey.keyVaultType must match activeKey.keyVaultType"
+
   onUpdate:
+  - name: When active key vault type changes it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                ingress:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                file:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                disk:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                nodePoolManagement:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                cloudProvider:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                network:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.22.0-x86_64
+        secretEncryption:
+          type: kms
+          kms:
+            provider: Azure
+            azure:
+              activeKey:
+                keyVaultName: test-vault
+                keyName: test-key
+                keyVersion: "1"
+                keyVaultType: KeyVault
+              workloadIdentity:
+                clientID: "22222222-2222-2222-2222-222222222222"
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                ingress:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                file:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                disk:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                nodePoolManagement:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                cloudProvider:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+                network:
+                  clientID: "11111111-1111-1111-1111-111111111111"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.22.0-x86_64
+        secretEncryption:
+          type: kms
+          kms:
+            provider: Azure
+            azure:
+              activeKey:
+                keyVaultName: test-vault
+                keyName: test-key
+                keyVersion: "2"
+                keyVaultType: ManagedHSM
+              workloadIdentity:
+                clientID: "22222222-2222-2222-2222-222222222222"
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "activeKey.keyVaultType is immutable"
+
   - name: When switching from kms to workloadIdentity it should fail
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1
@@ -478,7 +688,7 @@ tests:
             route: {}
     expectedError: "the KMS authentication mode is immutable once set"
 
-  - name: When only workloadIdentity is set and key version is updated it should succeed
+  - name: When an omitted active key vault type is updated to explicit KeyVault it should succeed
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1
       kind: HostedCluster
@@ -590,6 +800,7 @@ tests:
                 keyVaultName: test-vault
                 keyName: test-key
                 keyVersion: "2"
+                keyVaultType: KeyVault
               workloadIdentity:
                 clientID: "22222222-2222-2222-2222-222222222222"
         services:
@@ -671,6 +882,7 @@ tests:
               activeKey:
                 keyName: test-key
                 keyVaultName: test-vault
+                keyVaultType: KeyVault
                 keyVersion: '2'
               workloadIdentity:
                 clientID: 22222222-2222-2222-2222-222222222222

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hcpetcdbackups-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hcpetcdbackups-CustomNoUpgrade.crd.yaml
@@ -104,17 +104,18 @@ spec:
                         type: object
                       encryptionKeyURL:
                         description: |-
-                          encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-                          Must be a valid Azure Key Vault key URL in the format
-                          "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                          encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+                          Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+                          Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+                          Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                           This field is immutable once set and cannot be removed.
                         maxLength: 210
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
                         - message: encryptionKeyURL must be a valid Azure Key Vault
-                            HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                            or Managed HSM HTTPS URL
+                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr)|managedhsm\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                         - message: encryptionKeyURL is immutable
                           rule: self == oldSelf
                       keyPrefix:
@@ -375,16 +376,17 @@ spec:
                     properties:
                       encryptionKeyURL:
                         description: |-
-                          encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-                          Must be a valid Azure Key Vault key URL in the format
-                          "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                          encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+                          Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+                          Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+                          Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                         maxLength: 210
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
                         - message: encryptionKeyURL must be a valid Azure Key Vault
-                            HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                            or Managed HSM HTTPS URL
+                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr)|managedhsm\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                     required:
                     - encryptionKeyURL
                     type: object

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hcpetcdbackups-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hcpetcdbackups-CustomNoUpgrade.crd.yaml
@@ -104,17 +104,17 @@ spec:
                         type: object
                       encryptionKeyURL:
                         description: |-
-                          encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-                          Must be a valid Azure Key Vault key URL in the format
-                          "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                          encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+                          Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+                          Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                           This field is immutable once set and cannot be removed.
                         maxLength: 210
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
                         - message: encryptionKeyURL must be a valid Azure Key Vault
-                            HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                            or Managed HSM HTTPS URL
+                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.azure\\.net|managedhsm\\.(azure\\.net|usgovcloudapi\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                         - message: encryptionKeyURL is immutable
                           rule: self == oldSelf
                       keyPrefix:
@@ -375,16 +375,16 @@ spec:
                     properties:
                       encryptionKeyURL:
                         description: |-
-                          encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-                          Must be a valid Azure Key Vault key URL in the format
-                          "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                          encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+                          Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+                          Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                         maxLength: 210
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
                         - message: encryptionKeyURL must be a valid Azure Key Vault
-                            HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                            or Managed HSM HTTPS URL
+                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.azure\\.net|managedhsm\\.(azure\\.net|usgovcloudapi\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                     required:
                     - encryptionKeyURL
                     type: object

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hcpetcdbackups-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hcpetcdbackups-TechPreviewNoUpgrade.crd.yaml
@@ -104,17 +104,18 @@ spec:
                         type: object
                       encryptionKeyURL:
                         description: |-
-                          encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-                          Must be a valid Azure Key Vault key URL in the format
-                          "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                          encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+                          Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+                          Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+                          Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                           This field is immutable once set and cannot be removed.
                         maxLength: 210
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
                         - message: encryptionKeyURL must be a valid Azure Key Vault
-                            HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                            or Managed HSM HTTPS URL
+                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr)|managedhsm\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                         - message: encryptionKeyURL is immutable
                           rule: self == oldSelf
                       keyPrefix:
@@ -375,16 +376,17 @@ spec:
                     properties:
                       encryptionKeyURL:
                         description: |-
-                          encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-                          Must be a valid Azure Key Vault key URL in the format
-                          "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                          encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+                          Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+                          Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+                          Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                         maxLength: 210
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
                         - message: encryptionKeyURL must be a valid Azure Key Vault
-                            HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                            or Managed HSM HTTPS URL
+                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr)|managedhsm\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                     required:
                     - encryptionKeyURL
                     type: object

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hcpetcdbackups-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hcpetcdbackups-TechPreviewNoUpgrade.crd.yaml
@@ -104,17 +104,17 @@ spec:
                         type: object
                       encryptionKeyURL:
                         description: |-
-                          encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-                          Must be a valid Azure Key Vault key URL in the format
-                          "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                          encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+                          Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+                          Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                           This field is immutable once set and cannot be removed.
                         maxLength: 210
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
                         - message: encryptionKeyURL must be a valid Azure Key Vault
-                            HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                            or Managed HSM HTTPS URL
+                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.azure\\.net|managedhsm\\.(azure\\.net|usgovcloudapi\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                         - message: encryptionKeyURL is immutable
                           rule: self == oldSelf
                       keyPrefix:
@@ -375,16 +375,16 @@ spec:
                     properties:
                       encryptionKeyURL:
                         description: |-
-                          encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-                          Must be a valid Azure Key Vault key URL in the format
-                          "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                          encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+                          Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+                          Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                         maxLength: 210
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
                         - message: encryptionKeyURL must be a valid Azure Key Vault
-                            HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                            or Managed HSM HTTPS URL
+                          rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.azure\\.net|managedhsm\\.(azure\\.net|usgovcloudapi\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                     required:
                     - encryptionKeyURL
                     type: object

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -4232,16 +4232,16 @@ spec:
                             properties:
                               encryptionKeyURL:
                                 description: |-
-                                  encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-                                  Must be a valid Azure Key Vault key URL in the format
-                                  "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                                  encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+                                  Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+                                  Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                                 maxLength: 210
                                 minLength: 1
                                 type: string
                                 x-kubernetes-validations:
                                 - message: encryptionKeyURL must be a valid Azure
-                                    Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                                    Key Vault or Managed HSM HTTPS URL
+                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.azure\\.net|managedhsm\\.(azure\\.net|usgovcloudapi\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                             required:
                             - encryptionKeyURL
                             type: object
@@ -9457,18 +9457,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -9490,18 +9500,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -9608,6 +9628,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -10622,18 +10650,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -10857,18 +10894,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -4259,16 +4259,17 @@ spec:
                             properties:
                               encryptionKeyURL:
                                 description: |-
-                                  encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-                                  Must be a valid Azure Key Vault key URL in the format
-                                  "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                                  encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+                                  Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+                                  Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+                                  Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                                 maxLength: 210
                                 minLength: 1
                                 type: string
                                 x-kubernetes-validations:
                                 - message: encryptionKeyURL must be a valid Azure
-                                    Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                                    Key Vault or Managed HSM HTTPS URL
+                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr)|managedhsm\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                             required:
                             - encryptionKeyURL
                             type: object
@@ -7532,13 +7533,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -9484,15 +9485,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -9517,15 +9518,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -9551,6 +9552,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -9635,6 +9648,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -10649,15 +10666,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -10884,15 +10900,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -6058,13 +6058,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -7031,15 +7031,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -7064,15 +7064,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -7098,6 +7098,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -7182,6 +7194,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -8173,15 +8189,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -8408,15 +8423,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -6895,18 +6895,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6928,18 +6938,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -7046,6 +7066,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -8037,18 +8065,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -8272,18 +8309,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -3381,16 +3381,17 @@ spec:
                             properties:
                               encryptionKeyURL:
                                 description: |-
-                                  encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-                                  Must be a valid Azure Key Vault key URL in the format
-                                  "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                                  encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+                                  Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+                                  Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+                                  Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                                 maxLength: 210
                                 minLength: 1
                                 type: string
                                 x-kubernetes-validations:
                                 - message: encryptionKeyURL must be a valid Azure
-                                    Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                                    Key Vault or Managed HSM HTTPS URL
+                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr)|managedhsm\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                             required:
                             - encryptionKeyURL
                             type: object
@@ -6654,13 +6655,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -8606,15 +8607,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -8639,15 +8640,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -8673,6 +8674,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -8757,6 +8770,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -9760,15 +9777,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -9995,15 +10011,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -3341,16 +3341,16 @@ spec:
                             properties:
                               encryptionKeyURL:
                                 description: |-
-                                  encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-                                  Must be a valid Azure Key Vault key URL in the format
-                                  "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                                  encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+                                  Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+                                  Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                                 maxLength: 210
                                 minLength: 1
                                 type: string
                                 x-kubernetes-validations:
                                 - message: encryptionKeyURL must be a valid Azure
-                                    Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                                    Key Vault or Managed HSM HTTPS URL
+                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.azure\\.net|managedhsm\\.(azure\\.net|usgovcloudapi\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                             required:
                             - encryptionKeyURL
                             type: object
@@ -8566,18 +8566,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -8599,18 +8609,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -8717,6 +8737,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -9720,18 +9748,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -9955,18 +9992,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -4178,16 +4178,17 @@ spec:
                             properties:
                               encryptionKeyURL:
                                 description: |-
-                                  encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-                                  Must be a valid Azure Key Vault key URL in the format
-                                  "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                                  encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+                                  Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+                                  Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+                                  Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                                 maxLength: 210
                                 minLength: 1
                                 type: string
                                 x-kubernetes-validations:
                                 - message: encryptionKeyURL must be a valid Azure
-                                    Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                                    Key Vault or Managed HSM HTTPS URL
+                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr)|managedhsm\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                             required:
                             - encryptionKeyURL
                             type: object
@@ -7410,13 +7411,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -9337,15 +9338,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -9370,15 +9371,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -9404,6 +9405,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -9488,6 +9501,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -10467,15 +10484,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -10702,15 +10718,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -4151,16 +4151,16 @@ spec:
                             properties:
                               encryptionKeyURL:
                                 description: |-
-                                  encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-                                  Must be a valid Azure Key Vault key URL in the format
-                                  "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                                  encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+                                  Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+                                  Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                                 maxLength: 210
                                 minLength: 1
                                 type: string
                                 x-kubernetes-validations:
                                 - message: encryptionKeyURL must be a valid Azure
-                                    Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                                    Key Vault or Managed HSM HTTPS URL
+                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.azure\\.net|managedhsm\\.(azure\\.net|usgovcloudapi\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                             required:
                             - encryptionKeyURL
                             type: object
@@ -9310,18 +9310,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -9343,18 +9353,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -9461,6 +9481,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -10440,18 +10468,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -10675,18 +10712,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
@@ -6748,18 +6748,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6781,18 +6791,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -6899,6 +6919,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -7867,18 +7895,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -8102,18 +8139,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
@@ -5936,13 +5936,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -6884,15 +6884,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6917,15 +6917,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -6951,6 +6951,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -7035,6 +7047,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -8003,15 +8019,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -8238,15 +8253,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -3260,16 +3260,16 @@ spec:
                             properties:
                               encryptionKeyURL:
                                 description: |-
-                                  encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-                                  Must be a valid Azure Key Vault key URL in the format
-                                  "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                                  encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+                                  Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+                                  Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                                 maxLength: 210
                                 minLength: 1
                                 type: string
                                 x-kubernetes-validations:
                                 - message: encryptionKeyURL must be a valid Azure
-                                    Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                                    Key Vault or Managed HSM HTTPS URL
+                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.azure\\.net|managedhsm\\.(azure\\.net|usgovcloudapi\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                             required:
                             - encryptionKeyURL
                             type: object
@@ -8419,18 +8419,28 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -8452,18 +8462,28 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
+                                type: string
+                              keyVaultType:
+                                default: KeyVault
+                                description: |-
+                                  keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                                  The type is immutable; key rotation must remain within the same service.
+                                  When omitted, the type defaults to KeyVault.
+                                enum:
+                                - KeyVault
+                                - ManagedHSM
                                 type: string
                               keyVersion:
                                 description: keyVersion contains the version of the
@@ -8570,6 +8590,14 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: backupKey.keyVaultType must match activeKey.keyVaultType
+                          rule: '!has(self.backupKey) || (has(self.activeKey.keyVaultType)
+                            ? self.activeKey.keyVaultType : ''KeyVault'') == (has(self.backupKey.keyVaultType)
+                            ? self.backupKey.keyVaultType : ''KeyVault'')'
+                        - message: activeKey.keyVaultType is immutable
+                          rule: '(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType
+                            : ''KeyVault'') == (has(oldSelf.activeKey.keyVaultType)
+                            ? oldSelf.activeKey.keyVaultType : ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -9538,18 +9566,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key
@@ -9773,18 +9810,27 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
+                            type: string
+                          keyVaultType:
+                            default: KeyVault
+                            description: |-
+                              keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the type defaults to KeyVault.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           keyVersion:
                             description: keyVersion contains the version of the key

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -3300,16 +3300,17 @@ spec:
                             properties:
                               encryptionKeyURL:
                                 description: |-
-                                  encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-                                  Must be a valid Azure Key Vault key URL in the format
-                                  "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+                                  encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+                                  Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+                                  Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+                                  Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
                                 maxLength: 210
                                 minLength: 1
                                 type: string
                                 x-kubernetes-validations:
                                 - message: encryptionKeyURL must be a valid Azure
-                                    Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])
-                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.vault\\.azure\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
+                                    Key Vault or Managed HSM HTTPS URL
+                                  rule: self.matches('^https://[a-zA-Z0-9-]+\\.(vault\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr)|managedhsm\\.(azure\\.net|usgovcloudapi\\.net|azure\\.cn|microsoftazure\\.de|sovcloud-api\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')
                             required:
                             - encryptionKeyURL
                             type: object
@@ -6532,13 +6533,13 @@ spec:
                             ? has(self.workloadIdentities) : !has(self.workloadIdentities)'
                       cloud:
                         default: AzurePublicCloud
-                        description: 'cloud is the cloud environment identifier, valid
-                          values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33'
+                        description: cloud is the Azure cloud environment identifier.
                         enum:
                         - AzurePublicCloud
                         - AzureUSGovernmentCloud
                         - AzureChinaCloud
                         - AzureGermanCloud
+                        - AzureBleuCloud
                         - AzureStackCloud
                         type: string
                       containerRegistry:
@@ -8459,15 +8460,15 @@ spec:
                               encrypt new secrets
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -8492,15 +8493,15 @@ spec:
                               The system automatically manages the previous key via the status field.
                             properties:
                               keyName:
-                                description: keyName is the name of the keyvault key
-                                  used for encrypt/decrypt
+                                description: keyName is the name of the key used for
+                                  encrypt/decrypt.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
                               keyVaultName:
                                 description: |-
-                                  keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                                  Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                                  keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                                  Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                                   `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                                 maxLength: 255
                                 minLength: 1
@@ -8526,6 +8527,18 @@ spec:
                             - Public
                             - Private
                             - ""
+                            type: string
+                          keyVaultType:
+                            description: |-
+                              keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+                              Valid values are "KeyVault" and "ManagedHSM".
+                              When set to "KeyVault", both keys are hosted by Azure Key Vault.
+                              When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+                              The type is immutable; key rotation must remain within the same service.
+                              When omitted, the keys are treated as Key Vault keys.
+                            enum:
+                            - KeyVault
+                            - ManagedHSM
                             type: string
                           kms:
                             description: |-
@@ -8610,6 +8623,10 @@ spec:
                             both keys must reside in the same Key Vault
                           rule: '!has(self.backupKey) || self.backupKey.keyVaultName
                             == self.activeKey.keyVaultName'
+                        - message: keyVaultType is immutable
+                          rule: '(has(self.keyVaultType) ? self.keyVaultType : ''KeyVault'')
+                            == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType :
+                            ''KeyVault'')'
                         - message: kms and workloadIdentity are mutually exclusive
                           rule: '!(has(self.kms) && has(self.workloadIdentity))'
                         - message: one of kms or workloadIdentity must be set
@@ -9578,15 +9595,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1
@@ -9813,15 +9829,14 @@ spec:
                         description: azure holds the Azure KMS key identity fields.
                         properties:
                           keyName:
-                            description: keyName is the name of the keyvault key used
-                              for encrypt/decrypt
+                            description: keyName is the name of the key used for encrypt/decrypt.
                             maxLength: 255
                             minLength: 1
                             type: string
                           keyVaultName:
                             description: |-
-                              keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-                              Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+                              keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
                               `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
                             maxLength: 255
                             minLength: 1

--- a/cmd/util/azure_flag_descriptions.go
+++ b/cmd/util/azure_flag_descriptions.go
@@ -42,7 +42,7 @@ const (
 
 	// Encryption
 	EnableKMSDescription           = "Create a KMS workload identity for Azure Key Vault KMS encryption. Use this when the cluster will be configured with --encryption-key-id."
-	EncryptionKeyIDDescription     = "Azure Key Vault key identifier used to encrypt etcd data via KMSv2 (format: https://<vault>.vault.azure.net/keys/<key>/<version>)."
+	EncryptionKeyIDDescription     = "Azure Key Vault or Managed HSM key identifier used to encrypt etcd data via KMSv2 (formats: https://<vault>.vault.azure.net/keys/<key>/<version> or https://<hsm>.managedhsm.azure.net/keys/<key>/<version>)."
 	EncryptionAtHostDescription    = "Enable host-based encryption for VM disks and temp disks. Valid values: Enabled, Disabled."
 	DiskEncryptionSetIDDescription = "Full resource ID of an Azure Disk Encryption Set used to encrypt NodePool OS disks with customer-managed keys."
 
@@ -84,5 +84,5 @@ const (
 
 	// Common flags
 	NameDescription  = "A name for the HostedCluster. This name is used to identify resources and must be unique within the namespace."
-	CloudDescription = "Azure cloud environment. Valid values: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud."
+	CloudDescription = "Azure cloud environment. Valid values: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud, AzureBleuCloud."
 )

--- a/cmd/util/azure_flag_descriptions.go
+++ b/cmd/util/azure_flag_descriptions.go
@@ -42,7 +42,7 @@ const (
 
 	// Encryption
 	EnableKMSDescription           = "Create a KMS workload identity for Azure Key Vault KMS encryption. Use this when the cluster will be configured with --encryption-key-id."
-	EncryptionKeyIDDescription     = "Azure Key Vault key identifier used to encrypt etcd data via KMSv2 (format: https://<vault>.vault.azure.net/keys/<key>/<version>)."
+	EncryptionKeyIDDescription     = "Azure Key Vault or Managed HSM key identifier used to encrypt etcd data via KMSv2 (formats: https://<vault>.vault.azure.net/keys/<key>/<version> or https://<hsm>.managedhsm.azure.net/keys/<key>/<version>)."
 	EncryptionAtHostDescription    = "Enable host-based encryption for VM disks and temp disks. Valid values: Enabled, Disabled."
 	DiskEncryptionSetIDDescription = "Full resource ID of an Azure Disk Encryption Set used to encrypt NodePool OS disks with customer-managed keys."
 

--- a/contrib/managed-azure/setup_etcd_managed_hsm.sh
+++ b/contrib/managed-azure/setup_etcd_managed_hsm.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+set +x
+
+# Prerequisites: define these constants
+LOCATION="eastus"
+HSM_RG_NAME="example-kms"
+HSM_NAME="example-managed-hsm"
+KEY_NAME="example-key"
+SUBSCRIPTION_ID="<your-subscription-id-here>"
+
+# This is the object ID of your signed-in user or service principal that will administer the HSM.
+# Used to assign the initial HSM administrator role and create keys.
+# Find it with: az ad signed-in-user show --query id -o tsv
+USER_OBJECT_ID="<fill-me-out>"
+
+# This is the object ID of the KMS Managed Identity. This object ID can be found under the enterprise application for
+# your KMS Managed Identity.
+OBJECT_ID="<fill-me-out>"
+
+# Number of security domain key shares and required quorum for HSM activation.
+# At least 3 shares with a quorum of 2 is recommended.
+SD_SHARES=3
+SD_QUORUM=2
+
+# Create a resource group to hold the Managed HSM
+az group create --name "$HSM_RG_NAME" --location "$LOCATION"
+
+# Create the Managed HSM
+# Note: provisioning takes approximately 20+ minutes.
+az keyvault create \
+    --hsm-name "$HSM_NAME" \
+    --resource-group "$HSM_RG_NAME" \
+    --location "$LOCATION" \
+    --administrators "$USER_OBJECT_ID"
+
+echo "Waiting for Managed HSM provisioning to complete..."
+az keyvault wait --hsm-name "$HSM_NAME" --resource-group "$HSM_RG_NAME" --created
+
+# Activate the Managed HSM security domain.
+# Generate RSA key pairs that will protect the security domain download.
+SD_DIR=$(mktemp -d)
+for i in $(seq 0 $((SD_SHARES - 1))); do
+    openssl req -newkey rsa:2048 -nodes \
+        -keyout "${SD_DIR}/sd_key_${i}.pem" \
+        -x509 -days 365 \
+        -out "${SD_DIR}/sd_cert_${i}.pem" \
+        -subj "/CN=SecurityDomain${i}" 2>/dev/null
+done
+
+SD_CERT_ARGS=""
+for i in $(seq 0 $((SD_SHARES - 1))); do
+    SD_CERT_ARGS="${SD_CERT_ARGS} --sd-wrapping-keys ${SD_DIR}/sd_cert_${i}.pem"
+done
+
+# Download and activate the security domain
+# shellcheck disable=SC2086
+az keyvault security-domain download \
+    --hsm-name "$HSM_NAME" \
+    --security-domain-file "${SD_DIR}/security_domain.json" \
+    ${SD_CERT_ARGS} \
+    --sd-quorum "$SD_QUORUM"
+
+echo "Security domain downloaded to ${SD_DIR}/security_domain.json"
+echo "IMPORTANT: Back up the security domain file and key pairs — they are required to restore the HSM."
+
+# Assign the Managed HSM Crypto Officer role (key management) and
+# Crypto User role at /keys (data-plane key operations). Both are
+# needed to create keys — Administrator alone is not sufficient.
+az keyvault role assignment create \
+    --hsm-name "$HSM_NAME" \
+    --assignee "$USER_OBJECT_ID" \
+    --role "Managed HSM Crypto Officer" \
+    --scope "/"
+
+az keyvault role assignment create \
+    --hsm-name "$HSM_NAME" \
+    --assignee "$USER_OBJECT_ID" \
+    --role "Managed HSM Crypto User" \
+    --scope "/keys"
+
+# Wait for RBAC to propagate (~2-5 minutes for Managed HSM data-plane)
+echo "Waiting for RBAC propagation..."
+sleep 300
+
+# Create a key in the Managed HSM
+# Note: --protection is not used; all Managed HSM keys are HSM-backed.
+export KEY_ID
+KEY_ID=$(az keyvault key create \
+    --hsm-name "$HSM_NAME" \
+    --name "$KEY_NAME" \
+    --kty RSA-HSM \
+    --query key.kid \
+    -o tsv)
+
+echo ""
+echo "Encryption key created: $KEY_ID"
+echo ""
+
+# Assign the Managed HSM Crypto User role to the KMS Managed Identity
+az keyvault role assignment create \
+    --hsm-name "$HSM_NAME" \
+    --assignee "$OBJECT_ID" \
+    --role "Managed HSM Crypto User" \
+    --scope "/keys/${KEY_NAME}"
+
+echo ""
+echo "Setup complete. Pass the following flag when creating your Azure HostedCluster:"
+echo "  --encryption-key-id $KEY_ID"
+echo ""
+echo "Managed HSM requires OpenShift 4.22 or later."

--- a/contrib/managed-azure/setup_etcd_managed_hsm.sh
+++ b/contrib/managed-azure/setup_etcd_managed_hsm.sh
@@ -63,19 +63,31 @@ az keyvault security-domain download \
 echo "Security domain downloaded to ${SD_DIR}/security_domain.json"
 echo "IMPORTANT: Back up the security domain file and key pairs — they are required to restore the HSM."
 
-# Assign the Managed HSM Crypto Officer role so the user can create keys
+# Assign the Managed HSM Crypto Officer role (key management) and
+# Crypto User role at /keys (data-plane key operations). Both are
+# needed to create keys — Administrator alone is not sufficient.
 az keyvault role assignment create \
     --hsm-name "$HSM_NAME" \
     --assignee "$USER_OBJECT_ID" \
     --role "Managed HSM Crypto Officer" \
     --scope "/"
 
+az keyvault role assignment create \
+    --hsm-name "$HSM_NAME" \
+    --assignee "$USER_OBJECT_ID" \
+    --role "Managed HSM Crypto User" \
+    --scope "/keys"
+
+# Wait for RBAC to propagate (~2-5 minutes for Managed HSM data-plane)
+echo "Waiting for RBAC propagation..."
+sleep 300
+
 # Create a key in the Managed HSM
+# Note: --protection is not used; all Managed HSM keys are HSM-backed.
 export KEY_ID
 KEY_ID=$(az keyvault key create \
     --hsm-name "$HSM_NAME" \
     --name "$KEY_NAME" \
-    --protection software \
     --kty RSA-HSM \
     --query key.kid \
     -o tsv)

--- a/contrib/managed-azure/setup_etcd_managed_hsm.sh
+++ b/contrib/managed-azure/setup_etcd_managed_hsm.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set +x
+
+# Prerequisites: define these constants
+LOCATION="eastus"
+HSM_RG_NAME="example-kms"
+HSM_NAME="example-managed-hsm"
+KEY_NAME="example-key"
+SUBSCRIPTION_ID="<your-subscription-id-here>"
+
+# This is the object ID of your signed-in user or service principal that will administer the HSM.
+# Used to assign the initial HSM administrator role and create keys.
+# Find it with: az ad signed-in-user show --query id -o tsv
+USER_OBJECT_ID="<fill-me-out>"
+
+# This is the object ID of the KMS Managed Identity. This object ID can be found under the enterprise application for
+# your KMS Managed Identity.
+OBJECT_ID="<fill-me-out>"
+
+# Number of security domain key shares and required quorum for HSM activation.
+# At least 3 shares with a quorum of 2 is recommended.
+SD_SHARES=3
+SD_QUORUM=2
+
+# Create a resource group to hold the Managed HSM
+az group create --name "$HSM_RG_NAME" --location "$LOCATION"
+
+# Create the Managed HSM
+# Note: provisioning takes approximately 20+ minutes.
+az keyvault create \
+    --hsm-name "$HSM_NAME" \
+    --resource-group "$HSM_RG_NAME" \
+    --location "$LOCATION" \
+    --administrators "$USER_OBJECT_ID"
+
+echo "Waiting for Managed HSM provisioning to complete..."
+az keyvault wait --hsm-name "$HSM_NAME" --resource-group "$HSM_RG_NAME" --created
+
+# Activate the Managed HSM security domain.
+# Generate RSA key pairs that will protect the security domain download.
+SD_DIR=$(mktemp -d)
+for i in $(seq 0 $((SD_SHARES - 1))); do
+    openssl req -newkey rsa:2048 -nodes \
+        -keyout "${SD_DIR}/sd_key_${i}.pem" \
+        -x509 -days 365 \
+        -out "${SD_DIR}/sd_cert_${i}.pem" \
+        -subj "/CN=SecurityDomain${i}" 2>/dev/null
+done
+
+SD_CERT_ARGS=""
+for i in $(seq 0 $((SD_SHARES - 1))); do
+    SD_CERT_ARGS="${SD_CERT_ARGS} --sd-wrapping-keys ${SD_DIR}/sd_cert_${i}.pem"
+done
+
+# Download and activate the security domain
+# shellcheck disable=SC2086
+az keyvault security-domain download \
+    --hsm-name "$HSM_NAME" \
+    --security-domain-file "${SD_DIR}/security_domain.json" \
+    ${SD_CERT_ARGS} \
+    --sd-quorum "$SD_QUORUM"
+
+echo "Security domain downloaded to ${SD_DIR}/security_domain.json"
+echo "IMPORTANT: Back up the security domain file and key pairs — they are required to restore the HSM."
+
+# Assign the Managed HSM Crypto Officer role so the user can create keys
+az keyvault role assignment create \
+    --hsm-name "$HSM_NAME" \
+    --assignee "$USER_OBJECT_ID" \
+    --role "Managed HSM Crypto Officer" \
+    --scope "/"
+
+# Create a key in the Managed HSM
+export KEY_ID
+KEY_ID=$(az keyvault key create \
+    --hsm-name "$HSM_NAME" \
+    --name "$KEY_NAME" \
+    --protection software \
+    --kty RSA-HSM \
+    --query key.kid \
+    -o tsv)
+
+echo ""
+echo "Encryption key created: $KEY_ID"
+echo ""
+
+# Assign the Managed HSM Crypto User role to the KMS Managed Identity
+az keyvault role assignment create \
+    --hsm-name "$HSM_NAME" \
+    --assignee "$OBJECT_ID" \
+    --role "Managed HSM Crypto User" \
+    --scope "/keys/${KEY_NAME}"
+
+echo ""
+echo "Setup complete. Pass the following flag when creating your Azure HostedCluster:"
+echo "  --encryption-key-id $KEY_ID"
+echo ""
+echo "Managed HSM requires OpenShift 4.22 or later."

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3194,7 +3194,7 @@ func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Contex
 		return
 	}
 
-	azureKeyVaultDNSSuffix, err := hyperazureutil.GetKeyVaultDNSSuffixFromCloudType(hcp.Spec.Platform.Azure.Cloud)
+	azureKeyVaultDNSSuffix, err := hyperazureutil.GetKeyVaultDNSSuffix(hcp.Spec.Platform.Azure.Cloud, azureKmsSpec.KeyVaultType)
 	if err != nil {
 		conditions.SetFalseCondition(hcp, hyperv1.ValidAzureKMSConfig, hyperv1.InvalidAzureCredentialsReason,
 			fmt.Sprintf("vault dns suffix not available for cloud: %s", hcp.Spec.Platform.Azure.Cloud))

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3153,7 +3153,7 @@ func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Contex
 		return
 	}
 
-	azureKeyVaultDNSSuffix, err := hyperazureutil.GetKeyVaultDNSSuffixFromCloudType(hcp.Spec.Platform.Azure.Cloud)
+	azureKeyVaultDNSSuffix, err := hyperazureutil.GetKeyVaultDNSSuffix(hcp.Spec.Platform.Azure.Cloud, azureKmsSpec.ActiveKey.KeyVaultType)
 	if err != nil {
 		conditions.SetFalseCondition(hcp, hyperv1.ValidAzureKMSConfig, hyperv1.InvalidAzureCredentialsReason,
 			fmt.Sprintf("vault dns suffix not available for cloud: %s", hcp.Spec.Platform.Azure.Cloud))

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms.go
@@ -150,7 +150,7 @@ func deriveKMSKeys(kmsSpec *hyperv1.KMSSpec, encStatus *hyperv1.SecretEncryption
 			KeyName:      encStatus.ActiveKey.Azure.KeyName,
 			KeyVersion:   encStatus.ActiveKey.Azure.KeyVersion,
 		}
-		targetName, err := kms.AzureKMSProviderName(*targetKey)
+		targetName, err := kms.AzureKMSProviderName(*targetKey, kmsSpec.Azure.KeyVaultType)
 		if err != nil {
 			return keys, err
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms.go
@@ -144,11 +144,13 @@ func deriveKMSKeys(kmsSpec *hyperv1.KMSSpec, encStatus *hyperv1.SecretEncryption
 			KeyVaultName: encStatus.TargetKey.Azure.KeyVaultName,
 			KeyName:      encStatus.TargetKey.Azure.KeyName,
 			KeyVersion:   encStatus.TargetKey.Azure.KeyVersion,
+			KeyVaultType: encStatus.TargetKey.Azure.KeyVaultType,
 		}
 		oldKey := &hyperv1.AzureKMSKey{
 			KeyVaultName: encStatus.ActiveKey.Azure.KeyVaultName,
 			KeyName:      encStatus.ActiveKey.Azure.KeyName,
 			KeyVersion:   encStatus.ActiveKey.Azure.KeyVersion,
+			KeyVaultType: encStatus.ActiveKey.Azure.KeyVaultType,
 		}
 		targetName, err := kms.AzureKMSProviderName(*targetKey)
 		if err != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
@@ -38,8 +38,22 @@ const (
 )
 
 // AzureKMSProviderName computes the EncryptionConfiguration KMS provider name for an Azure KMS key.
-func AzureKMSProviderName(key hyperv1.AzureKMSKey) (string, error) {
-	h, err := util.HashStruct(key)
+func AzureKMSProviderName(key hyperv1.AzureKMSKey, keyVaultType hyperv1.AzureKMSKeyVaultType) (string, error) {
+	type keyIdentity struct {
+		KeyVaultName string                       `json:"keyVaultName,omitempty"`
+		KeyName      string                       `json:"keyName,omitempty"`
+		KeyVersion   string                       `json:"keyVersion,omitempty"`
+		KeyVaultType hyperv1.AzureKMSKeyVaultType `json:"keyVaultType,omitempty"`
+	}
+	id := keyIdentity{
+		KeyVaultName: key.KeyVaultName,
+		KeyName:      key.KeyName,
+		KeyVersion:   key.KeyVersion,
+	}
+	if keyVaultType == hyperv1.AzureKMSKeyVaultTypeManagedHSM {
+		id.KeyVaultType = keyVaultType
+	}
+	h, err := util.HashStruct(id)
 	if err != nil {
 		return "", err
 	}
@@ -113,7 +127,7 @@ func NewAzureKMSProvider(writeKey hyperv1.AzureKMSKey, readKey *hyperv1.AzureKMS
 func (p *azureKMSProvider) GenerateKMSEncryptionConfig(apiVersion string) (*v1.EncryptionConfiguration, error) {
 	var providerConfiguration []v1.ProviderConfiguration
 
-	writeKeyName, err := AzureKMSProviderName(p.writeKey)
+	writeKeyName, err := AzureKMSProviderName(p.writeKey, p.kmsSpec.KeyVaultType)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +140,7 @@ func (p *azureKMSProvider) GenerateKMSEncryptionConfig(apiVersion string) (*v1.E
 		},
 	})
 	if p.readKey != nil {
-		readKeyName, err := AzureKMSProviderName(*p.readKey)
+		readKeyName, err := AzureKMSProviderName(*p.readKey, p.kmsSpec.KeyVaultType)
 		if err != nil {
 			return nil, err
 		}
@@ -223,6 +237,9 @@ func (p *azureKMSProvider) buildKASContainerAzureKMS(kmsKey hyperv1.AzureKMSKey,
 			"--healthz-path=/healthz",
 			fmt.Sprintf("--config-file-path=%s/%s", azureKMSVolumeMounts.Path(c.Name, kasVolumeAzureKMSCredentials().Name), azureKMSCredsFileKey),
 			"-v=1",
+		}
+		if p.kmsSpec.KeyVaultType == hyperv1.AzureKMSKeyVaultTypeManagedHSM {
+			c.Args = append(c.Args, "--managed-hsm")
 		}
 		c.VolumeMounts = azureKMSVolumeMounts.ContainerMounts(c.Name)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
@@ -39,7 +39,20 @@ const (
 
 // AzureKMSProviderName computes the EncryptionConfiguration KMS provider name for an Azure KMS key.
 func AzureKMSProviderName(key hyperv1.AzureKMSKey) (string, error) {
-	h, err := util.HashStruct(key)
+	keyIdentity := struct {
+		KeyVaultName string                       `json:"keyVaultName,omitempty"`
+		KeyName      string                       `json:"keyName,omitempty"`
+		KeyVersion   string                       `json:"keyVersion,omitempty"`
+		KeyVaultType hyperv1.AzureKMSKeyVaultType `json:"keyVaultType,omitempty"`
+	}{
+		KeyVaultName: key.KeyVaultName,
+		KeyName:      key.KeyName,
+		KeyVersion:   key.KeyVersion,
+	}
+	if key.KeyVaultType == hyperv1.AzureKMSKeyVaultTypeManagedHSM {
+		keyIdentity.KeyVaultType = key.KeyVaultType
+	}
+	h, err := util.HashStruct(keyIdentity)
 	if err != nil {
 		return "", err
 	}
@@ -223,6 +236,9 @@ func (p *azureKMSProvider) buildKASContainerAzureKMS(kmsKey hyperv1.AzureKMSKey,
 			"--healthz-path=/healthz",
 			fmt.Sprintf("--config-file-path=%s/%s", azureKMSVolumeMounts.Path(c.Name, kasVolumeAzureKMSCredentials().Name), azureKMSCredsFileKey),
 			"-v=1",
+		}
+		if kmsKey.KeyVaultType == hyperv1.AzureKMSKeyVaultTypeManagedHSM {
+			c.Args = append(c.Args, "--managed-hsm")
 		}
 		c.VolumeMounts = azureKMSVolumeMounts.ContainerMounts(c.Name)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure_test.go
@@ -486,6 +486,98 @@ func TestGenerateKMSPodConfig_ActiveContainerArgs(t *testing.T) {
 	}
 }
 
+func TestBuildKASContainerAzureKMS(t *testing.T) {
+	tests := []struct {
+		name             string
+		keyVaultType     hyperv1.AzureKMSKeyVaultType
+		expectManagedHSM bool
+	}{
+		{
+			name:             "When keyVaultType is omitted, it should not pass the managed HSM flag",
+			expectManagedHSM: false,
+		},
+		{
+			name:             "When keyVaultType is KeyVault, it should not pass the managed HSM flag",
+			keyVaultType:     hyperv1.AzureKMSKeyVaultTypeKeyVault,
+			expectManagedHSM: false,
+		},
+		{
+			name:             "When keyVaultType is ManagedHSM, it should pass the managed HSM flag",
+			keyVaultType:     hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			expectManagedHSM: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := validAzureKMSSpecWithBackup()
+			spec.KeyVaultType = tt.keyVaultType
+			provider, err := newTestAzureKMSProvider(spec, "test-kms-image:latest", AzureKMSProviderOptions{})
+			g := NewWithT(t)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			podConfig, err := provider.GenerateKMSPodConfig()
+			g.Expect(err).NotTo(HaveOccurred())
+			active := findContainer(podConfig.Containers, "azure-kms-provider-active")
+			g.Expect(active).NotTo(BeNil())
+			backup := findContainer(podConfig.Containers, "azure-kms-provider-backup")
+			g.Expect(backup).NotTo(BeNil())
+			if tt.expectManagedHSM {
+				g.Expect(active.Args).To(ContainElement("--managed-hsm"))
+				g.Expect(backup.Args).To(ContainElement("--managed-hsm"))
+			} else {
+				g.Expect(active.Args).NotTo(ContainElement("--managed-hsm"))
+				g.Expect(backup.Args).NotTo(ContainElement("--managed-hsm"))
+			}
+		})
+	}
+}
+
+func TestAzureKMSProviderName(t *testing.T) {
+	const legacyProviderName = "azure-be23a676"
+	baseKey := hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "1"}
+
+	tests := []struct {
+		name         string
+		keyVaultType hyperv1.AzureKMSKeyVaultType
+		expectName   string
+		expectLegacy bool
+	}{
+		{
+			name:         "When keyVaultType is omitted, it should produce the legacy provider name",
+			expectName:   legacyProviderName,
+			expectLegacy: true,
+		},
+		{
+			name:         "When keyVaultType is KeyVault, it should preserve the legacy provider name",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeKeyVault,
+			expectName:   legacyProviderName,
+			expectLegacy: true,
+		},
+		{
+			name:         "When keyVaultType is ManagedHSM, it should produce a different provider name",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			expectLegacy: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			key := baseKey
+
+			name, err := AzureKMSProviderName(key, tt.keyVaultType)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			if tt.expectLegacy {
+				g.Expect(name).To(Equal(tt.expectName))
+			} else {
+				g.Expect(name).NotTo(Equal(legacyProviderName))
+			}
+		})
+	}
+}
+
 func TestGenerateKMSPodConfig_BackupContainerArgs(t *testing.T) {
 	g := NewWithT(t)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure_test.go
@@ -486,6 +486,71 @@ func TestGenerateKMSPodConfig_ActiveContainerArgs(t *testing.T) {
 	}
 }
 
+func TestBuildKASContainerAzureKMS(t *testing.T) {
+	tests := []struct {
+		name             string
+		keyVaultType     hyperv1.AzureKMSKeyVaultType
+		expectManagedHSM bool
+	}{
+		{
+			name:             "When keyVaultType is omitted it should not pass the managed HSM flag",
+			expectManagedHSM: false,
+		},
+		{
+			name:             "When keyVaultType is KeyVault it should not pass the managed HSM flag",
+			keyVaultType:     hyperv1.AzureKMSKeyVaultTypeKeyVault,
+			expectManagedHSM: false,
+		},
+		{
+			name:             "When keyVaultType is ManagedHSM it should pass the managed HSM flag",
+			keyVaultType:     hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			expectManagedHSM: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := validAzureKMSSpec()
+			spec.ActiveKey.KeyVaultType = tt.keyVaultType
+			provider, err := newTestAzureKMSProvider(spec, "test-kms-image:latest", AzureKMSProviderOptions{})
+			g := NewWithT(t)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			podConfig, err := provider.GenerateKMSPodConfig()
+			g.Expect(err).NotTo(HaveOccurred())
+			active := findContainer(podConfig.Containers, "azure-kms-provider-active")
+			g.Expect(active).NotTo(BeNil())
+			if tt.expectManagedHSM {
+				g.Expect(active.Args).To(ContainElement("--managed-hsm"))
+			} else {
+				g.Expect(active.Args).NotTo(ContainElement("--managed-hsm"))
+			}
+		})
+	}
+}
+
+func TestAzureKMSProviderName(t *testing.T) {
+	const legacyProviderName = "azure-be23a676"
+
+	legacyKey := hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "1"}
+	explicitKeyVault := legacyKey
+	explicitKeyVault.KeyVaultType = hyperv1.AzureKMSKeyVaultTypeKeyVault
+	managedHSMKey := legacyKey
+	managedHSMKey.KeyVaultType = hyperv1.AzureKMSKeyVaultTypeManagedHSM
+
+	legacyName, err := AzureKMSProviderName(legacyKey)
+	g := NewWithT(t)
+	g.Expect(err).NotTo(HaveOccurred())
+	explicitKeyVaultName, err := AzureKMSProviderName(explicitKeyVault)
+	g.Expect(err).NotTo(HaveOccurred())
+	managedHSMName, err := AzureKMSProviderName(managedHSMKey)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(legacyName).To(Equal(legacyProviderName))
+	g.Expect(explicitKeyVaultName).To(Equal(legacyProviderName), "explicit KeyVault must preserve the legacy provider name")
+	g.Expect(managedHSMName).NotTo(Equal(legacyProviderName))
+}
+
 func TestGenerateKMSPodConfig_BackupContainerArgs(t *testing.T) {
 	g := NewWithT(t)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms_test.go
@@ -106,8 +106,8 @@ func TestDeriveKMSKeys(t *testing.T) {
 				},
 			},
 			currentConfig: kmsEncryptionConfig(
-				mustAWSProviderName("arn:aws:kms:us-east-1:123456789:key/old-key"),
-				mustAWSProviderName("arn:aws:kms:us-east-1:123456789:key/new-key"),
+				mustAWSProviderName(t, "arn:aws:kms:us-east-1:123456789:key/old-key"),
+				mustAWSProviderName(t, "arn:aws:kms:us-east-1:123456789:key/new-key"),
 			),
 			kasConverged: true,
 			validate: func(g Gomega, keys kmsWriteReadKeys) {
@@ -116,7 +116,7 @@ func TestDeriveKMSKeys(t *testing.T) {
 			},
 		},
 		{
-			name: "When Azure rotation in progress and target key absent from config, it should use old key as write",
+			name: "When legacy Key Vault rotation is not ready for promotion, it should keep the old key as write and target as read",
 			kmsSpec: &hyperv1.KMSSpec{
 				Provider: hyperv1.AZURE,
 				Azure: &hyperv1.AzureKMSSpec{
@@ -139,6 +139,88 @@ func TestDeriveKMSKeys(t *testing.T) {
 				g.Expect(keys.azureRead.KeyVersion).To(Equal("v2"), "target key should be read-only during ReadOnlyDeploy")
 			},
 		},
+		{
+			name: "When legacy Key Vault rotation is ready for promotion, it should promote the target key and keep the old key as read",
+			kmsSpec: &hyperv1.KMSSpec{
+				Provider: hyperv1.AZURE,
+				Azure: &hyperv1.AzureKMSSpec{
+					ActiveKey: hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2"},
+				},
+			},
+			encStatus: &hyperv1.SecretEncryptionStatus{
+				ActiveKey: hyperv1.SecretEncryptionKeyStatus{
+					Provider: hyperv1.SecretEncryptionProviderAzure,
+					Azure:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"},
+				},
+				TargetKey: hyperv1.SecretEncryptionKeyStatus{
+					Provider: hyperv1.SecretEncryptionProviderAzure,
+					Azure:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2"},
+				},
+			},
+			currentConfig: kmsEncryptionConfig(
+				mustAzureProviderName(t, hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"}, ""),
+				mustAzureProviderName(t, hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2"}, ""),
+			),
+			kasConverged: true,
+			validate: func(g Gomega, keys kmsWriteReadKeys) {
+				g.Expect(keys.azureWrite.KeyVersion).To(Equal("v2"), "target key should be write after promotion")
+				g.Expect(keys.azureRead.KeyVersion).To(Equal("v1"), "old key should be read after promotion")
+			},
+		},
+		{
+			name: "When Managed HSM rotation is not ready for promotion, it should preserve the vault type on both keys",
+			kmsSpec: &hyperv1.KMSSpec{
+				Provider: hyperv1.AZURE,
+				Azure: &hyperv1.AzureKMSSpec{
+					ActiveKey:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2"},
+					KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+				},
+			},
+			encStatus: &hyperv1.SecretEncryptionStatus{
+				ActiveKey: hyperv1.SecretEncryptionKeyStatus{
+					Provider: hyperv1.SecretEncryptionProviderAzure,
+					Azure:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"},
+				},
+				TargetKey: hyperv1.SecretEncryptionKeyStatus{
+					Provider: hyperv1.SecretEncryptionProviderAzure,
+					Azure:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2"},
+				},
+			},
+			currentConfig: nil,
+			validate: func(g Gomega, keys kmsWriteReadKeys) {
+				g.Expect(keys.azureWrite.KeyVersion).To(Equal("v1"), "old key should be write during ReadOnlyDeploy")
+				g.Expect(keys.azureRead.KeyVersion).To(Equal("v2"), "target key should be read-only during ReadOnlyDeploy")
+			},
+		},
+		{
+			name: "When Managed HSM rotation is ready for promotion, it should preserve the vault type on both keys",
+			kmsSpec: &hyperv1.KMSSpec{
+				Provider: hyperv1.AZURE,
+				Azure: &hyperv1.AzureKMSSpec{
+					ActiveKey:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2"},
+					KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+				},
+			},
+			encStatus: &hyperv1.SecretEncryptionStatus{
+				ActiveKey: hyperv1.SecretEncryptionKeyStatus{
+					Provider: hyperv1.SecretEncryptionProviderAzure,
+					Azure:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"},
+				},
+				TargetKey: hyperv1.SecretEncryptionKeyStatus{
+					Provider: hyperv1.SecretEncryptionProviderAzure,
+					Azure:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2"},
+				},
+			},
+			currentConfig: kmsEncryptionConfig(
+				mustAzureProviderName(t, hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"}, hyperv1.AzureKMSKeyVaultTypeManagedHSM),
+				mustAzureProviderName(t, hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2"}, hyperv1.AzureKMSKeyVaultTypeManagedHSM),
+			),
+			kasConverged: true,
+			validate: func(g Gomega, keys kmsWriteReadKeys) {
+				g.Expect(keys.azureWrite.KeyVersion).To(Equal("v2"), "target key should be write after promotion")
+				g.Expect(keys.azureRead.KeyVersion).To(Equal("v1"), "old key should be read after promotion")
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -153,8 +235,21 @@ func TestDeriveKMSKeys(t *testing.T) {
 	}
 }
 
-func mustAWSProviderName(arn string) string {
-	name, _ := kms.AWSKMSProviderName(arn)
+func mustAWSProviderName(t *testing.T, arn string) string {
+	t.Helper()
+	name, err := kms.AWSKMSProviderName(arn)
+	if err != nil {
+		t.Fatalf("failed to compute AWS KMS provider name: %v", err)
+	}
+	return name
+}
+
+func mustAzureProviderName(t *testing.T, key hyperv1.AzureKMSKey, keyVaultType hyperv1.AzureKMSKeyVaultType) string {
+	t.Helper()
+	name, err := kms.AzureKMSProviderName(key, keyVaultType)
+	if err != nil {
+		t.Fatalf("failed to compute Azure KMS provider name: %v", err)
+	}
 	return name
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms_test.go
@@ -106,8 +106,8 @@ func TestDeriveKMSKeys(t *testing.T) {
 				},
 			},
 			currentConfig: kmsEncryptionConfig(
-				mustAWSProviderName("arn:aws:kms:us-east-1:123456789:key/old-key"),
-				mustAWSProviderName("arn:aws:kms:us-east-1:123456789:key/new-key"),
+				mustAWSProviderName(t, "arn:aws:kms:us-east-1:123456789:key/old-key"),
+				mustAWSProviderName(t, "arn:aws:kms:us-east-1:123456789:key/new-key"),
 			),
 			kasConverged: true,
 			validate: func(g Gomega, keys kmsWriteReadKeys) {
@@ -116,7 +116,7 @@ func TestDeriveKMSKeys(t *testing.T) {
 			},
 		},
 		{
-			name: "When Azure rotation in progress and target key absent from config it should use old key as write",
+			name: "When legacy Key Vault rotation is not ready for promotion, it should preserve the default vault type on both keys",
 			kmsSpec: &hyperv1.KMSSpec{
 				Provider: hyperv1.AZURE,
 				Azure: &hyperv1.AzureKMSSpec{
@@ -136,7 +136,95 @@ func TestDeriveKMSKeys(t *testing.T) {
 			currentConfig: nil,
 			validate: func(g Gomega, keys kmsWriteReadKeys) {
 				g.Expect(keys.azureWrite.KeyVersion).To(Equal("v1"), "old key should be write during ReadOnlyDeploy")
+				g.Expect(keys.azureWrite.KeyVaultType).To(BeEmpty())
 				g.Expect(keys.azureRead.KeyVersion).To(Equal("v2"), "target key should be read-only during ReadOnlyDeploy")
+				g.Expect(keys.azureRead.KeyVaultType).To(BeEmpty())
+			},
+		},
+		{
+			name: "When legacy Key Vault rotation is ready for promotion, it should preserve the default vault type on both keys",
+			kmsSpec: &hyperv1.KMSSpec{
+				Provider: hyperv1.AZURE,
+				Azure: &hyperv1.AzureKMSSpec{
+					ActiveKey: hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2"},
+				},
+			},
+			encStatus: &hyperv1.SecretEncryptionStatus{
+				ActiveKey: hyperv1.SecretEncryptionKeyStatus{
+					Provider: hyperv1.SecretEncryptionProviderAzure,
+					Azure:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"},
+				},
+				TargetKey: hyperv1.SecretEncryptionKeyStatus{
+					Provider: hyperv1.SecretEncryptionProviderAzure,
+					Azure:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2"},
+				},
+			},
+			currentConfig: kmsEncryptionConfig(
+				mustAzureProviderName(t, hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"}),
+				mustAzureProviderName(t, hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2"}),
+			),
+			kasConverged: true,
+			validate: func(g Gomega, keys kmsWriteReadKeys) {
+				g.Expect(keys.azureWrite.KeyVersion).To(Equal("v2"), "target key should be write after promotion")
+				g.Expect(keys.azureWrite.KeyVaultType).To(BeEmpty())
+				g.Expect(keys.azureRead.KeyVersion).To(Equal("v1"), "old key should be read after promotion")
+				g.Expect(keys.azureRead.KeyVaultType).To(BeEmpty())
+			},
+		},
+		{
+			name: "When Managed HSM rotation is not ready for promotion, it should preserve the vault type on both keys",
+			kmsSpec: &hyperv1.KMSSpec{
+				Provider: hyperv1.AZURE,
+				Azure: &hyperv1.AzureKMSSpec{
+					ActiveKey: hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2", KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM},
+				},
+			},
+			encStatus: &hyperv1.SecretEncryptionStatus{
+				ActiveKey: hyperv1.SecretEncryptionKeyStatus{
+					Provider: hyperv1.SecretEncryptionProviderAzure,
+					Azure:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1", KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM},
+				},
+				TargetKey: hyperv1.SecretEncryptionKeyStatus{
+					Provider: hyperv1.SecretEncryptionProviderAzure,
+					Azure:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2", KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM},
+				},
+			},
+			currentConfig: nil,
+			validate: func(g Gomega, keys kmsWriteReadKeys) {
+				g.Expect(keys.azureWrite.KeyVersion).To(Equal("v1"), "old key should be write during ReadOnlyDeploy")
+				g.Expect(keys.azureWrite.KeyVaultType).To(Equal(hyperv1.AzureKMSKeyVaultTypeManagedHSM))
+				g.Expect(keys.azureRead.KeyVersion).To(Equal("v2"), "target key should be read-only during ReadOnlyDeploy")
+				g.Expect(keys.azureRead.KeyVaultType).To(Equal(hyperv1.AzureKMSKeyVaultTypeManagedHSM))
+			},
+		},
+		{
+			name: "When Managed HSM rotation is ready for promotion, it should preserve the vault type on both keys",
+			kmsSpec: &hyperv1.KMSSpec{
+				Provider: hyperv1.AZURE,
+				Azure: &hyperv1.AzureKMSSpec{
+					ActiveKey: hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2", KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM},
+				},
+			},
+			encStatus: &hyperv1.SecretEncryptionStatus{
+				ActiveKey: hyperv1.SecretEncryptionKeyStatus{
+					Provider: hyperv1.SecretEncryptionProviderAzure,
+					Azure:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1", KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM},
+				},
+				TargetKey: hyperv1.SecretEncryptionKeyStatus{
+					Provider: hyperv1.SecretEncryptionProviderAzure,
+					Azure:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2", KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM},
+				},
+			},
+			currentConfig: kmsEncryptionConfig(
+				mustAzureProviderName(t, hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1", KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM}),
+				mustAzureProviderName(t, hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2", KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM}),
+			),
+			kasConverged: true,
+			validate: func(g Gomega, keys kmsWriteReadKeys) {
+				g.Expect(keys.azureWrite.KeyVersion).To(Equal("v2"), "target key should be write after promotion")
+				g.Expect(keys.azureWrite.KeyVaultType).To(Equal(hyperv1.AzureKMSKeyVaultTypeManagedHSM))
+				g.Expect(keys.azureRead.KeyVersion).To(Equal("v1"), "old key should be read after promotion")
+				g.Expect(keys.azureRead.KeyVaultType).To(Equal(hyperv1.AzureKMSKeyVaultTypeManagedHSM))
 			},
 		},
 	}
@@ -153,8 +241,21 @@ func TestDeriveKMSKeys(t *testing.T) {
 	}
 }
 
-func mustAWSProviderName(arn string) string {
-	name, _ := kms.AWSKMSProviderName(arn)
+func mustAWSProviderName(t *testing.T, arn string) string {
+	t.Helper()
+	name, err := kms.AWSKMSProviderName(arn)
+	if err != nil {
+		t.Fatalf("failed to compute AWS KMS provider name: %v", err)
+	}
+	return name
+}
+
+func mustAzureProviderName(t *testing.T, key hyperv1.AzureKMSKey) string {
+	t.Helper()
+	name, err := kms.AzureKMSProviderName(key)
+	if err != nil {
+		t.Fatalf("failed to compute Azure KMS provider name: %v", err)
+	}
 	return name
 }
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/reencryption/reencryption.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/reencryption/reencryption.go
@@ -102,9 +102,10 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, hcp *hyperv
 		return reconcile.Result{}, nil
 	}
 
-	specFingerprint := secretencryption.FingerprintFromKeyStatus(specKeyStatus)
+	kvt := azureKeyVaultType(hcp)
+	specFingerprint := secretencryption.FingerprintFromKeyStatus(specKeyStatus, kvt)
 
-	statusActiveFingerprint := secretencryption.FingerprintFromKeyStatus(&hcp.Status.SecretEncryption.ActiveKey)
+	statusActiveFingerprint := secretencryption.FingerprintFromKeyStatus(&hcp.Status.SecretEncryption.ActiveKey, kvt)
 
 	// Case 1: Status has no active key (first-time setup or upgrade bootstrap).
 	if hcp.Status.SecretEncryption.ActiveKey.Provider == "" {
@@ -163,8 +164,9 @@ func (r *Reconciler) startNewRotation(log logr.Logger, hcp *hyperv1.HostedContro
 
 	hcp.Status.SecretEncryption.TargetKey = *specKeyStatus.DeepCopy()
 
-	fromRef := secretencryption.KeyReferenceFromStatus(&hcp.Status.SecretEncryption.ActiveKey)
-	toRef := secretencryption.KeyReferenceFromStatus(specKeyStatus)
+	kvt := azureKeyVaultType(hcp)
+	fromRef := secretencryption.KeyReferenceFromStatus(&hcp.Status.SecretEncryption.ActiveKey, kvt)
+	toRef := secretencryption.KeyReferenceFromStatus(specKeyStatus, kvt)
 
 	entry := hyperv1.EncryptionMigrationHistory{
 		From:        fromRef,
@@ -191,7 +193,8 @@ func (r *Reconciler) startNewRotation(log logr.Logger, hcp *hyperv1.HostedContro
 // It inspects the EncryptionConfiguration and KAS Deployment convergence rather than
 // reading history[0].state. The history state is updated for observability only.
 func (r *Reconciler) handleInProgressRotation(ctx context.Context, log logr.Logger, hcp *hyperv1.HostedControlPlane, specFingerprint string) (reconcile.Result, error) {
-	targetFingerprint := secretencryption.FingerprintFromKeyStatus(&hcp.Status.SecretEncryption.TargetKey)
+	kvt := azureKeyVaultType(hcp)
+	targetFingerprint := secretencryption.FingerprintFromKeyStatus(&hcp.Status.SecretEncryption.TargetKey, kvt)
 
 	if specFingerprint != targetFingerprint {
 		log.Info("Spec key differs from target key during rotation, current rotation will complete first",
@@ -201,8 +204,8 @@ func (r *Reconciler) handleInProgressRotation(ctx context.Context, log logr.Logg
 
 	if len(hcp.Status.SecretEncryption.History) == 0 {
 		log.Info("Target key set but no history entry found, creating one")
-		fromRef := secretencryption.KeyReferenceFromStatus(&hcp.Status.SecretEncryption.ActiveKey)
-		toRef := secretencryption.KeyReferenceFromStatus(&hcp.Status.SecretEncryption.TargetKey)
+		fromRef := secretencryption.KeyReferenceFromStatus(&hcp.Status.SecretEncryption.ActiveKey, kvt)
+		toRef := secretencryption.KeyReferenceFromStatus(&hcp.Status.SecretEncryption.TargetKey, kvt)
 		entry := hyperv1.EncryptionMigrationHistory{
 			From:        fromRef,
 			To:          toRef,
@@ -342,7 +345,7 @@ func (r *Reconciler) computeTargetKeyProviderName(ctx context.Context, hcp *hype
 			KeyVaultName: tk.Azure.KeyVaultName,
 			KeyName:      tk.Azure.KeyName,
 			KeyVersion:   tk.Azure.KeyVersion,
-		})
+		}, azureKeyVaultType(hcp))
 
 	case hyperv1.SecretEncryptionProviderAWS:
 		if tk.AWS.ARN == "" {
@@ -389,7 +392,7 @@ func (r *Reconciler) handleMigratingPhase(log logr.Logger, hcp *hyperv1.HostedCo
 	}
 
 	resources := r.encryptedResources(hcp)
-	targetFingerprint := secretencryption.FingerprintFromKeyStatus(&hcp.Status.SecretEncryption.TargetKey)
+	targetFingerprint := secretencryption.FingerprintFromKeyStatus(&hcp.Status.SecretEncryption.TargetKey, azureKeyVaultType(hcp))
 	writeKey := fmt.Sprintf("encryption-key-%s", targetFingerprint)
 
 	allFinished := true
@@ -555,6 +558,15 @@ func parseGroupResource(rs string) schema.GroupResource {
 		return schema.GroupResource{Resource: parts[0]}
 	}
 	return schema.GroupResource{Resource: parts[0], Group: parts[1]}
+}
+
+// azureKeyVaultType returns the vault type (Key Vault or Managed HSM) from the Azure KMS configuration.
+// Returns empty string when the HCP is not configured for Azure KMS.
+func azureKeyVaultType(hcp *hyperv1.HostedControlPlane) hyperv1.AzureKMSKeyVaultType {
+	if hcp.Spec.SecretEncryption == nil || hcp.Spec.SecretEncryption.KMS == nil || hcp.Spec.SecretEncryption.KMS.Azure == nil {
+		return ""
+	}
+	return hcp.Spec.SecretEncryption.KMS.Azure.KeyVaultType
 }
 
 // prependHistory prepends a new entry to the history and trims it to maxHistoryEntries.

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/reencryption/reencryption.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/reencryption/reencryption.go
@@ -342,6 +342,7 @@ func (r *Reconciler) computeTargetKeyProviderName(ctx context.Context, hcp *hype
 			KeyVaultName: tk.Azure.KeyVaultName,
 			KeyName:      tk.Azure.KeyName,
 			KeyVersion:   tk.Azure.KeyVersion,
+			KeyVaultType: tk.Azure.KeyVaultType,
 		})
 
 	case hyperv1.SecretEncryptionProviderAWS:

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/reencryption/reencryption_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/reencryption/reencryption_test.go
@@ -481,8 +481,8 @@ func TestReconcile(t *testing.T) {
 						withActiveKey(oldKS),
 						withTargetKey(newKS),
 						withHistory(hyperv1.EncryptionMigrationHistory{
-							From:        secretencryption.KeyReferenceFromStatus(oldKS),
-							To:          secretencryption.KeyReferenceFromStatus(newKS),
+							From:        secretencryption.KeyReferenceFromStatus(oldKS, ""),
+							To:          secretencryption.KeyReferenceFromStatus(newKS, ""),
 							State:       hyperv1.EncryptionMigrationStateReadOnlyDeploy,
 							StartedTime: metav1.Time{Time: fixedTime},
 						}),
@@ -523,8 +523,8 @@ func TestReconcile(t *testing.T) {
 						withActiveKey(oldKS),
 						withTargetKey(newKS),
 						withHistory(hyperv1.EncryptionMigrationHistory{
-							From:        secretencryption.KeyReferenceFromStatus(oldKS),
-							To:          secretencryption.KeyReferenceFromStatus(newKS),
+							From:        secretencryption.KeyReferenceFromStatus(oldKS, ""),
+							To:          secretencryption.KeyReferenceFromStatus(newKS, ""),
 							State:       hyperv1.EncryptionMigrationStateReadOnlyDeploy,
 							StartedTime: metav1.Time{Time: fixedTime},
 						}),
@@ -562,8 +562,8 @@ func TestReconcile(t *testing.T) {
 						withActiveKey(oldKS),
 						withTargetKey(newKS),
 						withHistory(hyperv1.EncryptionMigrationHistory{
-							From:        secretencryption.KeyReferenceFromStatus(oldKS),
-							To:          secretencryption.KeyReferenceFromStatus(newKS),
+							From:        secretencryption.KeyReferenceFromStatus(oldKS, ""),
+							To:          secretencryption.KeyReferenceFromStatus(newKS, ""),
 							State:       hyperv1.EncryptionMigrationStateReadOnlyDeploy,
 							StartedTime: metav1.Time{Time: fixedTime},
 						}),
@@ -600,8 +600,8 @@ func TestReconcile(t *testing.T) {
 						withActiveKey(oldKS),
 						withTargetKey(newKS),
 						withHistory(hyperv1.EncryptionMigrationHistory{
-							From:        secretencryption.KeyReferenceFromStatus(oldKS),
-							To:          secretencryption.KeyReferenceFromStatus(newKS),
+							From:        secretencryption.KeyReferenceFromStatus(oldKS, ""),
+							To:          secretencryption.KeyReferenceFromStatus(newKS, ""),
 							State:       hyperv1.EncryptionMigrationStateWritePromote,
 							StartedTime: metav1.Time{Time: fixedTime},
 						}),
@@ -641,8 +641,8 @@ func TestReconcile(t *testing.T) {
 						withActiveKey(oldKS),
 						withTargetKey(newKS),
 						withHistory(hyperv1.EncryptionMigrationHistory{
-							From:        secretencryption.KeyReferenceFromStatus(oldKS),
-							To:          secretencryption.KeyReferenceFromStatus(newKS),
+							From:        secretencryption.KeyReferenceFromStatus(oldKS, ""),
+							To:          secretencryption.KeyReferenceFromStatus(newKS, ""),
 							State:       hyperv1.EncryptionMigrationStateMigrating,
 							StartedTime: metav1.Time{Time: fixedTime},
 						}),
@@ -675,8 +675,8 @@ func TestReconcile(t *testing.T) {
 						withActiveKey(oldKS),
 						withTargetKey(newKS),
 						withHistory(hyperv1.EncryptionMigrationHistory{
-							From:        secretencryption.KeyReferenceFromStatus(oldKS),
-							To:          secretencryption.KeyReferenceFromStatus(newKS),
+							From:        secretencryption.KeyReferenceFromStatus(oldKS, ""),
+							To:          secretencryption.KeyReferenceFromStatus(newKS, ""),
 							State:       hyperv1.EncryptionMigrationStateMigrating,
 							StartedTime: metav1.Time{Time: fixedTime},
 						}),
@@ -728,8 +728,8 @@ func TestReconcile(t *testing.T) {
 						withActiveKey(oldKS),
 						withTargetKey(newKS),
 						withHistory(hyperv1.EncryptionMigrationHistory{
-							From:        secretencryption.KeyReferenceFromStatus(oldKS),
-							To:          secretencryption.KeyReferenceFromStatus(newKS),
+							From:        secretencryption.KeyReferenceFromStatus(oldKS, ""),
+							To:          secretencryption.KeyReferenceFromStatus(newKS, ""),
 							State:       hyperv1.EncryptionMigrationStateMigrating,
 							StartedTime: metav1.Time{Time: fixedTime},
 						}),
@@ -795,8 +795,8 @@ func TestReconcile(t *testing.T) {
 						withActiveKey(oldKS),
 						withTargetKey(newKS),
 						withHistory(hyperv1.EncryptionMigrationHistory{
-							From:        secretencryption.KeyReferenceFromStatus(oldKS),
-							To:          secretencryption.KeyReferenceFromStatus(newKS),
+							From:        secretencryption.KeyReferenceFromStatus(oldKS, ""),
+							To:          secretencryption.KeyReferenceFromStatus(newKS, ""),
 							State:       hyperv1.EncryptionMigrationStateMigrating,
 							StartedTime: metav1.Time{Time: fixedTime},
 						}),
@@ -844,8 +844,8 @@ func TestReconcile(t *testing.T) {
 					withActiveKey(oldKS),
 					withTargetKey(midKS),
 					withHistory(hyperv1.EncryptionMigrationHistory{
-						From:        secretencryption.KeyReferenceFromStatus(oldKS),
-						To:          secretencryption.KeyReferenceFromStatus(midKS),
+						From:        secretencryption.KeyReferenceFromStatus(oldKS, ""),
+						To:          secretencryption.KeyReferenceFromStatus(midKS, ""),
 						State:       hyperv1.EncryptionMigrationStateWritePromote,
 						StartedTime: metav1.Time{Time: fixedTime},
 					}),
@@ -894,8 +894,8 @@ func TestReconcile(t *testing.T) {
 						withActiveKey(oldKS),
 						withTargetKey(newKS),
 						withHistory(hyperv1.EncryptionMigrationHistory{
-							From:        secretencryption.KeyReferenceFromStatus(oldKS),
-							To:          secretencryption.KeyReferenceFromStatus(newKS),
+							From:        secretencryption.KeyReferenceFromStatus(oldKS, ""),
+							To:          secretencryption.KeyReferenceFromStatus(newKS, ""),
 							State:       hyperv1.EncryptionMigrationStateMigrating,
 							StartedTime: metav1.Time{Time: fixedTime},
 						}),
@@ -1079,4 +1079,89 @@ func TestEncryptedResources(t *testing.T) {
 		resources := r.encryptedResources(hcp)
 		g.Expect(resources).To(BeNil())
 	})
+}
+
+func TestComputeTargetKeyProviderName(t *testing.T) {
+	tests := []struct {
+		name         string
+		targetKey    *hyperv1.SecretEncryptionKeyStatus
+		keyVaultType hyperv1.AzureKMSKeyVaultType
+		expectName   string
+		expectErr    bool
+	}{
+		{
+			name:      "When no target key is set, it should return an error",
+			targetKey: &hyperv1.SecretEncryptionKeyStatus{},
+			expectErr: true,
+		},
+		{
+			name: "When Azure target key omits KeyVaultType, it should produce the legacy provider name",
+			targetKey: secretencryption.KeyStatusFromAzureSpec(hyperv1.AzureKMSKey{
+				KeyVaultName: "vault",
+				KeyName:      "key",
+				KeyVersion:   "1",
+			}),
+		},
+		{
+			name: "When Azure target key has KeyVaultType KeyVault, it should produce the same name as omitted",
+			targetKey: secretencryption.KeyStatusFromAzureSpec(hyperv1.AzureKMSKey{
+				KeyVaultName: "vault",
+				KeyName:      "key",
+				KeyVersion:   "1",
+			}),
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeKeyVault,
+		},
+		{
+			name: "When Azure target key has KeyVaultType ManagedHSM, it should produce a different provider name",
+			targetKey: secretencryption.KeyStatusFromAzureSpec(hyperv1.AzureKMSKey{
+				KeyVaultName: "vault",
+				KeyName:      "key",
+				KeyVersion:   "1",
+			}),
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+		},
+	}
+
+	legacyKey := hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "1"}
+	legacyName, err := kms.AzureKMSProviderName(legacyKey, "")
+	if err != nil {
+		t.Fatalf("failed to compute legacy provider name: %v", err)
+	}
+
+	r := &Reconciler{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			hcp := newHCP()
+			hcp.Status.SecretEncryption.TargetKey = *tt.targetKey
+			// Set the KeyVaultType on the spec so azureKeyVaultType(hcp) returns it.
+			if tt.targetKey.Provider == hyperv1.SecretEncryptionProviderAzure {
+				hcp.Spec.SecretEncryption = &hyperv1.SecretEncryptionSpec{
+					Type: hyperv1.KMS,
+					KMS: &hyperv1.KMSSpec{
+						Provider: hyperv1.AZURE,
+						Azure: &hyperv1.AzureKMSSpec{
+							ActiveKey:    tt.targetKey.Azure,
+							KeyVaultType: tt.keyVaultType,
+						},
+					},
+				}
+			}
+
+			name, err := r.computeTargetKeyProviderName(context.Background(), hcp)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+
+			if tt.keyVaultType == hyperv1.AzureKMSKeyVaultTypeManagedHSM {
+				g.Expect(name).NotTo(Equal(legacyName),
+					"ManagedHSM target key should produce a different provider name than KeyVault")
+			} else {
+				g.Expect(name).To(Equal(legacyName),
+					"KeyVault or omitted target key should produce the legacy provider name")
+			}
+		})
+	}
 }

--- a/docs/content/how-to/azure/create-azure-cluster-with-options.md
+++ b/docs/content/how-to/azure/create-azure-cluster-with-options.md
@@ -154,8 +154,17 @@ This section walks through how to:
 1. Set up the flags needed when creating the Azure HostedCluster
 1. Verify the etcd encryption is setup and working properly 
 
-There is a `setup_etcd_kv.sh` script in the contrib folder in the HyperShift repo to help automate the first couple of 
-steps mentioned above. However, this guide will manually walk through those steps.
+!!! important "Managed HSM compatibility"
+
+    Azure Managed HSM for KMS encryption requires an OpenShift 4.22 or later HostedCluster release and is supported in Azure Public Cloud, Azure US Government Cloud, Azure China Cloud, Azure German Cloud, and Azure Bleu Cloud.
+    Do not configure Managed HSM on an earlier release because its control plane operator does not configure the Managed HSM endpoint or authentication scope.
+    Downgrading a HostedCluster after enabling Managed HSM is not supported.
+
+    The KMS vault type is immutable. An existing HostedCluster that uses Azure Key Vault cannot migrate to Managed HSM through key rotation; create a new HostedCluster to change between those services.
+    Custom Azure Stack Key Vault endpoints are not supported.
+
+There is a `setup_etcd_kv.sh` script in the contrib folder in the HyperShift repo to help automate the first couple of
+steps mentioned above. For Managed HSM, use `setup_etcd_managed_hsm.sh` instead. This guide will manually walk through the Key Vault setup steps below.
 
 1a) Create a resource group for the key vault that will house the key used for etcd encryption. 
 

--- a/docs/content/how-to/azure/create-azure-cluster-with-options.md
+++ b/docs/content/how-to/azure/create-azure-cluster-with-options.md
@@ -163,8 +163,8 @@ This section walks through how to:
     The KMS vault type is immutable. An existing HostedCluster that uses Azure Key Vault cannot migrate to Managed HSM through key rotation; create a new HostedCluster to change between those services.
     Managed HSM endpoints in other Azure clouds and custom Azure Stack Key Vault endpoints are not supported.
 
-There is a `setup_etcd_kv.sh` script in the contrib folder in the HyperShift repo to help automate the first couple of 
-steps mentioned above. However, this guide will manually walk through those steps.
+There is a `setup_etcd_kv.sh` script in the contrib folder in the HyperShift repo to help automate the first couple of
+steps mentioned above. For Managed HSM, use `setup_etcd_managed_hsm.sh` instead. However, this guide will manually walk through those steps.
 
 1a) Create a resource group for the key vault that will house the key used for etcd encryption. 
 

--- a/docs/content/how-to/azure/create-azure-cluster-with-options.md
+++ b/docs/content/how-to/azure/create-azure-cluster-with-options.md
@@ -154,6 +154,15 @@ This section walks through how to:
 1. Set up the flags needed when creating the Azure HostedCluster
 1. Verify the etcd encryption is setup and working properly 
 
+!!! important "Managed HSM compatibility"
+
+    Azure Managed HSM for KMS encryption requires an OpenShift 4.22 or later HostedCluster release and is supported in Azure Public Cloud and Azure US Government Cloud.
+    Do not configure Managed HSM on an earlier release because its control plane operator does not configure the Managed HSM endpoint or authentication scope.
+    Downgrading a HostedCluster after enabling Managed HSM is not supported.
+
+    The KMS vault type is immutable. An existing HostedCluster that uses Azure Key Vault cannot migrate to Managed HSM through key rotation; create a new HostedCluster to change between those services.
+    Managed HSM endpoints in other Azure clouds and custom Azure Stack Key Vault endpoints are not supported.
+
 There is a `setup_etcd_kv.sh` script in the contrib folder in the HyperShift repo to help automate the first couple of 
 steps mentioned above. However, this guide will manually walk through those steps.
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -11235,8 +11235,17 @@ This section walks through how to:
 1. Set up the flags needed when creating the Azure HostedCluster
 1. Verify the etcd encryption is setup and working properly
 
+!!! important "Managed HSM compatibility"
+
+    Azure Managed HSM for KMS encryption requires an OpenShift 4.22 or later HostedCluster release and is supported in Azure Public Cloud, Azure US Government Cloud, Azure China Cloud, Azure German Cloud, and Azure Bleu Cloud.
+    Do not configure Managed HSM on an earlier release because its control plane operator does not configure the Managed HSM endpoint or authentication scope.
+    Downgrading a HostedCluster after enabling Managed HSM is not supported.
+
+    The KMS vault type is immutable. An existing HostedCluster that uses Azure Key Vault cannot migrate to Managed HSM through key rotation; create a new HostedCluster to change between those services.
+    Custom Azure Stack Key Vault endpoints are not supported.
+
 There is a `setup_etcd_kv.sh` script in the contrib folder in the HyperShift repo to help automate the first couple of
-steps mentioned above. However, this guide will manually walk through those steps.
+steps mentioned above. For Managed HSM, use `setup_etcd_managed_hsm.sh` instead. This guide will manually walk through the Key Vault setup steps below.
 
 1a) Create a resource group for the key vault that will house the key used for etcd encryption.
 
@@ -42626,6 +42635,7 @@ applications and dev/test.</p>
 <a href="#hypershift.openshift.io/v1beta1.SecretEncryptionKeyStatus">SecretEncryptionKeyStatus</a>)
 </p>
 <p>
+<p>AzureKMSKey defines an Azure Key Vault or Managed HSM key used for KMS encryption.</p>
 </p>
 <table>
 <thead>
@@ -42643,8 +42653,8 @@ string
 </em>
 </td>
 <td>
-<p>keyVaultName is the name of the keyvault. Must match criteria specified at <a href="https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name">https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name</a>
-Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+<p>keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at <a href="https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name">https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name</a>
+Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
 <code>az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn &lt;YOUR APPLICATION CLIENT ID&gt;</code></p>
 </td>
 </tr>
@@ -42656,7 +42666,7 @@ string
 </em>
 </td>
 <td>
-<p>keyName is the name of the keyvault key used for encrypt/decrypt</p>
+<p>keyName is the name of the key used for encrypt/decrypt.</p>
 </td>
 </tr>
 <tr>
@@ -42672,13 +42682,36 @@ string
 </tr>
 </tbody>
 </table>
+###AzureKMSKeyVaultType { #hypershift.openshift.io/v1beta1.AzureKMSKeyVaultType }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1beta1.AzureKMSSpec">AzureKMSSpec</a>)
+</p>
+<p>
+<p>AzureKMSKeyVaultType specifies the Azure service that hosts a KMS key.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;KeyVault&#34;</p></td>
+<td><p>AzureKMSKeyVaultTypeKeyVault indicates that the key is hosted by Azure Key Vault.</p>
+</td>
+</tr><tr><td><p>&#34;ManagedHSM&#34;</p></td>
+<td><p>AzureKMSKeyVaultTypeManagedHSM indicates that the key is hosted by Azure Managed HSM.</p>
+</td>
+</tr></tbody>
+</table>
 ###AzureKMSSpec { #hypershift.openshift.io/v1beta1.AzureKMSSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1beta1.KMSSpec">KMSSpec</a>)
 </p>
 <p>
-<p>AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure key vault</p>
+<p>AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure Key Vault or Managed HSM.</p>
 </p>
 <table>
 <thead>
@@ -42749,6 +42782,25 @@ WorkloadIdentity
 with Azure Key Vault for KMS encryption via a token-minter sidecar.
 This identity must have &ldquo;Key Vault Crypto User&rdquo; role on the Key Vault.
 kms and workloadIdentity are mutually exclusive.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>keyVaultType</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1beta1.AzureKMSKeyVaultType">
+AzureKMSKeyVaultType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+Valid values are &ldquo;KeyVault&rdquo; and &ldquo;ManagedHSM&rdquo;.
+When set to &ldquo;KeyVault&rdquo;, both keys are hosted by Azure Key Vault.
+When set to &ldquo;ManagedHSM&rdquo;, both keys are hosted by Azure Managed HSM.
+The type is immutable; key rotation must remain within the same service.
+When omitted, the keys are treated as Key Vault keys.</p>
 </td>
 </tr>
 <tr>
@@ -43154,7 +43206,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>cloud is the cloud environment identifier, valid values could be found here: <a href="https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33">https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33</a></p>
+<p>cloud is the Azure cloud environment identifier.</p>
 </td>
 </tr>
 <tr>
@@ -47897,9 +47949,10 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-Must be a valid Azure Key Vault key URL in the format
-&ldquo;https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]&rdquo;.
+<p>encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 This field is immutable once set and cannot be removed.</p>
 </td>
 </tr>
@@ -48025,9 +48078,10 @@ string
 </em>
 </td>
 <td>
-<p>encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-Must be a valid Azure Key Vault key URL in the format
-&ldquo;https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]&rdquo;.</p>
+<p>encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.</p>
 </td>
 </tr>
 </tbody>
@@ -48161,9 +48215,10 @@ string
 </em>
 </td>
 <td>
-<p>encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-Must be a valid Azure Key Vault key URL in the format
-&ldquo;https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]&rdquo;.</p>
+<p>encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -11084,7 +11084,7 @@ This section walks through how to:
     Managed HSM endpoints in other Azure clouds and custom Azure Stack Key Vault endpoints are not supported.
 
 There is a `setup_etcd_kv.sh` script in the contrib folder in the HyperShift repo to help automate the first couple of
-steps mentioned above. However, this guide will manually walk through those steps.
+steps mentioned above. For Managed HSM, use `setup_etcd_managed_hsm.sh` instead. However, this guide will manually walk through those steps.
 
 1a) Create a resource group for the key vault that will house the key used for etcd encryption.
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -11074,6 +11074,15 @@ This section walks through how to:
 1. Set up the flags needed when creating the Azure HostedCluster
 1. Verify the etcd encryption is setup and working properly
 
+!!! important "Managed HSM compatibility"
+
+    Azure Managed HSM for KMS encryption requires an OpenShift 4.22 or later HostedCluster release and is supported in Azure Public Cloud and Azure US Government Cloud.
+    Do not configure Managed HSM on an earlier release because its control plane operator does not configure the Managed HSM endpoint or authentication scope.
+    Downgrading a HostedCluster after enabling Managed HSM is not supported.
+
+    The KMS vault type is immutable. An existing HostedCluster that uses Azure Key Vault cannot migrate to Managed HSM through key rotation; create a new HostedCluster to change between those services.
+    Managed HSM endpoints in other Azure clouds and custom Azure Stack Key Vault endpoints are not supported.
+
 There is a `setup_etcd_kv.sh` script in the contrib folder in the HyperShift repo to help automate the first couple of
 steps mentioned above. However, this guide will manually walk through those steps.
 
@@ -41886,6 +41895,7 @@ applications and dev/test.</p>
 <a href="#hypershift.openshift.io/v1beta1.SecretEncryptionKeyStatus">SecretEncryptionKeyStatus</a>)
 </p>
 <p>
+<p>AzureKMSKey defines an Azure Key Vault or Managed HSM key used for KMS encryption.</p>
 </p>
 <table>
 <thead>
@@ -41903,8 +41913,8 @@ string
 </em>
 </td>
 <td>
-<p>keyVaultName is the name of the keyvault. Must match criteria specified at <a href="https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name">https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name</a>
-Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+<p>keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at <a href="https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name">https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name</a>
+Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
 <code>az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn &lt;YOUR APPLICATION CLIENT ID&gt;</code></p>
 </td>
 </tr>
@@ -41916,7 +41926,7 @@ string
 </em>
 </td>
 <td>
-<p>keyName is the name of the keyvault key used for encrypt/decrypt</p>
+<p>keyName is the name of the key used for encrypt/decrypt.</p>
 </td>
 </tr>
 <tr>
@@ -41930,7 +41940,46 @@ string
 <p>keyVersion contains the version of the key to use</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>keyVaultType</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1beta1.AzureKMSKeyVaultType">
+AzureKMSKeyVaultType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+The type is immutable; key rotation must remain within the same service.
+When omitted, the type defaults to KeyVault.</p>
+</td>
+</tr>
 </tbody>
+</table>
+###AzureKMSKeyVaultType { #hypershift.openshift.io/v1beta1.AzureKMSKeyVaultType }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1beta1.AzureKMSKey">AzureKMSKey</a>)
+</p>
+<p>
+<p>AzureKMSKeyVaultType specifies the Azure service that hosts a KMS key.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;KeyVault&#34;</p></td>
+<td><p>AzureKMSKeyVaultTypeKeyVault indicates that the key is hosted by Azure Key Vault.</p>
+</td>
+</tr><tr><td><p>&#34;ManagedHSM&#34;</p></td>
+<td><p>AzureKMSKeyVaultTypeManagedHSM indicates that the key is hosted by Azure Managed HSM.</p>
+</td>
+</tr></tbody>
 </table>
 ###AzureKMSSpec { #hypershift.openshift.io/v1beta1.AzureKMSSpec }
 <p>
@@ -41938,7 +41987,7 @@ string
 <a href="#hypershift.openshift.io/v1beta1.KMSSpec">KMSSpec</a>)
 </p>
 <p>
-<p>AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure key vault</p>
+<p>AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure Key Vault or Managed HSM.</p>
 </p>
 <table>
 <thead>
@@ -47157,9 +47206,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-Must be a valid Azure Key Vault key URL in the format
-&ldquo;https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]&rdquo;.
+<p>encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 This field is immutable once set and cannot be removed.</p>
 </td>
 </tr>
@@ -47285,9 +47334,9 @@ string
 </em>
 </td>
 <td>
-<p>encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-Must be a valid Azure Key Vault key URL in the format
-&ldquo;https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]&rdquo;.</p>
+<p>encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.</p>
 </td>
 </tr>
 </tbody>
@@ -47421,9 +47470,9 @@ string
 </em>
 </td>
 <td>
-<p>encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-Must be a valid Azure Key Vault key URL in the format
-&ldquo;https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]&rdquo;.</p>
+<p>encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3522,6 +3522,7 @@ applications and dev/test.</p>
 <a href="#hypershift.openshift.io/v1beta1.SecretEncryptionKeyStatus">SecretEncryptionKeyStatus</a>)
 </p>
 <p>
+<p>AzureKMSKey defines an Azure Key Vault or Managed HSM key used for KMS encryption.</p>
 </p>
 <table>
 <thead>
@@ -3539,8 +3540,8 @@ string
 </em>
 </td>
 <td>
-<p>keyVaultName is the name of the keyvault. Must match criteria specified at <a href="https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name">https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name</a>
-Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+<p>keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at <a href="https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name">https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name</a>
+Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
 <code>az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn &lt;YOUR APPLICATION CLIENT ID&gt;</code></p>
 </td>
 </tr>
@@ -3552,7 +3553,7 @@ string
 </em>
 </td>
 <td>
-<p>keyName is the name of the keyvault key used for encrypt/decrypt</p>
+<p>keyName is the name of the key used for encrypt/decrypt.</p>
 </td>
 </tr>
 <tr>
@@ -3568,13 +3569,36 @@ string
 </tr>
 </tbody>
 </table>
+###AzureKMSKeyVaultType { #hypershift.openshift.io/v1beta1.AzureKMSKeyVaultType }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1beta1.AzureKMSSpec">AzureKMSSpec</a>)
+</p>
+<p>
+<p>AzureKMSKeyVaultType specifies the Azure service that hosts a KMS key.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;KeyVault&#34;</p></td>
+<td><p>AzureKMSKeyVaultTypeKeyVault indicates that the key is hosted by Azure Key Vault.</p>
+</td>
+</tr><tr><td><p>&#34;ManagedHSM&#34;</p></td>
+<td><p>AzureKMSKeyVaultTypeManagedHSM indicates that the key is hosted by Azure Managed HSM.</p>
+</td>
+</tr></tbody>
+</table>
 ###AzureKMSSpec { #hypershift.openshift.io/v1beta1.AzureKMSSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1beta1.KMSSpec">KMSSpec</a>)
 </p>
 <p>
-<p>AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure key vault</p>
+<p>AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure Key Vault or Managed HSM.</p>
 </p>
 <table>
 <thead>
@@ -3645,6 +3669,25 @@ WorkloadIdentity
 with Azure Key Vault for KMS encryption via a token-minter sidecar.
 This identity must have &ldquo;Key Vault Crypto User&rdquo; role on the Key Vault.
 kms and workloadIdentity are mutually exclusive.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>keyVaultType</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1beta1.AzureKMSKeyVaultType">
+AzureKMSKeyVaultType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+Valid values are &ldquo;KeyVault&rdquo; and &ldquo;ManagedHSM&rdquo;.
+When set to &ldquo;KeyVault&rdquo;, both keys are hosted by Azure Key Vault.
+When set to &ldquo;ManagedHSM&rdquo;, both keys are hosted by Azure Managed HSM.
+The type is immutable; key rotation must remain within the same service.
+When omitted, the keys are treated as Key Vault keys.</p>
 </td>
 </tr>
 <tr>
@@ -4050,7 +4093,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>cloud is the cloud environment identifier, valid values could be found here: <a href="https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33">https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33</a></p>
+<p>cloud is the Azure cloud environment identifier.</p>
 </td>
 </tr>
 <tr>
@@ -8793,9 +8836,10 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-Must be a valid Azure Key Vault key URL in the format
-&ldquo;https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]&rdquo;.
+<p>encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 This field is immutable once set and cannot be removed.</p>
 </td>
 </tr>
@@ -8921,9 +8965,10 @@ string
 </em>
 </td>
 <td>
-<p>encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-Must be a valid Azure Key Vault key URL in the format
-&ldquo;https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]&rdquo;.</p>
+<p>encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.</p>
 </td>
 </tr>
 </tbody>
@@ -9057,9 +9102,10 @@ string
 </em>
 </td>
 <td>
-<p>encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-Must be a valid Azure Key Vault key URL in the format
-&ldquo;https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]&rdquo;.</p>
+<p>encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3522,6 +3522,7 @@ applications and dev/test.</p>
 <a href="#hypershift.openshift.io/v1beta1.SecretEncryptionKeyStatus">SecretEncryptionKeyStatus</a>)
 </p>
 <p>
+<p>AzureKMSKey defines an Azure Key Vault or Managed HSM key used for KMS encryption.</p>
 </p>
 <table>
 <thead>
@@ -3539,8 +3540,8 @@ string
 </em>
 </td>
 <td>
-<p>keyVaultName is the name of the keyvault. Must match criteria specified at <a href="https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name">https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name</a>
-Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+<p>keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at <a href="https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name">https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name</a>
+Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
 <code>az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn &lt;YOUR APPLICATION CLIENT ID&gt;</code></p>
 </td>
 </tr>
@@ -3552,7 +3553,7 @@ string
 </em>
 </td>
 <td>
-<p>keyName is the name of the keyvault key used for encrypt/decrypt</p>
+<p>keyName is the name of the key used for encrypt/decrypt.</p>
 </td>
 </tr>
 <tr>
@@ -3566,7 +3567,46 @@ string
 <p>keyVersion contains the version of the key to use</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>keyVaultType</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1beta1.AzureKMSKeyVaultType">
+AzureKMSKeyVaultType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+The type is immutable; key rotation must remain within the same service.
+When omitted, the type defaults to KeyVault.</p>
+</td>
+</tr>
 </tbody>
+</table>
+###AzureKMSKeyVaultType { #hypershift.openshift.io/v1beta1.AzureKMSKeyVaultType }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1beta1.AzureKMSKey">AzureKMSKey</a>)
+</p>
+<p>
+<p>AzureKMSKeyVaultType specifies the Azure service that hosts a KMS key.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;KeyVault&#34;</p></td>
+<td><p>AzureKMSKeyVaultTypeKeyVault indicates that the key is hosted by Azure Key Vault.</p>
+</td>
+</tr><tr><td><p>&#34;ManagedHSM&#34;</p></td>
+<td><p>AzureKMSKeyVaultTypeManagedHSM indicates that the key is hosted by Azure Managed HSM.</p>
+</td>
+</tr></tbody>
 </table>
 ###AzureKMSSpec { #hypershift.openshift.io/v1beta1.AzureKMSSpec }
 <p>
@@ -3574,7 +3614,7 @@ string
 <a href="#hypershift.openshift.io/v1beta1.KMSSpec">KMSSpec</a>)
 </p>
 <p>
-<p>AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure key vault</p>
+<p>AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure Key Vault or Managed HSM.</p>
 </p>
 <table>
 <thead>
@@ -8793,9 +8833,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-Must be a valid Azure Key Vault key URL in the format
-&ldquo;https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]&rdquo;.
+<p>encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 This field is immutable once set and cannot be removed.</p>
 </td>
 </tr>
@@ -8921,9 +8961,9 @@ string
 </em>
 </td>
 <td>
-<p>encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-Must be a valid Azure Key Vault key URL in the format
-&ldquo;https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]&rdquo;.</p>
+<p>encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.</p>
 </td>
 </tr>
 </tbody>
@@ -9057,9 +9097,9 @@ string
 </em>
 </td>
 <td>
-<p>encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-Must be a valid Azure Key Vault key URL in the format
-&ldquo;https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]&rdquo;.</p>
+<p>encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.</p>
 </td>
 </tr>
 </tbody>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1535,6 +1535,25 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		return nil
 	})
 
+	// Block reconciliation when Managed HSM is configured on a release that
+	// does not support it (< 4.22). Sets ValidHostedClusterConfiguration=False.
+	report.execute("ManagedHSMVersionCheck", critical, func() error {
+		if report.shouldBlock() {
+			return nil
+		}
+		if err := validateManagedHSMVersion(hcluster, releaseImageVersion); err != nil {
+			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
+				Type:               string(hyperv1.ValidHostedClusterConfiguration),
+				ObservedGeneration: hcluster.Generation,
+				Status:             metav1.ConditionFalse,
+				Reason:             hyperv1.InvalidConfigurationReason,
+				Message:            err.Error(),
+			})
+			return err
+		}
+		return nil
+	})
+
 	report.executeOrBlock("OperatorDeployments", func() error {
 		return r.reconcileOperatorDeployments(ctx, createOrUpdate, hcluster, hcp, controlPlaneNamespace, p,
 			controlPlaneOperatorImage, utilitiesImage,
@@ -4404,6 +4423,27 @@ func (r *HostedClusterReconciler) validateAzureConfig(hc *hyperv1.HostedCluster)
 		)
 	}
 
+	return nil
+}
+
+var minManagedHSMVersion = semver.MustParse("4.22.0")
+
+func validateManagedHSMVersion(hc *hyperv1.HostedCluster, releaseVersion semver.Version) error {
+	if hc.Spec.Platform.Type != hyperv1.AzurePlatform {
+		return nil
+	}
+	if hc.Spec.SecretEncryption == nil ||
+		hc.Spec.SecretEncryption.KMS == nil ||
+		hc.Spec.SecretEncryption.KMS.Azure == nil {
+		return nil
+	}
+	if hc.Spec.SecretEncryption.KMS.Azure.KeyVaultType != hyperv1.AzureKMSKeyVaultTypeManagedHSM {
+		return nil
+	}
+	releaseVersion.Pre = nil
+	if releaseVersion.LT(minManagedHSMVersion) {
+		return fmt.Errorf("release image version %s does not support Azure Managed HSM, which requires version %s or newer", releaseVersion, minManagedHSMVersion)
+	}
 	return nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1536,27 +1536,15 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	})
 
 	report.execute("ManagedHSMVersionCheck", critical, func() error {
-		if hcluster.Spec.Platform.Type != hyperv1.AzurePlatform {
-			return nil
-		}
-		if hcluster.Spec.SecretEncryption == nil ||
-			hcluster.Spec.SecretEncryption.KMS == nil ||
-			hcluster.Spec.SecretEncryption.KMS.Azure == nil {
-			return nil
-		}
-		if hcluster.Spec.SecretEncryption.KMS.Azure.ActiveKey.KeyVaultType != hyperv1.AzureKMSKeyVaultTypeManagedHSM {
-			return nil
-		}
-		if releaseImageVersion.LT(semver.MustParse("4.22.0")) {
-			msg := fmt.Sprintf("Azure Managed HSM requires OpenShift 4.22 or later, but release image version is %s", releaseImageVersion)
+		if err := validateManagedHSMVersion(hcluster, releaseImageVersion); err != nil {
 			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
 				Type:               string(hyperv1.ValidHostedClusterConfiguration),
 				ObservedGeneration: hcluster.Generation,
 				Status:             metav1.ConditionFalse,
 				Reason:             hyperv1.InvalidConfigurationReason,
-				Message:            msg,
+				Message:            err.Error(),
 			})
-			return errors.New(msg)
+			return err
 		}
 		return nil
 	})
@@ -4430,6 +4418,26 @@ func (r *HostedClusterReconciler) validateAzureConfig(hc *hyperv1.HostedCluster)
 		)
 	}
 
+	return nil
+}
+
+var minManagedHSMVersion = semver.MustParse("4.22.0")
+
+func validateManagedHSMVersion(hc *hyperv1.HostedCluster, releaseVersion semver.Version) error {
+	if hc.Spec.Platform.Type != hyperv1.AzurePlatform {
+		return nil
+	}
+	if hc.Spec.SecretEncryption == nil ||
+		hc.Spec.SecretEncryption.KMS == nil ||
+		hc.Spec.SecretEncryption.KMS.Azure == nil {
+		return nil
+	}
+	if hc.Spec.SecretEncryption.KMS.Azure.ActiveKey.KeyVaultType != hyperv1.AzureKMSKeyVaultTypeManagedHSM {
+		return nil
+	}
+	if releaseVersion.LTE(minManagedHSMVersion) {
+		return fmt.Errorf("release image version %s does not support Azure Managed HSM, which requires a version newer than %s", releaseVersion, minManagedHSMVersion)
+	}
 	return nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -4435,8 +4435,8 @@ func validateManagedHSMVersion(hc *hyperv1.HostedCluster, releaseVersion semver.
 	if hc.Spec.SecretEncryption.KMS.Azure.ActiveKey.KeyVaultType != hyperv1.AzureKMSKeyVaultTypeManagedHSM {
 		return nil
 	}
-	if releaseVersion.LTE(minManagedHSMVersion) {
-		return fmt.Errorf("release image version %s does not support Azure Managed HSM, which requires a version newer than %s", releaseVersion, minManagedHSMVersion)
+	if releaseVersion.LT(minManagedHSMVersion) {
+		return fmt.Errorf("release image version %s does not support Azure Managed HSM, which requires version %s or newer", releaseVersion, minManagedHSMVersion)
 	}
 	return nil
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1535,6 +1535,32 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		return nil
 	})
 
+	report.execute("ManagedHSMVersionCheck", critical, func() error {
+		if hcluster.Spec.Platform.Type != hyperv1.AzurePlatform {
+			return nil
+		}
+		if hcluster.Spec.SecretEncryption == nil ||
+			hcluster.Spec.SecretEncryption.KMS == nil ||
+			hcluster.Spec.SecretEncryption.KMS.Azure == nil {
+			return nil
+		}
+		if hcluster.Spec.SecretEncryption.KMS.Azure.ActiveKey.KeyVaultType != hyperv1.AzureKMSKeyVaultTypeManagedHSM {
+			return nil
+		}
+		if releaseImageVersion.LT(semver.MustParse("4.22.0")) {
+			msg := fmt.Sprintf("Azure Managed HSM requires OpenShift 4.22 or later, but release image version is %s", releaseImageVersion)
+			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
+				Type:               string(hyperv1.ValidHostedClusterConfiguration),
+				ObservedGeneration: hcluster.Generation,
+				Status:             metav1.ConditionFalse,
+				Reason:             hyperv1.InvalidConfigurationReason,
+				Message:            msg,
+			})
+			return errors.New(msg)
+		}
+		return nil
+	})
+
 	report.executeOrBlock("OperatorDeployments", func() error {
 		return r.reconcileOperatorDeployments(ctx, createOrUpdate, hcluster, hcp, controlPlaneNamespace, p,
 			controlPlaneOperatorImage, utilitiesImage,

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -7277,6 +7277,111 @@ func TestValidateAzureConfig(t *testing.T) {
 	}
 }
 
+func TestValidateManagedHSMVersion(t *testing.T) {
+	managedHSMCluster := func() *hyperv1.HostedCluster {
+		return &hyperv1.HostedCluster{
+			Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.AzurePlatform,
+				},
+				SecretEncryption: &hyperv1.SecretEncryptionSpec{
+					Type: hyperv1.KMS,
+					KMS: &hyperv1.KMSSpec{
+						Azure: &hyperv1.AzureKMSSpec{
+							KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name        string
+		hc          *hyperv1.HostedCluster
+		version     semver.Version
+		expectError bool
+	}{
+		{
+			name: "When the platform is not Azure, it should skip validation",
+			hc: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+					},
+				},
+			},
+			version:     semver.MustParse("4.21.0"),
+			expectError: false,
+		},
+		{
+			name: "When Azure uses KeyVault, it should skip validation",
+			hc: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						Type: hyperv1.KMS,
+						KMS: &hyperv1.KMSSpec{
+							Azure: &hyperv1.AzureKMSSpec{
+								KeyVaultType: hyperv1.AzureKMSKeyVaultTypeKeyVault,
+							},
+						},
+					},
+				},
+			},
+			version:     semver.MustParse("4.21.0"),
+			expectError: false,
+		},
+		{
+			name:        "When the release version is 4.21, it should reject ManagedHSM",
+			hc:          managedHSMCluster(),
+			version:     semver.MustParse("4.21.3"),
+			expectError: true,
+		},
+		{
+			name:        "When the release version is exactly 4.22.0, it should accept ManagedHSM",
+			hc:          managedHSMCluster(),
+			version:     semver.MustParse("4.22.0"),
+			expectError: false,
+		},
+		{
+			name:        "When the release version is a 4.22 prerelease, it should accept ManagedHSM",
+			hc:          managedHSMCluster(),
+			version:     semver.MustParse("4.22.0-0.nightly-2026-08-18-152154"),
+			expectError: false,
+		},
+		{
+			name:        "When the release version is newer than 4.22, it should accept ManagedHSM",
+			hc:          managedHSMCluster(),
+			version:     semver.MustParse("4.23.0"),
+			expectError: false,
+		},
+		{
+			name:        "When the release version has a newer major version, it should accept ManagedHSM",
+			hc:          managedHSMCluster(),
+			version:     semver.MustParse("5.0.0"),
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateManagedHSMVersion(tc.hc, tc.version)
+			if tc.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+			}
+		})
+	}
+}
+
 func TestComputeEndpointServiceCondition(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -7305,7 +7305,7 @@ func TestValidateManagedHSMVersion(t *testing.T) {
 		expectError bool
 	}{
 		{
-			name: "When platform is not Azure it should skip validation",
+			name: "When the platform is not Azure, it should skip validation",
 			hc: &hyperv1.HostedCluster{
 				Spec: hyperv1.HostedClusterSpec{
 					Platform: hyperv1.PlatformSpec{
@@ -7317,7 +7317,7 @@ func TestValidateManagedHSMVersion(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "When Azure platform uses KeyVault it should skip validation",
+			name: "When Azure uses KeyVault, it should skip validation",
 			hc: &hyperv1.HostedCluster{
 				Spec: hyperv1.HostedClusterSpec{
 					Platform: hyperv1.PlatformSpec{
@@ -7339,27 +7339,27 @@ func TestValidateManagedHSMVersion(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "When release version is too low it should reject ManagedHSM",
+			name:        "When the release version is 4.21, it should reject ManagedHSM",
 			expectError: true,
 		},
 		{
-			name:        "When release version is exactly 4.22.0 it should reject ManagedHSM",
-			expectError: true,
-		},
-		{
-			name:        "When release version is 5.0 it should accept ManagedHSM",
+			name:        "When the release version is exactly 4.22.0, it should accept ManagedHSM",
 			expectError: false,
 		},
 		{
-			name:        "When release version is 5.1 it should accept ManagedHSM",
+			name:        "When the release version is newer than 4.22, it should accept ManagedHSM",
+			expectError: false,
+		},
+		{
+			name:        "When the release version has a newer major version, it should accept ManagedHSM",
 			expectError: false,
 		},
 	}
 
 	testCases[2].hc, testCases[2].version = managedHSMCluster("4.21.3")
 	testCases[3].hc, testCases[3].version = managedHSMCluster("4.22.0")
-	testCases[4].hc, testCases[4].version = managedHSMCluster("5.0.0")
-	testCases[5].hc, testCases[5].version = managedHSMCluster("5.1.0")
+	testCases[4].hc, testCases[4].version = managedHSMCluster("4.23.0")
+	testCases[5].hc, testCases[5].version = managedHSMCluster("5.0.0")
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -7277,6 +7277,106 @@ func TestValidateAzureConfig(t *testing.T) {
 	}
 }
 
+func TestValidateManagedHSMVersion(t *testing.T) {
+	managedHSMCluster := func(version string) (*hyperv1.HostedCluster, semver.Version) {
+		return &hyperv1.HostedCluster{
+			Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.AzurePlatform,
+				},
+				SecretEncryption: &hyperv1.SecretEncryptionSpec{
+					Type: hyperv1.KMS,
+					KMS: &hyperv1.KMSSpec{
+						Azure: &hyperv1.AzureKMSSpec{
+							ActiveKey: hyperv1.AzureKMSKey{
+								KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+							},
+						},
+					},
+				},
+			},
+		}, semver.MustParse(version)
+	}
+
+	testCases := []struct {
+		name        string
+		hc          *hyperv1.HostedCluster
+		version     semver.Version
+		expectError bool
+	}{
+		{
+			name: "When platform is not Azure it should skip validation",
+			hc: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+					},
+				},
+			},
+			version:     semver.MustParse("4.21.0"),
+			expectError: false,
+		},
+		{
+			name: "When Azure platform uses KeyVault it should skip validation",
+			hc: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						Type: hyperv1.KMS,
+						KMS: &hyperv1.KMSSpec{
+							Azure: &hyperv1.AzureKMSSpec{
+								ActiveKey: hyperv1.AzureKMSKey{
+									KeyVaultType: hyperv1.AzureKMSKeyVaultTypeKeyVault,
+								},
+							},
+						},
+					},
+				},
+			},
+			version:     semver.MustParse("4.21.0"),
+			expectError: false,
+		},
+		{
+			name:        "When release version is too low it should reject ManagedHSM",
+			expectError: true,
+		},
+		{
+			name:        "When release version is exactly 4.22.0 it should reject ManagedHSM",
+			expectError: true,
+		},
+		{
+			name:        "When release version is 5.0 it should accept ManagedHSM",
+			expectError: false,
+		},
+		{
+			name:        "When release version is 5.1 it should accept ManagedHSM",
+			expectError: false,
+		},
+	}
+
+	testCases[2].hc, testCases[2].version = managedHSMCluster("4.21.3")
+	testCases[3].hc, testCases[3].version = managedHSMCluster("4.22.0")
+	testCases[4].hc, testCases[4].version = managedHSMCluster("5.0.0")
+	testCases[5].hc, testCases[5].version = managedHSMCluster("5.1.0")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateManagedHSMVersion(tc.hc, tc.version)
+			if tc.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+			}
+		})
+	}
+}
+
 func TestComputeEndpointServiceCondition(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -7278,7 +7278,7 @@ func TestValidateAzureConfig(t *testing.T) {
 }
 
 func TestValidateManagedHSMVersion(t *testing.T) {
-	managedHSMCluster := func(version string) (*hyperv1.HostedCluster, semver.Version) {
+	managedHSMCluster := func() *hyperv1.HostedCluster {
 		return &hyperv1.HostedCluster{
 			Spec: hyperv1.HostedClusterSpec{
 				Platform: hyperv1.PlatformSpec{
@@ -7295,7 +7295,7 @@ func TestValidateManagedHSMVersion(t *testing.T) {
 					},
 				},
 			},
-		}, semver.MustParse(version)
+		}
 	}
 
 	testCases := []struct {
@@ -7340,26 +7340,29 @@ func TestValidateManagedHSMVersion(t *testing.T) {
 		},
 		{
 			name:        "When the release version is 4.21, it should reject ManagedHSM",
+			hc:          managedHSMCluster(),
+			version:     semver.MustParse("4.21.3"),
 			expectError: true,
 		},
 		{
 			name:        "When the release version is exactly 4.22.0, it should accept ManagedHSM",
+			hc:          managedHSMCluster(),
+			version:     semver.MustParse("4.22.0"),
 			expectError: false,
 		},
 		{
 			name:        "When the release version is newer than 4.22, it should accept ManagedHSM",
+			hc:          managedHSMCluster(),
+			version:     semver.MustParse("4.23.0"),
 			expectError: false,
 		},
 		{
 			name:        "When the release version has a newer major version, it should accept ManagedHSM",
+			hc:          managedHSMCluster(),
+			version:     semver.MustParse("5.0.0"),
 			expectError: false,
 		},
 	}
-
-	testCases[2].hc, testCases[2].version = managedHSMCluster("4.21.3")
-	testCases[3].hc, testCases[3].version = managedHSMCluster("4.22.0")
-	testCases[4].hc, testCases[4].version = managedHSMCluster("4.23.0")
-	testCases[5].hc, testCases[5].version = managedHSMCluster("5.0.0")
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -31,12 +31,12 @@ import (
 // Azure SDK has a 24-character limit for ApplicationID, and spaces are replaced with "/".
 const CPOUserAgent = "hypershift-cpo"
 
-// AzureEncryptionKey represents the information needed to access an encryption key in Azure Key Vault
-// This information comes from the encryption key ID, which is in the form of https://<vaultName>.vault.azure.net/keys/<keyName>/<keyVersion>
+// AzureEncryptionKey represents the information needed to access an encryption key in Azure Key Vault or Managed HSM.
 type AzureEncryptionKey struct {
 	KeyVaultName string
 	KeyName      string
 	KeyVersion   string
+	KeyVaultType hyperv1.AzureKMSKeyVaultType
 }
 
 // NewARMClientOptions creates Azure ARM client options with proper cloud configuration
@@ -56,7 +56,8 @@ func NewARMClientOptions(cloudConfig cloud.Configuration) *arm.ClientOptions {
 
 // GetAzureCloudConfiguration converts a cloud name string to the Azure SDK cloud.Configuration.
 // This function maps the cloud names used in the HyperShift API to the corresponding Azure SDK cloud configurations.
-// Valid cloud names are: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, and empty string (defaults to AzurePublicCloud).
+// Valid cloud names are AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud,
+// AzureGermanCloud, AzureBleuCloud, and empty string (defaults to AzurePublicCloud).
 // Returns an error if the cloud name is not recognized.
 func GetAzureCloudConfiguration(cloudName string) (cloud.Configuration, error) {
 	switch cloudName {
@@ -66,6 +67,26 @@ func GetAzureCloudConfiguration(cloudName string) (cloud.Configuration, error) {
 		return cloud.AzureGovernment, nil
 	case "AzureChinaCloud":
 		return cloud.AzureChina, nil
+	case "AzureGermanCloud":
+		return cloud.Configuration{
+			ActiveDirectoryAuthorityHost: "https://login.microsoftonline.de/",
+			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+				cloud.ResourceManager: {
+					Audience: "https://management.core.cloudapi.de/",
+					Endpoint: "https://management.microsoftazure.de",
+				},
+			},
+		}, nil
+	case "AzureBleuCloud":
+		return cloud.Configuration{
+			ActiveDirectoryAuthorityHost: "https://login.sovcloud-identity.fr/",
+			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+				cloud.ResourceManager: {
+					Audience: "https://management.sovcloud-api.fr/",
+					Endpoint: "https://management.sovcloud-api.fr",
+				},
+			},
+		}, nil
 	default:
 		return cloud.Configuration{}, fmt.Errorf("unknown Azure cloud: %s", cloudName)
 	}
@@ -389,19 +410,60 @@ func GetServicePrincipalScopes(subscriptionID, managedResourceGroupName, nsgReso
 // GetKeyVaultDNSSuffixFromCloudType simply mimics the functionality in environments.go from the Azure SDK, github.com/Azure/go-autorest.
 // This function is used to get the DNS suffix for the Key Vault based on the cloud type.
 func GetKeyVaultDNSSuffixFromCloudType(cloud string) (string, error) {
-	cloud = strings.ToUpper(cloud)
+	return GetKeyVaultDNSSuffix(cloud, hyperv1.AzureKMSKeyVaultTypeKeyVault)
+}
 
-	switch cloud {
+// GetKeyVaultDNSSuffix returns the cloud-specific DNS suffix for Azure Key Vault or Managed HSM.
+// An empty keyVaultType is treated as KeyVault for compatibility with existing API objects.
+// Supporting another cloud requires adding its suffix here, allowing it in GetAzureEncryptionKeyInfo,
+// and updating the HCPEtcdBackup encryptionKeyURL API validation.
+func GetKeyVaultDNSSuffix(cloud string, keyVaultType hyperv1.AzureKMSKeyVaultType) (string, error) {
+	normalizedCloud := strings.ToUpper(cloud)
+	managedHSM := false
+	switch keyVaultType {
+	case "", hyperv1.AzureKMSKeyVaultTypeKeyVault:
+	case hyperv1.AzureKMSKeyVaultTypeManagedHSM:
+		managedHSM = true
+	default:
+		return "", fmt.Errorf("unknown Azure KMS key vault type %q", keyVaultType)
+	}
+
+	switch normalizedCloud {
 	case "AZURECHINACLOUD":
-		return "vault.azure.cn", nil
+		if managedHSM {
+			return azureChinaManagedHSMDNSSuffix, nil
+		}
+		return azureChinaKeyVaultDNSSuffix, nil
 	case "AZURECLOUD":
-		return "vault.azure.net", nil
+		if managedHSM {
+			return azurePublicManagedHSMDNSSuffix, nil
+		}
+		return azurePublicKeyVaultDNSSuffix, nil
 	case "AZUREPUBLICCLOUD":
-		return "vault.azure.net", nil
+		if managedHSM {
+			return azurePublicManagedHSMDNSSuffix, nil
+		}
+		return azurePublicKeyVaultDNSSuffix, nil
 	case "AZUREUSGOVERNMENT":
-		return "vault.usgovcloudapi.net", nil
+		if managedHSM {
+			return azureGovernmentManagedHSMDNSSuffix, nil
+		}
+		return azureGovernmentKeyVaultDNSSuffix, nil
 	case "AZUREUSGOVERNMENTCLOUD":
-		return "vault.usgovcloudapi.net", nil
+		if managedHSM {
+			return azureGovernmentManagedHSMDNSSuffix, nil
+		}
+		return azureGovernmentKeyVaultDNSSuffix, nil
+	case "AZUREGERMANCLOUD":
+		if managedHSM {
+			return azureGermanManagedHSMDNSSuffix, nil
+		}
+		return azureGermanKeyVaultDNSSuffix, nil
+	case "AZUREBLEUCLOUD":
+		if managedHSM {
+			return azureBleuManagedHSMDNSSuffix, nil
+		}
+		return azureBleuKeyVaultDNSSuffix, nil
 	default:
 		return "", fmt.Errorf("unknown cloud type %q", cloud)
 	}
@@ -416,16 +478,16 @@ func GetKeyVaultFQDN(hcp *hyperv1.HostedControlPlane) (string, error) {
 		return "", fmt.Errorf("azure KMS is not configured")
 	}
 
-	vaultName := hcp.Spec.SecretEncryption.KMS.Azure.ActiveKey.KeyVaultName
-	suffix, err := GetKeyVaultDNSSuffixFromCloudType(hcp.Spec.Platform.Azure.Cloud)
+	azureKMS := hcp.Spec.SecretEncryption.KMS.Azure
+	activeKey := azureKMS.ActiveKey
+	suffix, err := GetKeyVaultDNSSuffix(hcp.Spec.Platform.Azure.Cloud, azureKMS.KeyVaultType)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to resolve Azure KMS DNS suffix: %w", err)
 	}
-	return fmt.Sprintf("%s.%s", vaultName, suffix), nil
+	return fmt.Sprintf("%s.%s", activeKey.KeyVaultName, suffix), nil
 }
 
-// GetAzureEncryptionKeyInfo extracts the key vault name, key name, and key version from an encryption key ID
-// The encryption key ID is in the form of https://<vaultName>.vault.azure.net/keys/<keyName>/<keyVersion>
+// GetAzureEncryptionKeyInfo extracts the vault name, key name, key version, and vault type from an encryption key ID.
 func GetAzureEncryptionKeyInfo(encryptionKeyID string) (*AzureEncryptionKey, error) {
 	parsed, err := url.Parse(encryptionKeyID)
 	if err != nil {
@@ -433,7 +495,7 @@ func GetAzureEncryptionKeyInfo(encryptionKeyID string) (*AzureEncryptionKey, err
 	}
 
 	// Ensure the host is present
-	host := parsed.Hostname()
+	host := strings.ToLower(parsed.Hostname())
 	if host == "" {
 		return nil, fmt.Errorf("invalid encryption key identifier %q: missing host", encryptionKeyID)
 
@@ -450,16 +512,26 @@ func GetAzureEncryptionKeyInfo(encryptionKeyID string) (*AzureEncryptionKey, err
 		return nil, fmt.Errorf("invalid encryption key identifier %q: expected /keys/<keyName>/<keyVersion>", encryptionKeyID)
 	}
 
-	// Ensure the vault name is present
-	vaultName := strings.Split(host, ".")[0]
-	if vaultName == "" {
-		return nil, fmt.Errorf("invalid encryption key identifier %q: could not derive vault name from host %q", encryptionKeyID, host)
+	vaultName, suffix, found := strings.Cut(host, ".")
+	if !found || vaultName == "" {
+		return nil, fmt.Errorf("invalid encryption key identifier %q: could not derive vault name and service suffix from host %q", encryptionKeyID, host)
+	}
+
+	var keyVaultType hyperv1.AzureKMSKeyVaultType
+	switch suffix {
+	case azurePublicKeyVaultDNSSuffix, azureGovernmentKeyVaultDNSSuffix, azureChinaKeyVaultDNSSuffix, azureGermanKeyVaultDNSSuffix, azureBleuKeyVaultDNSSuffix:
+		keyVaultType = hyperv1.AzureKMSKeyVaultTypeKeyVault
+	case azurePublicManagedHSMDNSSuffix, azureGovernmentManagedHSMDNSSuffix, azureChinaManagedHSMDNSSuffix, azureGermanManagedHSMDNSSuffix, azureBleuManagedHSMDNSSuffix:
+		keyVaultType = hyperv1.AzureKMSKeyVaultTypeManagedHSM
+	default:
+		return nil, fmt.Errorf("invalid encryption key identifier %q: unsupported Azure Key Vault host %q", encryptionKeyID, host)
 	}
 
 	return &AzureEncryptionKey{
 		KeyVaultName: vaultName,
 		KeyName:      parts[0],
 		KeyVersion:   parts[1],
+		KeyVaultType: keyVaultType,
 	}, nil
 }
 

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -31,12 +31,12 @@ import (
 // Azure SDK has a 24-character limit for ApplicationID, and spaces are replaced with "/".
 const CPOUserAgent = "hypershift-cpo"
 
-// AzureEncryptionKey represents the information needed to access an encryption key in Azure Key Vault
-// This information comes from the encryption key ID, which is in the form of https://<vaultName>.vault.azure.net/keys/<keyName>/<keyVersion>
+// AzureEncryptionKey represents the information needed to access an encryption key in Azure Key Vault or Managed HSM.
 type AzureEncryptionKey struct {
 	KeyVaultName string
 	KeyName      string
 	KeyVersion   string
+	KeyVaultType hyperv1.AzureKMSKeyVaultType
 }
 
 // NewARMClientOptions creates Azure ARM client options with proper cloud configuration
@@ -389,19 +389,59 @@ func GetServicePrincipalScopes(subscriptionID, managedResourceGroupName, nsgReso
 // GetKeyVaultDNSSuffixFromCloudType simply mimics the functionality in environments.go from the Azure SDK, github.com/Azure/go-autorest.
 // This function is used to get the DNS suffix for the Key Vault based on the cloud type.
 func GetKeyVaultDNSSuffixFromCloudType(cloud string) (string, error) {
-	cloud = strings.ToUpper(cloud)
+	return GetKeyVaultDNSSuffix(cloud, hyperv1.AzureKMSKeyVaultTypeKeyVault)
+}
 
-	switch cloud {
+const (
+	azurePublicKeyVaultDNSSuffix       = "vault.azure.net"
+	azurePublicManagedHSMDNSSuffix     = "managedhsm.azure.net"
+	azureGovernmentKeyVaultDNSSuffix   = "vault.usgovcloudapi.net"
+	azureGovernmentManagedHSMDNSSuffix = "managedhsm.usgovcloudapi.net"
+	azureChinaKeyVaultDNSSuffix        = "vault.azure.cn"
+)
+
+// GetKeyVaultDNSSuffix returns the cloud-specific DNS suffix for Azure Key Vault or Managed HSM.
+// An empty keyVaultType is treated as KeyVault for compatibility with existing API objects.
+// Managed HSM support is intentionally limited to Azure Public Cloud and Azure US Government Cloud.
+// Supporting another cloud requires adding its suffix here, allowing it in GetAzureEncryptionKeyInfo,
+// and updating the HCPEtcdBackup encryptionKeyURL API validation.
+func GetKeyVaultDNSSuffix(cloud string, keyVaultType hyperv1.AzureKMSKeyVaultType) (string, error) {
+	normalizedCloud := strings.ToUpper(cloud)
+	managedHSM := false
+	switch keyVaultType {
+	case "", hyperv1.AzureKMSKeyVaultTypeKeyVault:
+	case hyperv1.AzureKMSKeyVaultTypeManagedHSM:
+		managedHSM = true
+	default:
+		return "", fmt.Errorf("unknown Azure KMS key vault type %q", keyVaultType)
+	}
+
+	switch normalizedCloud {
 	case "AZURECHINACLOUD":
-		return "vault.azure.cn", nil
+		if managedHSM {
+			return "", fmt.Errorf("Azure Managed HSM is not supported in cloud type %q", cloud) //nolint:staticcheck // Azure Managed HSM is a proper noun
+		}
+		return azureChinaKeyVaultDNSSuffix, nil
 	case "AZURECLOUD":
-		return "vault.azure.net", nil
+		if managedHSM {
+			return azurePublicManagedHSMDNSSuffix, nil
+		}
+		return azurePublicKeyVaultDNSSuffix, nil
 	case "AZUREPUBLICCLOUD":
-		return "vault.azure.net", nil
+		if managedHSM {
+			return azurePublicManagedHSMDNSSuffix, nil
+		}
+		return azurePublicKeyVaultDNSSuffix, nil
 	case "AZUREUSGOVERNMENT":
-		return "vault.usgovcloudapi.net", nil
+		if managedHSM {
+			return azureGovernmentManagedHSMDNSSuffix, nil
+		}
+		return azureGovernmentKeyVaultDNSSuffix, nil
 	case "AZUREUSGOVERNMENTCLOUD":
-		return "vault.usgovcloudapi.net", nil
+		if managedHSM {
+			return azureGovernmentManagedHSMDNSSuffix, nil
+		}
+		return azureGovernmentKeyVaultDNSSuffix, nil
 	default:
 		return "", fmt.Errorf("unknown cloud type %q", cloud)
 	}
@@ -416,16 +456,15 @@ func GetKeyVaultFQDN(hcp *hyperv1.HostedControlPlane) (string, error) {
 		return "", fmt.Errorf("azure KMS is not configured")
 	}
 
-	vaultName := hcp.Spec.SecretEncryption.KMS.Azure.ActiveKey.KeyVaultName
-	suffix, err := GetKeyVaultDNSSuffixFromCloudType(hcp.Spec.Platform.Azure.Cloud)
+	activeKey := hcp.Spec.SecretEncryption.KMS.Azure.ActiveKey
+	suffix, err := GetKeyVaultDNSSuffix(hcp.Spec.Platform.Azure.Cloud, activeKey.KeyVaultType)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to resolve Azure KMS DNS suffix: %w", err)
 	}
-	return fmt.Sprintf("%s.%s", vaultName, suffix), nil
+	return fmt.Sprintf("%s.%s", activeKey.KeyVaultName, suffix), nil
 }
 
-// GetAzureEncryptionKeyInfo extracts the key vault name, key name, and key version from an encryption key ID
-// The encryption key ID is in the form of https://<vaultName>.vault.azure.net/keys/<keyName>/<keyVersion>
+// GetAzureEncryptionKeyInfo extracts the vault name, key name, key version, and vault type from an encryption key ID.
 func GetAzureEncryptionKeyInfo(encryptionKeyID string) (*AzureEncryptionKey, error) {
 	parsed, err := url.Parse(encryptionKeyID)
 	if err != nil {
@@ -433,7 +472,7 @@ func GetAzureEncryptionKeyInfo(encryptionKeyID string) (*AzureEncryptionKey, err
 	}
 
 	// Ensure the host is present
-	host := parsed.Hostname()
+	host := strings.ToLower(parsed.Hostname())
 	if host == "" {
 		return nil, fmt.Errorf("invalid encryption key identifier %q: missing host", encryptionKeyID)
 
@@ -450,16 +489,26 @@ func GetAzureEncryptionKeyInfo(encryptionKeyID string) (*AzureEncryptionKey, err
 		return nil, fmt.Errorf("invalid encryption key identifier %q: expected /keys/<keyName>/<keyVersion>", encryptionKeyID)
 	}
 
-	// Ensure the vault name is present
-	vaultName := strings.Split(host, ".")[0]
-	if vaultName == "" {
-		return nil, fmt.Errorf("invalid encryption key identifier %q: could not derive vault name from host %q", encryptionKeyID, host)
+	vaultName, suffix, found := strings.Cut(host, ".")
+	if !found || vaultName == "" {
+		return nil, fmt.Errorf("invalid encryption key identifier %q: could not derive vault name and service suffix from host %q", encryptionKeyID, host)
+	}
+
+	var keyVaultType hyperv1.AzureKMSKeyVaultType
+	switch suffix {
+	case azurePublicKeyVaultDNSSuffix, azureGovernmentKeyVaultDNSSuffix, azureChinaKeyVaultDNSSuffix:
+		keyVaultType = hyperv1.AzureKMSKeyVaultTypeKeyVault
+	case azurePublicManagedHSMDNSSuffix, azureGovernmentManagedHSMDNSSuffix:
+		keyVaultType = hyperv1.AzureKMSKeyVaultTypeManagedHSM
+	default:
+		return nil, fmt.Errorf("invalid encryption key identifier %q: unsupported Azure Key Vault host %q", encryptionKeyID, host)
 	}
 
 	return &AzureEncryptionKey{
 		KeyVaultName: vaultName,
 		KeyName:      parts[0],
 		KeyVersion:   parts[1],
+		KeyVaultType: keyVaultType,
 	}, nil
 }
 

--- a/support/azureutil/azureutil_test.go
+++ b/support/azureutil/azureutil_test.go
@@ -602,6 +602,29 @@ func TestGetKeyVaultFQDN(t *testing.T) {
 			wantFQDN: "gov-vault.vault.usgovcloudapi.net",
 		},
 		{
+			name: "When Azure KMS uses Managed HSM, it should return the Managed HSM FQDN",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Azure: &hyperv1.AzurePlatformSpec{
+							Cloud: "AzurePublicCloud",
+						},
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						KMS: &hyperv1.KMSSpec{
+							Azure: &hyperv1.AzureKMSSpec{
+								ActiveKey: hyperv1.AzureKMSKey{
+									KeyVaultName: "my-hsm",
+								},
+								KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+							},
+						},
+					},
+				},
+			},
+			wantFQDN: "my-hsm.managedhsm.azure.net",
+		},
+		{
 			name: "When SecretEncryption is nil, it should return error",
 			hcp: &hyperv1.HostedControlPlane{
 				Spec: hyperv1.HostedControlPlaneSpec{
@@ -668,6 +691,90 @@ func TestGetKeyVaultFQDN(t *testing.T) {
 	}
 }
 
+func TestGetKeyVaultDNSSuffix(t *testing.T) {
+	tests := []struct {
+		name         string
+		cloud        string
+		keyVaultType hyperv1.AzureKMSKeyVaultType
+		wantSuffix   string
+		wantErr      bool
+	}{
+		{
+			name:       "When keyVaultType is omitted, it should return the standard Key Vault suffix",
+			cloud:      "AzurePublicCloud",
+			wantSuffix: "vault.azure.net",
+		},
+		{
+			name:         "When keyVaultType is ManagedHSM in public cloud, it should return the Managed HSM suffix",
+			cloud:        "AzurePublicCloud",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantSuffix:   "managedhsm.azure.net",
+		},
+		{
+			name:         "When keyVaultType is ManagedHSM in government cloud, it should return the government Managed HSM suffix",
+			cloud:        "AzureUSGovernmentCloud",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantSuffix:   "managedhsm.usgovcloudapi.net",
+		},
+		{
+			name:         "When keyVaultType is ManagedHSM in China cloud, it should return the China Managed HSM suffix",
+			cloud:        "AzureChinaCloud",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantSuffix:   "managedhsm.azure.cn",
+		},
+		{
+			name:         "When keyVaultType is KeyVault in China cloud, it should return the China Key Vault suffix",
+			cloud:        "AzureChinaCloud",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeKeyVault,
+			wantSuffix:   "vault.azure.cn",
+		},
+		{
+			name:         "When keyVaultType is ManagedHSM in German cloud, it should return the German Managed HSM suffix",
+			cloud:        "AzureGermanCloud",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantSuffix:   "managedhsm.microsoftazure.de",
+		},
+		{
+			name:         "When keyVaultType is KeyVault in German cloud, it should return the German Key Vault suffix",
+			cloud:        "AzureGermanCloud",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeKeyVault,
+			wantSuffix:   "vault.microsoftazure.de",
+		},
+		{
+			name:         "When keyVaultType is ManagedHSM in Bleu cloud, it should return the Bleu Managed HSM suffix",
+			cloud:        "AzureBleuCloud",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantSuffix:   "managedhsm.sovcloud-api.fr",
+		},
+		{
+			name:         "When keyVaultType is KeyVault in Bleu cloud, it should return the Bleu Key Vault suffix",
+			cloud:        "AzureBleuCloud",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeKeyVault,
+			wantSuffix:   "vault.sovcloud-api.fr",
+		},
+		{
+			// keyVaultType is validated before the cloud switch, so this errors regardless of cloud.
+			name:         "When keyVaultType is unknown, it should return an error",
+			cloud:        "AzurePublicCloud",
+			keyVaultType: "Unknown",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, err := GetKeyVaultDNSSuffix(tt.cloud, tt.keyVaultType)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.wantSuffix))
+		})
+	}
+}
+
 func TestGetAzureEncryptionKeyInfo(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -675,6 +782,7 @@ func TestGetAzureEncryptionKeyInfo(t *testing.T) {
 		wantVaultHost  string
 		wantKeyName    string
 		wantKeyVersion string
+		wantVaultType  hyperv1.AzureKMSKeyVaultType
 		wantErr        bool
 	}{
 		{
@@ -683,7 +791,64 @@ func TestGetAzureEncryptionKeyInfo(t *testing.T) {
 			wantVaultHost:  "example-kms",
 			wantKeyName:    "example-key",
 			wantKeyVersion: "1234abcd",
+			wantVaultType:  hyperv1.AzureKMSKeyVaultTypeKeyVault,
 			wantErr:        false,
+		},
+		{
+			name:           "When given a Managed HSM key ID, it should identify the vault type",
+			id:             "https://example-hsm.managedhsm.azure.net/keys/example-key/1234abcd",
+			wantVaultHost:  "example-hsm",
+			wantKeyName:    "example-key",
+			wantKeyVersion: "1234abcd",
+			wantVaultType:  hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantErr:        false,
+		},
+		{
+			name:           "When given a US Government Managed HSM key ID, it should identify the vault type",
+			id:             "https://example-hsm.managedhsm.usgovcloudapi.net/keys/example-key/1234abcd",
+			wantVaultHost:  "example-hsm",
+			wantKeyName:    "example-key",
+			wantKeyVersion: "1234abcd",
+			wantVaultType:  hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantErr:        false,
+		},
+		{
+			name:           "When given an uppercase US Government Managed HSM key ID, it should normalize and parse the host",
+			id:             "https://EXAMPLE-HSM.MANAGEDHSM.USGOVCLOUDAPI.NET/keys/example-key/1234abcd",
+			wantVaultHost:  "example-hsm",
+			wantKeyName:    "example-key",
+			wantKeyVersion: "1234abcd",
+			wantVaultType:  hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantErr:        false,
+		},
+		{
+			name:           "When given a China Managed HSM key ID, it should identify the vault type",
+			id:             "https://example-hsm.managedhsm.azure.cn/keys/example-key/1234abcd",
+			wantVaultHost:  "example-hsm",
+			wantKeyName:    "example-key",
+			wantKeyVersion: "1234abcd",
+			wantVaultType:  hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+		},
+		{
+			name:           "When given a German Managed HSM key ID, it should identify the vault type",
+			id:             "https://example-hsm.managedhsm.microsoftazure.de/keys/example-key/1234abcd",
+			wantVaultHost:  "example-hsm",
+			wantKeyName:    "example-key",
+			wantKeyVersion: "1234abcd",
+			wantVaultType:  hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+		},
+		{
+			name:           "When given a Bleu Managed HSM key ID, it should identify the vault type",
+			id:             "https://example-hsm.managedhsm.sovcloud-api.fr/keys/example-key/1234abcd",
+			wantVaultHost:  "example-hsm",
+			wantKeyName:    "example-key",
+			wantKeyVersion: "1234abcd",
+			wantVaultType:  hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+		},
+		{
+			name:    "When given an unrecognized Azure key host, it should return an error",
+			id:      "https://example-hsm.managedhsm.invalid/keys/example-key/1234abcd",
+			wantErr: true,
 		},
 		{
 			name:    "When key id missing version, it should error",
@@ -706,6 +871,7 @@ func TestGetAzureEncryptionKeyInfo(t *testing.T) {
 			wantVaultHost:  "example-kms",
 			wantKeyName:    "example-key",
 			wantKeyVersion: "1234abcd",
+			wantVaultType:  hyperv1.AzureKMSKeyVaultTypeKeyVault,
 			wantErr:        false,
 		},
 		{
@@ -729,6 +895,7 @@ func TestGetAzureEncryptionKeyInfo(t *testing.T) {
 			g.Expect(got.KeyVaultName).To(Equal(tt.wantVaultHost))
 			g.Expect(got.KeyName).To(Equal(tt.wantKeyName))
 			g.Expect(got.KeyVersion).To(Equal(tt.wantKeyVersion))
+			g.Expect(got.KeyVaultType).To(Equal(tt.wantVaultType))
 		})
 	}
 }
@@ -1065,6 +1232,34 @@ func TestGetAzureCloudConfiguration(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name:      "When the cloud name is AzureGermanCloud, it should return the German cloud configuration",
+			cloudName: "AzureGermanCloud",
+			wantCloud: cloud.Configuration{
+				ActiveDirectoryAuthorityHost: "https://login.microsoftonline.de/",
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {
+						Audience: "https://management.core.cloudapi.de/",
+						Endpoint: "https://management.microsoftazure.de",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "When the cloud name is AzureBleuCloud, it should return the Bleu cloud configuration",
+			cloudName: "AzureBleuCloud",
+			wantCloud: cloud.Configuration{
+				ActiveDirectoryAuthorityHost: "https://login.sovcloud-identity.fr/",
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {
+						Audience: "https://management.sovcloud-api.fr/",
+						Endpoint: "https://management.sovcloud-api.fr",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name:      "When cloud name is invalid, it should return an error",
 			cloudName: "InvalidCloud",
 			wantCloud: cloud.Configuration{},
@@ -1086,9 +1281,11 @@ func TestGetAzureCloudConfiguration(t *testing.T) {
 				return
 			}
 			if !tt.wantErr {
-				// Compare the ActiveDirectoryAuthorityHost to verify we got the right cloud configuration
 				if gotCloud.ActiveDirectoryAuthorityHost != tt.wantCloud.ActiveDirectoryAuthorityHost {
 					t.Errorf("GetAzureCloudConfiguration() = %v, want %v", gotCloud, tt.wantCloud)
+				}
+				if gotCloud.Services[cloud.ResourceManager] != tt.wantCloud.Services[cloud.ResourceManager] {
+					t.Errorf("GetAzureCloudConfiguration() resource manager configuration = %v, want %v", gotCloud.Services[cloud.ResourceManager], tt.wantCloud.Services[cloud.ResourceManager])
 				}
 			}
 		})

--- a/support/azureutil/azureutil_test.go
+++ b/support/azureutil/azureutil_test.go
@@ -602,6 +602,29 @@ func TestGetKeyVaultFQDN(t *testing.T) {
 			wantFQDN: "gov-vault.vault.usgovcloudapi.net",
 		},
 		{
+			name: "When Azure KMS uses Managed HSM it should return the Managed HSM FQDN",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Azure: &hyperv1.AzurePlatformSpec{
+							Cloud: "AzurePublicCloud",
+						},
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						KMS: &hyperv1.KMSSpec{
+							Azure: &hyperv1.AzureKMSSpec{
+								ActiveKey: hyperv1.AzureKMSKey{
+									KeyVaultName: "my-hsm",
+									KeyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantFQDN: "my-hsm.managedhsm.azure.net",
+		},
+		{
 			name: "When SecretEncryption is nil it should return error",
 			hcp: &hyperv1.HostedControlPlane{
 				Spec: hyperv1.HostedControlPlaneSpec{
@@ -668,6 +691,65 @@ func TestGetKeyVaultFQDN(t *testing.T) {
 	}
 }
 
+func TestGetKeyVaultDNSSuffix(t *testing.T) {
+	tests := []struct {
+		name         string
+		cloud        string
+		keyVaultType hyperv1.AzureKMSKeyVaultType
+		wantSuffix   string
+		wantErr      bool
+	}{
+		{
+			name:       "When keyVaultType is omitted it should return the standard Key Vault suffix",
+			cloud:      "AzurePublicCloud",
+			wantSuffix: "vault.azure.net",
+		},
+		{
+			name:         "When keyVaultType is ManagedHSM in public cloud it should return the Managed HSM suffix",
+			cloud:        "AzurePublicCloud",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantSuffix:   "managedhsm.azure.net",
+		},
+		{
+			name:         "When keyVaultType is ManagedHSM in government cloud, it should return the government Managed HSM suffix",
+			cloud:        "AzureUSGovernmentCloud",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantSuffix:   "managedhsm.usgovcloudapi.net",
+		},
+		{
+			name:         "When keyVaultType is ManagedHSM in China cloud, it should return an unsupported cloud error",
+			cloud:        "AzureChinaCloud",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantErr:      true,
+		},
+		{
+			name:         "When keyVaultType is KeyVault in China cloud, it should return the China Key Vault suffix",
+			cloud:        "AzureChinaCloud",
+			keyVaultType: hyperv1.AzureKMSKeyVaultTypeKeyVault,
+			wantSuffix:   "vault.azure.cn",
+		},
+		{
+			name:         "When keyVaultType is unknown it should return an error",
+			cloud:        "AzurePublicCloud",
+			keyVaultType: "Unknown",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, err := GetKeyVaultDNSSuffix(tt.cloud, tt.keyVaultType)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.wantSuffix))
+		})
+	}
+}
+
 func TestGetAzureEncryptionKeyInfo(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -675,6 +757,7 @@ func TestGetAzureEncryptionKeyInfo(t *testing.T) {
 		wantVaultHost  string
 		wantKeyName    string
 		wantKeyVersion string
+		wantVaultType  hyperv1.AzureKMSKeyVaultType
 		wantErr        bool
 	}{
 		{
@@ -683,7 +766,45 @@ func TestGetAzureEncryptionKeyInfo(t *testing.T) {
 			wantVaultHost:  "example-kms",
 			wantKeyName:    "example-key",
 			wantKeyVersion: "1234abcd",
+			wantVaultType:  hyperv1.AzureKMSKeyVaultTypeKeyVault,
 			wantErr:        false,
+		},
+		{
+			name:           "When given a Managed HSM key ID it should identify the vault type",
+			id:             "https://example-hsm.managedhsm.azure.net/keys/example-key/1234abcd",
+			wantVaultHost:  "example-hsm",
+			wantKeyName:    "example-key",
+			wantKeyVersion: "1234abcd",
+			wantVaultType:  hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantErr:        false,
+		},
+		{
+			name:           "When given a US Government Managed HSM key ID, it should identify the vault type",
+			id:             "https://example-hsm.managedhsm.usgovcloudapi.net/keys/example-key/1234abcd",
+			wantVaultHost:  "example-hsm",
+			wantKeyName:    "example-key",
+			wantKeyVersion: "1234abcd",
+			wantVaultType:  hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantErr:        false,
+		},
+		{
+			name:           "When given an uppercase US Government Managed HSM key ID, it should normalize and parse the host",
+			id:             "https://EXAMPLE-HSM.MANAGEDHSM.USGOVCLOUDAPI.NET/keys/example-key/1234abcd",
+			wantVaultHost:  "example-hsm",
+			wantKeyName:    "example-key",
+			wantKeyVersion: "1234abcd",
+			wantVaultType:  hyperv1.AzureKMSKeyVaultTypeManagedHSM,
+			wantErr:        false,
+		},
+		{
+			name:    "When given a Managed HSM key ID for an unsupported cloud, it should return an error",
+			id:      "https://example-hsm.managedhsm.azure.cn/keys/example-key/1234abcd",
+			wantErr: true,
+		},
+		{
+			name:    "When given an unrecognized Azure key host, it should return an error",
+			id:      "https://example-hsm.managedhsm.invalid/keys/example-key/1234abcd",
+			wantErr: true,
 		},
 		{
 			name:    "When key id missing version it should error",
@@ -706,6 +827,7 @@ func TestGetAzureEncryptionKeyInfo(t *testing.T) {
 			wantVaultHost:  "example-kms",
 			wantKeyName:    "example-key",
 			wantKeyVersion: "1234abcd",
+			wantVaultType:  hyperv1.AzureKMSKeyVaultTypeKeyVault,
 			wantErr:        false,
 		},
 		{
@@ -729,6 +851,7 @@ func TestGetAzureEncryptionKeyInfo(t *testing.T) {
 			g.Expect(got.KeyVaultName).To(Equal(tt.wantVaultHost))
 			g.Expect(got.KeyName).To(Equal(tt.wantKeyName))
 			g.Expect(got.KeyVersion).To(Equal(tt.wantKeyVersion))
+			g.Expect(got.KeyVaultType).To(Equal(tt.wantVaultType))
 		})
 	}
 }

--- a/support/azureutil/constants.go
+++ b/support/azureutil/constants.go
@@ -25,3 +25,16 @@ const (
 	// PEConnectionStateRejected indicates a Private Endpoint connection has been rejected.
 	PEConnectionStateRejected = "Rejected"
 )
+
+const (
+	azurePublicKeyVaultDNSSuffix       = "vault.azure.net"
+	azurePublicManagedHSMDNSSuffix     = "managedhsm.azure.net"
+	azureGovernmentKeyVaultDNSSuffix   = "vault.usgovcloudapi.net"
+	azureGovernmentManagedHSMDNSSuffix = "managedhsm.usgovcloudapi.net"
+	azureChinaKeyVaultDNSSuffix        = "vault.azure.cn"
+	azureChinaManagedHSMDNSSuffix      = "managedhsm.azure.cn"
+	azureGermanKeyVaultDNSSuffix       = "vault.microsoftazure.de"
+	azureGermanManagedHSMDNSSuffix     = "managedhsm.microsoftazure.de"
+	azureBleuKeyVaultDNSSuffix         = "vault.sovcloud-api.fr"
+	azureBleuManagedHSMDNSSuffix       = "managedhsm.sovcloud-api.fr"
+)

--- a/support/secretencryption/fingerprint.go
+++ b/support/secretencryption/fingerprint.go
@@ -15,8 +15,12 @@ func DataHash(data []byte) string {
 }
 
 // FingerprintAzureKMSKey computes the SHA-256 fingerprint for an Azure KMS key.
-func FingerprintAzureKMSKey(key hyperv1.AzureKMSKey) string {
-	return DataHash([]byte(key.KeyVaultName + "/" + key.KeyName + "/" + key.KeyVersion))
+func FingerprintAzureKMSKey(key hyperv1.AzureKMSKey, keyVaultType hyperv1.AzureKMSKeyVaultType) string {
+	identity := key.KeyVaultName + "/" + key.KeyName + "/" + key.KeyVersion
+	if keyVaultType == hyperv1.AzureKMSKeyVaultTypeManagedHSM {
+		identity += "/" + string(keyVaultType)
+	}
+	return DataHash([]byte(identity))
 }
 
 // FingerprintAWSKMSKey computes the SHA-256 fingerprint for an AWS KMS key.
@@ -41,7 +45,8 @@ func FingerprintAESCBCKey(secretName string, dataHash string) string {
 }
 
 // FingerprintFromKeyStatus computes the fingerprint from a SecretEncryptionKeyStatus.
-func FingerprintFromKeyStatus(status *hyperv1.SecretEncryptionKeyStatus) string {
+// keyVaultType is only used for Azure KMS keys and is ignored for other providers.
+func FingerprintFromKeyStatus(status *hyperv1.SecretEncryptionKeyStatus, keyVaultType hyperv1.AzureKMSKeyVaultType) string {
 	if status == nil {
 		return ""
 	}
@@ -50,7 +55,7 @@ func FingerprintFromKeyStatus(status *hyperv1.SecretEncryptionKeyStatus) string 
 		if status.Azure.KeyVaultName == "" {
 			return ""
 		}
-		return FingerprintAzureKMSKey(status.Azure)
+		return FingerprintAzureKMSKey(status.Azure, keyVaultType)
 	case hyperv1.SecretEncryptionProviderAWS:
 		if status.AWS.ARN == "" {
 			return ""

--- a/support/secretencryption/fingerprint.go
+++ b/support/secretencryption/fingerprint.go
@@ -16,7 +16,11 @@ func DataHash(data []byte) string {
 
 // FingerprintAzureKMSKey computes the SHA-256 fingerprint for an Azure KMS key.
 func FingerprintAzureKMSKey(key hyperv1.AzureKMSKey) string {
-	return DataHash([]byte(key.KeyVaultName + "/" + key.KeyName + "/" + key.KeyVersion))
+	identity := key.KeyVaultName + "/" + key.KeyName + "/" + key.KeyVersion
+	if key.KeyVaultType == hyperv1.AzureKMSKeyVaultTypeManagedHSM {
+		identity += "/" + string(key.KeyVaultType)
+	}
+	return DataHash([]byte(identity))
 }
 
 // FingerprintAWSKMSKey computes the SHA-256 fingerprint for an AWS KMS key.

--- a/support/secretencryption/fingerprint_test.go
+++ b/support/secretencryption/fingerprint_test.go
@@ -10,20 +10,35 @@ import (
 
 func TestFingerprintAzureKMSKey(t *testing.T) {
 	t.Parallel()
-	t.Run("When computing Azure KMS fingerprint it should be deterministic", func(t *testing.T) {
+	t.Run("When computing Azure KMS fingerprint, it should be deterministic", func(t *testing.T) {
 		g := NewWithT(t)
 		key := hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"}
-		fp1 := FingerprintAzureKMSKey(key)
-		fp2 := FingerprintAzureKMSKey(key)
+		fp1 := FingerprintAzureKMSKey(key, "")
+		fp2 := FingerprintAzureKMSKey(key, "")
 		g.Expect(fp1).To(Equal(fp2))
 		g.Expect(fp1).ToNot(BeEmpty())
 	})
 
-	t.Run("When Azure KMS key version changes it should produce a different fingerprint", func(t *testing.T) {
+	t.Run("When Azure KMS key version changes, it should produce a different fingerprint", func(t *testing.T) {
 		g := NewWithT(t)
 		key1 := hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"}
 		key2 := hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2"}
-		g.Expect(FingerprintAzureKMSKey(key1)).ToNot(Equal(FingerprintAzureKMSKey(key2)))
+		g.Expect(FingerprintAzureKMSKey(key1, "")).ToNot(Equal(FingerprintAzureKMSKey(key2, "")))
+	})
+
+	t.Run("When KeyVault type is explicit, it should preserve the legacy fingerprint", func(t *testing.T) {
+		const legacyFingerprint = "d5962eb588f841eaa664c407524cfeff2eb31432751370611c35737a8b81da35"
+
+		g := NewWithT(t)
+		legacyKey := hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"}
+		g.Expect(FingerprintAzureKMSKey(legacyKey, "")).To(Equal(legacyFingerprint))
+		g.Expect(FingerprintAzureKMSKey(legacyKey, hyperv1.AzureKMSKeyVaultTypeKeyVault)).To(Equal(legacyFingerprint))
+	})
+
+	t.Run("When vault type changes to ManagedHSM, it should produce a different fingerprint", func(t *testing.T) {
+		g := NewWithT(t)
+		key := hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"}
+		g.Expect(FingerprintAzureKMSKey(key, hyperv1.AzureKMSKeyVaultTypeManagedHSM)).ToNot(Equal(FingerprintAzureKMSKey(key, "")))
 	})
 }
 
@@ -106,7 +121,7 @@ func TestFingerprintFromKeyStatus(t *testing.T) {
 	t.Parallel()
 	t.Run("When status is nil it should return empty string", func(t *testing.T) {
 		g := NewWithT(t)
-		g.Expect(FingerprintFromKeyStatus(nil)).To(BeEmpty())
+		g.Expect(FingerprintFromKeyStatus(nil, "")).To(BeEmpty())
 	})
 
 	t.Run("When Azure status is provided it should match spec fingerprint", func(t *testing.T) {
@@ -116,7 +131,7 @@ func TestFingerprintFromKeyStatus(t *testing.T) {
 			Provider: hyperv1.SecretEncryptionProviderAzure,
 			Azure:    hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"},
 		}
-		g.Expect(FingerprintFromKeyStatus(status)).To(Equal(FingerprintAzureKMSKey(key)))
+		g.Expect(FingerprintFromKeyStatus(status, "")).To(Equal(FingerprintAzureKMSKey(key, "")))
 	})
 
 	t.Run("When AWS status is provided it should match spec fingerprint", func(t *testing.T) {
@@ -126,7 +141,7 @@ func TestFingerprintFromKeyStatus(t *testing.T) {
 			Provider: hyperv1.SecretEncryptionProviderAWS,
 			AWS:      hyperv1.AWSKMSKeyEntry{ARN: arn},
 		}
-		g.Expect(FingerprintFromKeyStatus(status)).To(Equal(FingerprintAWSKMSKey(arn)))
+		g.Expect(FingerprintFromKeyStatus(status, "")).To(Equal(FingerprintAWSKMSKey(arn)))
 	})
 
 	t.Run("When IBMCloud status is provided it should match spec fingerprint", func(t *testing.T) {
@@ -136,7 +151,7 @@ func TestFingerprintFromKeyStatus(t *testing.T) {
 			Provider: hyperv1.SecretEncryptionProviderIBMCloud,
 			IBMCloud: entry,
 		}
-		g.Expect(FingerprintFromKeyStatus(status)).To(Equal(FingerprintIBMCloudKMSKeyList([]hyperv1.IBMCloudKMSKeyEntry{entry})))
+		g.Expect(FingerprintFromKeyStatus(status, "")).To(Equal(FingerprintIBMCloudKMSKeyList([]hyperv1.IBMCloudKMSKeyEntry{entry})))
 	})
 
 	t.Run("When AESCBC status is provided it should match spec fingerprint", func(t *testing.T) {
@@ -148,7 +163,7 @@ func TestFingerprintFromKeyStatus(t *testing.T) {
 				DataHash: "abc123",
 			},
 		}
-		g.Expect(FingerprintFromKeyStatus(status)).To(Equal(FingerprintAESCBCKey("my-secret", "abc123")))
+		g.Expect(FingerprintFromKeyStatus(status, "")).To(Equal(FingerprintAESCBCKey("my-secret", "abc123")))
 	})
 
 	t.Run("When Azure status has empty fields it should return empty string", func(t *testing.T) {
@@ -156,7 +171,7 @@ func TestFingerprintFromKeyStatus(t *testing.T) {
 		status := &hyperv1.SecretEncryptionKeyStatus{
 			Provider: hyperv1.SecretEncryptionProviderAzure,
 		}
-		g.Expect(FingerprintFromKeyStatus(status)).To(BeEmpty())
+		g.Expect(FingerprintFromKeyStatus(status, "")).To(BeEmpty())
 	})
 
 	t.Run("When AWS status has empty ARN it should return empty string", func(t *testing.T) {
@@ -164,7 +179,7 @@ func TestFingerprintFromKeyStatus(t *testing.T) {
 		status := &hyperv1.SecretEncryptionKeyStatus{
 			Provider: hyperv1.SecretEncryptionProviderAWS,
 		}
-		g.Expect(FingerprintFromKeyStatus(status)).To(BeEmpty())
+		g.Expect(FingerprintFromKeyStatus(status, "")).To(BeEmpty())
 	})
 
 	t.Run("When IBMCloud status has empty CRKID it should return empty string", func(t *testing.T) {
@@ -172,7 +187,7 @@ func TestFingerprintFromKeyStatus(t *testing.T) {
 		status := &hyperv1.SecretEncryptionKeyStatus{
 			Provider: hyperv1.SecretEncryptionProviderIBMCloud,
 		}
-		g.Expect(FingerprintFromKeyStatus(status)).To(BeEmpty())
+		g.Expect(FingerprintFromKeyStatus(status, "")).To(BeEmpty())
 	})
 
 	t.Run("When AESCBC status has empty data hash it should return empty string", func(t *testing.T) {
@@ -180,6 +195,6 @@ func TestFingerprintFromKeyStatus(t *testing.T) {
 		status := &hyperv1.SecretEncryptionKeyStatus{
 			Provider: hyperv1.SecretEncryptionProviderAESCBC,
 		}
-		g.Expect(FingerprintFromKeyStatus(status)).To(BeEmpty())
+		g.Expect(FingerprintFromKeyStatus(status, "")).To(BeEmpty())
 	})
 }

--- a/support/secretencryption/fingerprint_test.go
+++ b/support/secretencryption/fingerprint_test.go
@@ -25,6 +25,25 @@ func TestFingerprintAzureKMSKey(t *testing.T) {
 		key2 := hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v2"}
 		g.Expect(FingerprintAzureKMSKey(key1)).ToNot(Equal(FingerprintAzureKMSKey(key2)))
 	})
+
+	t.Run("When KeyVault type is explicit it should preserve the legacy fingerprint", func(t *testing.T) {
+		const legacyFingerprint = "d5962eb588f841eaa664c407524cfeff2eb31432751370611c35737a8b81da35"
+
+		g := NewWithT(t)
+		legacyKey := hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"}
+		explicitKeyVault := legacyKey
+		explicitKeyVault.KeyVaultType = hyperv1.AzureKMSKeyVaultTypeKeyVault
+		g.Expect(FingerprintAzureKMSKey(legacyKey)).To(Equal(legacyFingerprint))
+		g.Expect(FingerprintAzureKMSKey(explicitKeyVault)).To(Equal(legacyFingerprint))
+	})
+
+	t.Run("When vault type changes to ManagedHSM it should produce a different fingerprint", func(t *testing.T) {
+		g := NewWithT(t)
+		keyVaultKey := hyperv1.AzureKMSKey{KeyVaultName: "vault", KeyName: "key", KeyVersion: "v1"}
+		managedHSMKey := keyVaultKey
+		managedHSMKey.KeyVaultType = hyperv1.AzureKMSKeyVaultTypeManagedHSM
+		g.Expect(FingerprintAzureKMSKey(managedHSMKey)).ToNot(Equal(FingerprintAzureKMSKey(keyVaultKey)))
+	})
 }
 
 func TestFingerprintAWSKMSKey(t *testing.T) {

--- a/support/secretencryption/keystatus.go
+++ b/support/secretencryption/keystatus.go
@@ -81,11 +81,12 @@ func KeyStatusFromSpec(spec *hyperv1.SecretEncryptionSpec, aescbcDataHash string
 }
 
 // KeyReferenceFromStatus extracts an EncryptionKeyReference from a SecretEncryptionKeyStatus.
-func KeyReferenceFromStatus(status *hyperv1.SecretEncryptionKeyStatus) hyperv1.EncryptionKeyReference {
+// keyVaultType is only used for Azure KMS keys and is ignored for other providers.
+func KeyReferenceFromStatus(status *hyperv1.SecretEncryptionKeyStatus, keyVaultType hyperv1.AzureKMSKeyVaultType) hyperv1.EncryptionKeyReference {
 	if status == nil {
 		return hyperv1.EncryptionKeyReference{}
 	}
-	fp := FingerprintFromKeyStatus(status)
+	fp := FingerprintFromKeyStatus(status, keyVaultType)
 	return hyperv1.EncryptionKeyReference{
 		Provider:    status.Provider,
 		Fingerprint: fp,

--- a/support/secretencryption/keystatus_test.go
+++ b/support/secretencryption/keystatus_test.go
@@ -119,7 +119,7 @@ func TestKeyReferenceFromStatus(t *testing.T) {
 	t.Parallel()
 	t.Run("When status is nil it should return empty reference", func(t *testing.T) {
 		g := NewWithT(t)
-		ref := KeyReferenceFromStatus(nil)
+		ref := KeyReferenceFromStatus(nil, "")
 		g.Expect(ref.Provider).To(BeEmpty())
 		g.Expect(ref.Fingerprint).To(BeEmpty())
 	})
@@ -130,7 +130,7 @@ func TestKeyReferenceFromStatus(t *testing.T) {
 			Provider: hyperv1.SecretEncryptionProviderAzure,
 			Azure:    hyperv1.AzureKMSKey{KeyVaultName: "v", KeyName: "k", KeyVersion: "1"},
 		}
-		ref := KeyReferenceFromStatus(status)
+		ref := KeyReferenceFromStatus(status, "")
 		g.Expect(ref.Provider).To(Equal(hyperv1.SecretEncryptionProviderAzure))
 		g.Expect(ref.Fingerprint).ToNot(BeEmpty())
 	})

--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -322,12 +322,17 @@ func (a *AzurePlatformConfig) postCreateExternalOIDC(ctx context.Context, cl crc
 }
 
 func (a *AzurePlatformConfig) TestMatrix(releaseImage string) TestMatrix {
+	publicLabelFilter := "self-managed-azure-public || nodepool-lifecycle || secret-encryption || control-plane-workloads || hosted-cluster-security"
+	if strings.Contains(strings.ToLower(a.encryptionKeyID), ".managedhsm.") {
+		publicLabelFilter += " || azure-managed-hsm"
+	}
+
 	return TestMatrix{
 		Parallel: []TestGroup{
 			{
 				Name:        "public",
 				Variant:     "public",
-				LabelFilter: "self-managed-azure-public || nodepool-lifecycle || secret-encryption || control-plane-workloads || hosted-cluster-security",
+				LabelFilter: publicLabelFilter,
 				Skip:        "KAS allowed CIDRs",
 				JUnitFile:   "junit_self_managed_azure_public.xml",
 			},

--- a/test/e2e/v2/lifecycle/azure_test.go
+++ b/test/e2e/v2/lifecycle/azure_test.go
@@ -1,0 +1,43 @@
+//go:build e2ev2
+
+package lifecycle
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAzurePlatformConfigTestMatrix(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		encryptionKeyID          string
+		expectManagedHSMCoverage bool
+	}{
+		{
+			name:                     "When the encryption key is in Managed HSM, it should select Managed HSM coverage",
+			encryptionKeyID:          "https://test-hsm.managedhsm.azure.net/keys/test-key/version",
+			expectManagedHSMCoverage: true,
+		},
+		{
+			name:                     "When the encryption key is in Key Vault, it should not select Managed HSM coverage",
+			encryptionKeyID:          "https://test-vault.vault.azure.net/keys/test-key/version",
+			expectManagedHSMCoverage: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &AzurePlatformConfig{encryptionKeyID: tc.encryptionKeyID}
+			matrix := cfg.TestMatrix("")
+
+			if len(matrix.Parallel) == 0 {
+				t.Fatal("expected Azure test matrix to contain a public test group")
+			}
+			hasManagedHSMCoverage := strings.Contains(matrix.Parallel[0].LabelFilter, "azure-managed-hsm")
+			if hasManagedHSMCoverage != tc.expectManagedHSMCoverage {
+				t.Fatalf("expected Managed HSM coverage selection to be %t, got %t in label filter %q",
+					tc.expectManagedHSMCoverage, hasManagedHSMCoverage, matrix.Parallel[0].LabelFilter)
+			}
+		})
+	}
+}

--- a/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
@@ -61,6 +61,20 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 					"ActiveKey.KeyVersion must be set")
 			})
 
+			It("should have a valid KeyVaultType when set", func() {
+				testCtx := getTestCtx()
+				hc := testCtx.GetHostedCluster()
+				azureKMS := hc.Spec.SecretEncryption.KMS.Azure
+
+				if azureKMS.ActiveKey.KeyVaultType == "" {
+					Skip("KeyVaultType is not set on this hosted cluster")
+				}
+
+				Expect(azureKMS.ActiveKey.KeyVaultType).To(
+					BeElementOf(hyperv1.AzureKMSKeyVaultTypeKeyVault, hyperv1.AzureKMSKeyVaultTypeManagedHSM),
+					"ActiveKey.KeyVaultType must be KeyVault or ManagedHSM")
+			})
+
 			It("should have KMS authentication configured", func() {
 				testCtx := getTestCtx()
 				hc := testCtx.GetHostedCluster()

--- a/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
@@ -25,12 +25,15 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/podspec"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // KMSSpecValidationTest validates that the HostedCluster's SecretEncryption KMS spec
@@ -100,61 +103,186 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 	})
 }
 
-// KMSFunctionalValidationTest validates that secrets stored in etcd are encrypted
-// using KMSv2. Creates a test secret in the hosted cluster, reads it from etcd
-// via etcdctl, and asserts the k8s:enc:kms:v2 prefix. Cleans up via DeferCleanup.
+// KMSFunctionalValidationTest validates KMS encryption, API read-back, and
+// persistence across a control-plane-operator restart. It cleans up created
+// secrets with DeferCleanup.
 func KMSFunctionalValidationTest(getTestCtx internal.TestContextGetter) {
 	Context("KMS Functional Validation", func() {
-		It("should encrypt secrets in etcd using KMSv2", func() {
+		It("When a secret is created, it should be encrypted in etcd and readable through the hosted cluster API", Label("kms-read-back"), func() {
 			e2eutil.GinkgoAtLeast(e2eutil.Version417)
 			testCtx := getTestCtx()
-			ctx := testCtx.Context
 
-			hostedClusterClient := testCtx.GetHostedClusterClient()
-			Expect(hostedClusterClient).NotTo(BeNil(),
-				"hosted cluster client is required; KubeConfig may not be set")
-
-			testSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "e2e-kms-test-secret",
-					Namespace: "default",
-				},
-				Type: corev1.SecretTypeOpaque,
-				Data: map[string][]byte{
-					"testKey": []byte("testData"),
-				},
-			}
-			Expect(hostedClusterClient.Create(ctx, testSecret)).To(Succeed(),
-				"failed to create test secret in hosted cluster")
-
-			DeferCleanup(func() {
-				if err := hostedClusterClient.Delete(context.Background(), testSecret); err != nil && !apierrors.IsNotFound(err) {
-					GinkgoWriter.Printf("WARNING: failed to cleanup test secret: %v\n", err)
-				}
+			testSecret := createKMSTestSecret(testCtx, "e2e-kms-read-back-", map[string][]byte{
+				"testKey": []byte("testData"),
 			})
+			expectSecretReadable(testCtx, testSecret)
+			expectSecretEncryptedInEtcd(testCtx, testSecret)
+		})
 
-			secretEtcdKey := fmt.Sprintf("/kubernetes.io/secrets/%s/%s",
-				testSecret.Namespace, testSecret.Name)
-			command := []string{
-				"/usr/bin/etcdctl",
-				"--endpoints=localhost:2379",
-				"--cacert=/etc/etcd/tls/etcd-ca/ca.crt",
-				"--cert=/etc/etcd/tls/client/etcd-client.crt",
-				"--key=/etc/etcd/tls/client/etcd-client.key",
-				"get",
-				secretEtcdKey,
-			}
+		It("When the control-plane-operator restarts, it should preserve KMS secret encryption", Label("cpo-restart-persistence"), func() {
+			e2eutil.GinkgoAtLeast(e2eutil.Version417)
+			testCtx := getTestCtx()
 
-			output, err := e2eutil.RunCommandInPod(ctx, testCtx.MgmtClient, "etcd",
-				testCtx.ControlPlaneNamespace, command, "etcd", 5*time.Minute)
-			Expect(err).NotTo(HaveOccurred(), "failed to execute etcdctl command")
-			Expect(output).NotTo(BeEmpty(), "etcdctl returned empty output for key %s", secretEtcdKey)
-			Expect(output).To(ContainSubstring("k8s:enc:kms:v2"),
-				"secret should be encrypted using KMSv2")
-			Expect(output).NotTo(ContainSubstring("testData"),
-				"secret data should not be readable in plaintext from etcd")
+			existingSecret := createKMSTestSecret(testCtx, "e2e-kms-before-cpo-restart-", map[string][]byte{
+				"beforeRestart": []byte("encryptedBeforeRestart"),
+			})
+			expectSecretReadable(testCtx, existingSecret)
+			expectSecretEncryptedInEtcd(testCtx, existingSecret)
+
+			restartControlPlaneOperator(testCtx)
+			Expect(internal.WaitForControlPlaneDeploymentsReadiness(testCtx, 10*time.Minute, nil)).To(Succeed(),
+				"control plane deployments did not settle after the control-plane-operator restart")
+
+			expectSecretReadable(testCtx, existingSecret)
+
+			newSecret := createKMSTestSecret(testCtx, "e2e-kms-after-cpo-restart-", map[string][]byte{
+				"afterRestart": []byte("encryptedAfterRestart"),
+			})
+			expectSecretReadable(testCtx, newSecret)
+			expectSecretEncryptedInEtcd(testCtx, newSecret)
 		})
 	})
+}
+
+// ManagedHSMConfigurationTest verifies that Managed HSM-specific CI exercises the intended Azure KMS path.
+func ManagedHSMConfigurationTest(getTestCtx internal.TestContextGetter) {
+	It("When Managed HSM coverage is selected, it should configure ActiveKey.KeyVaultType as ManagedHSM", func() {
+		hc := getTestCtx().GetHostedCluster()
+		Expect(hc).NotTo(BeNil(), "HostedCluster is required for Managed HSM validation")
+		Expect(hc.Spec.Platform.Type).To(Equal(hyperv1.AzurePlatform),
+			"Managed HSM coverage requires an Azure HostedCluster")
+		Expect(hc.Spec.SecretEncryption).NotTo(BeNil(),
+			"Managed HSM coverage requires secret encryption")
+		Expect(hc.Spec.SecretEncryption.KMS).NotTo(BeNil(),
+			"Managed HSM coverage requires KMS secret encryption")
+		Expect(hc.Spec.SecretEncryption.KMS.Azure).NotTo(BeNil(),
+			"Managed HSM coverage requires Azure KMS")
+		Expect(hc.Spec.SecretEncryption.KMS.Azure.ActiveKey.KeyVaultType).To(Equal(hyperv1.AzureKMSKeyVaultTypeManagedHSM),
+			"Managed HSM coverage must not run with an ordinary Key Vault")
+	})
+}
+
+func createKMSTestSecret(testCtx *internal.TestContext, namePrefix string, data map[string][]byte) *corev1.Secret {
+	GinkgoHelper()
+
+	hostedClusterClient := testCtx.GetHostedClusterClient()
+	Expect(hostedClusterClient).NotTo(BeNil(),
+		"hosted cluster client is required; KubeConfig may not be set")
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: namePrefix,
+			Namespace:    "default",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+	Expect(hostedClusterClient.Create(testCtx.Context, secret)).To(Succeed(),
+		"failed to create test secret in hosted cluster")
+	DeferCleanup(func() {
+		err := hostedClusterClient.Delete(testCtx.Context, secret)
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete test secret %s/%s", secret.Namespace, secret.Name)
+	})
+	return secret
+}
+
+func expectSecretReadable(testCtx *internal.TestContext, expected *corev1.Secret) {
+	GinkgoHelper()
+
+	actual := &corev1.Secret{}
+	Expect(testCtx.GetHostedClusterClient().Get(testCtx.Context, crclient.ObjectKeyFromObject(expected), actual)).To(Succeed(),
+		"failed to read test secret %s/%s through the hosted cluster API", expected.Namespace, expected.Name)
+	Expect(actual.Data).To(Equal(expected.Data),
+		"test secret %s/%s data changed after KMS decryption", expected.Namespace, expected.Name)
+}
+
+func expectSecretEncryptedInEtcd(testCtx *internal.TestContext, secret *corev1.Secret) {
+	GinkgoHelper()
+
+	secretEtcdKey := fmt.Sprintf("/kubernetes.io/secrets/%s/%s", secret.Namespace, secret.Name)
+	command := []string{
+		"/usr/bin/etcdctl",
+		"--endpoints=localhost:2379",
+		"--cacert=/etc/etcd/tls/etcd-ca/ca.crt",
+		"--cert=/etc/etcd/tls/client/etcd-client.crt",
+		"--key=/etc/etcd/tls/client/etcd-client.key",
+		"get",
+		secretEtcdKey,
+	}
+
+	output, err := e2eutil.RunCommandInPod(testCtx.Context, testCtx.MgmtClient, "etcd",
+		testCtx.ControlPlaneNamespace, command, "etcd", 5*time.Minute)
+	Expect(err).NotTo(HaveOccurred(), "failed to execute etcdctl command")
+	Expect(output).NotTo(BeEmpty(), "etcdctl returned empty output for key %s", secretEtcdKey)
+	Expect(output).To(ContainSubstring("k8s:enc:kms:v2"),
+		"secret should be encrypted using KMSv2")
+	for key, value := range secret.Data {
+		Expect(output).NotTo(ContainSubstring(string(value)),
+			"secret data key %q should not be readable in plaintext from etcd", key)
+	}
+}
+
+func restartControlPlaneOperator(testCtx *internal.TestContext) {
+	GinkgoHelper()
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "control-plane-operator",
+			Namespace: testCtx.ControlPlaneNamespace,
+		},
+	}
+	Expect(testCtx.MgmtClient.Get(testCtx.Context, crclient.ObjectKeyFromObject(deployment), deployment)).To(Succeed(),
+		"failed to get the control-plane-operator Deployment")
+	workload := internal.WorkloadInfo{
+		Kind:      "Deployment",
+		Name:      deployment.Name,
+		Namespace: deployment.Namespace,
+		UID:       deployment.UID,
+	}
+	pods, err := internal.GetWorkloadPods(testCtx.Context, testCtx.MgmtClient, workload)
+	Expect(err).NotTo(HaveOccurred(), "failed to get control-plane-operator pods")
+	Expect(pods).NotTo(BeEmpty(), "expected at least one control-plane-operator pod")
+
+	var originalPod *corev1.Pod
+	for i := range pods {
+		if podspec.IsPodReady(&pods[i]) {
+			originalPod = &pods[i]
+			break
+		}
+	}
+	Expect(originalPod).NotTo(BeNil(), "expected a ready control-plane-operator pod")
+	originalUID := originalPod.UID
+	Expect(testCtx.MgmtClient.Delete(testCtx.Context, originalPod)).To(Succeed(),
+		"failed to delete control-plane-operator pod %s", originalPod.Name)
+
+	e2eutil.EventuallyObjects(GinkgoTB(), testCtx.Context, "control-plane-operator pod to be replaced and ready",
+		func(ctx context.Context) ([]*corev1.Pod, error) {
+			currentPods, err := internal.GetWorkloadPods(ctx, testCtx.MgmtClient, workload)
+			podPointers := make([]*corev1.Pod, len(currentPods))
+			for i := range currentPods {
+				podPointers[i] = &currentPods[i]
+			}
+			return podPointers, err
+		},
+		[]e2eutil.Predicate[[]*corev1.Pod]{
+			func(pods []*corev1.Pod) (bool, string, error) {
+				return len(pods) > 0, "expected at least one control-plane-operator pod", nil
+			},
+		},
+		[]e2eutil.Predicate[*corev1.Pod]{
+			func(pod *corev1.Pod) (bool, string, error) {
+				return pod.UID != originalUID, fmt.Sprintf("pod %s still has original UID %s", pod.Name, originalUID), nil
+			},
+			func(pod *corev1.Pod) (bool, string, error) {
+				return podspec.IsPodReady(pod), fmt.Sprintf("pod %s is not ready", pod.Name), nil
+			},
+		},
+		e2eutil.WithInterval(5*time.Second),
+		e2eutil.WithTimeout(10*time.Minute),
+	)
 }
 
 // RegisterHostedClusterSecretEncryptionTests registers all secret encryption tests.
@@ -177,4 +305,15 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:SecretEncryption] Ho
 	})
 
 	RegisterHostedClusterSecretEncryptionTests(func() *internal.TestContext { return testCtx })
+})
+
+var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:AzureManagedHSM] Azure Managed HSM Secret Encryption", Label("azure-managed-hsm"), func() {
+	var testCtx *internal.TestContext
+
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+	})
+
+	ManagedHSMConfigurationTest(func() *internal.TestContext { return testCtx })
 })

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
@@ -365,9 +365,9 @@ type AzureNodePoolOSDisk struct {
 // +kubebuilder:validation:XValidation:rule="has(self.topology) && (self.topology == 'Private' || self.topology == 'PublicAndPrivate') ? has(self.private) : !has(self.private)",message="private is required when topology is Private or PublicAndPrivate, and forbidden otherwise"
 // +kubebuilder:validation:XValidation:rule="!has(self.private) || self.private.type != 'PrivateLink' || self.azureAuthenticationConfig.azureAuthenticationConfigType != 'WorkloadIdentities' || has(self.azureAuthenticationConfig.workloadIdentities.controlPlaneOperator)",message="workloadIdentities.controlPlaneOperator is required when Private Link is configured with WorkloadIdentities authentication"
 type AzurePlatformSpec struct {
-	// cloud is the cloud environment identifier, valid values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33
+	// cloud is the Azure cloud environment identifier.
 	//
-	// +kubebuilder:validation:Enum=AzurePublicCloud;AzureUSGovernmentCloud;AzureChinaCloud;AzureGermanCloud;AzureStackCloud
+	// +kubebuilder:validation:Enum=AzurePublicCloud;AzureUSGovernmentCloud;AzureChinaCloud;AzureGermanCloud;AzureBleuCloud;AzureStackCloud
 	// +kubebuilder:default="AzurePublicCloud"
 	// +optional
 	Cloud string `json:"cloud,omitempty"`
@@ -914,9 +914,10 @@ const (
 	AzureKeyVaultPrivate AzureKeyVaultAccessType = "Private"
 )
 
-// AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure key vault
+// AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure Key Vault or Managed HSM.
 //
 // +kubebuilder:validation:XValidation:rule="!has(self.backupKey) || self.backupKey.keyVaultName == self.activeKey.keyVaultName",message="backupKey.keyVaultName must match activeKey.keyVaultName; both keys must reside in the same Key Vault"
+// +kubebuilder:validation:XValidation:rule="(has(self.keyVaultType) ? self.keyVaultType : 'KeyVault') == (has(oldSelf.keyVaultType) ? oldSelf.keyVaultType : 'KeyVault')",message="keyVaultType is immutable"
 // +kubebuilder:validation:XValidation:rule="!(has(self.kms) && has(self.workloadIdentity))",message="kms and workloadIdentity are mutually exclusive"
 // +kubebuilder:validation:XValidation:rule="has(self.kms) || has(self.workloadIdentity)",message="one of kms or workloadIdentity must be set"
 // +kubebuilder:validation:XValidation:rule="has(self.kms) == has(oldSelf.kms)",message="the KMS authentication mode is immutable once set"
@@ -948,6 +949,15 @@ type AzureKMSSpec struct {
 	// +optional
 	WorkloadIdentity WorkloadIdentity `json:"workloadIdentity,omitzero"`
 
+	// keyVaultType specifies whether activeKey and backupKey are hosted by Azure Key Vault or Azure Managed HSM.
+	// Valid values are "KeyVault" and "ManagedHSM".
+	// When set to "KeyVault", both keys are hosted by Azure Key Vault.
+	// When set to "ManagedHSM", both keys are hosted by Azure Managed HSM.
+	// The type is immutable; key rotation must remain within the same service.
+	// When omitted, the keys are treated as Key Vault keys.
+	// +optional
+	KeyVaultType AzureKMSKeyVaultType `json:"keyVaultType,omitempty"`
+
 	// keyVaultAccess specifies how the Key Vault should be accessed.
 	// When set to "Private", the control plane routes Key Vault traffic through
 	// the private router to reach the Key Vault's private endpoint in the customer VNet.
@@ -957,16 +967,28 @@ type AzureKMSSpec struct {
 	KeyVaultAccess AzureKeyVaultAccessType `json:"keyVaultAccess,omitempty"`
 }
 
+// AzureKMSKeyVaultType specifies the Azure service that hosts a KMS key.
+// +kubebuilder:validation:Enum=KeyVault;ManagedHSM
+type AzureKMSKeyVaultType string
+
+const (
+	// AzureKMSKeyVaultTypeKeyVault indicates that the key is hosted by Azure Key Vault.
+	AzureKMSKeyVaultTypeKeyVault AzureKMSKeyVaultType = "KeyVault"
+	// AzureKMSKeyVaultTypeManagedHSM indicates that the key is hosted by Azure Managed HSM.
+	AzureKMSKeyVaultTypeManagedHSM AzureKMSKeyVaultType = "ManagedHSM"
+)
+
+// AzureKMSKey defines an Azure Key Vault or Managed HSM key used for KMS encryption.
 type AzureKMSKey struct {
-	// keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-	// Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+	// keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+	// Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
 	// `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=255
 	// +required
 	KeyVaultName string `json:"keyVaultName,omitempty"`
 
-	// keyName is the name of the keyvault key used for encrypt/decrypt
+	// keyName is the name of the key used for encrypt/decrypt.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=255
 	// +required

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
@@ -914,9 +914,11 @@ const (
 	AzureKeyVaultPrivate AzureKeyVaultAccessType = "Private"
 )
 
-// AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure key vault
+// AzureKMSSpec defines metadata about the configuration of the Azure KMS Secret Encryption provider using Azure Key Vault or Managed HSM.
 //
 // +kubebuilder:validation:XValidation:rule="!has(self.backupKey) || self.backupKey.keyVaultName == self.activeKey.keyVaultName",message="backupKey.keyVaultName must match activeKey.keyVaultName; both keys must reside in the same Key Vault"
+// +kubebuilder:validation:XValidation:rule="!has(self.backupKey) || (has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType : 'KeyVault') == (has(self.backupKey.keyVaultType) ? self.backupKey.keyVaultType : 'KeyVault')",message="backupKey.keyVaultType must match activeKey.keyVaultType"
+// +kubebuilder:validation:XValidation:rule="(has(self.activeKey.keyVaultType) ? self.activeKey.keyVaultType : 'KeyVault') == (has(oldSelf.activeKey.keyVaultType) ? oldSelf.activeKey.keyVaultType : 'KeyVault')",message="activeKey.keyVaultType is immutable"
 // +kubebuilder:validation:XValidation:rule="!(has(self.kms) && has(self.workloadIdentity))",message="kms and workloadIdentity are mutually exclusive"
 // +kubebuilder:validation:XValidation:rule="has(self.kms) || has(self.workloadIdentity)",message="one of kms or workloadIdentity must be set"
 // +kubebuilder:validation:XValidation:rule="has(self.kms) == has(oldSelf.kms)",message="the KMS authentication mode is immutable once set"
@@ -957,16 +959,28 @@ type AzureKMSSpec struct {
 	KeyVaultAccess AzureKeyVaultAccessType `json:"keyVaultAccess,omitempty"`
 }
 
+// AzureKMSKeyVaultType specifies the Azure service that hosts a KMS key.
+// +kubebuilder:validation:Enum=KeyVault;ManagedHSM
+type AzureKMSKeyVaultType string
+
+const (
+	// AzureKMSKeyVaultTypeKeyVault indicates that the key is hosted by Azure Key Vault.
+	AzureKMSKeyVaultTypeKeyVault AzureKMSKeyVaultType = "KeyVault"
+	// AzureKMSKeyVaultTypeManagedHSM indicates that the key is hosted by Azure Managed HSM.
+	AzureKMSKeyVaultTypeManagedHSM AzureKMSKeyVaultType = "ManagedHSM"
+)
+
+// AzureKMSKey defines an Azure Key Vault or Managed HSM key used for KMS encryption.
 type AzureKMSKey struct {
-	// keyVaultName is the name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
-	// Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI:
+	// keyVaultName is the name of the Key Vault or Managed HSM. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+	// Your Microsoft Entra application used to create the cluster must be authorized to access this resource, e.g using the AzureCLI:
 	// `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn <YOUR APPLICATION CLIENT ID>`
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=255
 	// +required
 	KeyVaultName string `json:"keyVaultName,omitempty"`
 
-	// keyName is the name of the keyvault key used for encrypt/decrypt
+	// keyName is the name of the key used for encrypt/decrypt.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=255
 	// +required
@@ -977,6 +991,13 @@ type AzureKMSKey struct {
 	// +kubebuilder:validation:MaxLength=255
 	// +required
 	KeyVersion string `json:"keyVersion,omitempty"`
+
+	// keyVaultType specifies whether the key is hosted by Azure Key Vault or Azure Managed HSM.
+	// The type is immutable; key rotation must remain within the same service.
+	// When omitted, the type defaults to KeyVault.
+	// +optional
+	// +default="KeyVault"
+	KeyVaultType AzureKMSKeyVaultType `json:"keyVaultType,omitempty"`
 }
 
 // AzureAuthenticationType is a discriminated union type that contains the Azure authentication configuration for an

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/etcdbackup_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/etcdbackup_types.go
@@ -178,14 +178,15 @@ type HCPEtcdBackupAzureBlob struct {
 	// +required
 	Credentials SecretReference `json:"credentials,omitzero"`
 
-	// encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-	// Must be a valid Azure Key Vault key URL in the format
-	// "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+	// encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+	// Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+	// Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+	// Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 	// This field is immutable once set and cannot be removed.
 	// +optional
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=210
-	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.vault\\\\.azure\\\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.(vault\\\\.(azure\\\\.net|usgovcloudapi\\\\.net|azure\\\\.cn|microsoftazure\\\\.de|sovcloud-api\\\\.fr)|managedhsm\\\\.(azure\\\\.net|usgovcloudapi\\\\.net|azure\\\\.cn|microsoftazure\\\\.de|sovcloud-api\\\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="encryptionKeyURL is immutable"
 	EncryptionKeyURL string `json:"encryptionKeyURL,omitempty"`
 }
@@ -249,13 +250,14 @@ type HCPEtcdBackupEncryptionMetadataAWS struct {
 // HCPEtcdBackupEncryptionMetadataAzure contains Azure-specific encryption metadata.
 // The values here reflect the encryption settings from the HCPEtcdBackupConfig input.
 type HCPEtcdBackupEncryptionMetadataAzure struct {
-	// encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-	// Must be a valid Azure Key Vault key URL in the format
-	// "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+	// encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+	// Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+	// Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+	// Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=210
-	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.vault\\\\.azure\\\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.(vault\\\\.(azure\\\\.net|usgovcloudapi\\\\.net|azure\\\\.cn|microsoftazure\\\\.de|sovcloud-api\\\\.fr)|managedhsm\\\\.(azure\\\\.net|usgovcloudapi\\\\.net|azure\\\\.cn|microsoftazure\\\\.de|sovcloud-api\\\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 	EncryptionKeyURL string `json:"encryptionKeyURL,omitempty"`
 }
 
@@ -349,12 +351,13 @@ type HCPEtcdBackupConfigAWS struct {
 
 // HCPEtcdBackupConfigAzure defines Azure-specific encryption settings for etcd backups.
 type HCPEtcdBackupConfigAzure struct {
-	// encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-	// Must be a valid Azure Key Vault key URL in the format
-	// "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+	// encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+	// Key Vault URLs are supported in Azure Public Cloud (vault.azure.net), Azure US Government Cloud (vault.usgovcloudapi.net), Azure China Cloud (vault.azure.cn), Azure German Cloud (vault.microsoftazure.de), and Azure Bleu Cloud (vault.sovcloud-api.fr).
+	// Managed HSM URLs are supported in Azure Public Cloud (managedhsm.azure.net), Azure US Government Cloud (managedhsm.usgovcloudapi.net), Azure China Cloud (managedhsm.azure.cn), Azure German Cloud (managedhsm.microsoftazure.de), and Azure Bleu Cloud (managedhsm.sovcloud-api.fr).
+	// Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=210
-	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.vault\\\\.azure\\\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.(vault\\\\.(azure\\\\.net|usgovcloudapi\\\\.net|azure\\\\.cn|microsoftazure\\\\.de|sovcloud-api\\\\.fr)|managedhsm\\\\.(azure\\\\.net|usgovcloudapi\\\\.net|azure\\\\.cn|microsoftazure\\\\.de|sovcloud-api\\\\.fr))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 	EncryptionKeyURL string `json:"encryptionKeyURL,omitempty"`
 }

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/etcdbackup_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/etcdbackup_types.go
@@ -178,14 +178,14 @@ type HCPEtcdBackupAzureBlob struct {
 	// +required
 	Credentials SecretReference `json:"credentials,omitzero"`
 
-	// encryptionKeyURL is the URL of the Azure Key Vault key used for encryption.
-	// Must be a valid Azure Key Vault key URL in the format
-	// "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+	// encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption.
+	// Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+	// Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 	// This field is immutable once set and cannot be removed.
 	// +optional
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=210
-	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.vault\\\\.azure\\\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.(vault\\\\.azure\\\\.net|managedhsm\\\\.(azure\\\\.net|usgovcloudapi\\\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="encryptionKeyURL is immutable"
 	EncryptionKeyURL string `json:"encryptionKeyURL,omitempty"`
 }
@@ -249,13 +249,13 @@ type HCPEtcdBackupEncryptionMetadataAWS struct {
 // HCPEtcdBackupEncryptionMetadataAzure contains Azure-specific encryption metadata.
 // The values here reflect the encryption settings from the HCPEtcdBackupConfig input.
 type HCPEtcdBackupEncryptionMetadataAzure struct {
-	// encryptionKeyURL is the URL of the Azure Key Vault key used for encryption of the backup.
-	// Must be a valid Azure Key Vault key URL in the format
-	// "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+	// encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key used for encryption of the backup.
+	// Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+	// Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=210
-	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.vault\\\\.azure\\\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.(vault\\\\.azure\\\\.net|managedhsm\\\\.(azure\\\\.net|usgovcloudapi\\\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 	EncryptionKeyURL string `json:"encryptionKeyURL,omitempty"`
 }
 
@@ -349,12 +349,12 @@ type HCPEtcdBackupConfigAWS struct {
 
 // HCPEtcdBackupConfigAzure defines Azure-specific encryption settings for etcd backups.
 type HCPEtcdBackupConfigAzure struct {
-	// encryptionKeyURL is the URL of the Azure Key Vault key to use for encrypting etcd backup artifacts.
-	// Must be a valid Azure Key Vault key URL in the format
-	// "https://<vault-name>.vault.azure.net/keys/<key-name>[/<key-version>]".
+	// encryptionKeyURL is the URL of the Azure Key Vault or Managed HSM key to use for encrypting etcd backup artifacts.
+	// Managed HSM URLs support Azure Public Cloud and Azure US Government Cloud.
+	// Supporting another cloud requires adding its DNS suffix to this validation and the Azure endpoint resolver.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=210
-	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.vault\\\\.azure\\\\.net/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault HTTPS URL (https://<vault>.vault.azure.net/keys/<key-name>[/<key-version>])"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^https://[a-zA-Z0-9-]+\\\\.(vault\\\\.azure\\\\.net|managedhsm\\\\.(azure\\\\.net|usgovcloudapi\\\\.net))/keys/[a-zA-Z0-9-]+(/[a-zA-Z0-9]+)?$')",message="encryptionKeyURL must be a valid Azure Key Vault or Managed HSM HTTPS URL"
 	EncryptionKeyURL string `json:"encryptionKeyURL,omitempty"`
 }


### PR DESCRIPTION
## What this PR does / why we need it

Adds Azure Managed HSM support for control-plane KMS encryption. The API distinguishes Azure Key Vault from Managed HSM, and the selected type is carried through endpoint resolution, sidecar configuration, validation, status, rotation, and provider identity generation.

Existing Azure Key Vault provider names and fingerprints remain unchanged when `keyVaultType` is omitted or explicitly set to `KeyVault`.

## Compatibility and limitations

- Managed HSM requires an OpenShift 4.22 or later HostedCluster release, including 4.22 prerelease payloads.
- Azure Public, US Government, China, German, and Bleu cloud Key Vault and Managed HSM endpoints are supported.
- Managed HSM is unsupported on earlier releases because their control plane operator does not configure its endpoint or authentication scope.
- `.spec.secretEncryption.kms.azure.keyVaultType` applies to the entire Azure KMS configuration, including active, backup, status-derived, and rotation target keys.
- `keyVaultType` is immutable. Existing HostedClusters cannot migrate between Key Vault and Managed HSM; a new HostedCluster is required.
- Downgrading a HostedCluster after enabling Managed HSM is unsupported.
- Custom Azure Stack Key Vault endpoints are not supported.

## Which issue(s) this PR fixes

Fixes https://redhat.atlassian.net/browse/OCPSTRAT-3549

## Special notes for reviewers

The Azure Managed HSM path was manually verified against a live subscription before review. End-to-end revalidation of the review fixes is in progress.

## Checklist

- [x] Subject and description added to both commit and PR.
- [x] Relevant issue referenced.
- [x] Documentation included.
- [x] Unit and envtest coverage included.