### PR TITLE
CNTRLPLANE-3874,CNTRLPLANE-3873,OCPBUGS-94518: update azure CPO overrides for 4.20, 4.21, 4.22

### DIFF
--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
@@ -9,120 +9,165 @@ platforms:
         cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:88c55ea554f7e62a64e34ff8d3be45ef85ef6b80fe4e9b0240b9a1aa226f9d98
       - version: 4.19.10
         cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:88c55ea554f7e62a64e34ff8d3be45ef85ef6b80fe4e9b0240b9a1aa226f9d98
-      # Beginning of OCPBUGS-86567 overrides 4.20 section
+      # Beginning of CNTRLPLANE-3874 overrides 4.20 section
+      # Supersedes OCPBUGS-86567 image: this build (commit f0b902e199f7)
+      # includes PR #9055 and all previously overridden fixes.
       - version: 4.20.0
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.1
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.2
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.3
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.4
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.5
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.6
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.7
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.8
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.9
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.10
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.11
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.12
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.13
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.14
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.15
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.16
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.17
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.18
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.19
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.20
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.21
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.22
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.23
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
       - version: 4.20.24
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:155e4eee5b551ba9c4f3690e677be2b7a9bf90dca0ba4e8978a39fc16b46bcbb
-      # End of OCPBUGS-86567 overrides 4.20 section
-      # Beginning of OCPBUGS-86416 overrides 4.21 section
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
+      - version: 4.20.25
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
+      - version: 4.20.26
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
+      - version: 4.20.27
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
+      - version: 4.20.28
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
+      - version: 4.20.29
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
+      - version: 4.20.30
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
+      - version: 4.20.31
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
+      - version: 4.20.32
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20@sha256:5cd2bef11bcf56da0c39ff5a47c2f563d63873e76a6033da9a07bcd8c7f2dc38
+      # 4.20.33 does not need an override: PR #9055 merged (2026-07-31)
+      # before the 4.20.33 development cutoff (2026-08-05).
+      # End of CNTRLPLANE-3874 overrides 4.20 section
+      # Beginning of CNTRLPLANE-3873 overrides 4.21 section
+      # Supersedes OCPBUGS-86416 image: this build (commit 982167956e0d)
+      # includes PR #9054 and all previously overridden fixes.
       - version: 4.21.0
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.1
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.2
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.3
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.4
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.5
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.6
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.7
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.8
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.9
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.10
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.11
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.12
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.13
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.14
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.15
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.16
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.17
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
       - version: 4.21.18
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:1b3f1bf728e722d333f7214afb348b9d629c2134247c5440d7d98a87c34c6f61
-      # End of OCPBUGS-86416 overrides 4.21 section
-      # 4.22 does not need an override: the fix (PR #8564) landed before rc.5
-      # (SOURCE_GIT_COMMIT=d6c72d15350752e315c198f7a68558ae4086e3c7) and GA will include it.
-      # Beginning of CNTRLPLANE-3619/CNTRLPLANE-3656/OCPBUGS-98627/OCPBUGS-98220 overrides 4.22 section
-      # Supersedes the previous CNTRLPLANE-3619/3656 image: this build (commit fb3b1a355476)
-      # includes PRs #8721, #8790, #8972, and #8998.
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
+      - version: 4.21.19
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
+      - version: 4.21.20
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
+      - version: 4.21.21
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
+      - version: 4.21.22
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
+      - version: 4.21.23
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
+      - version: 4.21.24
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
+      - version: 4.21.25
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
+      - version: 4.21.26
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
+      - version: 4.21.27
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21@sha256:a51e0fe65fad5e135cc2858fe54a9c2009d4f68316ae642fb1040c704d29f8d1
+      # 4.21.28 does not need an override: PR #9054 merged (2026-07-31)
+      # before the 4.21.28 development cutoff (2026-08-05).
+      # End of CNTRLPLANE-3873 overrides 4.21 section
+      # Beginning of OCPBUGS-94518 overrides 4.22 section
+      # Supersedes CNTRLPLANE-3619/CNTRLPLANE-3656/OCPBUGS-98627/OCPBUGS-98220 image:
+      # this build (commit 41cbcdfa522b) includes PR #8865 and all previously
+      # overridden fixes (#8721, #8790, #8972, #8998).
       - version: 4.22.0
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:4ab09941d2338e729553d456d5e46a1aa504078247f2d53c8dd705cced45ec22
       - version: 4.22.1
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:4ab09941d2338e729553d456d5e46a1aa504078247f2d53c8dd705cced45ec22
       - version: 4.22.2
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:4ab09941d2338e729553d456d5e46a1aa504078247f2d53c8dd705cced45ec22
       - version: 4.22.3
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:4ab09941d2338e729553d456d5e46a1aa504078247f2d53c8dd705cced45ec22
       - version: 4.22.4
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:4ab09941d2338e729553d456d5e46a1aa504078247f2d53c8dd705cced45ec22
       - version: 4.22.5
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:4ab09941d2338e729553d456d5e46a1aa504078247f2d53c8dd705cced45ec22
       - version: 4.22.6
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:9b53131cd8ac0760388e5d25464aae45aea4dc593607f3840713a4056418b930
-      # 4.22.7 does not need an override: all four PRs (#8721, #8790, #8972, #8998)
-      # merged before the 4.22.7 development cutoff (2026-07-22).
-      # End of CNTRLPLANE-3619/CNTRLPLANE-3656/OCPBUGS-98627/OCPBUGS-98220 overrides 4.22 section
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:4ab09941d2338e729553d456d5e46a1aa504078247f2d53c8dd705cced45ec22
+      - version: 4.22.7
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:4ab09941d2338e729553d456d5e46a1aa504078247f2d53c8dd705cced45ec22
+      - version: 4.22.8
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22@sha256:4ab09941d2338e729553d456d5e46a1aa504078247f2d53c8dd705cced45ec22
+      # 4.22.9 does not need an override: PR #8865 merged (2026-08-03)
+      # before the 4.22.9 development cutoff (2026-08-05).
+      # End of OCPBUGS-94518 overrides 4.22 section
     testing:
       # Update the image refs below to indicate which images should be used for CPO override
       # testing. Currently, we only test one latest/previous combination. In the future, we

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -484,6 +484,9 @@ func pollCASLogsForPausedNodeGroup(t *testing.T, ctx context.Context, controlPla
 // 8. Unpause and wait for clean convergence to numNodes
 func testAutoscalerRespectsNodePoolPause(ctx context.Context, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, numNodes, max int32) func(t *testing.T) {
 	return func(t *testing.T) {
+		// spec.autoscaling.scaleDown requires CPO support added in 4.18 (CNTRLPLANE-952).
+		e2eutil.AtLeast(t, e2eutil.Version418)
+
 		g := NewWithT(t)
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()


### PR DESCRIPTION
## Summary

- Update azure CPO image overrides with newer Konflux push builds that include recent backports
- **4.20**: [CNTRLPLANE-3874](https://redhat.atlassian.net/browse/CNTRLPLANE-3874) — PR #9055 (controlPlaneVersion backport), versions 4.20.0–4.20.32. Supersedes OCPBUGS-86567 image.
- **4.21**: [CNTRLPLANE-3873](https://redhat.atlassian.net/browse/CNTRLPLANE-3873) — PR #9054 (controlPlaneVersion backport), versions 4.21.0–4.21.27. Supersedes OCPBUGS-86416 image.
- **4.22**: OCPBUGS-94518 — PR #8865 (ACR pull identity), versions 4.22.0–4.22.8. Supersedes CNTRLPLANE-3619/3656/OCPBUGS-98627/98220 image.
- All new images verified to contain previously overridden fixes (ancestor check passed)
- Next z-streams (4.20.33, 4.21.28, 4.22.9) do not need overrides: all PRs merged before their development cutoffs (2026-08-05)

branch: 4.20 wants: https://github.com/openshift/hypershift/pull/9055
branch: 4.21 wants: https://github.com/openshift/hypershift/pull/9054
branch: 4.22 wants: https://github.com/openshift/hypershift/pull/8865

## Test plan

- [x] `go test ./hypershift-operator/controlplaneoperator-overrides/...` passes
- [x] All override images verified pullable via `skopeo inspect`
- [x] All claimed PRs verified present in images via `verify-pr-in-image.sh`
- [x] New images verified to supersede old images (ancestor check)
- [ ] `/validate-pr-override-images` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Azure control plane operator overrides for OpenShift 4.20, 4.21, and 4.22.
  * Added override coverage through OpenShift 4.22.8.
  * Refreshed image versions and removed overrides that are no longer required.
  * Improved release-version alignment for Azure control plane behavior across supported OpenShift versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->