### PR TITLE
OCPBUGS-101766: enable TLSAdherence feature gate part on TechPreviewNoUpgrade

### DIFF
--- a/api/hypershift/v1beta1/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/api/hypershift/v1beta1/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -51,6 +51,9 @@
                     },
                     {
                         "name": "EtcdSharding"
+                    },
+                    {
+                        "name": "TLSAdherence"
                     }
                 ],
                 "version": ""

--- a/cmd/install/assets/crds/hypershift-operator/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -51,6 +51,9 @@
                     },
                     {
                         "name": "EtcdSharding"
+                    },
+                    {
+                        "name": "TLSAdherence"
                     }
                 ],
                 "version": ""

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -708,6 +708,42 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                         type: object
+                      tlsAdherence:
+                        description: |-
+                          tlsAdherence controls if components in the cluster adhere to the TLS security profile
+                          configured on this APIServer resource.
+
+                          Valid values are "LegacyAdheringComponentsOnly" and "StrictAllComponents".
+
+                          When set to "LegacyAdheringComponentsOnly", components that already honor the
+                          cluster-wide TLS profile continue to do so. Components that do not already honor
+                          it continue to use their individual TLS configurations.
+
+                          When set to "StrictAllComponents", all components must honor the configured TLS
+                          profile unless they have a component-specific TLS configuration that overrides
+                          it. This mode is recommended for security-conscious deployments and is required
+                          for certain compliance frameworks.
+
+                          Note: Some components such as Kubelet and IngressController have their own
+                          dedicated TLS configuration mechanisms via KubeletConfig and IngressController
+                          CRs respectively. When these component-specific TLS configurations are set,
+                          they take precedence over the cluster-wide tlsSecurityProfile. When not set,
+                          these components fall back to the cluster-wide default.
+
+                          Components that encounter an unknown value for tlsAdherence should treat it
+                          as "StrictAllComponents" and log a warning to ensure forward compatibility
+                          while defaulting to the more secure behavior.
+
+                          This field is optional.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is LegacyAdheringComponentsOnly.
+
+                          Once set, this field may be changed to a different value, but may not be removed.
+                        enum:
+                        - LegacyAdheringComponentsOnly
+                        - StrictAllComponents
+                        type: string
                       tlsSecurityProfile:
                         description: |-
                           tlsSecurityProfile specifies settings for TLS connections for externally exposed servers.
@@ -865,6 +901,10 @@ spec:
                             type: string
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: tlsAdherence may not be removed once set
+                      rule: 'has(oldSelf.tlsAdherence) ? has(self.tlsAdherence) :
+                        true'
                   authentication:
                     description: |-
                       authentication specifies cluster-wide settings for authentication (like OAuth and

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -655,6 +655,42 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                         type: object
+                      tlsAdherence:
+                        description: |-
+                          tlsAdherence controls if components in the cluster adhere to the TLS security profile
+                          configured on this APIServer resource.
+
+                          Valid values are "LegacyAdheringComponentsOnly" and "StrictAllComponents".
+
+                          When set to "LegacyAdheringComponentsOnly", components that already honor the
+                          cluster-wide TLS profile continue to do so. Components that do not already honor
+                          it continue to use their individual TLS configurations.
+
+                          When set to "StrictAllComponents", all components must honor the configured TLS
+                          profile unless they have a component-specific TLS configuration that overrides
+                          it. This mode is recommended for security-conscious deployments and is required
+                          for certain compliance frameworks.
+
+                          Note: Some components such as Kubelet and IngressController have their own
+                          dedicated TLS configuration mechanisms via KubeletConfig and IngressController
+                          CRs respectively. When these component-specific TLS configurations are set,
+                          they take precedence over the cluster-wide tlsSecurityProfile. When not set,
+                          these components fall back to the cluster-wide default.
+
+                          Components that encounter an unknown value for tlsAdherence should treat it
+                          as "StrictAllComponents" and log a warning to ensure forward compatibility
+                          while defaulting to the more secure behavior.
+
+                          This field is optional.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is LegacyAdheringComponentsOnly.
+
+                          Once set, this field may be changed to a different value, but may not be removed.
+                        enum:
+                        - LegacyAdheringComponentsOnly
+                        - StrictAllComponents
+                        type: string
                       tlsSecurityProfile:
                         description: |-
                           tlsSecurityProfile specifies settings for TLS connections for externally exposed servers.
@@ -812,6 +848,10 @@ spec:
                             type: string
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: tlsAdherence may not be removed once set
+                      rule: 'has(oldSelf.tlsAdherence) ? has(self.tlsAdherence) :
+                        true'
                   authentication:
                     description: |-
                       authentication specifies cluster-wide settings for authentication (like OAuth and


### PR DESCRIPTION
## What this PR does / why we need it:

This PR makes `TLSAdherence` feature gate part of the `TechPreviewNoUpgrade` group. 

## Special notes for your reviewer:

This does not make the `TLSAdherence` part of the Default group so hypershift must be installed using `hypershift install --tech-preview-no-upgrade`.


## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled the `TLSAdherence` feature in the TechPreviewNoUpgrade configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->