### PR TITLE
OCPBUGS-100279: load plugin explicitly in bare mode for skill resolution

### DIFF
--- a/.github/workflows/restructure-commits.yaml
+++ b/.github/workflows/restructure-commits.yaml
@@ -21,7 +21,9 @@ jobs:
     with:
       command-name: restructure-commits
       status-message: "Restructuring commits"
+      trusted-commands: "commands/restructure-commits.md skills/git-commit-format/SKILL.md"
       claude-prompt: >-
-        /restructure-commits -- You are running in CI. Do NOT push — the workflow handles pushing.
+        Follow the "Restructure Commits by Component" instructions from the system prompt.
+        You are running in CI. Do NOT push — the workflow handles pushing.
       max-turns: 200
     secrets: inherit

--- a/.github/workflows/reusable-claude-on-pr.yaml
+++ b/.github/workflows/reusable-claude-on-pr.yaml
@@ -23,6 +23,12 @@ on:
         description: Space-separated list of allowed Claude tools
         type: string
         default: "Bash Read Write Edit Grep Glob WebFetch"
+      trusted-commands:
+        description: >-
+          Space-separated list of .claude/ files to load from the trusted main branch
+          (e.g. "commands/restructure-commits.md skills/git-commit-format/SKILL.md")
+        type: string
+        default: ""
 
 jobs:
   run:
@@ -90,6 +96,18 @@ jobs:
             git update-ref refs/heads/main refs/remotes/upstream/main
           fi
 
+      - name: Load trusted commands from main
+        if: inputs.trusted-commands != ''
+        env:
+          TRUSTED_COMMANDS: ${{ inputs.trusted-commands }}
+        run: |
+          git rev-parse --verify refs/heads/main >/dev/null 2>&1 || git update-ref refs/heads/main refs/remotes/origin/main
+          for file in $TRUSTED_COMMANDS; do
+            echo "--- Loading .claude/$file from main ---"
+            git show "main:.claude/$file" >> /tmp/trusted-system-prompt.md
+            printf '\n---\n' >> /tmp/trusted-system-prompt.md
+          done
+
       - name: Authenticate to GCP via WIF
         id: gcp-auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
@@ -134,7 +152,11 @@ jobs:
           claude plugin marketplace add openshift-eng/ai-helpers
           claude plugin install openshift-developer@ai-helpers
           claude --version
-          claude -p "$CLAUDE_PROMPT" --bare --model claude-opus-4-6 --max-turns "$MAX_TURNS" --allowedTools "$ALLOWED_TOOLS" --verbose --output-format stream-json
+          TRUSTED_PROMPT_ARGS=""
+          if [[ -f /tmp/trusted-system-prompt.md ]]; then
+            TRUSTED_PROMPT_ARGS="--append-system-prompt-file /tmp/trusted-system-prompt.md"
+          fi
+          claude -p "$CLAUDE_PROMPT" --bare $TRUSTED_PROMPT_ARGS --model claude-opus-4-6 --max-turns "$MAX_TURNS" --allowedTools "$ALLOWED_TOOLS" --verbose --output-format stream-json
 
       - name: Push changes
         env:


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes the `/restructure-commits` workflow failing with `Unknown command: /restructure-commits` after PR #9214 introduced `--bare` mode to the reusable Claude workflow.

`--bare` blocks loading `.claude/commands/` from the workspace, which is where `/restructure-commits` is defined. Since the whole point of `--bare` is to prevent loading untrusted content from fork checkouts, we can't just disable it. Instead, this PR loads the command files from the trusted `main` branch via `git show` and passes them to Claude via `--append-system-prompt-file`.

### Changes:

- **Add `trusted-commands` input** to the reusable workflow — callers specify which `.claude/` files to load from the `main` branch (e.g. `commands/restructure-commits.md skills/git-commit-format/SKILL.md`).
- **Extract trusted commands from main** — a new step uses `git show main:.claude/$file` to build a system prompt file from the trusted branch, not the fork checkout.
- **Create `refs/heads/main` for same-repo PRs** — `actions/checkout` doesn't create a local `main` ref, so the step creates one from `origin/main` if needed (fork PRs already have it from the upstream remote step).
- **Update restructure-commits caller** — passes `trusted-commands` and changes the prompt to reference the system prompt instructions instead of the `/restructure-commits` slash command.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/OCPBUGS-100279

## Special notes for your reviewer:

Follow-up to #9214. The rebase workflow is unaffected — its instructions are already inline in the prompt and don't depend on any `.claude/commands/` files.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading approved instruction files into automated review prompts.
  * Updated commit-restructuring automation to use standardized guidance and prohibit CI-initiated pushes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->