### PR TITLE
NO-JIRA: Add Dan Mace to core-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -18,6 +18,7 @@ aliases:
     - cblecker
     - jparrill
     - devguyio
+    - ironcladlou
   core-reviewers:
     - enxebre
     - csrwng


### PR DESCRIPTION
Add Dan Mace to core-approvers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new core approver to the project’s approval roster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->