### PR TITLE
OCPBUGS-104543: fix test isolation bug in EnsureDefaultSecurityGroupTagsTest

### DIFF
--- a/test/e2e/v2/tests/hosted_cluster_aws_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_aws_test.go
@@ -114,6 +114,19 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 				if err != nil && !apierrors.IsNotFound(err) {
 					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to restore HostedCluster AWS resource tags")
 				}
+
+				tc.ValidateHostedClusterClient()
+				hcClient := tc.GetHostedClusterClient()
+				Eventually(func(g Gomega) {
+					infra := &configv1.Infrastructure{}
+					g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, infra)).To(Succeed())
+					g.Expect(infra.Status.PlatformStatus).NotTo(BeNil())
+					g.Expect(infra.Status.PlatformStatus.AWS).NotTo(BeNil())
+					g.Expect(infra.Status.PlatformStatus.AWS.ResourceTags).NotTo(
+						ContainElement(configv1.AWSResourceTag{Key: day2TagKey, Value: day2TagValue}),
+						"cleanup: day-2 tag should be removed from infrastructure resource",
+					)
+				}, 5*time.Minute, 10*time.Second).Should(Succeed())
 			})
 
 			Eventually(func(g Gomega) {
@@ -140,7 +153,13 @@ func EnsureInfrastructureResourceTagsTest(getTestCtx internal.TestContextGetter)
 				Skip("HostedCluster does not have AWS platform spec")
 			}
 
-			specTags := hc.Spec.Platform.AWS.ResourceTags
+			// Re-fetch to get current server state; the cached hc pointer may be
+			// stale if a prior test mutated it via UpdateObject.
+			freshHC := &hyperv1.HostedCluster{}
+			Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKeyFromObject(hc), freshHC)).To(Succeed(),
+				"failed to re-fetch HostedCluster")
+
+			specTags := freshHC.Spec.Platform.AWS.ResourceTags
 			if len(specTags) == 0 {
 				Skip("HostedCluster does not have AWS resource tags configured")
 			}


### PR DESCRIPTION
Before this commit, `EnsureDefaultSecurityGroupTagsTest()` mutated the cluster but used a fire-and-forget deferred cleanup, causing downstream tests which observe the same state to sometimes see the polluted state, leading to failed assertions (e.g. `EnsureInfrastructureResourceTagsTest()`).

The test also read cached hostedcluster state from the test context which is mutated by other tests. That issue is systemic.

This commit updates the deferred cleanup method to await convergence of the mutation rollback to make the test more fully isolated. It also uses a targeted fix for the cached hostedcluster lookup by fetching a fresh instance for assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved verification that removed AWS infrastructure tags are successfully cleared after restoring the HostedCluster’s original tags.
  - Added retry handling to account for eventual updates, with verification continuing for up to five minutes.
  - Refined tag validation to use the latest HostedCluster information, reducing the risk of inaccurate results from stale data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->