### PR TITLE
CNTRLPLANE-3902: Add product-cli unit tests for kubeconfig

### DIFF
--- a/product-cli/cmd/kubeconfig/create_test.go
+++ b/product-cli/cmd/kubeconfig/create_test.go
@@ -1,0 +1,72 @@
+package kubeconfig
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hypershiftkubeconfig "github.com/openshift/hypershift/cmd/kubeconfig"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "When kubeconfig create command is created, it should have 'kubeconfig' as use",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+				g.Expect(cmd.Use).To(Equal("kubeconfig"))
+			},
+		},
+		{
+			name: "When kubeconfig create command is created, it should set long description from shared package",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+				g.Expect(cmd.Long).To(Equal(hypershiftkubeconfig.Description))
+			},
+		},
+		{
+			name: "When kubeconfig create command is created, it should default namespace to clusters",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("namespace")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal("clusters"))
+			},
+		},
+		{
+			name: "When kubeconfig create command is created, it should register name flag with empty default",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(BeEmpty())
+			},
+		},
+		{
+			name: "When kubeconfig create command is created, it should default port-forward to false",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewCreateCommand()
+
+				flag := cmd.Flag("port-forward")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal("false"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.test(t)
+		})
+	}
+}

--- a/product-cli/cmd/kubeconfig/create_test.go
+++ b/product-cli/cmd/kubeconfig/create_test.go
@@ -1,0 +1,107 @@
+package kubeconfig
+
+import (
+	"sort"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hypershiftkubeconfig "github.com/openshift/hypershift/cmd/kubeconfig"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test func(t *testing.T, cmd *cobra.Command)
+	}{
+		{
+			name: "When kubeconfig create command is created, it should have 'kubeconfig' as use",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.Use).To(Equal("kubeconfig"))
+			},
+		},
+		{
+			name: "When kubeconfig create command is created, it should set long description from shared package",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.Long).To(Equal(hypershiftkubeconfig.Description))
+			},
+		},
+		{
+			name: "When kubeconfig create command is created, it should silence usage on error",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.SilenceUsage).To(BeTrue())
+			},
+		},
+		{
+			name: "When kubeconfig create command is created, it should wire a RunE handler",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+				g.Expect(cmd.RunE).ToNot(BeNil())
+			},
+		},
+		{
+			name: "When kubeconfig create command is created, it should default namespace to clusters",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+
+				flag := cmd.Flag("namespace")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal("clusters"))
+			},
+		},
+		{
+			name: "When kubeconfig create command is created, it should register name flag with empty default",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+
+				flag := cmd.Flag("name")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(BeEmpty())
+			},
+		},
+		{
+			name: "When kubeconfig create command is created, it should default port-forward to false",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+
+				flag := cmd.Flag("port-forward")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal("false"))
+			},
+		},
+		{
+			name: "When kubeconfig create command is created, it should register exactly the expected flags",
+			test: func(t *testing.T, cmd *cobra.Command) {
+				g := NewWithT(t)
+
+				expectedFlags := []string{
+					"name",
+					"namespace",
+					"port-forward",
+				}
+				var actualFlags []string
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					actualFlags = append(actualFlags, f.Name)
+				})
+				sort.Strings(actualFlags)
+				g.Expect(actualFlags).To(Equal(expectedFlags))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := NewCreateCommand()
+			tt.test(t, cmd)
+		})
+	}
+}


### PR DESCRIPTION
The wiring in product-cli/cmd/kubeconfig/create.go is untested.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

Created `product-cli/cmd/kubeconfig/create_test.go` — 5 tests validating:

- `Use` field equals `"kubeconfig"`
- `Long` description matches the shared `Description` constant
- `namespace` flag defaults to `"clusters"`
- `name` flag registered with empty default
- `port-forward` flag defaults to `false`

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3902

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for the kubeconfig creation command’s metadata, error handling, handler wiring, defaults, and registered flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->