### PR TITLE
CNTRLPLANE-3903: Add unit test for hcp version command

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -20,28 +20,29 @@ func NewVersionCommand() *cobra.Command {
 		Short:        "Prints HyperShift CLI version",
 		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
+			out := cmd.OutOrStdout()
 			if commitOnly {
-				fmt.Printf("%s\n", supportedversion.GetRevision())
+				fmt.Fprintf(out, "%s\n", supportedversion.GetRevision())
 				return
 			}
-			fmt.Printf("Client Version: %s\n", supportedversion.String())
+			fmt.Fprintf(out, "Client Version: %s\n", supportedversion.String())
 			if clientOnly {
 				return
 			}
 
 			client, err := util.GetClient()
 			if err != nil {
-				fmt.Printf("failed to connect to server: %v", err)
+				fmt.Fprintf(out, "failed to connect to server: %v", err)
 				return
 			}
 
 			supportedVersions, serverVersion, err := supportedversion.GetSupportedOCPVersions(cmd.Context(), namespace, client, nil)
 			if err != nil {
-				fmt.Printf("failed to get supported OCP versions: %v\n", err)
+				fmt.Fprintf(out, "failed to get supported OCP versions: %v\n", err)
 				return
 			}
-			fmt.Printf("Server Version: %s\n", serverVersion)
-			fmt.Printf("Server Supports OCP Versions: %s\n", strings.Join(supportedVersions.Versions, ", "))
+			fmt.Fprintf(out, "Server Version: %s\n", serverVersion)
+			fmt.Fprintf(out, "Server Supports OCP Versions: %s\n", strings.Join(supportedVersions.Versions, ", "))
 		},
 	}
 

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -1,0 +1,98 @@
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/supportedversion"
+)
+
+func TestNewVersionCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "When commit-only flag is not set, it should include client version in output",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewVersionCommand()
+				cmd.SetArgs([]string{"--client-only"})
+
+				var buf bytes.Buffer
+				cmd.SetOut(&buf)
+				err := cmd.Execute()
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(buf.String()).To(HavePrefix("Client Version:"))
+			},
+		},
+		{
+			name: "When commit-only flag is set, it should print only the revision",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewVersionCommand()
+				cmd.SetArgs([]string{"--commit-only"})
+
+				var buf bytes.Buffer
+				cmd.SetOut(&buf)
+				err := cmd.Execute()
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(buf.String()).To(Equal(fmt.Sprintf("%s\n", supportedversion.GetRevision())))
+			},
+		},
+		{
+			name: "When client-only flag is set, it should print only the client version",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewVersionCommand()
+				cmd.SetArgs([]string{"--client-only"})
+
+				var buf bytes.Buffer
+				cmd.SetOut(&buf)
+				err := cmd.Execute()
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(buf.String()).To(Equal(fmt.Sprintf("Client Version: %s\n", supportedversion.String())))
+			},
+		},
+		{
+			name: "When no flags are set, it should print client version and fail gracefully without a server",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+
+				t.Setenv("KUBECONFIG", "/nonexistent/kubeconfig")
+				t.Setenv("KUBERNETES_SERVICE_HOST", "")
+
+				cmd := NewVersionCommand()
+				cmd.SetArgs([]string{})
+
+				var buf bytes.Buffer
+				cmd.SetOut(&buf)
+				err := cmd.Execute()
+				g.Expect(err).ToNot(HaveOccurred())
+				output := buf.String()
+				g.Expect(output).To(HavePrefix("Client Version:"))
+				g.Expect(output).To(ContainSubstring("failed to connect to server:"))
+			},
+		},
+		{
+			name: "When version command is created, it should default namespace to hypershift",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewVersionCommand()
+
+				flag := cmd.Flag("namespace")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal("hypershift"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.test(t)
+		})
+	}
+}

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -1,0 +1,119 @@
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/supportedversion"
+)
+
+func TestNewVersionCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "When version command is created, it should have 'version' as use",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewVersionCommand()
+				g.Expect(cmd.Use).To(Equal("version"))
+			},
+		},
+		{
+			name: "When version command is created, it should register commit-only flag with false default",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewVersionCommand()
+
+				flag := cmd.Flag("commit-only")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal("false"))
+			},
+		},
+		{
+			name: "When version command is created, it should register client-only flag with false default",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewVersionCommand()
+
+				flag := cmd.Flag("client-only")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal("false"))
+			},
+		},
+		{
+			name: "When version command is created, it should default namespace to hypershift",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewVersionCommand()
+
+				flag := cmd.Flag("namespace")
+				g.Expect(flag).ToNot(BeNil())
+				g.Expect(flag.DefValue).To(Equal("hypershift"))
+			},
+		},
+		{
+			name: "When commit-only flag is set, it should print only the revision",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewVersionCommand()
+				cmd.SetArgs([]string{"--commit-only"})
+
+				output := captureStdout(t, func() {
+					_ = cmd.Execute()
+				})
+
+				g.Expect(output).To(Equal(fmt.Sprintf("%s\n", supportedversion.GetRevision())))
+			},
+		},
+		{
+			name: "When client-only flag is set, it should print only the client version",
+			test: func(t *testing.T) {
+				g := NewWithT(t)
+				cmd := NewVersionCommand()
+				cmd.SetArgs([]string{"--client-only"})
+
+				output := captureStdout(t, func() {
+					_ = cmd.Execute()
+				})
+
+				g.Expect(output).To(Equal(fmt.Sprintf("Client Version: %s\n", supportedversion.String())))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.test(t)
+		})
+	}
+}
+
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	os.Stdout = origStdout
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("failed to read captured output: %v", err)
+	}
+
+	return buf.String()
+}


### PR DESCRIPTION
`hcp version` has zero test coverage at any layer.
The shared `cmd/version/version.go` has no test file.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
Created `cmd/version/version_test.go` — 6 tests validating:

- `Use` field equals `"version"`
- `commit-only` flag defaults to `false`
- `client-only` flag defaults to `false`
- `namespace` flag defaults to `"hypershift"`
- `--commit-only` output format: prints only the revision
- `--client-only` output format: prints `"Client Version: ..."` with the expected version string

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3903

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Version information and connection errors now appear in the configured command output destination, improving support for redirected and embedded command output.
* **Tests**
  * Added coverage for version command names, default flags, namespaces, and output options.
  * Added verification for commit-only and client-only output modes.
  * Added support for reliably capturing and validating command output during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->