### PR TITLE
OCPBUGS-104528: fix(test): skip CustomNoUpgrade CRDs on k8s < 1.31 in envtest

### DIFF
--- a/.github/workflows/envtest-kube-reusable.yaml
+++ b/.github/workflows/envtest-kube-reusable.yaml
@@ -48,7 +48,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: arc-runner-set
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/envtest-ocp-reusable.yaml
+++ b/.github/workflows/envtest-ocp-reusable.yaml
@@ -48,7 +48,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: arc-runner-set
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/test/envtest/generator.go
+++ b/test/envtest/generator.go
@@ -20,12 +20,19 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	kyaml "sigs.k8s.io/yaml"
 )
+
+// minK8sMinorVersionForCELFormatLibrary is the minimum k8s minor version that
+// supports the CEL format library (format.dns1123Subdomain(), format.labelValue(),
+// etc.), introduced in k8s 1.31 via KEP-4222. CustomNoUpgrade CRDs that use
+// these functions cannot be installed on older API servers.
+const minK8sMinorVersionForCELFormatLibrary = 31
 
 // LoadTestSuiteSpecs recursively walks the given paths looking for any .yaml file
 // inside a tests/ directory structure (matching openshift/api conventions).
@@ -177,6 +184,17 @@ func GenerateTestSuite(suiteSpec SuiteSpec) {
 
 			BeforeEach(OncePerOrdered, func() {
 				Expect(k8sClient).ToNot(BeNil(), "Kubernetes client is not initialised")
+
+				// CustomNoUpgrade CRDs may contain CEL rules (e.g. format.*) that
+				// require k8s 1.31+. Skip on older versions to avoid CRD install failures.
+				// TODO(OCPBUGS-104528): remove this skip once the envtest matrix has a
+				// well-defined sliding window of supported versions and 1.30 is dropped.
+				if featureSetAnnotation := baseCRD.Annotations["release.openshift.io/feature-set"]; featureSetAnnotation != "" {
+					featureSets := sets.New[string](strings.Split(featureSetAnnotation, ",")...)
+					if featureSets.Has("CustomNoUpgrade") && k8sMinorVersion < minK8sMinorVersionForCELFormatLibrary {
+						Skip(fmt.Sprintf("CustomNoUpgrade CRDs require k8s >= 1.%d for CEL format library support (current: 1.%d)", minK8sMinorVersionForCELFormatLibrary, k8sMinorVersion))
+					}
+				}
 
 				// Retry CRD installation — a previous suite may still be deleting the same CRD.
 				var crds []*apiextensionsv1.CustomResourceDefinition

--- a/test/envtest/suite_test.go
+++ b/test/envtest/suite_test.go
@@ -29,6 +29,7 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 var ctx = context.Background()
 var suites []SuiteSpec
+var k8sMinorVersion int
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -73,6 +74,7 @@ var _ = BeforeSuite(func() {
 	minorInt, err := strconv.Atoi(strings.Split(serverVersion.Minor, "+")[0])
 	Expect(err).ToNot(HaveOccurred())
 	Expect(minorInt).To(BeNumerically(">=", 25), fmt.Sprintf("This test suite requires a Kube API server of at least version 1.25, current version is 1.%s", serverVersion.Minor))
+	k8sMinorVersion = minorInt
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
## What this PR does / why we need it:
CustomNoUpgrade CRD variants from vendored openshift/api now use CEL format library functions (format.dns1123Subdomain, etc.) that require k8s 1.31+ (KEP-4222). This causes CRD installation failures on k8s 1.30 (OCP 4.17) for feature-gated test suites that load CustomNoUpgrade CRDs.

Skip these CRD variants at test time when the envtest API server is older than 1.31.

## Which issue(s) this PR fixes:
Fixes [OCPBUGS-104528](https://redhat.atlassian.net/browse/OCPBUGS-104528)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Kubernetes version checks for environment-based test suites.
  * Older Kubernetes versions now skip unsupported custom resource tests and report the required and detected versions.
  * Added validation that the Kubernetes API server meets the minimum supported version.
  * Increased environment test job timeouts to improve reliability on Kubernetes and OpenShift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->