### PR TITLE
CNTRLPLANE-3871: e2e: Remove osImageStream cleanup that violates immutability

### DIFF
--- a/test/e2e/v2/tests/nodepool_osimagestream_test.go
+++ b/test/e2e/v2/tests/nodepool_osimagestream_test.go
@@ -421,21 +421,9 @@ func NodePoolOSImageStreamExplicitDefaultNoRolloutTest(getTestCtx internal.TestC
 			"failed to patch NodePool %s with osImageStream=%s", defaultNP.Name, versionDerivedDefault)
 		GinkgoWriter.Printf("Patched NodePool %s with osImageStream=%s\n", defaultNP.Name, versionDerivedDefault)
 
-		// Restore the original state on cleanup.
-		DeferCleanup(func() {
-			current := &hyperv1.NodePool{}
-			if err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), current); err != nil {
-				if !apierrors.IsNotFound(err) {
-					GinkgoWriter.Printf("Warning: failed to get NodePool %s for cleanup: %v\n", defaultNP.Name, err)
-				}
-				return
-			}
-			cleanupBase := current.DeepCopy()
-			current.Spec.OSImageStream.Name = ""
-			Expect(testCtx.MgmtClient.Patch(ctx, current, crclient.MergeFrom(cleanupBase))).To(Succeed(),
-				"cleanup: failed to restore NodePool %s osImageStream", defaultNP.Name)
-			GinkgoWriter.Printf("Restored NodePool %s osImageStream to unset\n", defaultNP.Name)
-		})
+		// No cleanup needed: osImageStream is immutable once set (CEL validation
+		// rejects removal), and we set it to the version-derived default which is
+		// semantically equivalent to the original unset state.
 
 		// Verify the config hash does not change over time.
 		// The controller normalizes the explicit default to empty for hash computation,


### PR DESCRIPTION
## Summary
- Remove the `DeferCleanup` block in `NodePoolOSImageStreamExplicitDefaultNoRolloutTest` that attempted to unset `osImageStream` after setting it to the version-derived default
- A CEL validation rule prevents removing `osImageStream` once set, causing cleanup to fail with a 422 error
- No restoration is needed since the test sets the field to the same value the controller derives implicitly

## Jira
https://issues.redhat.com/browse/CNTRLPLANE-3871

## Test plan
- [ ] `e2e-v2-aws-techpreview-osimagestream` job passes without the 422 cleanup error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end coverage for default OS image stream behavior.
  * Simplified cleanup handling while preserving validation of version-derived defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->