### PR TITLE
NO-JIRA: fix(build): bump hack/tools Go version to 1.26.0 to match main module

### DIFF
--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hypershift/hack/tools
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0


### PR DESCRIPTION
The k8s v0.36.2 bump (9ca8c141c) updated the main and api modules to Go 1.26 but missed hack/tools, breaking make generate and make verify running locally for pre-commit.

## What this PR does / why we need it:
The version mismatch broke make commands, and that's blocking my PR here: https://github.com/openshift/hypershift/pull/9199. I got them running successfully with this change and created a dedicated PR.
## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes: No Jira. I'm not sure how to use the OCP Jira. 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version used by development utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->