### PR TITLE
test: wait for global pull secret propagation

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2154,18 +2154,18 @@ func EnsureGlobalPullSecret(t *testing.T, ctx context.Context, mgmtClient crclie
 		err = createAdditionalPullSecret(ctx, guestClient, additionalPullSecretDummyData, additionalPullSecretName, additionalPullSecretNamespace)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to create additional-pull-secret secret")
 
-		// Check if HCCO generates the GlobalPullSecret secret in the kube-system namespace in the DataPlane
+		// Check if HCCO generates the GlobalPullSecret secret in the kube-system namespace in the DataPlane.
+		// This is a controller-propagation boundary. Use the same bounded budget as the
+		// earlier HCCO propagation checks so a recoverable HCCO replacement does not
+		// turn into a false test failure.
 		t.Run("Check if GlobalPullSecret secret is in the right place at Dataplane", func(t *testing.T) {
 			globalPullSecret := hccomanifests.GlobalPullSecret()
-			g.Eventually(func() error {
-				if err := guestClient.Get(ctx, crclient.ObjectKey{Name: globalPullSecret.Name, Namespace: globalPullSecret.Namespace}, globalPullSecret); err != nil {
-					return err
-				}
-				g.Expect(globalPullSecret.Data).NotTo(BeEmpty(), "global-pull-secret secret is empty")
-				g.Expect(globalPullSecret.Data[corev1.DockerConfigJsonKey]).NotTo(BeEmpty(), "global-pull-secret secret is empty")
-				oldglobalPullSecretData = globalPullSecret.Data[corev1.DockerConfigJsonKey]
-				return nil
-			}, 30*time.Second, 5*time.Second).Should(Succeed(), "global-pull-secret secret is not present")
+			data, err := waitForGlobalPullSecret(ctx, guestClient, crclient.ObjectKeyFromObject(globalPullSecret), 150*time.Second, 5*time.Second)
+			if err != nil {
+				logHCCODeploymentStatus(t, ctx, mgmtClient, entryHostedCluster)
+			}
+			g.Expect(err).NotTo(HaveOccurred(), "global-pull-secret secret is not present")
+			oldglobalPullSecretData = data
 		})
 
 		t.Run("Wait for critical DaemonSets to be ready - first check", func(t *testing.T) {
@@ -4536,6 +4536,61 @@ func ExtractVersionFromReleaseImage(releaseImage string) string {
 
 	// No known architecture suffix found, return the tag as-is
 	return tag
+}
+
+// waitForGlobalPullSecret waits for HCCO to create a non-empty destination
+// Secret. It retains the final observation in the returned error so an e2e
+// timeout identifies whether the Secret was absent or incomplete.
+func waitForGlobalPullSecret(ctx context.Context, guestClient crclient.Client, key crclient.ObjectKey, timeout, interval time.Duration) ([]byte, error) {
+	var (
+		data    []byte
+		lastErr error
+	)
+
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		secret := &corev1.Secret{}
+		if err := guestClient.Get(ctx, key, secret); err != nil {
+			lastErr = fmt.Errorf("read %s/%s: %w", key.Namespace, key.Name, err)
+			return false, nil
+		}
+		if len(secret.Data) == 0 || len(secret.Data[corev1.DockerConfigJsonKey]) == 0 {
+			lastErr = fmt.Errorf("read %s/%s: Secret data is empty", key.Namespace, key.Name)
+			return false, nil
+		}
+		data = slices.Clone(secret.Data[corev1.DockerConfigJsonKey])
+		return true, nil
+	})
+	if err != nil && lastErr != nil {
+		return nil, fmt.Errorf("global-pull-secret did not become ready within %s: %w", timeout, lastErr)
+	}
+	return data, err
+}
+
+// logHCCODeploymentStatus emits credentials-safe management-side HCCO state
+// after a terminal destination-Secret timeout. It deliberately logs only
+// Deployment status fields and condition reasons, never Secret data.
+func logHCCODeploymentStatus(t *testing.T, ctx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+	deployment := &appsv1.Deployment{}
+	if err := mgmtClient.Get(ctx, crclient.ObjectKey{Name: "hosted-cluster-config-operator", Namespace: namespace}, deployment); err != nil {
+		t.Logf("HCCO deployment %s/%s is not readable after global-pull-secret timeout: %v", namespace, "hosted-cluster-config-operator", err)
+		return
+	}
+
+	t.Logf("HCCO deployment %s/%s status: generation=%d observedGeneration=%d replicas=%d updated=%d ready=%d available=%d unavailable=%d",
+		namespace,
+		deployment.Name,
+		deployment.Generation,
+		deployment.Status.ObservedGeneration,
+		deployment.Status.Replicas,
+		deployment.Status.UpdatedReplicas,
+		deployment.Status.ReadyReplicas,
+		deployment.Status.AvailableReplicas,
+		deployment.Status.UnavailableReplicas,
+	)
+	for _, condition := range deployment.Status.Conditions {
+		t.Logf("HCCO deployment condition: type=%s status=%s reason=%s", condition.Type, condition.Status, condition.Reason)
+	}
 }
 
 // WaitForDeploymentAvailable waits for a deployment to be ready.

--- a/test/e2e/util/util_test.go
+++ b/test/e2e/util/util_test.go
@@ -31,25 +31,25 @@ func TestWaitForGlobalPullSecret(t *testing.T) {
 		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 	}
 
-	t.Run("returns a copy of populated docker config data", func(t *testing.T) {
+	t.Run("When the destination Secret is populated it should return a copy of the docker config data", func(t *testing.T) {
 		g := NewWithT(t)
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Namespace: key.Namespace, Name: key.Name},
 			Data:       map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`)},
 		}
 		data, err := waitForGlobalPullSecret(context.Background(), newClient(secret), key, time.Second, time.Millisecond)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(data).To(Equal([]byte(`{"auths":{}}`)))
+		g.Expect(err).NotTo(HaveOccurred(), "wait for a populated global-pull-secret")
+		g.Expect(data).To(Equal([]byte(`{"auths":{}}`)), "return the docker config data")
 		data[0] = 'x'
-		g.Expect(secret.Data[corev1.DockerConfigJsonKey]).To(Equal([]byte(`{"auths":{}}`)))
+		g.Expect(secret.Data[corev1.DockerConfigJsonKey]).To(Equal([]byte(`{"auths":{}}`)), "return a copy instead of mutating the Secret data")
 	})
 
-	t.Run("reports the final not found observation on timeout", func(t *testing.T) {
+	t.Run("When the destination Secret is absent it should report the final NotFound observation on timeout", func(t *testing.T) {
 		g := NewWithT(t)
 		_, err := waitForGlobalPullSecret(context.Background(), newClient(), key, 20*time.Millisecond, time.Millisecond)
-		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("read kube-system/global-pull-secret"))
-		g.Expect(err.Error()).To(ContainSubstring("not found"))
+		g.Expect(err).To(HaveOccurred(), "return a bounded timeout error")
+		g.Expect(err.Error()).To(ContainSubstring("read kube-system/global-pull-secret"), "identify the destination Secret")
+		g.Expect(err.Error()).To(ContainSubstring("not found"), "retain the final NotFound observation")
 	})
 }
 

--- a/test/e2e/util/util_test.go
+++ b/test/e2e/util/util_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"crypto/x509"
 	"testing"
 	"time"
@@ -11,8 +12,46 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/certs"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestWaitForGlobalPullSecret(t *testing.T) {
+	key := client.ObjectKey{Namespace: "kube-system", Name: "global-pull-secret"}
+	newClient := func(objects ...client.Object) client.Client {
+		t.Helper()
+		scheme := runtime.NewScheme()
+		if err := corev1.AddToScheme(scheme); err != nil {
+			t.Fatalf("add corev1 scheme: %v", err)
+		}
+		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	}
+
+	t.Run("returns a copy of populated docker config data", func(t *testing.T) {
+		g := NewWithT(t)
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: key.Namespace, Name: key.Name},
+			Data:       map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`)},
+		}
+		data, err := waitForGlobalPullSecret(context.Background(), newClient(secret), key, time.Second, time.Millisecond)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(data).To(Equal([]byte(`{"auths":{}}`)))
+		data[0] = 'x'
+		g.Expect(secret.Data[corev1.DockerConfigJsonKey]).To(Equal([]byte(`{"auths":{}}`)))
+	})
+
+	t.Run("reports the final not found observation on timeout", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := waitForGlobalPullSecret(context.Background(), newClient(), key, 20*time.Millisecond, time.Millisecond)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("read kube-system/global-pull-secret"))
+		g.Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+}
 
 func TestAllowedCIDRsTargetService(t *testing.T) {
 	const ns = "test-hcp"


### PR DESCRIPTION
## What changed

- Give the hosted data-plane `global-pull-secret` 150 seconds to appear. The old limit was 30 seconds.
- Keep the existing five-second poll interval.
- On terminal timeout, log only Hosted Cluster Config Operator Deployment status fields and condition reasons.
- Preserve the last safe object-state error, such as `NotFound` or empty data.

## Why

Two OpenShift 5.0 CI runs failed at the same check. The destination Secret appeared 39 and 41 seconds after the source Secret. In each run, the replacement Hosted Cluster Config Operator pod started just before it created the destination Secret. The controller recovered, but the test had already stopped at 30 seconds.

This change gives the expected controller propagation a bounded budget. It does not change controller predicates, reconciliation, DaemonSets, rollout behavior, or the kubelet-config-verifier test. It does not log Secret data.

## Validation

- `gofmt` passed.
- `git diff --check` passed.
- Focused fake-client tests cover the ready Secret and final `NotFound` timeout cases.
- An independent source review found no blocking issue.

The local focused package compile exceeded a deliberate 4,000,000 KiB virtual-memory cap while compiling the AWS EC2 dependency graph. The test binary did not run locally. This draft requires CI validation before it is ready for merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved global pull-secret validation by waiting for usable Docker configuration data before continuing.
  * Added clearer timeout reporting when the destination secret is missing or incomplete.
  * Protected stored credential data from unintended changes during validation.

* **Tests**
  * Added coverage for successful secret retrieval, data isolation, and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->