### PR TITLE
CNTRLPLANE-3997: add workflow to publish docs to Cloudflare Pages on merge

### DIFF
--- a/.github/workflows/docs-deploy-reusable.yaml
+++ b/.github/workflows/docs-deploy-reusable.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: arc-runner-set
     timeout-minutes: 5
     environment:
-      name: docs-preview
+      name: ${{ inputs.production && 'docs-production' || 'docs-preview' }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -43,7 +43,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy site --project-name=hypershift --production --commit-dirty=true
       - name: Deploy to Cloudflare Pages (Preview)
-        if: ${{ !inputs.production }}
+        if: ${{ !inputs.production && inputs.branch != '' }}
         env:
           npm_config_cache: ${{ runner.temp }}/.npm
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0

--- a/.github/workflows/docs-deploy-reusable.yaml
+++ b/.github/workflows/docs-deploy-reusable.yaml
@@ -1,0 +1,53 @@
+name: Docs Deploy (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      production:
+        description: 'Deploy to production (hypershift.pages.dev)'
+        required: false
+        type: boolean
+        default: false
+      branch:
+        description: 'Cloudflare Pages branch for preview deployments'
+        required: false
+        type: string
+
+permissions:
+  deployments: write
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Pages
+    runs-on: arc-runner-set
+    timeout-minutes: 5
+    environment:
+      name: docs-preview
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docs-site
+          path: site
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '20'
+        env:
+          npm_config_cache: ${{ runner.temp }}/.npm
+      - name: Deploy to Cloudflare Pages (Production)
+        if: inputs.production
+        env:
+          npm_config_cache: ${{ runner.temp }}/.npm
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy site --project-name=hypershift --production --commit-dirty=true
+      - name: Deploy to Cloudflare Pages (Preview)
+        if: ${{ !inputs.production }}
+        env:
+          npm_config_cache: ${{ runner.temp }}/.npm
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy site --project-name=hypershift --branch=${{ inputs.branch }} --commit-dirty=true

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -1,0 +1,30 @@
+name: Docs Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-publish.yaml'
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  build:
+    name: Build Docs
+    permissions:
+      contents: read
+    uses: openshift/hypershift/.github/workflows/docs-build-reusable.yaml@main
+
+  deploy:
+    name: Deploy Production
+    needs: build
+    permissions:
+      deployments: write
+    uses: openshift/hypershift/.github/workflows/docs-deploy-reusable.yaml@main
+    with:
+      production: true
+    secrets: inherit

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -12,6 +12,10 @@ permissions:
   contents: read
   deployments: write
 
+concurrency:
+  group: docs-production
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build Docs


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`docs-publish.yaml`) that deploys HyperShift documentation to Cloudflare Pages production when docs changes are merged to main
- Adds a reusable deploy workflow (`docs-deploy-reusable.yaml`) that supports both production (`--production`) and preview (`--branch=<name>`) deployment modes
- Eliminates the current workaround of using the `celebdor/hypershift` fork to trigger production doc updates

## Test plan

- [ ] Verify workflow triggers on a docs/ change merged to main
- [ ] Verify production deployment reaches `hypershift.pages.dev`
- [ ] Verify existing PR preview flow (`docs-build.yaml` → `docs-deploy.yaml`) is unaffected

Ref: [CNTRLPLANE-3997](https://redhat.atlassian.net/browse/CNTRLPLANE-3997)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated documentation deployment to Cloudflare Pages.
  * Supports both production releases and branch-specific preview deployments.
  * Documentation changes pushed to the main branch now trigger an automated build and production deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->