### PR TITLE
OCPBUGS-100279: isolate Claude from push credentials in PR workflows

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -22,8 +22,8 @@ jobs:
       command-name: rebase
       status-message: "Rebasing PR onto main"
       claude-prompt: >-
-        Rebase this branch onto the latest upstream main and force push.
-        You are running in CI. Force push with --force-with-lease when done without asking for confirmation.
+        Rebase this branch onto the latest upstream main. Do NOT push — the workflow handles pushing.
+        You are running in CI.
         The 'origin' remote may point to a fork; the workflow has already added an 'upstream' remote for fork PRs.
         Steps:
         1) Run 'git remote -v' to identify remotes
@@ -31,11 +31,6 @@ jobs:
         3) git fetch <chosen-remote> main
         4) git rebase <chosen-remote>/main
         5) If there are conflicts, resolve them while preserving the intent of the PR changes
-        6) git push --force-with-lease origin
-        If the push fails with a permission or authentication error, post a PR comment using
-        'gh pr comment' explaining that the rebase succeeded locally but the push failed because
-        the PR does not allow maintainer edits, and ask the author to enable 'Allow edits from
-        maintainers' and retry /rebase. Do NOT report success if the push failed.
         Report what was done.
       max-turns: 50
       allowed-tools: "Bash Read Write Edit Grep Glob"

--- a/.github/workflows/restructure-commits.yaml
+++ b/.github/workflows/restructure-commits.yaml
@@ -22,10 +22,6 @@ jobs:
       command-name: restructure-commits
       status-message: "Restructuring commits"
       claude-prompt: >-
-        /restructure-commits -- You are running in CI. Force push with --force-with-lease when done without asking for confirmation.
-        If the push fails with a permission or authentication error, post a PR comment using
-        'gh pr comment' explaining that the restructuring succeeded locally but the push failed because
-        the PR does not allow maintainer edits, and ask the author to enable 'Allow edits from
-        maintainers' and retry /restructure-commits.
+        /restructure-commits -- You are running in CI. Do NOT push — the workflow handles pushing.
       max-turns: 200
     secrets: inherit

--- a/.github/workflows/reusable-claude-on-pr.yaml
+++ b/.github/workflows/reusable-claude-on-pr.yaml
@@ -77,7 +77,7 @@ jobs:
           ref: ${{ steps.pr.outputs.branch }}
           repository: ${{ steps.pr.outputs.repo }}
           token: ${{ steps.app-token.outputs.token || github.token }}
-          persist-credentials: true
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Add upstream remote
@@ -122,7 +122,6 @@ jobs:
           CLAUDE_CODE_USE_VERTEX: "1"
           CLOUD_ML_REGION: global
           ANTHROPIC_VERTEX_PROJECT_ID: hosted-control-planes
-          GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
           CLAUDE_PROMPT: ${{ inputs.claude-prompt }}
@@ -135,4 +134,20 @@ jobs:
           claude plugin marketplace add openshift-eng/ai-helpers
           claude plugin install openshift-developer@ai-helpers
           claude --version
-          claude -p "$CLAUDE_PROMPT" --model claude-opus-4-6 --max-turns "$MAX_TURNS" --allowedTools "$ALLOWED_TOOLS" --verbose --output-format stream-json
+          claude -p "$CLAUDE_PROMPT" --bare --model claude-opus-4-6 --max-turns "$MAX_TURNS" --allowedTools "$ALLOWED_TOOLS" --verbose --output-format stream-json
+
+      - name: Push changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUSH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          PR_REPO: ${{ steps.pr.outputs.repo }}
+          PR_BRANCH: ${{ steps.pr.outputs.branch }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${PR_REPO}.git"
+          if ! git -c core.hooksPath=/dev/null push --force-with-lease origin "HEAD:${PR_BRANCH}" 2>&1; then
+            gh pr comment "$PR_NUMBER" --repo "$REPO" \
+              --body "⚠️ The operation succeeded locally but the push failed. If this is a fork PR, please enable **Allow edits from maintainers** and retry."
+            exit 1
+          fi


### PR DESCRIPTION
## What this PR does / why we need it:

Hardens the `reusable-claude-on-pr.yaml` GitHub Actions workflow against context file injection and credential exposure when operating on fork PRs.

The workflow previously checked out fork PR content with `persist-credentials: true` and passed `GH_TOKEN` (a write-scoped token) to the Claude step's environment. An external PR author could craft malicious `CLAUDE.md`/`AGENTS.md` files or pre-commit hooks that Claude would load and execute with Bash access, gaining access to the repo write token and GCP WIF credentials.

### Changes:

- **Add `--bare` to the Claude invocation** — prevents loading `CLAUDE.md`/`AGENTS.md` from the fork checkout and skips hooks, eliminating context file and pre-commit hook injection vectors. Skills still resolve via `/skill-name` so `/restructure-commits` continues to work.
- **Set `persist-credentials: false`** — prevents the checkout action from storing the write token in `.git/config`.
- **Remove `GH_TOKEN` from the Claude step's env** — Claude no longer has access to a write-scoped token during execution.
- **Add a dedicated post-Claude push step** — acquires the token only at push time and handles push failures with a PR comment.
- **Update caller prompts** (`rebase.yaml`, `restructure-commits.yaml`) — remove push instructions from Claude prompts since the workflow now handles pushing.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/OCPBUGS-100279

## Special notes for your reviewer:

The severity was reassessed to CVSS 4.2 / Medium (down from 8.0 / High) — see the [detailed assessment](https://redhat.atlassian.net/browse/OCPBUGS-100279?focusedCommentId=17851736). This is CI tooling, not product code.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated pull request maintenance workflows.
  * Branch updates are now handled more reliably through centralized automation.
  * Reduced the risk of duplicate or conflicting pushes during automated rebasing and commit restructuring.
  * Added clearer failure handling when automated changes cannot be applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->