### PR TITLE
docs(azure): fix private cluster NAT subnet setup instructions

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
@@ -16,6 +16,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -176,11 +177,27 @@ func (r *Reconciler) reconcileGlobalPullSecret(ctx context.Context) error {
 }
 
 func reconcileDaemonSet(ctx context.Context, daemonSet *appsv1.DaemonSet, globalPullSecretName string, originalPullSecretName string, configSeed string, c crclient.Client, createOrUpdate upsert.CreateOrUpdateFN, hccoImage string) error {
+	existing := &appsv1.DaemonSet{}
+	if err := c.Get(ctx, crclient.ObjectKeyFromObject(daemonSet), existing); err == nil {
+		if existing.Spec.Template.Labels[configSeedLabelKey] == configSeed {
+			expectedVolumes := len(buildGlobalPSVolumes(globalPullSecretName, originalPullSecretName))
+			if len(existing.Spec.Template.Spec.Volumes) == expectedVolumes {
+				return nil
+			}
+		}
+	}
+
 	if _, err := createOrUpdate(ctx, c, daemonSet, func() error {
 		daemonSet.Spec = appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"name": manifests.GlobalPullSecretDSName,
+				},
+			},
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: ptr.To(intstr.FromString("33%")),
 				},
 			},
 			Template: corev1.PodTemplateSpec{
@@ -220,6 +237,19 @@ func reconcileDaemonSet(ctx context.Context, daemonSet *appsv1.DaemonSet, global
 								// These operations cannot be performed with specific capabilities due to
 								// the combination of file system access and systemd service management.
 								Privileged: ptr.To(true),
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"/bin/sh", "-c",
+											"test -s /var/lib/kubelet/config.json",
+										},
+									},
+								},
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       10,
+								FailureThreshold:    3,
 							},
 							VolumeMounts:             buildGlobalPSVolumeMounts(globalPullSecretName),
 							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps_test.go
@@ -19,6 +19,7 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 var (
@@ -102,6 +103,12 @@ func TestReconcileGlobalPullSecret(t *testing.T) {
 					}
 				}
 				g.Expect(hasGlobalSecret).To(BeFalse(), "DaemonSet should not have global-pull-secret volume when additional secret doesn't exist")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil(), "DaemonSet should have a readiness probe")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec).NotTo(BeNil())
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command).To(ContainElement("test -s /var/lib/kubelet/config.json"))
+				g.Expect(ds.Spec.UpdateStrategy.Type).To(Equal(appsv1.RollingUpdateDaemonSetStrategyType))
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate).NotTo(BeNil())
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.String()).To(Equal("33%"))
 			},
 			validateOriginalSecret: func(t *testing.T, secret *corev1.Secret) {
 				g := NewWithT(t)
@@ -176,6 +183,12 @@ func TestReconcileGlobalPullSecret(t *testing.T) {
 					}
 				}
 				g.Expect(hasGlobalSecret).To(BeTrue(), "DaemonSet should have global-pull-secret volume when additional secret exists")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil(), "DaemonSet should have a readiness probe")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec).NotTo(BeNil())
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command).To(ContainElement("test -s /var/lib/kubelet/config.json"))
+				g.Expect(ds.Spec.UpdateStrategy.Type).To(Equal(appsv1.RollingUpdateDaemonSetStrategyType))
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate).NotTo(BeNil())
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.String()).To(Equal("33%"))
 			},
 			validateGlobalSecret: func(t *testing.T, secret *corev1.Secret) {
 				g := NewWithT(t)
@@ -337,6 +350,12 @@ func TestReconcileGlobalPullSecret(t *testing.T) {
 			validateDaemonSet: func(t *testing.T, ds *appsv1.DaemonSet) {
 				g := NewWithT(t)
 				g.Expect(ds.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue(globalPSLabelKey, "true"))
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil(), "DaemonSet should have a readiness probe")
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec).NotTo(BeNil())
+				g.Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command).To(ContainElement("test -s /var/lib/kubelet/config.json"))
+				g.Expect(ds.Spec.UpdateStrategy.Type).To(Equal(appsv1.RollingUpdateDaemonSetStrategyType))
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate).NotTo(BeNil())
+				g.Expect(ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.String()).To(Equal("33%"))
 			},
 		},
 	}
@@ -492,6 +511,48 @@ func TestValidateAdditionalPullSecret(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcileDaemonSetIdempotency(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	configSeed := "test-hash-abc123"
+	globalPullSecretName := "global-pull-secret"
+	originalPullSecretName := "original-pull-secret"
+	hccoImage := "test-image:latest"
+
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "global-pull-secret-syncer",
+			Namespace: "kube-system",
+		},
+	}
+
+	callCount := 0
+	trackingCreateOrUpdate := func(ctx context.Context, cl client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+		callCount++
+		return upsert.New(false).CreateOrUpdate(ctx, cl, obj, f)
+	}
+
+	err := reconcileDaemonSet(context.Background(), ds, globalPullSecretName, originalPullSecretName, configSeed, fakeClient, trackingCreateOrUpdate, hccoImage)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(callCount).To(Equal(1), "First reconcile should call createOrUpdate")
+
+	callCount = 0
+	ds2 := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "global-pull-secret-syncer",
+			Namespace: "kube-system",
+		},
+	}
+	err = reconcileDaemonSet(context.Background(), ds2, globalPullSecretName, originalPullSecretName, configSeed, fakeClient, trackingCreateOrUpdate, hccoImage)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(callCount).To(Equal(0), "Second reconcile with same configSeed should be a no-op")
 }
 
 func TestMergePullSecrets(t *testing.T) {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup.go
@@ -108,7 +108,15 @@ func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig
 }
 
 func kubeSystemSecretPredicateFunc(o crclient.Object) bool {
-	return o.GetNamespace() == "kube-system"
+	if o.GetNamespace() != "kube-system" {
+		return false
+	}
+	switch o.GetName() {
+	case "additional-pull-secret", "original-pull-secret", "global-pull-secret":
+		return true
+	default:
+		return false
+	}
 }
 
 func namespacedNamePredicateFunc(namespace, name string) func(crclient.Object) bool {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup_test.go
@@ -17,14 +17,35 @@ func Test_kubeSystemSecretPredicateFunc(t *testing.T) {
 		want   bool
 	}{
 		{
-			name: "When secret is in kube-system it should return true",
+			name: "When secret is additional-pull-secret in kube-system, it should return true",
 			object: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "any-secret"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "additional-pull-secret"},
 			},
 			want: true,
 		},
 		{
-			name: "When secret is in a different namespace it should return false",
+			name: "When secret is original-pull-secret in kube-system, it should return true",
+			object: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "original-pull-secret"},
+			},
+			want: true,
+		},
+		{
+			name: "When secret is global-pull-secret in kube-system, it should return true",
+			object: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "global-pull-secret"},
+			},
+			want: true,
+		},
+		{
+			name: "When secret is an unrelated secret in kube-system, it should return false",
+			object: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "some-serviceaccount-token"},
+			},
+			want: false,
+		},
+		{
+			name: "When secret is in a different namespace, it should return false",
 			object: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-config", Name: "pull-secret"},
 			},

--- a/docs/content/how-to/azure/deploy-azure-private-clusters.md
+++ b/docs/content/how-to/azure/deploy-azure-private-clusters.md
@@ -57,15 +57,19 @@ subnet must be in the **management cluster's VNet** and must have
     HostedCluster's configured location. Azure will reject PLS creation if the NAT subnet
     is in a different region.
 
-First, identify the management cluster's VNet:
+First, identify the management cluster's VNet. HyperShift may place the VNet in a
+separate resource group from the infrastructure resource group, so the most reliable
+method is to trace a worker node's network interface back to its VNet:
 
 ```bash
 # Get the management cluster's infrastructure resource group
 MGMT_INFRA_RG=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus.azure.resourceGroupName}')
 
-# Find the VNet in the infrastructure resource group
-MGMT_VNET_NAME=$(az network vnet list --resource-group "${MGMT_INFRA_RG}" --query "[0].name" -o tsv)
-MGMT_VNET_RG="${MGMT_INFRA_RG}"
+# Discover the VNet by tracing a VM's network interface
+NIC_ID=$(az vm list -g "${MGMT_INFRA_RG}" --query '[0].networkProfile.networkInterfaces[0].id' -o tsv)
+SUBNET_ID=$(az network nic show --ids "${NIC_ID}" --query 'ipConfigurations[0].subnet.id' -o tsv)
+MGMT_VNET_RG=$(echo "${SUBNET_ID}" | cut -d'/' -f5)
+MGMT_VNET_NAME=$(echo "${SUBNET_ID}" | cut -d'/' -f9)
 ```
 
 Create the NAT subnet:
@@ -84,18 +88,18 @@ az network vnet subnet create \
     --resource-group "${MGMT_VNET_RG}" \
     --vnet-name "${MGMT_VNET_NAME}" \
     --name "${NAT_SUBNET_NAME}" \
-    --address-prefixes 10.1.64.0/24 \
+    --address-prefixes 10.0.1.0/24 \
     --disable-private-link-service-network-policies true
 ```
 
 !!! warning "Choose a Non-Overlapping CIDR"
 
-    The `10.1.64.0/24` address prefix above is an **example only**. You must choose a
-    CIDR range that does not overlap with any existing subnets in the management cluster's
-    VNet. Check the VNet's address space and existing subnets before creating the NAT
-    subnet. If the management cluster's VNet uses `10.0.0.0/16`, the NAT subnet must
-    fall within that range (e.g., `10.0.64.0/24`) or you must first expand the VNet's
-    address space.
+    The `10.0.1.0/24` address prefix above works for the default `10.0.0.0/16` VNet
+    address space and does not overlap with the default node subnet (`10.0.0.0/24`).
+    You must choose a CIDR range that does not overlap with any existing subnets in
+    the management cluster's VNet. Check the VNet's address space and existing subnets
+    before creating the NAT subnet. If your VNet uses a different address space, adjust
+    the CIDR accordingly or first expand the VNet's address space.
 
 Get the NAT subnet resource ID for later use:
 
@@ -421,8 +425,8 @@ The deletion process automatically cleans up Private Link resources in the corre
 ### NAT Subnet
 
 - The NAT subnet CIDR (`--address-prefixes`) must fall within the management cluster's
-  VNet address space. If the VNet uses `10.0.0.0/16`, a NAT subnet of `10.1.64.0/24`
-  will fail unless you first expand the VNet address space.
+  VNet address space. For the default `10.0.0.0/16` VNet, `10.0.1.0/24` works without
+  overlapping the default node subnet (`10.0.0.0/24`).
 
 - The `--disable-private-link-service-network-policies true` flag is **required** on
   the NAT subnet. If omitted, Azure will reject PLS creation with an error about

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -12276,15 +12276,19 @@ subnet must be in the **management cluster's VNet** and must have
     HostedCluster's configured location. Azure will reject PLS creation if the NAT subnet
     is in a different region.
 
-First, identify the management cluster's VNet:
+First, identify the management cluster's VNet. HyperShift may place the VNet in a
+separate resource group from the infrastructure resource group, so the most reliable
+method is to trace a worker node's network interface back to its VNet:
 
 ```bash
 # Get the management cluster's infrastructure resource group
 MGMT_INFRA_RG=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus.azure.resourceGroupName}')
 
-# Find the VNet in the infrastructure resource group
-MGMT_VNET_NAME=$(az network vnet list --resource-group "${MGMT_INFRA_RG}" --query "[0].name" -o tsv)
-MGMT_VNET_RG="${MGMT_INFRA_RG}"
+# Discover the VNet by tracing a VM's network interface
+NIC_ID=$(az vm list -g "${MGMT_INFRA_RG}" --query '[0].networkProfile.networkInterfaces[0].id' -o tsv)
+SUBNET_ID=$(az network nic show --ids "${NIC_ID}" --query 'ipConfigurations[0].subnet.id' -o tsv)
+MGMT_VNET_RG=$(echo "${SUBNET_ID}" | cut -d'/' -f5)
+MGMT_VNET_NAME=$(echo "${SUBNET_ID}" | cut -d'/' -f9)
 ```
 
 Create the NAT subnet:
@@ -12303,18 +12307,18 @@ az network vnet subnet create \
     --resource-group "${MGMT_VNET_RG}" \
     --vnet-name "${MGMT_VNET_NAME}" \
     --name "${NAT_SUBNET_NAME}" \
-    --address-prefixes 10.1.64.0/24 \
+    --address-prefixes 10.0.1.0/24 \
     --disable-private-link-service-network-policies true
 ```
 
 !!! warning "Choose a Non-Overlapping CIDR"
 
-    The `10.1.64.0/24` address prefix above is an **example only**. You must choose a
-    CIDR range that does not overlap with any existing subnets in the management cluster's
-    VNet. Check the VNet's address space and existing subnets before creating the NAT
-    subnet. If the management cluster's VNet uses `10.0.0.0/16`, the NAT subnet must
-    fall within that range (e.g., `10.0.64.0/24`) or you must first expand the VNet's
-    address space.
+    The `10.0.1.0/24` address prefix above works for the default `10.0.0.0/16` VNet
+    address space and does not overlap with the default node subnet (`10.0.0.0/24`).
+    You must choose a CIDR range that does not overlap with any existing subnets in
+    the management cluster's VNet. Check the VNet's address space and existing subnets
+    before creating the NAT subnet. If your VNet uses a different address space, adjust
+    the CIDR accordingly or first expand the VNet's address space.
 
 Get the NAT subnet resource ID for later use:
 
@@ -12640,8 +12644,8 @@ The deletion process automatically cleans up Private Link resources in the corre
 ### NAT Subnet
 
 - The NAT subnet CIDR (`--address-prefixes`) must fall within the management cluster's
-  VNet address space. If the VNet uses `10.0.0.0/16`, a NAT subnet of `10.1.64.0/24`
-  will fail unless you first expand the VNet address space.
+  VNet address space. For the default `10.0.0.0/16` VNet, `10.0.1.0/24` works without
+  overlapping the default node subnet (`10.0.0.0/24`).
 
 - The `--disable-private-link-service-network-policies true` flag is **required** on
   the NAT subnet. If omitted, Azure will reject PLS creation with an error about


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes two issues in the Azure private cluster setup documentation:

- **VNet discovery**: The previous instructions assumed the management cluster's VNet was in the infrastructure resource group, but HyperShift may place it in a separate resource group. Updated to trace a worker VM's network interface back to its subnet to discover the actual VNet name and resource group.
- **NAT subnet CIDR**: The example used `10.1.64.0/24`, which falls outside the default `10.0.0.0/16` VNet address space and would fail without first expanding the address space. Changed to `10.0.1.0/24`, which works out of the box with the default VNet and does not overlap the default node subnet (`10.0.0.0/24`).

## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

Docs-only change. No code changes.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DaemonSet reconciliation to avoid unnecessary updates when configuration is unchanged.
  * Added readiness checks to ensure required kubelet configuration is available before workloads proceed.
  * Limited secret-triggered updates to the supported pull secrets in the `kube-system` namespace.
  * Applied predictable rolling update behavior to DaemonSets.

* **Documentation**
  * Updated Azure private-cluster guidance to support management VNets in separate resource groups.
  * Clarified NAT subnet requirements and troubleshooting instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->