### PR TITLE
OCPBUGS-104505: fix(ci): trigger envtest workflows on dependency changes

### DIFF
--- a/.github/workflows/envtest-kube-reusable.yaml
+++ b/.github/workflows/envtest-kube-reusable.yaml
@@ -37,11 +37,22 @@ jobs:
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if git diff --name-only "$ref" | grep -qE '^(api/|test/envtest/|cmd/install/assets/crds/hypershift-operator/tests/|karpenter-operator/controllers/karpenter/assets/tests/|\.github/workflows/envtest-kube(-reusable)?\.yaml$)'; then
-            echo "should_run=true"
+          echo "Diff ref: $ref"
+          pattern='^(api/|test/envtest/|cmd/install/assets/crds/|karpenter-operator/controllers/karpenter/assets/tests/|hack/tools/|\.github/workflows/envtest-kube(-reusable)?\.yaml$)'
+          diff_output=$(git diff --name-only "$ref" 2>/dev/null)
+          diff_rc=$?
+          if [ $diff_rc -ne 0 ]; then
+            echo "git diff failed (exit $diff_rc). Ref: $ref"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          elif matched=$(echo "$diff_output" | grep -E "$pattern"); then
+            echo "Matched files:"
+            echo "$matched"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "should_run=false"
-          fi >> "$GITHUB_OUTPUT"
+            echo "No relevant files changed. Diff output:"
+            echo "$diff_output" | sed -n '1,50p'
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
 
   envtest-kube:
     name: Envtest Vanilla Kube ${{ matrix.version }}

--- a/.github/workflows/envtest-ocp-reusable.yaml
+++ b/.github/workflows/envtest-ocp-reusable.yaml
@@ -37,11 +37,22 @@ jobs:
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if git diff --name-only "$ref" | grep -qE '^(api/|test/envtest/|cmd/install/assets/crds/hypershift-operator/tests/|karpenter-operator/controllers/karpenter/assets/tests/|\.github/workflows/envtest-ocp(-reusable)?\.yaml$)'; then
-            echo "should_run=true"
+          echo "Diff ref: $ref"
+          pattern='^(api/|test/envtest/|cmd/install/assets/crds/|karpenter-operator/controllers/karpenter/assets/tests/|hack/tools/|\.github/workflows/envtest-ocp(-reusable)?\.yaml$)'
+          diff_output=$(git diff --name-only "$ref" 2>/dev/null)
+          diff_rc=$?
+          if [ $diff_rc -ne 0 ]; then
+            echo "git diff failed (exit $diff_rc). Ref: $ref"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          elif matched=$(echo "$diff_output" | grep -E "$pattern"); then
+            echo "Matched files:"
+            echo "$matched"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "should_run=false"
-          fi >> "$GITHUB_OUTPUT"
+            echo "No relevant files changed. Diff output:"
+            echo "$diff_output" | sed -n '1,50p'
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
 
   envtest-ocp:
     name: Envtest OCP (K8s ${{ matrix.version }})


### PR DESCRIPTION
## What this PR does / why we need it:
Dependency updates can alter upstream CRD schemas or API types, breaking CEL/API validation rules which envtest checks.
The envtest change-detection regexes only matched `api/`, `test/envtest/`, and `CRD` test asset paths, so dependency changing PRs skipped envtest entirely.

Added `go.mod`, `go.sum`, and `vendor/` to the grep patterns in both `envtest-kube-reusable.yaml` and `envtest-ocp-reusable.yaml`.

## Which issue(s) this PR fixes:
Fixes [OCPBUGS-104505](https://redhat.atlassian.net/browse/OCPBUGS-104505)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved automated environment validation workflows for Kubernetes and OpenShift.
  - Validation now runs when vendored dependencies, custom resource definitions, or other relevant project files change.
  - Change detection more reliably handles unavailable or empty comparisons, preventing unnecessary validation runs.
  - Added clearer reporting of comparison references, results, matched files, and validation decisions for easier troubleshooting and more predictable checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->