### PR TITLE
NO-JIRA: add e2e-approvers owner alias, grant Dan Mace e2e role

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,6 +9,8 @@ aliases:
     - enxebre
     - csrwng
     - sjenning
+  e2e-approvers:
+    - ironcladlou
   core-approvers:
     - enxebre
     - csrwng

--- a/test/e2e/OWNERS
+++ b/test/e2e/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- e2e-approvers
+reviewers:
+- e2e-approvers


### PR DESCRIPTION
This commit adds an `e2e-approvers` role to enable granular reviewer and approver assignment for the e2e machinery.

Add Dan Mace to the reviewer/approver list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated end-to-end test review assignments.
  - Added an alias for designated end-to-end test approvers and reviewers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->