### PR TITLE
CNTRLPLANE-3201: feat(e2e): enable etcd snapshot backup test on Azure 

### DIFF
--- a/test/e2e/v2/backuprestore/velero.go
+++ b/test/e2e/v2/backuprestore/velero.go
@@ -97,6 +97,31 @@ func isPodReady(pod *corev1.Pod) bool {
 	return false
 }
 
+// WaitForBackupStorageLocationAvailable waits for the BackupStorageLocation with the given
+// name to reach the Available phase. OADP reconciles the BSL from the DataProtectionApplication
+// asynchronously, so it can still be Unavailable for a short time after Velero itself is running,
+// which would otherwise fail any Backup/Schedule created against it with FailedValidation.
+func WaitForBackupStorageLocationAvailable(testCtx *internal.TestContext, name string) error {
+	err := wait.PollUntilContextTimeout(testCtx.Context, PollInterval, BackupTimeout, true, func(ctx context.Context) (bool, error) {
+		bsl, err := getVeleroResource(ctx, testCtx.MgmtClient, DefaultOADPNamespace, name, "BackupStorageLocation")
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		phase, _, err := unstructured.NestedString(bsl.Object, "status", "phase")
+		if err != nil {
+			return false, fmt.Errorf("failed to get BackupStorageLocation phase: %w", err)
+		}
+		return phase == "Available", nil
+	})
+	if err != nil {
+		return fmt.Errorf("BackupStorageLocation %s did not become Available: %w", name, err)
+	}
+	return nil
+}
+
 // WaitForBackupCompletion waits for a backup to complete.
 // If backupName is provided, it waits for that specific backup.
 // If backupName is empty, it finds the most recent backup matching the HostedCluster name/namespace.

--- a/test/e2e/v2/backuprestore/velero.go
+++ b/test/e2e/v2/backuprestore/velero.go
@@ -186,24 +186,13 @@ func getLatestBackupForHostedCluster(ctx context.Context, client crclient.Client
 	return getLatestVeleroResourceForHostedCluster(ctx, client, oadpNamespace, hcName, hcNamespace, "Backup", "BackupList")
 }
 
-// WaitForScheduleCompletion waits for the most recent backup created by a schedule to complete.
-// It finds the latest backup with label velero.io/schedule-name: scheduleName and waits for it to finish.
-func WaitForScheduleCompletion(testCtx *internal.TestContext, scheduleName string) error {
-	// Find the most recent backup created by this schedule
-	backupName, err := getLatestBackupForSchedule(testCtx.Context, testCtx.MgmtClient, DefaultOADPNamespace, scheduleName)
-	if err != nil {
+// WaitForScheduleBackupCreated waits until a schedule has created a backup, without waiting
+// for that backup to reach a final state.
+func WaitForScheduleBackupCreated(testCtx *internal.TestContext, scheduleName string) error {
+	if _, err := getLatestBackupForSchedule(testCtx.Context, testCtx.MgmtClient, DefaultOADPNamespace, scheduleName); err != nil {
 		return fmt.Errorf("failed to find backup for schedule %s: %w", scheduleName, err)
 	}
-
-	// Wait for backup to reach a final state
-	checkFn := isBackupInFinalState(testCtx.MgmtClient, DefaultOADPNamespace, backupName)
-	if err := wait.PollUntilContextTimeout(testCtx.Context, PollInterval, BackupTimeout, true, func(ctx context.Context) (bool, error) {
-		return checkFn(ctx)
-	}); err != nil {
-		return fmt.Errorf("backup %s (from schedule %s) did not reach final state within %v: %w", backupName, scheduleName, BackupTimeout, err)
-	}
-
-	return ensureBackupSuccessful(testCtx.Context, testCtx.MgmtClient, DefaultOADPNamespace, backupName)
+	return nil
 }
 
 // getLatestBackupForSchedule finds the most recent backup with label velero.io/schedule-name: scheduleName.

--- a/test/e2e/v2/backuprestore/velero.go
+++ b/test/e2e/v2/backuprestore/velero.go
@@ -218,22 +218,9 @@ func getLatestBackupForHostedCluster(ctx context.Context, client crclient.Client
 
 // WaitForScheduleBackupCreated waits until a schedule has created a backup, without waiting
 // for that backup to reach a final state.
-//
-// It propagates schedule lookup errors, including timeout errors wrapped with "failed to find
-// backup for schedule" message after polling for 5 minutes.
 func WaitForScheduleBackupCreated(testCtx *internal.TestContext, scheduleName string) error {
-	if _, err := getLatestBackupForSchedule(testCtx.Context, testCtx.MgmtClient, DefaultOADPNamespace, scheduleName); err != nil {
-		return fmt.Errorf("failed to find backup for schedule %s: %w", scheduleName, err)
-	}
-	return nil
-}
-
-// getLatestBackupForSchedule finds the most recent backup with label velero.io/schedule-name: scheduleName.
-// It waits for a backup to exist before returning, polling until a backup is created by the schedule.
-func getLatestBackupForSchedule(ctx context.Context, client crclient.Client, oadpNamespace string, scheduleName string) (string, error) {
-	var backupName string
 	// Wait for a backup to be created by the schedule
-	err := wait.PollUntilContextTimeout(ctx, PollInterval, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(testCtx.Context, PollInterval, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		backupList := &unstructured.UnstructuredList{}
 		backupList.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   "velero.io",
@@ -245,27 +232,25 @@ func getLatestBackupForSchedule(ctx context.Context, client crclient.Client, oad
 		labelSelector := crclient.MatchingLabels{
 			"velero.io/schedule-name": scheduleName,
 		}
-		if lastErr := client.List(ctx, backupList, crclient.InNamespace(oadpNamespace), labelSelector); lastErr != nil {
+		if lastErr := testCtx.MgmtClient.List(ctx, backupList, crclient.InNamespace(DefaultOADPNamespace), labelSelector); lastErr != nil {
 			return false, lastErr
 		}
 		if len(backupList.Items) == 0 {
 			return false, nil
 		}
-
-		// Sort by creation timestamp (most recent first)
-		sort.Slice(backupList.Items, func(i, j int) bool {
-			return backupList.Items[i].GetCreationTimestamp().After(backupList.Items[j].GetCreationTimestamp().Time)
-		})
-
-		backupName = backupList.Items[0].GetName()
+		if failed, err := isBackupInFailedState(testCtx.MgmtClient, DefaultOADPNamespace, backupList.Items[0].GetName())(ctx); err != nil {
+			return false, err
+		} else if failed {
+			return false, fmt.Errorf("backup %s is in a failing state", backupList.Items[0].GetName())
+		}
 		return true, nil
 	})
 
 	if err != nil {
-		return "", fmt.Errorf("failed to find backup for schedule %s within timeout: %w", scheduleName, err)
+		return fmt.Errorf("failed to find backup for schedule %s within timeout: %w", scheduleName, err)
 	}
 
-	return backupName, nil
+	return nil
 }
 
 // getVeleroResource retrieves a Velero resource (Backup, Restore, or Schedule) by name.
@@ -292,12 +277,12 @@ func getBackup(ctx context.Context, client crclient.Client, namespace, name stri
 	return getVeleroResource(ctx, client, namespace, name, "Backup")
 }
 
-// isVeleroResourceInFinalState returns a function that checks if a Velero resource (Backup or Restore)
-// is in a final state. This can be both success and failure.
-func isVeleroResourceInFinalState(
+// isVeleroResourceInState returns a function that checks if a Velero resource (Backup or Restore)
+// is in a desired state.
+func isVeleroResourceInState(
 	client crclient.Client,
 	namespace, name, kind string,
-	phasesNotDone []string,
+	states []string,
 	getResourceFunc func(context.Context, crclient.Client, string, string) (*unstructured.Unstructured, error),
 ) func(context.Context) (bool, error) {
 	return func(ctx context.Context) (bool, error) {
@@ -316,30 +301,31 @@ func isVeleroResourceInFinalState(
 			return false, nil
 		}
 
-		// Check if phase is in the "not done" list
-		for _, notDonePhase := range phasesNotDone {
-			if phase == notDonePhase {
-				return false, nil
-			}
-		}
-		return true, nil
+		return slices.Contains(states, phase), nil
 	}
 }
 
 // isBackupInFinalState returns a function that checks if a backup is in a final state. This
 // can be both success and failure.
 func isBackupInFinalState(client crclient.Client, namespace, name string) func(context.Context) (bool, error) {
-	phasesNotDone := []string{
-		BackupPhaseNew,
-		BackupPhaseQueued,
-		BackupPhaseReadyToStart,
-		BackupPhaseInProgress,
-		BackupPhaseWaitingForPluginOperations,
-		BackupPhaseWaitingForPluginOperationsPartiallyFailed,
-		BackupPhaseFinalizing,
-		BackupPhaseFinalizingPartiallyFailed,
+	finalStates := []string{
+		BackupPhaseCompleted,
+		BackupPhaseFailed,
+		BackupPhasePartiallyFailed,
 	}
-	return isVeleroResourceInFinalState(client, namespace, name, "backup", phasesNotDone, getBackup)
+	return isVeleroResourceInState(client, namespace, name, "backup", finalStates, getBackup)
+}
+
+// isBackupInFailedState returns a function that checks if a backup is in a failing state.
+// This can be both partially failed and failed.
+func isBackupInFailedState(client crclient.Client, namespace, name string) func(context.Context) (bool, error) {
+	failedStates := []string{
+		BackupPhaseWaitingForPluginOperationsPartiallyFailed,
+		BackupPhaseFinalizingPartiallyFailed,
+		BackupPhaseFailed,
+		BackupPhasePartiallyFailed,
+	}
+	return isVeleroResourceInState(client, namespace, name, "backup", failedStates, getBackup)
 }
 
 // WaitForRestoreCompletion waits for a restore to complete.
@@ -406,15 +392,12 @@ func getRestore(ctx context.Context, client crclient.Client, namespace, name str
 // isRestoreInFinalState returns a function that checks if a restore is in a final state.
 // This can be both success and failure.
 func isRestoreInFinalState(client crclient.Client, namespace, name string) func(context.Context) (bool, error) {
-	phasesNotDone := []string{
-		RestorePhaseNew,
-		RestorePhaseInProgress,
-		RestorePhaseWaitingForPluginOperations,
-		RestorePhaseWaitingForPluginOperationsPartiallyFailed,
-		RestorePhaseFinalizing,
-		RestorePhaseFinalizingPartiallyFailed,
+	finalStates := []string{
+		RestorePhaseCompleted,
+		RestorePhaseFailed,
+		RestorePhasePartiallyFailed,
 	}
-	return isVeleroResourceInFinalState(client, namespace, name, "restore", phasesNotDone, getRestore)
+	return isVeleroResourceInState(client, namespace, name, "restore", finalStates, getRestore)
 }
 
 // DeleteOADPSchedule deletes a Velero Schedule resource.

--- a/test/e2e/v2/backuprestore/velero.go
+++ b/test/e2e/v2/backuprestore/velero.go
@@ -12,11 +12,13 @@ import (
 	"time"
 
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -101,6 +103,9 @@ func isPodReady(pod *corev1.Pod) bool {
 // name to reach the Available phase. OADP reconciles the BSL from the DataProtectionApplication
 // asynchronously, so it can still be Unavailable for a short time after Velero itself is running,
 // which would otherwise fail any Backup/Schedule created against it with FailedValidation.
+//
+// It retries NotFound errors through BackupTimeout, returns other lookup or status errors
+// immediately, and wraps timeout errors with a descriptive message.
 func WaitForBackupStorageLocationAvailable(testCtx *internal.TestContext, name string) error {
 	err := wait.PollUntilContextTimeout(testCtx.Context, PollInterval, BackupTimeout, true, func(ctx context.Context) (bool, error) {
 		bsl, err := getVeleroResource(ctx, testCtx.MgmtClient, DefaultOADPNamespace, name, "BackupStorageLocation")
@@ -213,6 +218,9 @@ func getLatestBackupForHostedCluster(ctx context.Context, client crclient.Client
 
 // WaitForScheduleBackupCreated waits until a schedule has created a backup, without waiting
 // for that backup to reach a final state.
+//
+// It propagates schedule lookup errors, including timeout errors wrapped with "failed to find
+// backup for schedule" message after polling for 5 minutes.
 func WaitForScheduleBackupCreated(testCtx *internal.TestContext, scheduleName string) error {
 	if _, err := getLatestBackupForSchedule(testCtx.Context, testCtx.MgmtClient, DefaultOADPNamespace, scheduleName); err != nil {
 		return fmt.Errorf("failed to find backup for schedule %s: %w", scheduleName, err)

--- a/test/e2e/v2/backuprestore/velero.go
+++ b/test/e2e/v2/backuprestore/velero.go
@@ -47,6 +47,10 @@ const (
 	RestorePhaseCompleted                                 = "Completed"
 	RestorePhaseFailed                                    = "Failed"
 	RestorePhasePartiallyFailed                           = "PartiallyFailed"
+
+	BSLPhaseAvailable = "Available"
+
+	ScheduleBackupCreationTimeout = 5 * time.Minute
 )
 
 // EnsureVeleroPodRunning checks if at least one Velero pod is running and ready in the specified namespace.
@@ -119,7 +123,7 @@ func WaitForBackupStorageLocationAvailable(testCtx *internal.TestContext, name s
 		if err != nil {
 			return false, fmt.Errorf("failed to get BackupStorageLocation phase: %w", err)
 		}
-		return phase == "Available", nil
+		return phase == BSLPhaseAvailable, nil
 	})
 	if err != nil {
 		return fmt.Errorf("BackupStorageLocation %s did not become Available: %w", name, err)
@@ -220,7 +224,7 @@ func getLatestBackupForHostedCluster(ctx context.Context, client crclient.Client
 // for that backup to reach a final state.
 func WaitForScheduleBackupCreated(testCtx *internal.TestContext, scheduleName string) error {
 	// Wait for a backup to be created by the schedule
-	err := wait.PollUntilContextTimeout(testCtx.Context, PollInterval, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(testCtx.Context, PollInterval, ScheduleBackupCreationTimeout, true, func(ctx context.Context) (bool, error) {
 		backupList := &unstructured.UnstructuredList{}
 		backupList.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   "velero.io",
@@ -238,10 +242,13 @@ func WaitForScheduleBackupCreated(testCtx *internal.TestContext, scheduleName st
 		if len(backupList.Items) == 0 {
 			return false, nil
 		}
-		if failed, err := isBackupInFailedState(testCtx.MgmtClient, DefaultOADPNamespace, backupList.Items[0].GetName())(ctx); err != nil {
+		backupName := backupList.Items[0].GetName()
+		failed, err := isBackupInFailedState(testCtx.MgmtClient, DefaultOADPNamespace, backupName)(ctx)
+		if err != nil {
 			return false, err
-		} else if failed {
-			return false, fmt.Errorf("backup %s is in a failing state", backupList.Items[0].GetName())
+		}
+		if failed {
+			return false, fmt.Errorf("backup %s is in a failing state", backupName)
 		}
 		return true, nil
 	})

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -230,8 +230,8 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 			err = backuprestore.WaitForBackupCompletion(testCtx, backupName)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Waiting for schedule to have one backup completed")
-			err = backuprestore.WaitForScheduleCompletion(testCtx, scheduleName)
+			By("Waiting for schedule to create a backup")
+			err = backuprestore.WaitForScheduleBackupCreated(testCtx, scheduleName)
 			Expect(err).NotTo(HaveOccurred())
 
 		})

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -191,6 +191,10 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 				})
 			}
 
+			By("Waiting for BackupStorageLocation to be Available")
+			err := backuprestore.WaitForBackupStorageLocationAvailable(testCtx, testCtx.ClusterName)
+			Expect(err).NotTo(HaveOccurred())
+
 			// Create schedule first to test parallel execution of backup and schedule and
 			// to speed up the test execution.
 			By("Creating schedule")
@@ -203,7 +207,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 				StorageLocation:   testCtx.ClusterName,
 				IncludeNamespaces: platformCfg.additionalNamespaces,
 			}
-			err := backuprestore.RunOADPSchedule(testCtx.Context, GinkgoLogr.WithName("backup-restore"), testCtx.ArtifactDir, scheduleOpts)
+			err = backuprestore.RunOADPSchedule(testCtx.Context, GinkgoLogr.WithName("backup-restore"), testCtx.ArtifactDir, scheduleOpts)
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -63,9 +63,10 @@ const (
 )
 
 type backupRestorePlatformConfig struct {
-	excludeWorkloads     []string
-	postRestoreHook      func(testCtx *internal.TestContext) error
-	additionalNamespaces []string
+	excludeWorkloads      []string
+	postRestoreHook       func(testCtx *internal.TestContext) error
+	additionalNamespaces  []string
+	supportsHCPETCDBackup bool
 }
 
 var backupRestorePlatforms = map[hyperv1.PlatformType]backupRestorePlatformConfig{
@@ -81,6 +82,7 @@ var backupRestorePlatforms = map[hyperv1.PlatformType]backupRestorePlatformConfi
 			}
 			return backuprestore.RunFixDrOidcIam(testCtx.Context, GinkgoLogr.WithName("backup-restore"), testCtx.ArtifactDir, fixOpts)
 		},
+		supportsHCPETCDBackup: true,
 	},
 	hyperv1.AgentPlatform: {
 		excludeWorkloads: []string{"router", "karpenter", "karpenter-operator", "cloud-network-config-controller"},
@@ -94,8 +96,9 @@ var backupRestorePlatforms = map[hyperv1.PlatformType]backupRestorePlatformConfi
 		postRestoreHook:  nil,
 	},
 	hyperv1.AzurePlatform: {
-		excludeWorkloads: []string{"router", "karpenter", "karpenter-operator"},
-		postRestoreHook:  nil,
+		excludeWorkloads:      []string{"router", "karpenter", "karpenter-operator"},
+		postRestoreHook:       nil,
+		supportsHCPETCDBackup: true,
 	},
 }
 
@@ -395,10 +398,12 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 		Expect(testCtx).NotTo(BeNil())
 		hostedCluster := testCtx.GetHostedCluster()
 		Expect(hostedCluster).NotTo(BeNil(), "HostedCluster should be set up")
-		if hostedCluster.Spec.Platform.Type != hyperv1.AWSPlatform {
-			Skip("etcd snapshot backup test only supported on AWS")
+
+		cfg, found := backupRestorePlatforms[hostedCluster.Spec.Platform.Type]
+		if !(found && cfg.supportsHCPETCDBackup) {
+			Skip(fmt.Sprintf("etcd snapshot backup test not supported on platform %s", hostedCluster.Spec.Platform.Type))
 		}
-		platformCfg = backupRestorePlatforms[hyperv1.AWSPlatform]
+		platformCfg = cfg
 
 		By("Checking if HCPEtcdBackup feature gate is enabled")
 		hcpEtcdBackupList := &hyperv1.HCPEtcdBackupList{}

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -193,6 +193,10 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 				})
 			}
 
+			By("Waiting for BackupStorageLocation to be Available")
+			err := backuprestore.WaitForBackupStorageLocationAvailable(testCtx, testCtx.ClusterName)
+			Expect(err).NotTo(HaveOccurred())
+
 			// Create schedule first to test parallel execution of backup and schedule and
 			// to speed up the test execution.
 			By("Creating schedule")

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -63,9 +63,10 @@ const (
 )
 
 type backupRestorePlatformConfig struct {
-	excludeWorkloads     []string
-	postRestoreHook      func(testCtx *internal.TestContext) error
-	additionalNamespaces []string
+	excludeWorkloads      []string
+	postRestoreHook       func(testCtx *internal.TestContext) error
+	additionalNamespaces  []string
+	supportsHCPETCDBackup bool
 }
 
 var backupRestorePlatforms = map[hyperv1.PlatformType]backupRestorePlatformConfig{
@@ -81,6 +82,7 @@ var backupRestorePlatforms = map[hyperv1.PlatformType]backupRestorePlatformConfi
 			}
 			return backuprestore.RunFixDrOidcIam(testCtx.Context, GinkgoLogr.WithName("backup-restore"), testCtx.ArtifactDir, fixOpts)
 		},
+		supportsHCPETCDBackup: true,
 	},
 	hyperv1.AgentPlatform: {
 		excludeWorkloads: []string{"router", "karpenter", "karpenter-operator", "cloud-network-config-controller"},
@@ -94,8 +96,9 @@ var backupRestorePlatforms = map[hyperv1.PlatformType]backupRestorePlatformConfi
 		postRestoreHook:  nil,
 	},
 	hyperv1.AzurePlatform: {
-		excludeWorkloads: []string{"router", "karpenter", "karpenter-operator"},
-		postRestoreHook:  nil,
+		excludeWorkloads:      []string{"router", "karpenter", "karpenter-operator"},
+		postRestoreHook:       nil,
+		supportsHCPETCDBackup: true,
 	},
 }
 
@@ -395,8 +398,14 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 	BeforeAll(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil())
-		testCtx.SkipIfNotPlatform(hyperv1.AWSPlatform)
-		platformCfg = backupRestorePlatforms[hyperv1.AWSPlatform]
+		hostedCluster := testCtx.GetHostedCluster()
+		Expect(hostedCluster).NotTo(BeNil(), "HostedCluster should be set up")
+
+		cfg, found := backupRestorePlatforms[hostedCluster.Spec.Platform.Type]
+		if !(found && cfg.supportsHCPETCDBackup) {
+			Skip(fmt.Sprintf("etcd snapshot backup test not supported on platform %s", hostedCluster.Spec.Platform.Type))
+		}
+		platformCfg = cfg
 
 		By("Checking if HCPEtcdBackup feature gate is enabled")
 		hcpEtcdBackupList := &hyperv1.HCPEtcdBackupList{}

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -31,12 +31,14 @@ import (
 	"github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/backuprestore"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -194,7 +196,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 			}
 
 			By("Waiting for BackupStorageLocation to be Available")
-			err := backuprestore.WaitForBackupStorageLocationAvailable(testCtx, testCtx.ClusterName)
+			err = backuprestore.WaitForBackupStorageLocationAvailable(testCtx, testCtx.ClusterName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Create schedule first to test parallel execution of backup and schedule and
@@ -402,7 +404,8 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 	BeforeAll(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil())
-		hostedCluster := testCtx.GetHostedCluster()
+		hostedCluster, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		Expect(hostedCluster).NotTo(BeNil(), "HostedCluster should be set up")
 
 		cfg, found := backupRestorePlatforms[hostedCluster.Spec.Platform.Type]
@@ -413,7 +416,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 
 		By("Checking if HCPEtcdBackup feature gate is enabled")
 		hcpEtcdBackupList := &hyperv1.HCPEtcdBackupList{}
-		err := testCtx.MgmtClient.List(testCtx.Context, hcpEtcdBackupList, crclient.InNamespace(testCtx.ControlPlaneNamespace))
+		err = testCtx.MgmtClient.List(testCtx.Context, hcpEtcdBackupList, crclient.InNamespace(testCtx.ControlPlaneNamespace))
 		if err != nil {
 			if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
 				Skip("HCPEtcdBackup feature gate is not enabled (CRD not installed). " +

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -232,8 +232,8 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 			err = backuprestore.WaitForBackupCompletion(testCtx, backupName)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Waiting for schedule to have one backup completed")
-			err = backuprestore.WaitForScheduleCompletion(testCtx, scheduleName)
+			By("Waiting for schedule to create a backup")
+			err = backuprestore.WaitForScheduleBackupCreated(testCtx, scheduleName)
 			Expect(err).NotTo(HaveOccurred())
 
 		})

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -508,6 +508,10 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 
 	Context(ContextBackup, func() {
 		It("should create backup with etcd snapshot method", func() {
+			By("Waiting for BackupStorageLocation to be Available")
+			err := backuprestore.WaitForBackupStorageLocationAvailable(testCtx, testCtx.ClusterName)
+			Expect(err).NotTo(HaveOccurred())
+
 			By("Creating backup with etcd snapshot options")
 			backupName = oadp.GenerateBackupName(
 				testCtx.ClusterName,
@@ -520,7 +524,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 				StorageLocation: testCtx.ClusterName,
 				UseEtcdSnapshot: true,
 			}
-			err := backuprestore.RunOADPBackup(testCtx.Context, GinkgoLogr.WithName("backup-restore"), testCtx.ArtifactDir, backupOpts)
+			err = backuprestore.RunOADPBackup(testCtx.Context, GinkgoLogr.WithName("backup-restore"), testCtx.ArtifactDir, backupOpts)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for backup to complete")


### PR DESCRIPTION
## What this PR does / why we need it:
* Extend the AWS-only skip condition and platformCfg lookup to also support Azure, keyed off the HostedCluster's actual platform type.
* Replace WaitForScheduleCompletion with WaitForScheduleBackupCreated so the test only confirms a backup was created by the schedule, without waiting for it to reach a final state. Waiting for two backups to complete (one created directly, one through Velero Schedule) in each tests is time consuming and often times out.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Related to https://redhat.atlassian.net/browse/CNTRLPLANE-3201

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup and restore test reliability by waiting for backup storage to become available before scheduled runs begin.
  * Updated schedule validation to continue once the latest scheduled backup is created.
* **Tests**
  * Expanded etcd snapshot backup coverage to supported AWS and Azure environments.
  * Tests now detect platform capabilities dynamically and skip unsupported environments automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->