### PR TITLE
ROSAENG-63186: fix(hcco): Add VAP to protect kas-bootstrap RBAC bindings from deletion

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies.go
@@ -17,6 +17,7 @@ import (
 
 	k8sadmissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -35,7 +36,14 @@ const (
 	AdmissionPolicyNameICSP               = "icsp"
 	AdmissionPolicyNameInfra              = "infra"
 	AdmissionPolicyNameNTOMirroredConfigs = "ntomirroredconfigmaps"
+	AdmissionPolicyNameRBAC               = "managed-rbac"
 	cnoSAUser                             = "system:serviceaccount:openshift-network-operator:cluster-network-operator"
+
+	// systemAdminUser is the identity behind the localhost kubeconfig, which the KAS bootstrap
+	// container uses to apply the managed ClusterRoleBindings on every kube-apiserver start.
+	// Note that this is also the identity in the admin kubeconfig published on the HostedCluster,
+	// so whoever holds that kubeconfig is deliberately left able to modify those bindings.
+	systemAdminUser = "system:admin"
 
 	BaseCelExpression = "has(object.spec) && has(oldObject.spec) && object.spec == oldObject.spec"
 )
@@ -74,6 +82,10 @@ func ReconcileKASValidatingAdmissionPolicies(ctx context.Context, hcp *hyperv1.H
 
 	if err := reconcileConfigMapsValidatingAdmissionPolicy(ctx, client, createOrUpdate); err != nil {
 		return fmt.Errorf("failed to reconcile Mirrored Configs Validating Admission Policy: %w", err)
+	}
+
+	if err := reconcileRBACValidatingAdmissionPolicy(ctx, client, createOrUpdate); err != nil {
+		return fmt.Errorf("failed to reconcile RBAC Validating Admission Policy: %w", err)
 	}
 
 	return nil
@@ -184,6 +196,29 @@ func reconcileConfigMapsValidatingAdmissionPolicy(ctx context.Context, client cl
 	if err := mirroredConfigsAdmissionPolicy.reconcileAdmissionPolicy(ctx, client, createOrUpdate); err != nil {
 		return fmt.Errorf("error reconciling mirrored ConfigMaps Validating Admission Policy: %w", err)
 	}
+	return nil
+}
+
+func reconcileRBACValidatingAdmissionPolicy(ctx context.Context, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
+	rbacAdmissionPolicy := AdmissionPolicy{Name: AdmissionPolicyNameRBAC}
+	rbacAPIVersion := []string{rbacv1.SchemeGroupVersion.Version}
+	rbacAPIGroup := []string{rbacv1.SchemeGroupVersion.Group}
+	rbacResources := []string{"clusterrolebindings"}
+
+	// Deliberately a local copy rather than the shared HCCOUserValidation: this policy widens the
+	// whitelist and must not leak that into the policies reconciled after it.
+	rbacValidation := HCCOUserValidation
+	rbacValidation.Expression = generateCelExpression(append(userWhiteList, systemAdminUser))
+	rbacAdmissionPolicy.Validations = []k8sadmissionv1.Validation{rbacValidation}
+	rbacAdmissionPolicy.MatchConstraints = constructPolicyMatchConstraints(rbacResources, rbacAPIVersion, rbacAPIGroup, []k8sadmissionv1.OperationType{"UPDATE", "DELETE"})
+	rbacAdmissionPolicy.MatchConstraints.ResourceRules[0].ResourceNames = []string{
+		"hcco-cluster-admin",
+		"kas-bootstrap-container-cluster-admin",
+	}
+	if err := rbacAdmissionPolicy.reconcileAdmissionPolicy(ctx, client, createOrUpdate); err != nil {
+		return fmt.Errorf("error reconciling RBAC Validating Admission Policy: %w", err)
+	}
+
 	return nil
 }
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies.go
@@ -17,6 +17,7 @@ import (
 
 	k8sadmissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -35,6 +36,7 @@ const (
 	AdmissionPolicyNameICSP               = "icsp"
 	AdmissionPolicyNameInfra              = "infra"
 	AdmissionPolicyNameNTOMirroredConfigs = "ntomirroredconfigmaps"
+	AdmissionPolicyNameRBAC               = "managed-rbac"
 	cnoSAUser                             = "system:serviceaccount:openshift-network-operator:cluster-network-operator"
 
 	BaseCelExpression = "has(object.spec) && has(oldObject.spec) && object.spec == oldObject.spec"
@@ -74,6 +76,10 @@ func ReconcileKASValidatingAdmissionPolicies(ctx context.Context, hcp *hyperv1.H
 
 	if err := reconcileConfigMapsValidatingAdmissionPolicy(ctx, client, createOrUpdate); err != nil {
 		return fmt.Errorf("failed to reconcile Mirrored Configs Validating Admission Policy: %w", err)
+	}
+
+	if err := reconcileRBACValidatingAdmissionPolicy(ctx, client, createOrUpdate); err != nil {
+		return fmt.Errorf("failed to reconcile RBAC Validating Admission Policy: %w", err)
 	}
 
 	return nil
@@ -184,6 +190,26 @@ func reconcileConfigMapsValidatingAdmissionPolicy(ctx context.Context, client cl
 	if err := mirroredConfigsAdmissionPolicy.reconcileAdmissionPolicy(ctx, client, createOrUpdate); err != nil {
 		return fmt.Errorf("error reconciling mirrored ConfigMaps Validating Admission Policy: %w", err)
 	}
+	return nil
+}
+
+func reconcileRBACValidatingAdmissionPolicy(ctx context.Context, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
+	rbacAdmissionPolicy := AdmissionPolicy{Name: AdmissionPolicyNameRBAC}
+	rbacAPIVersion := []string{rbacv1.SchemeGroupVersion.Version}
+	rbacAPIGroup := []string{rbacv1.SchemeGroupVersion.Group}
+	rbacResources := []string{"clusterrolebindings"}
+
+	HCCOUserValidation.Expression = generateCelExpression(userWhiteList)
+	rbacAdmissionPolicy.Validations = []k8sadmissionv1.Validation{HCCOUserValidation}
+	rbacAdmissionPolicy.MatchConstraints = constructPolicyMatchConstraints(rbacResources, rbacAPIVersion, rbacAPIGroup, []k8sadmissionv1.OperationType{"UPDATE", "DELETE"})
+	rbacAdmissionPolicy.MatchConstraints.ResourceRules[0].ResourceNames = []string{
+		"hcco-cluster-admin",
+		"kas-bootstrap-container-cluster-admin",
+	}
+	if err := rbacAdmissionPolicy.reconcileAdmissionPolicy(ctx, client, createOrUpdate); err != nil {
+		return fmt.Errorf("error reconciling RBAC Validating Admission Policy: %w", err)
+	}
+
 	return nil
 }
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies_test.go
@@ -8,9 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/upsert"
 
 	k8sadmissionv1 "k8s.io/api/admissionregistration/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -140,6 +142,42 @@ func TestGenerateCelExpression(t *testing.T) {
 	}
 }
 
+func TestReconcileRBACValidatingAdmissionPolicy(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	c := fake.NewClientBuilder().Build()
+	g.Expect(reconcileRBACValidatingAdmissionPolicy(t.Context(), c, upsert.New(false).CreateOrUpdate)).To(Succeed())
+
+	vap := &k8sadmissionv1.ValidatingAdmissionPolicy{}
+	g.Expect(c.Get(t.Context(), client.ObjectKey{Name: AdmissionPolicyNameRBAC}, vap)).To(Succeed())
+
+	rule := vap.Spec.MatchConstraints.ResourceRules[0]
+	g.Expect(rule.APIGroups).To(ConsistOf(rbacv1.SchemeGroupVersion.Group))
+	g.Expect(rule.APIVersions).To(ConsistOf(rbacv1.SchemeGroupVersion.Version))
+	g.Expect(rule.Resources).To(ConsistOf("clusterrolebindings"))
+	g.Expect(rule.Operations).To(ConsistOf(k8sadmissionv1.OperationType("UPDATE"), k8sadmissionv1.OperationType("DELETE")))
+	g.Expect(rule.ResourceNames).To(ConsistOf("hcco-cluster-admin", "kas-bootstrap-container-cluster-admin"))
+
+	// system:admin has to be whitelisted here and only here: the KAS bootstrap container applies
+	// kas-bootstrap-container-cluster-admin under that identity on every kube-apiserver start, and
+	// a denial crash-loops the container.
+	expression := vap.Spec.Validations[0].Expression
+	g.Expect(expression).To(ContainSubstring("'system:admin'"))
+	g.Expect(expression).To(ContainSubstring(fmt.Sprintf("'system:%s'", config.HCCOUser)))
+	g.Expect(expression).To(ContainSubstring(fmt.Sprintf("'system:%s'", config.KASBootstrapContainerUser)))
+
+	// The shared HCCOUserValidation must not have been widened with system:admin, otherwise every
+	// policy reconciled afterwards would inherit that whitelist entry.
+	g.Expect(HCCOUserValidation.Expression).NotTo(ContainSubstring("'system:admin'"))
+	// ...and the shared userWhiteList must not have been extended in place by the append.
+	g.Expect(userWhiteList).NotTo(ContainElement(systemAdminUser))
+
+	binding := &k8sadmissionv1.ValidatingAdmissionPolicyBinding{}
+	g.Expect(c.Get(t.Context(), client.ObjectKey{Name: AdmissionPolicyNameRBAC + "-binding"}, binding)).To(Succeed())
+	g.Expect(binding.Spec.PolicyName).To(Equal(AdmissionPolicyNameRBAC))
+	g.Expect(binding.Spec.ValidationActions).To(ConsistOf(k8sadmissionv1.Deny))
+}
+
 func failOnNthCreateOrUpdate(n int) upsert.CreateOrUpdateFN {
 	call := 0
 	return func(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
@@ -261,6 +299,12 @@ func TestReconcileKASValidatingAdmissionPolicies(t *testing.T) {
 			createOrUpdate: failOnNthCreateOrUpdate(9),
 			wantErr:        true,
 			errSubstr:      "error reconciling mirrored ConfigMaps Validating Admission Policy",
+		},
+		{
+			name:           "When RBAC VAP reconcile fails, it should return a wrapped RBAC error",
+			createOrUpdate: failOnNthCreateOrUpdate(11),
+			wantErr:        true,
+			errSubstr:      "failed to reconcile RBAC Validating Admission Policy",
 		},
 	}
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies_test.go
@@ -262,6 +262,12 @@ func TestReconcileKASValidatingAdmissionPolicies(t *testing.T) {
 			wantErr:        true,
 			errSubstr:      "error reconciling mirrored ConfigMaps Validating Admission Policy",
 		},
+		{
+			name:           "When RBAC VAP reconcile fails, it should return a wrapped RBAC error",
+			createOrUpdate: failOnNthCreateOrUpdate(11),
+			wantErr:        true,
+			errSubstr:      "failed to reconcile RBAC Validating Admission Policy",
+		},
 	}
 
 	for _, tt := range tests {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -107,6 +107,9 @@ var initialObjects = []client.Object{
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameMirror)),
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameICSP)),
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameInfra)),
+	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameNTOMirroredConfigs)),
+	manifests.ValidatingAdmissionPolicy(kas.AdmissionPolicyNameRBAC),
+	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameRBAC)),
 
 	&operatorsv1alpha1.CatalogSource{ObjectMeta: metav1.ObjectMeta{Name: "redhat-marketplace", Namespace: "openshift-marketplace"}},
 	fakeOperatorHub(),

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -107,6 +107,9 @@ var initialObjects = []client.Object{
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameMirror)),
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameICSP)),
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameInfra)),
+	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameNTOMirroredConfigs)),
+	manifests.ValidatingAdmissionPolicy(kas.AdmissionPolicyNameRBAC),
+	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameRBAC)),
 
 	fakeOperatorHub(),
 	manifests.KASConnectionCheckerDeployment(),

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -57,6 +57,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -399,6 +400,27 @@ func WaitForGuestClient(t testing.TB, ctx context.Context, client crclient.Clien
 		t.Fatalf("could not create client for guest cluster: %v", err)
 	}
 	return guestClient
+}
+
+// guestClientImpersonating returns a guest cluster client that impersonates the given username in
+// the system:masters group. The group keeps the request authorized, so admission is what decides
+// the outcome, while the username is one no admission policy whitelists.
+func guestClientImpersonating(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, username string) crclient.Client {
+	g := NewWithT(t)
+	guestKubeConfigSecretData := WaitForGuestKubeConfig(t, ctx, client, hostedCluster)
+
+	guestConfig, err := clientcmd.RESTConfigFromKubeConfig(guestKubeConfigSecretData)
+	g.Expect(err).NotTo(HaveOccurred(), "couldn't load guest kubeconfig")
+	guestConfig.QPS = -1
+	guestConfig.Burst = -1
+	guestConfig.Impersonate = rest.ImpersonationConfig{
+		UserName: username,
+		Groups:   []string{"system:masters"},
+	}
+
+	impersonatingClient, err := crclient.New(guestConfig, crclient.Options{Scheme: scheme})
+	g.Expect(err).NotTo(HaveOccurred(), "could not create impersonating client for guest cluster")
+	return impersonatingClient
 }
 
 func GetGuestKubeconfigHost(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) (string, error) {
@@ -2762,6 +2784,9 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 			hccokasvap.AdmissionPolicyNameInfra,
 			hccokasvap.AdmissionPolicyNameNTOMirroredConfigs,
 		}
+		if IsGreaterThanOrEqualTo(Version51) {
+			requiredVAPs = append(requiredVAPs, hccokasvap.AdmissionPolicyNameRBAC)
+		}
 		presentVAPs := []string{}
 		for _, vap := range validatingAdmissionPolicies.Items {
 			presentVAPs = append(presentVAPs, vap.Name)
@@ -2786,6 +2811,26 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 		apiServerCP.Spec.Audit.Profile = configv1.AllRequestBodiesAuditProfileType
 		err = guestClient.Update(ctx, apiServerCP)
 		g.Expect(err).To(HaveOccurred(), fmt.Sprintf("Failed block apiservers configuration update: %v", err))
+	})
+	t.Run("EnsureValidatingAdmissionPoliciesBlockRBACDeletion", func(t *testing.T) {
+		CPOAtLeast(t, Version51, hc)
+		g := NewWithT(t)
+		t.Log("Checking that VAP blocks deletion of protected ClusterRoleBindings")
+		// The admin kubeconfig authenticates as system:admin, which the policy whitelists so the
+		// KAS bootstrap container can apply these bindings. Impersonate an unrelated user to
+		// exercise the path the policy actually guards.
+		impersonatingClient := guestClientImpersonating(t, ctx, mgmtClient, hc, "hypershift-e2e-rbac-vap-test")
+		for _, name := range []string{"hcco-cluster-admin", "kas-bootstrap-container-cluster-admin"} {
+			crb := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: name}}
+			err := impersonatingClient.Get(ctx, crclient.ObjectKeyFromObject(crb), crb)
+			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get %s ClusterRoleBinding: %v", name, err))
+			// Dry run: admission still evaluates the policy, but a cluster missing the VAP is not
+			// left without a binding HCCO depends on.
+			err = impersonatingClient.Delete(ctx, crb, crclient.DryRunAll)
+			g.Expect(err).To(HaveOccurred(), "VAP should block deletion of %s ClusterRoleBinding", name)
+			g.Expect(err.Error()).To(ContainSubstring("ValidatingAdmissionPolicy"),
+				fmt.Sprintf("rejection should come from a ValidatingAdmissionPolicy, got: %v", err))
+		}
 	})
 	t.Run("EnsureValidatingAdmissionPoliciesDontBlockStatusModifications", func(t *testing.T) {
 		g := NewWithT(t)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -57,6 +57,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2730,6 +2731,7 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 			hccokasvap.AdmissionPolicyNameICSP,
 			hccokasvap.AdmissionPolicyNameInfra,
 			hccokasvap.AdmissionPolicyNameNTOMirroredConfigs,
+			hccokasvap.AdmissionPolicyNameRBAC,
 		}
 		presentVAPs := []string{}
 		for _, vap := range validatingAdmissionPolicies.Items {
@@ -2755,6 +2757,20 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 		apiServerCP.Spec.Audit.Profile = configv1.AllRequestBodiesAuditProfileType
 		err = guestClient.Update(ctx, apiServerCP)
 		g.Expect(err).To(HaveOccurred(), fmt.Sprintf("Failed block apiservers configuration update: %v", err))
+	})
+	t.Run("EnsureValidatingAdmissionPoliciesBlockRBACDeletion", func(t *testing.T) {
+		CPOAtLeast(t, Version418, hc)
+		g := NewWithT(t)
+		t.Log("Checking that VAP blocks deletion of hcco-cluster-admin ClusterRoleBinding")
+		crb := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "hcco-cluster-admin",
+			},
+		}
+		err := guestClient.Get(ctx, crclient.ObjectKeyFromObject(crb), crb)
+		g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get hcco-cluster-admin ClusterRoleBinding: %v", err))
+		err = guestClient.Delete(ctx, crb)
+		g.Expect(err).To(HaveOccurred(), "VAP should block deletion of hcco-cluster-admin ClusterRoleBinding")
 	})
 	t.Run("EnsureValidatingAdmissionPoliciesDontBlockStatusModifications", func(t *testing.T) {
 		g := NewWithT(t)

--- a/test/e2e/v2/tests/hosted_cluster_security_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_security_test.go
@@ -29,6 +29,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hccokasvap "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas"
+	hyperapi "github.com/openshift/hypershift/support/api"
 	suppconfig "github.com/openshift/hypershift/support/config"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
@@ -36,9 +37,11 @@ import (
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -133,6 +136,9 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 					hccokasvap.AdmissionPolicyNameInfra,
 					hccokasvap.AdmissionPolicyNameNTOMirroredConfigs,
 				}
+				if tc.VersionAtLeast(e2eutil.Version51) {
+					requiredVAPs = append(requiredVAPs, hccokasvap.AdmissionPolicyNameRBAC)
+				}
 				vapNames := make([]string, 0, len(vapList.Items))
 				for _, vap := range vapList.Items {
 					vapNames = append(vapNames, vap.Name)
@@ -163,6 +169,36 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 				g.Expect(err.Error()).To(ContainSubstring("ValidatingAdmissionPolicy"),
 					"rejection should be from a ValidatingAdmissionPolicy, got: %v", err)
 			}, time.Minute, 5*time.Second).Should(Succeed())
+		})
+
+		It("should deny unauthorized deletion of kas-bootstrap RBAC bindings via VAPs", func() {
+			tc.SkipIfVersionBelow(e2eutil.Version51)
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			// The admin kubeconfig authenticates as system:admin, which the policy whitelists so
+			// the KAS bootstrap container can apply these bindings. Impersonate an unrelated user
+			// to exercise the path the policy actually guards; system:masters keeps the request
+			// authorized so admission is what decides the outcome.
+			restConfig, err := tc.GetHostedClusterRESTConfig(hc)
+			Expect(err).NotTo(HaveOccurred())
+			restConfig.Impersonate = rest.ImpersonationConfig{
+				UserName: "hypershift-e2e-rbac-vap-test",
+				Groups:   []string{"system:masters"},
+			}
+			hcClient, err := crclient.New(restConfig, crclient.Options{Scheme: hyperapi.Scheme})
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, name := range []string{"hcco-cluster-admin", "kas-bootstrap-container-cluster-admin"} {
+				crb := &rbacv1.ClusterRoleBinding{}
+				Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: name}, crb)).To(Succeed(),
+					"protected ClusterRoleBinding %s should exist", name)
+				// Dry run: admission still evaluates the policy, but a cluster missing the VAP is
+				// not left without a binding HCCO depends on.
+				err := hcClient.Delete(tc.Context, crb, crclient.DryRunAll)
+				Expect(err).To(HaveOccurred(), "VAP should block deletion of %s ClusterRoleBinding", name)
+				Expect(err.Error()).To(ContainSubstring("ValidatingAdmissionPolicy"),
+					"rejection should be from a ValidatingAdmissionPolicy, got: %v", err)
+			}
 		})
 
 		It("should allow status modifications via VAPs", func() {

--- a/test/e2e/v2/tests/hosted_cluster_security_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_security_test.go
@@ -36,6 +36,7 @@ import (
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -131,6 +132,7 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 					hccokasvap.AdmissionPolicyNameICSP,
 					hccokasvap.AdmissionPolicyNameInfra,
 					hccokasvap.AdmissionPolicyNameNTOMirroredConfigs,
+					hccokasvap.AdmissionPolicyNameRBAC,
 				}
 				vapNames := make([]string, 0, len(vapList.Items))
 				for _, vap := range vapList.Items {
@@ -155,6 +157,17 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 				}
 				err := hcClient.Update(tc.Context, apiServerCopy)
 				g.Expect(err).To(HaveOccurred(), "VAP should block audit profile modification")
+				g.Expect(err.Error()).To(ContainSubstring("ValidatingAdmissionPolicy"),
+					"rejection should be from a ValidatingAdmissionPolicy, got: %v", err)
+			}, time.Minute, 5*time.Second).Should(Succeed())
+		})
+
+		It("should deny unauthorized deletion of kas-bootstrap RBAC bindings via VAPs", func() {
+			Eventually(func(g Gomega) {
+				crb := &rbacv1.ClusterRoleBinding{}
+				g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "hcco-cluster-admin"}, crb)).To(Succeed())
+				err := hcClient.Delete(tc.Context, crb)
+				g.Expect(err).To(HaveOccurred(), "VAP should block deletion of hcco-cluster-admin ClusterRoleBinding")
 				g.Expect(err.Error()).To(ContainSubstring("ValidatingAdmissionPolicy"),
 					"rejection should be from a ValidatingAdmissionPolicy, got: %v", err)
 			}, time.Minute, 5*time.Second).Should(Succeed())


### PR DESCRIPTION
## What this PR does / why we need it:

Customers can delete the hcco-cluster-admin or
kas-bootstrap-container-cluster-admin ClusterRoleBindings in the guest cluster, breaking HCCO reconciliation. These bindings are only re-applied on KAS pod restart with no continuous reconciliation.

Add a new ValidatingAdmissionPolicy scoped to these two ClusterRoleBindings that blocks UPDATE and DELETE for all users except the HCCO and kas-bootstrap-container identities (which are just `system:admin`)

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes [ROSAENG-63186](https://redhat.atlassian.net/browse/ROSAENG-63186)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added RBAC admission-policy support for hosted clusters.
- Added protection for designated administrator role bindings by blocking unauthorized updates and deletions.
- Enforced restrictions on changes to specified cluster role bindings.

## Bug Fixes
- Reconciliation now reports failures when the RBAC policy cannot be applied.
- Added validation confirming the RBAC policy is configured and enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->