### PR TITLE
CNTRLPLANE-3863: improve v2 test isolation

### DIFF
--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift/hypershift/support/releaseinfo"
 
 	"github.com/blang/semver"
-	"github.com/onsi/ginkgo/v2"
 )
 
 var (
@@ -67,32 +66,9 @@ func SetReleaseImageVersion(ctx context.Context, latestReleaseImage string, pull
 	return nil
 }
 
-func SetReleaseVersionFromHostedCluster(ctx context.Context, hostedCluster *hyperv1.HostedCluster) error {
-	if hostedCluster.Status.Version == nil || len(hostedCluster.Status.Version.History) == 0 || hostedCluster.Status.Version.History[0].Version == "" {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "WARNING: cannot determine release version from HostedCluster")
-		return nil
-	}
-	hcVersion := hostedCluster.Status.Version.History[0].Version
-	var err error
-	releaseVersion, err = semver.Parse(hcVersion)
-	if err != nil {
-		return fmt.Errorf("error parsing version: %w", err)
-	}
-	releaseVersion.Patch = 0
-	releaseVersion.Pre = nil
-	releaseVersion.Build = nil
-	return nil
-}
-
 func AtLeast(t *testing.T, version semver.Version) {
 	if releaseVersion.LT(version) {
 		t.Skipf("Only tested in %s and later", version)
-	}
-}
-
-func GinkgoAtLeast(version semver.Version) {
-	if releaseVersion.LT(version) {
-		ginkgo.Skip(fmt.Sprintf("Only tested in %s and later", version))
 	}
 }
 

--- a/test/e2e/v2/AGENTS.md
+++ b/test/e2e/v2/AGENTS.md
@@ -44,9 +44,9 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneWorkload
 })
 ```
 
-### 3. Fail-Loud Philosophy
+### 3. Test Cluster Assumptions / Invariants
 
-Framework functions panic with diagnostic messages rather than returning errors silently. `GetHostedCluster()` uses `sync.Once` to fetch lazily and panics on failure. `GetEnvVarValue()` panics on unregistered variables. Tests assume the hosted cluster is fully operational before they run — there is no startup polling.
+Tests assume the hosted cluster is fully operational before they run — there is no startup polling.
 
 ### 4. Test Assertion Patterns
 

--- a/test/e2e/v2/backuprestore/cleanup.go
+++ b/test/e2e/v2/backuprestore/cleanup.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
@@ -62,7 +63,9 @@ const (
 // 7. Wait for hosted cluster namespace to be fully deleted
 func BreakHostedClusterPreservingMachines(testCtx *internal.TestContext, logger logr.Logger) error {
 	// Agent platform: prepare resources to prevent agent unbinding and node reboots
-	if testCtx.GetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform {
+	hc, err := testCtx.GetHostedCluster()
+	Expect(err).NotTo(HaveOccurred())
+	if hc.Spec.Platform.Type == hyperv1.AgentPlatform {
 		logger.Info("Preparing Agent platform resources before break")
 		if err := prepareAgentPlatformForBreak(testCtx, logger); err != nil {
 			return fmt.Errorf("failed to prepare Agent platform for break: %w", err)
@@ -422,7 +425,8 @@ func UnpauseAgentCAPIResources(testCtx *internal.TestContext, logger logr.Logger
 // It annotates Agent CRs with skip-spoke-cleanup and sets preserveOnDelete on ClusterDeployment
 // to prevent agents from being unbound and hosts from being rebooted by Ironic.
 func prepareAgentPlatformForBreak(testCtx *internal.TestContext, logger logr.Logger) error {
-	hc := testCtx.GetHostedCluster()
+	hc, err := testCtx.GetHostedCluster()
+	Expect(err).NotTo(HaveOccurred())
 	if hc.Spec.Platform.Agent == nil || hc.Spec.Platform.Agent.AgentNamespace == "" {
 		return fmt.Errorf("agent namespace not set on HostedCluster")
 	}

--- a/test/e2e/v2/backuprestore/cleanup.go
+++ b/test/e2e/v2/backuprestore/cleanup.go
@@ -62,7 +62,7 @@ const (
 // 7. Wait for hosted cluster namespace to be fully deleted
 func BreakHostedClusterPreservingMachines(testCtx *internal.TestContext, logger logr.Logger) error {
 	// Agent platform: prepare resources to prevent agent unbinding and node reboots
-	if testCtx.GetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform {
+	if testCtx.MustGetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform {
 		logger.Info("Preparing Agent platform resources before break")
 		if err := prepareAgentPlatformForBreak(testCtx, logger); err != nil {
 			return fmt.Errorf("failed to prepare Agent platform for break: %w", err)
@@ -422,7 +422,7 @@ func UnpauseAgentCAPIResources(testCtx *internal.TestContext, logger logr.Logger
 // It annotates Agent CRs with skip-spoke-cleanup and sets preserveOnDelete on ClusterDeployment
 // to prevent agents from being unbound and hosts from being rebooted by Ironic.
 func prepareAgentPlatformForBreak(testCtx *internal.TestContext, logger logr.Logger) error {
-	hc := testCtx.GetHostedCluster()
+	hc := testCtx.MustGetHostedCluster()
 	if hc.Spec.Platform.Agent == nil || hc.Spec.Platform.Agent.AgentNamespace == "" {
 		return fmt.Errorf("agent namespace not set on HostedCluster")
 	}

--- a/test/e2e/v2/backuprestore/cleanup.go
+++ b/test/e2e/v2/backuprestore/cleanup.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
@@ -62,7 +63,9 @@ const (
 // 7. Wait for hosted cluster namespace to be fully deleted
 func BreakHostedClusterPreservingMachines(testCtx *internal.TestContext, logger logr.Logger) error {
 	// Agent platform: prepare resources to prevent agent unbinding and node reboots
-	if testCtx.MustGetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform {
+	hc, err := testCtx.GetHostedCluster()
+	Expect(err).NotTo(HaveOccurred())
+	if hc.Spec.Platform.Type == hyperv1.AgentPlatform {
 		logger.Info("Preparing Agent platform resources before break")
 		if err := prepareAgentPlatformForBreak(testCtx, logger); err != nil {
 			return fmt.Errorf("failed to prepare Agent platform for break: %w", err)
@@ -422,7 +425,8 @@ func UnpauseAgentCAPIResources(testCtx *internal.TestContext, logger logr.Logger
 // It annotates Agent CRs with skip-spoke-cleanup and sets preserveOnDelete on ClusterDeployment
 // to prevent agents from being unbound and hosts from being rebooted by Ironic.
 func prepareAgentPlatformForBreak(testCtx *internal.TestContext, logger logr.Logger) error {
-	hc := testCtx.MustGetHostedCluster()
+	hc, err := testCtx.GetHostedCluster()
+	Expect(err).NotTo(HaveOccurred())
 	if hc.Spec.Platform.Agent == nil || hc.Spec.Platform.Agent.AgentNamespace == "" {
 		return fmt.Errorf("agent namespace not set on HostedCluster")
 	}

--- a/test/e2e/v2/internal/test_context.go
+++ b/test/e2e/v2/internal/test_context.go
@@ -19,9 +19,10 @@ package internal
 import (
 	"context"
 	"fmt"
-	"sync"
 
+	"github.com/blang/semver"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
@@ -38,110 +39,145 @@ type TestContextGetter func() *TestContext
 
 type TestContext struct {
 	context.Context
-	MgmtClient                  crclient.Client
-	ClusterName                 string
-	ClusterNamespace            string
-	ControlPlaneNamespace       string
-	ArtifactDir                 string
-	HostedClusterConfigured     bool
-	hostedCluster               *hyperv1.HostedCluster
-	hostedClusterOnce           sync.Once
-	hostedClusterClient         crclient.Client
-	hostedClusterClientOnce     sync.Once
-	hostedClusterRESTConfig     *rest.Config
-	hostedClusterRESTConfigOnce sync.Once
+	MgmtClient            crclient.Client
+	ClusterName           string
+	ClusterNamespace      string
+	ControlPlaneNamespace string
+	ArtifactDir           string
 }
 
-// GetHostedCluster returns the HostedCluster associated with this test context.
-// The result is cached by sync.Once — callers must ensure the cluster is ready before the first call.
-// Returns nil if ClusterName or ClusterNamespace are not set.
-// Panics if the HostedCluster fetch or release version extraction fails.
-func (tc *TestContext) GetHostedCluster() *hyperv1.HostedCluster {
-	tc.hostedClusterOnce.Do(func() {
-		if tc.ClusterName == "" || tc.ClusterNamespace == "" {
-			return
-		}
-
-		hostedCluster := &hyperv1.HostedCluster{}
-		err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
-			Namespace: tc.ClusterNamespace,
-			Name:      tc.ClusterName,
-		}, hostedCluster)
-		if err != nil {
-			panic(fmt.Sprintf("failed to get HostedCluster %s/%s: %v", tc.ClusterNamespace, tc.ClusterName, err))
-		}
-
-		err = e2eutil.SetReleaseVersionFromHostedCluster(tc.Context, hostedCluster)
-		if err != nil {
-			panic(fmt.Sprintf("failed to set release version from HostedCluster: %v", err))
-		}
-
-		tc.hostedCluster = hostedCluster
-	})
-	return tc.hostedCluster
-}
-
-// getHostedClusterRESTConfig fetches the kubeconfig secret and returns a REST config.
-// Returns nil if the HostedCluster is not available or its KubeConfig status is not set.
-// Panics on any other failure.
-func (tc *TestContext) getHostedClusterRESTConfig() *rest.Config {
-	hc := tc.GetHostedCluster()
-	if hc == nil || hc.Status.KubeConfig == nil {
-		return nil
+// GetHostedCluster fetches the HostedCluster from the management cluster.
+// Returns an error if no cluster name/namespace is configured or if the API
+// call fails.
+func (tc *TestContext) GetHostedCluster() (*hyperv1.HostedCluster, error) {
+	if tc.ClusterName == "" || tc.ClusterNamespace == "" {
+		return nil, fmt.Errorf("no hosted cluster configured for this test run (E2E_HOSTED_CLUSTER_NAME and E2E_HOSTED_CLUSTER_NAMESPACE must be set)")
 	}
+	hostedCluster := &hyperv1.HostedCluster{}
+	err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+		Namespace: tc.ClusterNamespace,
+		Name:      tc.ClusterName,
+	}, hostedCluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get HostedCluster %s/%s: %w", tc.ClusterNamespace, tc.ClusterName, err)
+	}
+	return hostedCluster, nil
+}
 
+// GetHostedClusterVersion fetches the HostedCluster and parses its version.
+// Returns an error if the cluster cannot be fetched or the version cannot be
+// parsed.
+func (tc *TestContext) GetHostedClusterVersion() (semver.Version, error) {
+	hc, err := tc.GetHostedCluster()
+	if err != nil {
+		return semver.Version{}, err
+	}
+	if hc.Status.Version != nil && len(hc.Status.Version.History) > 0 && hc.Status.Version.History[0].Version != "" {
+		releaseVersion, err := semver.Parse(hc.Status.Version.History[0].Version)
+		if err != nil {
+			return semver.Version{}, fmt.Errorf("error parsing version: %w", err)
+		}
+		releaseVersion.Patch = 0
+		releaseVersion.Pre = nil
+		releaseVersion.Build = nil
+		return releaseVersion, nil
+	}
+	return semver.Version{}, nil
+}
+
+// GetHostedClusterRESTConfig returns the REST config for the hosted cluster.
+// Returns an error if the kubeconfig secret cannot be fetched or parsed.
+func (tc *TestContext) GetHostedClusterRESTConfig(hc *hyperv1.HostedCluster) (*rest.Config, error) {
+	if hc.Status.KubeConfig == nil {
+		return nil, fmt.Errorf("kubeconfig status not yet available for HostedCluster %s/%s", hc.Namespace, hc.Name)
+	}
 	var kubeconfigSecret corev1.Secret
 	err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
 		Namespace: hc.Namespace,
 		Name:      hc.Status.KubeConfig.Name,
 	}, &kubeconfigSecret)
 	if err != nil {
-		panic(fmt.Sprintf("failed to get kubeconfig secret %s/%s: %v", hc.Namespace, hc.Status.KubeConfig.Name, err))
+		return nil, fmt.Errorf("failed to get kubeconfig secret %s/%s: %w", hc.Namespace, hc.Status.KubeConfig.Name, err)
 	}
 
 	kubeconfigData, ok := kubeconfigSecret.Data["kubeconfig"]
 	if !ok || len(kubeconfigData) == 0 {
-		panic(fmt.Sprintf("kubeconfig key not found or empty in secret %s/%s", hc.Namespace, hc.Status.KubeConfig.Name))
+		return nil, fmt.Errorf("kubeconfig key not found or empty in secret %s/%s", hc.Namespace, hc.Status.KubeConfig.Name)
 	}
 
 	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
 	if err != nil {
-		panic(fmt.Sprintf("failed to create REST config from kubeconfig: %v", err))
+		return nil, fmt.Errorf("failed to create REST config from kubeconfig: %w", err)
 	}
 	restConfig.QPS = 200
 	restConfig.Burst = 300
 
-	return restConfig
+	return restConfig, nil
 }
 
-// GetHostedClusterClient returns a controller-runtime client for the hosted cluster.
-// The result is cached by sync.Once — callers must ensure the cluster is ready before the first call.
-// Returns nil if the HostedCluster is not available or its KubeConfig status is not set.
-// Panics on any other initialization failure.
-func (tc *TestContext) GetHostedClusterClient() crclient.Client {
-	tc.hostedClusterClientOnce.Do(func() {
-		restConfig := tc.GetHostedClusterRESTConfig()
-		if restConfig == nil {
+// GetHostedClusterClient returns a controller-runtime client for the hosted
+// cluster. Returns an error if the kubeconfig or client setup fails.
+func (tc *TestContext) GetHostedClusterClient(hc *hyperv1.HostedCluster) (crclient.Client, error) {
+	restConfig, err := tc.GetHostedClusterRESTConfig(hc)
+	if err != nil {
+		return nil, err
+	}
+	if restConfig == nil {
+		return nil, fmt.Errorf("expected a REST config for hostedcluster")
+	}
+	client, err := crclient.New(restConfig, crclient.Options{Scheme: hyperapi.Scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create hosted cluster client: %w", err)
+	}
+	return client, nil
+}
+
+// VersionAtLeast returns true if the hosted cluster version is at least v.
+// Fails the test if the version cannot be determined.
+func (tc *TestContext) VersionAtLeast(v semver.Version) bool {
+	GinkgoHelper()
+	version, err := tc.GetHostedClusterVersion()
+	Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster version for %s/%s", tc.ClusterNamespace, tc.ClusterName)
+	return !version.LT(v)
+}
+
+// SkipIfVersionBelow skips the test if the hosted cluster version is below
+// minVersion. Returns the detected version on success.
+func (tc *TestContext) SkipIfVersionBelow(minVersion semver.Version) semver.Version {
+	GinkgoHelper()
+	version, err := tc.GetHostedClusterVersion()
+	Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster version for %s/%s", tc.ClusterNamespace, tc.ClusterName)
+	if version.LT(minVersion) {
+		Skip(fmt.Sprintf("Only tested in %s and later", minVersion))
+	}
+	return version
+}
+
+// SkipIfNotPlatform skips the test unless the hosted cluster matches one of the
+// given platforms. Fails the test if the HostedCluster cannot be fetched.
+func (tc *TestContext) SkipIfNotPlatform(platforms ...hyperv1.PlatformType) {
+	GinkgoHelper()
+	hc, err := tc.GetHostedCluster()
+	Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster for platform check")
+	for _, p := range platforms {
+		if hc.Spec.Platform.Type == p {
 			return
 		}
-		client, err := crclient.New(restConfig, crclient.Options{Scheme: hyperapi.Scheme})
-		if err != nil {
-			panic(fmt.Sprintf("failed to create hosted cluster client: %v", err))
-		}
-		tc.hostedClusterClient = client
-	})
-	return tc.hostedClusterClient
+	}
+	Skip(fmt.Sprintf("test only applies to platforms %v, got %s", platforms, hc.Spec.Platform.Type))
 }
 
-// GetHostedClusterRESTConfig returns the raw REST config for the hosted cluster.
-// The result is cached by sync.Once — callers must ensure the cluster is ready before the first call.
-// Returns nil if the HostedCluster is not available or its KubeConfig status is not set.
-// Panics on any other initialization failure.
-func (tc *TestContext) GetHostedClusterRESTConfig() *rest.Config {
-	tc.hostedClusterRESTConfigOnce.Do(func() {
-		tc.hostedClusterRESTConfig = tc.getHostedClusterRESTConfig()
-	})
-	return tc.hostedClusterRESTConfig
+// SkipIfPlatform skips the test if the hosted cluster matches any of the given
+// platforms. Fails the test if the HostedCluster cannot be fetched.
+func (tc *TestContext) SkipIfPlatform(platforms ...hyperv1.PlatformType) {
+	GinkgoHelper()
+	hc, err := tc.GetHostedCluster()
+	Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster for platform check")
+	for _, p := range platforms {
+		if hc.Spec.Platform.Type == p {
+			Skip(fmt.Sprintf("test does not apply to platform %s", p))
+		}
+	}
 }
 
 var testCtx *TestContext
@@ -152,24 +188,6 @@ func GetTestContext() *TestContext {
 
 func SetTestContext(ctx *TestContext) {
 	testCtx = ctx
-}
-
-func SetupTestContext(ctx context.Context, hostedClusterName, hostedClusterNamespace string) (*TestContext, error) {
-	mgmtClient, err := e2eutil.GetClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get management client: %w", err)
-	}
-
-	testCtx := &TestContext{
-		Context:                 ctx,
-		MgmtClient:              mgmtClient,
-		ClusterName:             hostedClusterName,
-		ClusterNamespace:        hostedClusterNamespace,
-		ControlPlaneNamespace:   manifests.HostedControlPlaneNamespace(hostedClusterNamespace, hostedClusterName),
-		HostedClusterConfigured: hostedClusterName != "" && hostedClusterNamespace != "",
-	}
-
-	return testCtx, nil
 }
 
 // SetupTestContextFromEnv initializes the test context from environment variables.
@@ -194,27 +212,8 @@ func SetupTestContextFromEnv(ctx context.Context) (*TestContext, error) {
 		testCtx.ClusterName = hostedClusterName
 		testCtx.ClusterNamespace = hostedClusterNamespace
 		testCtx.ControlPlaneNamespace = manifests.HostedControlPlaneNamespace(hostedClusterNamespace, hostedClusterName)
-		testCtx.HostedClusterConfigured = true
 	}
 	testCtx.ArtifactDir = artifactDir
 
 	return testCtx, nil
-}
-
-// ValidateHostedCluster skips the test if no hosted cluster was configured for this run.
-// Panics if a hosted cluster was configured but cannot be fetched.
-func (tc *TestContext) ValidateHostedCluster() {
-	if !tc.HostedClusterConfigured {
-		Skip("no hosted cluster configured for this test run")
-	}
-	tc.GetHostedCluster()
-}
-
-// ValidateHostedClusterClient skips the test if no hosted cluster was configured.
-// Panics if the hosted cluster client cannot be initialized.
-func (tc *TestContext) ValidateHostedClusterClient() {
-	tc.ValidateHostedCluster()
-	if tc.GetHostedClusterClient() == nil {
-		panic("hosted cluster client not available — kubeconfig may not be ready")
-	}
 }

--- a/test/e2e/v2/internal/test_context.go
+++ b/test/e2e/v2/internal/test_context.go
@@ -19,9 +19,10 @@ package internal
 import (
 	"context"
 	"fmt"
-	"sync"
 
+	"github.com/blang/semver"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
@@ -38,110 +39,163 @@ type TestContextGetter func() *TestContext
 
 type TestContext struct {
 	context.Context
-	MgmtClient                  crclient.Client
-	ClusterName                 string
-	ClusterNamespace            string
-	ControlPlaneNamespace       string
-	ArtifactDir                 string
-	HostedClusterConfigured     bool
-	hostedCluster               *hyperv1.HostedCluster
-	hostedClusterOnce           sync.Once
-	hostedClusterClient         crclient.Client
-	hostedClusterClientOnce     sync.Once
-	hostedClusterRESTConfig     *rest.Config
-	hostedClusterRESTConfigOnce sync.Once
+	MgmtClient            crclient.Client
+	ClusterName           string
+	ClusterNamespace      string
+	ControlPlaneNamespace string
+	ArtifactDir           string
 }
 
-// GetHostedCluster returns the HostedCluster associated with this test context.
-// The result is cached by sync.Once — callers must ensure the cluster is ready before the first call.
-// Returns nil if ClusterName or ClusterNamespace are not set.
-// Panics if the HostedCluster fetch or release version extraction fails.
-func (tc *TestContext) GetHostedCluster() *hyperv1.HostedCluster {
-	tc.hostedClusterOnce.Do(func() {
-		if tc.ClusterName == "" || tc.ClusterNamespace == "" {
-			return
-		}
-
-		hostedCluster := &hyperv1.HostedCluster{}
-		err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
-			Namespace: tc.ClusterNamespace,
-			Name:      tc.ClusterName,
-		}, hostedCluster)
-		if err != nil {
-			panic(fmt.Sprintf("failed to get HostedCluster %s/%s: %v", tc.ClusterNamespace, tc.ClusterName, err))
-		}
-
-		err = e2eutil.SetReleaseVersionFromHostedCluster(tc.Context, hostedCluster)
-		if err != nil {
-			panic(fmt.Sprintf("failed to set release version from HostedCluster: %v", err))
-		}
-
-		tc.hostedCluster = hostedCluster
-	})
-	return tc.hostedCluster
-}
-
-// getHostedClusterRESTConfig fetches the kubeconfig secret and returns a REST config.
-// Returns nil if the HostedCluster is not available or its KubeConfig status is not set.
-// Panics on any other failure.
-func (tc *TestContext) getHostedClusterRESTConfig() *rest.Config {
-	hc := tc.GetHostedCluster()
-	if hc == nil || hc.Status.KubeConfig == nil {
-		return nil
+// getHostedCluster fetches the HostedCluster from the management cluster.
+// Returns an error if no cluster name/namespace is configured or if the API
+// call fails.
+func (tc *TestContext) getHostedCluster() (*hyperv1.HostedCluster, error) {
+	if tc.ClusterName == "" || tc.ClusterNamespace == "" {
+		return nil, fmt.Errorf("no hosted cluster configured for this test run (E2E_HOSTED_CLUSTER_NAME and E2E_HOSTED_CLUSTER_NAMESPACE must be set)")
 	}
+	hostedCluster := &hyperv1.HostedCluster{}
+	err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+		Namespace: tc.ClusterNamespace,
+		Name:      tc.ClusterName,
+	}, hostedCluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get HostedCluster %s/%s: %w", tc.ClusterNamespace, tc.ClusterName, err)
+	}
+	return hostedCluster, nil
+}
 
+func (tc *TestContext) getHostedClusterVersion() (*hyperv1.HostedCluster, semver.Version, error) {
+	version := semver.Version{}
+	hc, err := tc.getHostedCluster()
+	if err != nil {
+		return nil, version, err
+	}
+	if hc.Status.Version != nil && len(hc.Status.Version.History) > 0 && hc.Status.Version.History[0].Version != "" {
+		releaseVersion, err := semver.Parse(hc.Status.Version.History[0].Version)
+		if err != nil {
+			return nil, version, fmt.Errorf("error parsing version: %w", err)
+		}
+		releaseVersion.Patch = 0
+		releaseVersion.Pre = nil
+		releaseVersion.Build = nil
+		version = releaseVersion
+	}
+	return hc, version, nil
+}
+
+func (tc *TestContext) getHostedClusterRESTConfig(hc *hyperv1.HostedCluster) (*rest.Config, error) {
 	var kubeconfigSecret corev1.Secret
 	err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
 		Namespace: hc.Namespace,
 		Name:      hc.Status.KubeConfig.Name,
 	}, &kubeconfigSecret)
 	if err != nil {
-		panic(fmt.Sprintf("failed to get kubeconfig secret %s/%s: %v", hc.Namespace, hc.Status.KubeConfig.Name, err))
+		return nil, fmt.Errorf("failed to get kubeconfig secret %s/%s: %w", hc.Namespace, hc.Status.KubeConfig.Name, err)
 	}
 
 	kubeconfigData, ok := kubeconfigSecret.Data["kubeconfig"]
 	if !ok || len(kubeconfigData) == 0 {
-		panic(fmt.Sprintf("kubeconfig key not found or empty in secret %s/%s", hc.Namespace, hc.Status.KubeConfig.Name))
+		return nil, fmt.Errorf("kubeconfig key not found or empty in secret %s/%s", hc.Namespace, hc.Status.KubeConfig.Name)
 	}
 
 	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
 	if err != nil {
-		panic(fmt.Sprintf("failed to create REST config from kubeconfig: %v", err))
+		return nil, fmt.Errorf("failed to create REST config from kubeconfig: %w", err)
 	}
 	restConfig.QPS = 200
 	restConfig.Burst = 300
 
-	return restConfig
+	return restConfig, nil
 }
 
-// GetHostedClusterClient returns a controller-runtime client for the hosted cluster.
-// The result is cached by sync.Once — callers must ensure the cluster is ready before the first call.
-// Returns nil if the HostedCluster is not available or its KubeConfig status is not set.
-// Panics on any other initialization failure.
-func (tc *TestContext) GetHostedClusterClient() crclient.Client {
-	tc.hostedClusterClientOnce.Do(func() {
-		restConfig := tc.GetHostedClusterRESTConfig()
-		if restConfig == nil {
+func (tc *TestContext) getHostedClusterClient(hc *hyperv1.HostedCluster) (crclient.Client, error) {
+	restConfig, err := tc.getHostedClusterRESTConfig(hc)
+	if err != nil {
+		return nil, err
+	}
+	if restConfig == nil {
+		return nil, fmt.Errorf("expected a REST config for hostedcluster")
+	}
+	client, err := crclient.New(restConfig, crclient.Options{Scheme: hyperapi.Scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create hosted cluster client: %w", err)
+	}
+	return client, nil
+}
+
+// MustGetHostedCluster fetches the HostedCluster, failing the test via Expect
+// on error. Do not call inside Eventually or other retry closures.
+func (tc *TestContext) MustGetHostedCluster() *hyperv1.HostedCluster {
+	GinkgoHelper()
+	hc, err := tc.getHostedCluster()
+	Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster %s/%s", tc.ClusterNamespace, tc.ClusterName)
+	return hc
+}
+
+// VersionAtLeast returns true if the hosted cluster version is at least v.
+// Fails the test if the version cannot be determined.
+func (tc *TestContext) VersionAtLeast(v semver.Version) bool {
+	GinkgoHelper()
+	_, version, err := tc.getHostedClusterVersion()
+	Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster version for %s/%s", tc.ClusterNamespace, tc.ClusterName)
+	return !version.LT(v)
+}
+
+// MustGetHostedClusterClient returns a controller-runtime client for the hosted
+// cluster, failing the test on error. Do not call inside retry closures.
+func (tc *TestContext) MustGetHostedClusterClient() crclient.Client {
+	GinkgoHelper()
+	hc := tc.MustGetHostedCluster()
+	client, err := tc.getHostedClusterClient(hc)
+	Expect(err).NotTo(HaveOccurred(), "failed to get hosted cluster client for %s/%s", tc.ClusterNamespace, tc.ClusterName)
+	return client
+}
+
+// MustGetHostedClusterRESTConfig returns the REST config for the hosted cluster,
+// failing the test on error. Do not call inside retry closures.
+func (tc *TestContext) MustGetHostedClusterRESTConfig() *rest.Config {
+	GinkgoHelper()
+	hc := tc.MustGetHostedCluster()
+	cfg, err := tc.getHostedClusterRESTConfig(hc)
+	Expect(err).NotTo(HaveOccurred(), "failed to get hosted cluster REST config for %s/%s", tc.ClusterNamespace, tc.ClusterName)
+	return cfg
+}
+
+// SkipIfVersionBelow skips the test if the hosted cluster version is below
+// minVersion. Returns the detected version on success.
+func (tc *TestContext) SkipIfVersionBelow(minVersion semver.Version) semver.Version {
+	GinkgoHelper()
+	_, version, err := tc.getHostedClusterVersion()
+	Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster version for %s/%s", tc.ClusterNamespace, tc.ClusterName)
+	if version.LT(minVersion) {
+		Skip(fmt.Sprintf("Only tested in %s and later", minVersion))
+	}
+	return version
+}
+
+// SkipIfNotPlatform skips the test unless the hosted cluster matches one of the
+// given platforms.
+func (tc *TestContext) SkipIfNotPlatform(platforms ...hyperv1.PlatformType) {
+	GinkgoHelper()
+	hc := tc.MustGetHostedCluster()
+	for _, p := range platforms {
+		if hc.Spec.Platform.Type == p {
 			return
 		}
-		client, err := crclient.New(restConfig, crclient.Options{Scheme: hyperapi.Scheme})
-		if err != nil {
-			panic(fmt.Sprintf("failed to create hosted cluster client: %v", err))
-		}
-		tc.hostedClusterClient = client
-	})
-	return tc.hostedClusterClient
+	}
+	Skip(fmt.Sprintf("test only applies to platforms %v, got %s", platforms, hc.Spec.Platform.Type))
 }
 
-// GetHostedClusterRESTConfig returns the raw REST config for the hosted cluster.
-// The result is cached by sync.Once — callers must ensure the cluster is ready before the first call.
-// Returns nil if the HostedCluster is not available or its KubeConfig status is not set.
-// Panics on any other initialization failure.
-func (tc *TestContext) GetHostedClusterRESTConfig() *rest.Config {
-	tc.hostedClusterRESTConfigOnce.Do(func() {
-		tc.hostedClusterRESTConfig = tc.getHostedClusterRESTConfig()
-	})
-	return tc.hostedClusterRESTConfig
+// SkipIfPlatform skips the test if the hosted cluster matches any of the given
+// platforms.
+func (tc *TestContext) SkipIfPlatform(platforms ...hyperv1.PlatformType) {
+	GinkgoHelper()
+	hc := tc.MustGetHostedCluster()
+	for _, p := range platforms {
+		if hc.Spec.Platform.Type == p {
+			Skip(fmt.Sprintf("test does not apply to platform %s", p))
+		}
+	}
 }
 
 var testCtx *TestContext
@@ -152,24 +206,6 @@ func GetTestContext() *TestContext {
 
 func SetTestContext(ctx *TestContext) {
 	testCtx = ctx
-}
-
-func SetupTestContext(ctx context.Context, hostedClusterName, hostedClusterNamespace string) (*TestContext, error) {
-	mgmtClient, err := e2eutil.GetClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get management client: %w", err)
-	}
-
-	testCtx := &TestContext{
-		Context:                 ctx,
-		MgmtClient:              mgmtClient,
-		ClusterName:             hostedClusterName,
-		ClusterNamespace:        hostedClusterNamespace,
-		ControlPlaneNamespace:   manifests.HostedControlPlaneNamespace(hostedClusterNamespace, hostedClusterName),
-		HostedClusterConfigured: hostedClusterName != "" && hostedClusterNamespace != "",
-	}
-
-	return testCtx, nil
 }
 
 // SetupTestContextFromEnv initializes the test context from environment variables.
@@ -194,27 +230,8 @@ func SetupTestContextFromEnv(ctx context.Context) (*TestContext, error) {
 		testCtx.ClusterName = hostedClusterName
 		testCtx.ClusterNamespace = hostedClusterNamespace
 		testCtx.ControlPlaneNamespace = manifests.HostedControlPlaneNamespace(hostedClusterNamespace, hostedClusterName)
-		testCtx.HostedClusterConfigured = true
 	}
 	testCtx.ArtifactDir = artifactDir
 
 	return testCtx, nil
-}
-
-// ValidateHostedCluster skips the test if no hosted cluster was configured for this run.
-// Panics if a hosted cluster was configured but cannot be fetched.
-func (tc *TestContext) ValidateHostedCluster() {
-	if !tc.HostedClusterConfigured {
-		Skip("no hosted cluster configured for this test run")
-	}
-	tc.GetHostedCluster()
-}
-
-// ValidateHostedClusterClient skips the test if no hosted cluster was configured.
-// Panics if the hosted cluster client cannot be initialized.
-func (tc *TestContext) ValidateHostedClusterClient() {
-	tc.ValidateHostedCluster()
-	if tc.GetHostedClusterClient() == nil {
-		panic("hosted cluster client not available — kubeconfig may not be ready")
-	}
 }

--- a/test/e2e/v2/internal/test_context.go
+++ b/test/e2e/v2/internal/test_context.go
@@ -46,10 +46,10 @@ type TestContext struct {
 	ArtifactDir           string
 }
 
-// getHostedCluster fetches the HostedCluster from the management cluster.
+// GetHostedCluster fetches the HostedCluster from the management cluster.
 // Returns an error if no cluster name/namespace is configured or if the API
 // call fails.
-func (tc *TestContext) getHostedCluster() (*hyperv1.HostedCluster, error) {
+func (tc *TestContext) GetHostedCluster() (*hyperv1.HostedCluster, error) {
 	if tc.ClusterName == "" || tc.ClusterNamespace == "" {
 		return nil, fmt.Errorf("no hosted cluster configured for this test run (E2E_HOSTED_CLUSTER_NAME and E2E_HOSTED_CLUSTER_NAMESPACE must be set)")
 	}
@@ -64,26 +64,30 @@ func (tc *TestContext) getHostedCluster() (*hyperv1.HostedCluster, error) {
 	return hostedCluster, nil
 }
 
-func (tc *TestContext) getHostedClusterVersion() (*hyperv1.HostedCluster, semver.Version, error) {
-	version := semver.Version{}
-	hc, err := tc.getHostedCluster()
+// GetHostedClusterVersion fetches the HostedCluster and parses its version.
+// Returns an error if the cluster cannot be fetched or the version cannot be
+// parsed.
+func (tc *TestContext) GetHostedClusterVersion() (semver.Version, error) {
+	hc, err := tc.GetHostedCluster()
 	if err != nil {
-		return nil, version, err
+		return semver.Version{}, err
 	}
 	if hc.Status.Version != nil && len(hc.Status.Version.History) > 0 && hc.Status.Version.History[0].Version != "" {
 		releaseVersion, err := semver.Parse(hc.Status.Version.History[0].Version)
 		if err != nil {
-			return nil, version, fmt.Errorf("error parsing version: %w", err)
+			return semver.Version{}, fmt.Errorf("error parsing version: %w", err)
 		}
 		releaseVersion.Patch = 0
 		releaseVersion.Pre = nil
 		releaseVersion.Build = nil
-		version = releaseVersion
+		return releaseVersion, nil
 	}
-	return hc, version, nil
+	return semver.Version{}, nil
 }
 
-func (tc *TestContext) getHostedClusterRESTConfig(hc *hyperv1.HostedCluster) (*rest.Config, error) {
+// GetHostedClusterRESTConfig returns the REST config for the hosted cluster.
+// Returns an error if the kubeconfig secret cannot be fetched or parsed.
+func (tc *TestContext) GetHostedClusterRESTConfig(hc *hyperv1.HostedCluster) (*rest.Config, error) {
 	var kubeconfigSecret corev1.Secret
 	err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
 		Namespace: hc.Namespace,
@@ -108,8 +112,10 @@ func (tc *TestContext) getHostedClusterRESTConfig(hc *hyperv1.HostedCluster) (*r
 	return restConfig, nil
 }
 
-func (tc *TestContext) getHostedClusterClient(hc *hyperv1.HostedCluster) (crclient.Client, error) {
-	restConfig, err := tc.getHostedClusterRESTConfig(hc)
+// GetHostedClusterClient returns a controller-runtime client for the hosted
+// cluster. Returns an error if the kubeconfig or client setup fails.
+func (tc *TestContext) GetHostedClusterClient(hc *hyperv1.HostedCluster) (crclient.Client, error) {
+	restConfig, err := tc.GetHostedClusterRESTConfig(hc)
 	if err != nil {
 		return nil, err
 	}
@@ -123,49 +129,20 @@ func (tc *TestContext) getHostedClusterClient(hc *hyperv1.HostedCluster) (crclie
 	return client, nil
 }
 
-// MustGetHostedCluster fetches the HostedCluster, failing the test via Expect
-// on error. Do not call inside Eventually or other retry closures.
-func (tc *TestContext) MustGetHostedCluster() *hyperv1.HostedCluster {
-	GinkgoHelper()
-	hc, err := tc.getHostedCluster()
-	Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster %s/%s", tc.ClusterNamespace, tc.ClusterName)
-	return hc
-}
-
 // VersionAtLeast returns true if the hosted cluster version is at least v.
 // Fails the test if the version cannot be determined.
 func (tc *TestContext) VersionAtLeast(v semver.Version) bool {
 	GinkgoHelper()
-	_, version, err := tc.getHostedClusterVersion()
+	version, err := tc.GetHostedClusterVersion()
 	Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster version for %s/%s", tc.ClusterNamespace, tc.ClusterName)
 	return !version.LT(v)
-}
-
-// MustGetHostedClusterClient returns a controller-runtime client for the hosted
-// cluster, failing the test on error. Do not call inside retry closures.
-func (tc *TestContext) MustGetHostedClusterClient() crclient.Client {
-	GinkgoHelper()
-	hc := tc.MustGetHostedCluster()
-	client, err := tc.getHostedClusterClient(hc)
-	Expect(err).NotTo(HaveOccurred(), "failed to get hosted cluster client for %s/%s", tc.ClusterNamespace, tc.ClusterName)
-	return client
-}
-
-// MustGetHostedClusterRESTConfig returns the REST config for the hosted cluster,
-// failing the test on error. Do not call inside retry closures.
-func (tc *TestContext) MustGetHostedClusterRESTConfig() *rest.Config {
-	GinkgoHelper()
-	hc := tc.MustGetHostedCluster()
-	cfg, err := tc.getHostedClusterRESTConfig(hc)
-	Expect(err).NotTo(HaveOccurred(), "failed to get hosted cluster REST config for %s/%s", tc.ClusterNamespace, tc.ClusterName)
-	return cfg
 }
 
 // SkipIfVersionBelow skips the test if the hosted cluster version is below
 // minVersion. Returns the detected version on success.
 func (tc *TestContext) SkipIfVersionBelow(minVersion semver.Version) semver.Version {
 	GinkgoHelper()
-	_, version, err := tc.getHostedClusterVersion()
+	version, err := tc.GetHostedClusterVersion()
 	Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster version for %s/%s", tc.ClusterNamespace, tc.ClusterName)
 	if version.LT(minVersion) {
 		Skip(fmt.Sprintf("Only tested in %s and later", minVersion))
@@ -174,10 +151,11 @@ func (tc *TestContext) SkipIfVersionBelow(minVersion semver.Version) semver.Vers
 }
 
 // SkipIfNotPlatform skips the test unless the hosted cluster matches one of the
-// given platforms.
+// given platforms. Fails the test if the HostedCluster cannot be fetched.
 func (tc *TestContext) SkipIfNotPlatform(platforms ...hyperv1.PlatformType) {
 	GinkgoHelper()
-	hc := tc.MustGetHostedCluster()
+	hc, err := tc.GetHostedCluster()
+	Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster for platform check")
 	for _, p := range platforms {
 		if hc.Spec.Platform.Type == p {
 			return
@@ -187,10 +165,11 @@ func (tc *TestContext) SkipIfNotPlatform(platforms ...hyperv1.PlatformType) {
 }
 
 // SkipIfPlatform skips the test if the hosted cluster matches any of the given
-// platforms.
+// platforms. Fails the test if the HostedCluster cannot be fetched.
 func (tc *TestContext) SkipIfPlatform(platforms ...hyperv1.PlatformType) {
 	GinkgoHelper()
-	hc := tc.MustGetHostedCluster()
+	hc, err := tc.GetHostedCluster()
+	Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster for platform check")
 	for _, p := range platforms {
 		if hc.Spec.Platform.Type == p {
 			Skip(fmt.Sprintf("test does not apply to platform %s", p))

--- a/test/e2e/v2/internal/workload_registry.go
+++ b/test/e2e/v2/internal/workload_registry.go
@@ -519,8 +519,12 @@ func ShouldSkipWorkloadForPlatform(workload WorkloadSpec, hostedCluster *hyperv1
 // This is a generic function that handles both Deployments and StatefulSets.
 func validateControlPlaneWorkloadsByType(testCtx *TestContext, workloadTypes []string, excludeWorkloads []string) error {
 	workloads := GetControlPlaneWorkloads()
+	hostedCluster, err := testCtx.GetHostedCluster()
+	if err != nil {
+		return fmt.Errorf("failed to get HostedCluster: %w", err)
+	}
 	for _, workload := range workloads {
-		if ShouldSkipWorkloadForPlatform(workload, testCtx.GetHostedCluster()) {
+		if ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 			continue
 		}
 		if !slices.Contains(workloadTypes, workload.Type) {

--- a/test/e2e/v2/internal/workload_registry.go
+++ b/test/e2e/v2/internal/workload_registry.go
@@ -519,7 +519,10 @@ func ShouldSkipWorkloadForPlatform(workload WorkloadSpec, hostedCluster *hyperv1
 // This is a generic function that handles both Deployments and StatefulSets.
 func validateControlPlaneWorkloadsByType(testCtx *TestContext, workloadTypes []string, excludeWorkloads []string) error {
 	workloads := GetControlPlaneWorkloads()
-	hostedCluster := testCtx.MustGetHostedCluster()
+	hostedCluster, err := testCtx.GetHostedCluster()
+	if err != nil {
+		return fmt.Errorf("failed to get HostedCluster: %w", err)
+	}
 	for _, workload := range workloads {
 		if ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 			continue

--- a/test/e2e/v2/internal/workload_registry.go
+++ b/test/e2e/v2/internal/workload_registry.go
@@ -519,8 +519,9 @@ func ShouldSkipWorkloadForPlatform(workload WorkloadSpec, hostedCluster *hyperv1
 // This is a generic function that handles both Deployments and StatefulSets.
 func validateControlPlaneWorkloadsByType(testCtx *TestContext, workloadTypes []string, excludeWorkloads []string) error {
 	workloads := GetControlPlaneWorkloads()
+	hostedCluster := testCtx.MustGetHostedCluster()
 	for _, workload := range workloads {
-		if ShouldSkipWorkloadForPlatform(workload, testCtx.GetHostedCluster()) {
+		if ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 			continue
 		}
 		if !slices.Contains(workloadTypes, workload.Type) {

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -113,8 +113,8 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 	BeforeAll(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil())
-		hostedCluster := testCtx.GetHostedCluster()
-		Expect(hostedCluster).NotTo(BeNil(), "HostedCluster should be set up")
+		hostedCluster, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		cfg, supported := backupRestorePlatforms[hostedCluster.Spec.Platform.Type]
 		if !supported {
 			Skip(fmt.Sprintf("Backup/restore test not supported on platform %s", hostedCluster.Spec.Platform.Type))
@@ -177,7 +177,9 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 
 	Context(ContextBackup, func() {
 		It("should create backup and schedule successfully", func() {
-			if testCtx.GetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform {
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			if hc.Spec.Platform.Type == hyperv1.AgentPlatform {
 				By("Pausing AgentMachine and AgentCluster CRs")
 				err := backuprestore.PauseAgentCAPIResources(testCtx, GinkgoLogr.WithName("backup-restore"))
 				Expect(err).NotTo(HaveOccurred())
@@ -200,7 +202,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 				StorageLocation:   testCtx.ClusterName,
 				IncludeNamespaces: platformCfg.additionalNamespaces,
 			}
-			err := backuprestore.RunOADPSchedule(testCtx.Context, GinkgoLogr.WithName("backup-restore"), testCtx.ArtifactDir, scheduleOpts)
+			err = backuprestore.RunOADPSchedule(testCtx.Context, GinkgoLogr.WithName("backup-restore"), testCtx.ArtifactDir, scheduleOpts)
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
@@ -282,7 +284,9 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 	Context(ContextPostRestoreControlPlane, func() {
 		It("should have control plane healthy after restore", func() {
 			// TODO(mgencur): Remove this condition once https://redhat.atlassian.net/browse/MGMT-23509 is fixed
-			skipNodePoolValidation := testCtx.GetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			skipNodePoolValidation := hc.Spec.Platform.Type == hyperv1.AgentPlatform
 			validatePostRestoreControlPlane(testCtx, platformCfg.excludeWorkloads, expectedConditions, skipNodePoolValidation)
 		})
 	})
@@ -307,8 +311,6 @@ func getNodePool(testCtx *internal.TestContext) (*hyperv1.NodePool, error) {
 }
 
 func validateBeforeEach(testCtx *internal.TestContext) {
-	testCtx.ValidateHostedCluster()
-
 	err := backuprestore.EnsureVeleroPodRunning(testCtx)
 	if err != nil {
 		Fail(fmt.Sprintf("Velero is not running: %v", err))
@@ -393,11 +395,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 	BeforeAll(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil())
-		hostedCluster := testCtx.GetHostedCluster()
-		Expect(hostedCluster).NotTo(BeNil(), "HostedCluster should be set up")
-		if hostedCluster.Spec.Platform.Type != hyperv1.AWSPlatform {
-			Skip("etcd snapshot backup test only supported on AWS")
-		}
+		testCtx.SkipIfNotPlatform(hyperv1.AWSPlatform)
 		platformCfg = backupRestorePlatforms[hyperv1.AWSPlatform]
 
 		By("Checking if HCPEtcdBackup feature gate is enabled")

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -113,8 +113,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 	BeforeAll(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil())
-		hostedCluster := testCtx.GetHostedCluster()
-		Expect(hostedCluster).NotTo(BeNil(), "HostedCluster should be set up")
+		hostedCluster := testCtx.MustGetHostedCluster()
 		cfg, supported := backupRestorePlatforms[hostedCluster.Spec.Platform.Type]
 		if !supported {
 			Skip(fmt.Sprintf("Backup/restore test not supported on platform %s", hostedCluster.Spec.Platform.Type))
@@ -177,7 +176,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 
 	Context(ContextBackup, func() {
 		It("should create backup and schedule successfully", func() {
-			if testCtx.GetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform {
+			if testCtx.MustGetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform {
 				By("Pausing AgentMachine and AgentCluster CRs")
 				err := backuprestore.PauseAgentCAPIResources(testCtx, GinkgoLogr.WithName("backup-restore"))
 				Expect(err).NotTo(HaveOccurred())
@@ -282,7 +281,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 	Context(ContextPostRestoreControlPlane, func() {
 		It("should have control plane healthy after restore", func() {
 			// TODO(mgencur): Remove this condition once https://redhat.atlassian.net/browse/MGMT-23509 is fixed
-			skipNodePoolValidation := testCtx.GetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform
+			skipNodePoolValidation := testCtx.MustGetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform
 			validatePostRestoreControlPlane(testCtx, platformCfg.excludeWorkloads, expectedConditions, skipNodePoolValidation)
 		})
 	})
@@ -307,8 +306,6 @@ func getNodePool(testCtx *internal.TestContext) (*hyperv1.NodePool, error) {
 }
 
 func validateBeforeEach(testCtx *internal.TestContext) {
-	testCtx.ValidateHostedCluster()
-
 	err := backuprestore.EnsureVeleroPodRunning(testCtx)
 	if err != nil {
 		Fail(fmt.Sprintf("Velero is not running: %v", err))
@@ -393,11 +390,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 	BeforeAll(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil())
-		hostedCluster := testCtx.GetHostedCluster()
-		Expect(hostedCluster).NotTo(BeNil(), "HostedCluster should be set up")
-		if hostedCluster.Spec.Platform.Type != hyperv1.AWSPlatform {
-			Skip("etcd snapshot backup test only supported on AWS")
-		}
+		testCtx.SkipIfNotPlatform(hyperv1.AWSPlatform)
 		platformCfg = backupRestorePlatforms[hyperv1.AWSPlatform]
 
 		By("Checking if HCPEtcdBackup feature gate is enabled")

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -113,7 +113,8 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 	BeforeAll(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil())
-		hostedCluster := testCtx.MustGetHostedCluster()
+		hostedCluster, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		cfg, supported := backupRestorePlatforms[hostedCluster.Spec.Platform.Type]
 		if !supported {
 			Skip(fmt.Sprintf("Backup/restore test not supported on platform %s", hostedCluster.Spec.Platform.Type))
@@ -176,7 +177,9 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 
 	Context(ContextBackup, func() {
 		It("should create backup and schedule successfully", func() {
-			if testCtx.MustGetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform {
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			if hc.Spec.Platform.Type == hyperv1.AgentPlatform {
 				By("Pausing AgentMachine and AgentCluster CRs")
 				err := backuprestore.PauseAgentCAPIResources(testCtx, GinkgoLogr.WithName("backup-restore"))
 				Expect(err).NotTo(HaveOccurred())
@@ -199,7 +202,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 				StorageLocation:   testCtx.ClusterName,
 				IncludeNamespaces: platformCfg.additionalNamespaces,
 			}
-			err := backuprestore.RunOADPSchedule(testCtx.Context, GinkgoLogr.WithName("backup-restore"), testCtx.ArtifactDir, scheduleOpts)
+			err = backuprestore.RunOADPSchedule(testCtx.Context, GinkgoLogr.WithName("backup-restore"), testCtx.ArtifactDir, scheduleOpts)
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
@@ -281,7 +284,9 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 	Context(ContextPostRestoreControlPlane, func() {
 		It("should have control plane healthy after restore", func() {
 			// TODO(mgencur): Remove this condition once https://redhat.atlassian.net/browse/MGMT-23509 is fixed
-			skipNodePoolValidation := testCtx.MustGetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			skipNodePoolValidation := hc.Spec.Platform.Type == hyperv1.AgentPlatform
 			validatePostRestoreControlPlane(testCtx, platformCfg.excludeWorkloads, expectedConditions, skipNodePoolValidation)
 		})
 	})

--- a/test/e2e/v2/tests/control_plane_pki_operator_test.go
+++ b/test/e2e/v2/tests/control_plane_pki_operator_test.go
@@ -71,7 +71,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			tc = getTestCtx()
 
 			// Capture original TLS security profile from HostedCluster
-			hostedCluster := tc.GetHostedCluster()
+			hostedCluster := tc.MustGetHostedCluster()
 			if hostedCluster.Spec.Configuration != nil &&
 				hostedCluster.Spec.Configuration.APIServer != nil &&
 				hostedCluster.Spec.Configuration.APIServer.TLSSecurityProfile != nil {
@@ -105,7 +105,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 
 		It("should have minTLSVersion set to VersionTLS12 with default/intermediate profile", func() {
 			// Check HostedCluster TLS profile configuration
-			hostedCluster := tc.GetHostedCluster()
+			hostedCluster := tc.MustGetHostedCluster()
 
 			// Only run for nil (default) or explicit Intermediate profile
 			hasProfile := hostedCluster.Spec.Configuration != nil &&
@@ -134,7 +134,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 
 		It("should accept both TLS 1.2 and TLS 1.3 connections with intermediate profile", func() {
 			// Check HostedCluster TLS profile configuration
-			hostedCluster := tc.GetHostedCluster()
+			hostedCluster := tc.MustGetHostedCluster()
 
 			// Only run for nil (default) or explicit Intermediate profile
 			hasProfile := hostedCluster.Spec.Configuration != nil &&
@@ -568,8 +568,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:PKIOperator] Control
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterControlPlanePKIOperatorTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/control_plane_pki_operator_test.go
+++ b/test/e2e/v2/tests/control_plane_pki_operator_test.go
@@ -71,7 +71,8 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			tc = getTestCtx()
 
 			// Capture original TLS security profile from HostedCluster
-			hostedCluster := tc.MustGetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			if hostedCluster.Spec.Configuration != nil &&
 				hostedCluster.Spec.Configuration.APIServer != nil &&
 				hostedCluster.Spec.Configuration.APIServer.TLSSecurityProfile != nil {
@@ -79,7 +80,6 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			}
 
 			// Setup management cluster REST config and kubernetes client for pod exec
-			var err error
 			mgmtRestConfig, err = e2eutil.GetConfig()
 			Expect(err).NotTo(HaveOccurred(), "failed to get management cluster REST config")
 			mgmtKubeClient, err = kubernetes.NewForConfig(mgmtRestConfig)
@@ -105,7 +105,8 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 
 		It("should have minTLSVersion set to VersionTLS12 with default/intermediate profile", func() {
 			// Check HostedCluster TLS profile configuration
-			hostedCluster := tc.MustGetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			// Only run for nil (default) or explicit Intermediate profile
 			hasProfile := hostedCluster.Spec.Configuration != nil &&
@@ -121,7 +122,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			// Check ConfigMap in management cluster control plane namespace
 			mgmtClient := tc.MgmtClient
 			cm := &corev1.ConfigMap{}
-			err := mgmtClient.Get(tc.Context, crclient.ObjectKey{
+			err = mgmtClient.Get(tc.Context, crclient.ObjectKey{
 				Namespace: tc.ControlPlaneNamespace,
 				Name:      pkiOperatorConfigMapName,
 			}, cm)
@@ -134,7 +135,8 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 
 		It("should accept both TLS 1.2 and TLS 1.3 connections with intermediate profile", func() {
 			// Check HostedCluster TLS profile configuration
-			hostedCluster := tc.MustGetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			// Only run for nil (default) or explicit Intermediate profile
 			hasProfile := hostedCluster.Spec.Configuration != nil &&

--- a/test/e2e/v2/tests/control_plane_tls_operator_test.go
+++ b/test/e2e/v2/tests/control_plane_tls_operator_test.go
@@ -382,20 +382,21 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 		BeforeAll(func() {
 			tc = getTestCtx()
 
-			// Capture original TLS security profile from HostedCluster
-			hostedCluster := tc.GetHostedCluster()
-			if hostedCluster.Spec.Configuration != nil &&
-				hostedCluster.Spec.Configuration.APIServer != nil &&
-				hostedCluster.Spec.Configuration.APIServer.TLSSecurityProfile != nil {
-				originalTLSProfile = hostedCluster.Spec.Configuration.APIServer.TLSSecurityProfile.DeepCopy()
-			}
-
 			// Setup management cluster REST config and kubernetes client for pod exec
 			var err error
 			mgmtRestConfig, err = e2eutil.GetConfig()
 			Expect(err).NotTo(HaveOccurred(), "failed to get management cluster REST config")
 			mgmtKubeClient, err = kubernetes.NewForConfig(mgmtRestConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to create management cluster kubernetes client")
+
+			// Capture original TLS security profile for AfterAll restoration
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			if hostedCluster.Spec.Configuration != nil &&
+				hostedCluster.Spec.Configuration.APIServer != nil &&
+				hostedCluster.Spec.Configuration.APIServer.TLSSecurityProfile != nil {
+				originalTLSProfile = hostedCluster.Spec.Configuration.APIServer.TLSSecurityProfile.DeepCopy()
+			}
 		})
 
 		It("control-plane-pki-operator should have control-plane-pki-operator-config ConfigMap with TLS configuration", func() {
@@ -416,12 +417,13 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("control-plane-pki-operator should have minTLSVersion set to VersionTLS12 with default/intermediate profile", func() {
-			hostedCluster := tc.GetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			requireDefaultOrIntermediateTLSProfile(hostedCluster)
 
 			mgmtClient := tc.MgmtClient
 			cm := &corev1.ConfigMap{}
-			err := mgmtClient.Get(tc.Context, crclient.ObjectKey{
+			err = mgmtClient.Get(tc.Context, crclient.ObjectKey{
 				Namespace: tc.ControlPlaneNamespace,
 				Name:      pkiOperatorTLSComponent.configMapName,
 			}, cm)
@@ -433,7 +435,8 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("aws-pod-identity-webhook should have --tls-min-version set to VersionTLS12 with default/intermediate profile", func() {
-			hostedCluster := tc.GetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			skipIfComponentNotApplicable(awsPodIdentityWebhookTLSComponent, hostedCluster)
 			requireDefaultOrIntermediateTLSProfile(hostedCluster)
 
@@ -444,7 +447,8 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("control-plane-pki-operator should accept both TLS 1.2 and TLS 1.3 connections with intermediate profile", func() {
-			hostedCluster := tc.GetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			requireDefaultOrIntermediateTLSProfile(hostedCluster)
 
 			verifyComponentTLSConnectivity(tc.Context, tc, tc.MgmtClient, mgmtKubeClient, mgmtRestConfig,
@@ -455,7 +459,8 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("aws-pod-identity-webhook should accept both TLS 1.2 and TLS 1.3 connections with intermediate profile", func() {
-			hostedCluster := tc.GetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			skipIfComponentNotApplicable(awsPodIdentityWebhookTLSComponent, hostedCluster)
 			requireDefaultOrIntermediateTLSProfile(hostedCluster)
 
@@ -761,8 +766,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneTLS] Con
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterControlPlanePKIOperatorTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/control_plane_upgrade_test.go
+++ b/test/e2e/v2/tests/control_plane_upgrade_test.go
@@ -31,9 +31,9 @@ import (
 func ControlPlaneUpgradeTest(getTestCtx internal.TestContextGetter) {
 	It("should upgrade the control plane from N-1 to latest", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedCluster()
 		ctx := testCtx.Context
-		hc := testCtx.GetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")
 		Expect(latestImage).NotTo(BeEmpty(), "E2E_LATEST_RELEASE_IMAGE must be set for upgrade tests")
@@ -44,7 +44,7 @@ func ControlPlaneUpgradeTest(getTestCtx internal.TestContextGetter) {
 		}
 		GinkgoWriter.Printf("Starting upgrade from version %s to image %s\n", startingVersion, latestImage)
 
-		err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+		err = e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 			obj.Spec.Release.Image = latestImage
 			if obj.Annotations == nil {
 				obj.Annotations = make(map[string]string)
@@ -54,11 +54,13 @@ func ControlPlaneUpgradeTest(getTestCtx internal.TestContextGetter) {
 		Expect(err).NotTo(HaveOccurred(), "failed to update hosted cluster release image")
 
 		By("Waiting for control plane components to complete rollout")
-		e2eutil.GinkgoAtLeast(e2eutil.Version420)
+		testCtx.SkipIfVersionBelow(e2eutil.Version420)
 		e2eutil.WaitForControlPlaneComponentRollout(GinkgoTB(), ctx, testCtx.MgmtClient, hc, startingVersion)
 
+		hc, err = testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for control plane version to complete rollout")
-		e2eutil.GinkgoAtLeast(e2eutil.Version422)
+		testCtx.SkipIfVersionBelow(e2eutil.Version422)
 		e2eutil.WaitForControlPlaneRollout(GinkgoTB(), ctx, testCtx.MgmtClient, hc)
 
 		By("Waiting for data plane rollout to complete")

--- a/test/e2e/v2/tests/control_plane_upgrade_test.go
+++ b/test/e2e/v2/tests/control_plane_upgrade_test.go
@@ -32,7 +32,8 @@ func ControlPlaneUpgradeTest(getTestCtx internal.TestContextGetter) {
 	It("should upgrade the control plane from N-1 to latest", func() {
 		testCtx := getTestCtx()
 		ctx := testCtx.Context
-		hc := testCtx.MustGetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")
 		Expect(latestImage).NotTo(BeEmpty(), "E2E_LATEST_RELEASE_IMAGE must be set for upgrade tests")
@@ -43,7 +44,7 @@ func ControlPlaneUpgradeTest(getTestCtx internal.TestContextGetter) {
 		}
 		GinkgoWriter.Printf("Starting upgrade from version %s to image %s\n", startingVersion, latestImage)
 
-		err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+		err = e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 			obj.Spec.Release.Image = latestImage
 			if obj.Annotations == nil {
 				obj.Annotations = make(map[string]string)
@@ -56,7 +57,8 @@ func ControlPlaneUpgradeTest(getTestCtx internal.TestContextGetter) {
 		testCtx.SkipIfVersionBelow(e2eutil.Version420)
 		e2eutil.WaitForControlPlaneComponentRollout(GinkgoTB(), ctx, testCtx.MgmtClient, hc, startingVersion)
 
-		hc = testCtx.MustGetHostedCluster()
+		hc, err = testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for control plane version to complete rollout")
 		testCtx.SkipIfVersionBelow(e2eutil.Version422)
 		e2eutil.WaitForControlPlaneRollout(GinkgoTB(), ctx, testCtx.MgmtClient, hc)

--- a/test/e2e/v2/tests/control_plane_upgrade_test.go
+++ b/test/e2e/v2/tests/control_plane_upgrade_test.go
@@ -31,9 +31,8 @@ import (
 func ControlPlaneUpgradeTest(getTestCtx internal.TestContextGetter) {
 	It("should upgrade the control plane from N-1 to latest", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedCluster()
 		ctx := testCtx.Context
-		hc := testCtx.GetHostedCluster()
+		hc := testCtx.MustGetHostedCluster()
 
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")
 		Expect(latestImage).NotTo(BeEmpty(), "E2E_LATEST_RELEASE_IMAGE must be set for upgrade tests")
@@ -54,11 +53,12 @@ func ControlPlaneUpgradeTest(getTestCtx internal.TestContextGetter) {
 		Expect(err).NotTo(HaveOccurred(), "failed to update hosted cluster release image")
 
 		By("Waiting for control plane components to complete rollout")
-		e2eutil.GinkgoAtLeast(e2eutil.Version420)
+		testCtx.SkipIfVersionBelow(e2eutil.Version420)
 		e2eutil.WaitForControlPlaneComponentRollout(GinkgoTB(), ctx, testCtx.MgmtClient, hc, startingVersion)
 
+		hc = testCtx.MustGetHostedCluster()
 		By("Waiting for control plane version to complete rollout")
-		e2eutil.GinkgoAtLeast(e2eutil.Version422)
+		testCtx.SkipIfVersionBelow(e2eutil.Version422)
 		e2eutil.WaitForControlPlaneRollout(GinkgoTB(), ctx, testCtx.MgmtClient, hc)
 
 		By("Waiting for data plane rollout to complete")

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -59,8 +59,9 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
 	Context("Deployment generation", func() {
 		BeforeEach(func() {
 			testCtx := getTestCtx()
-			hostedCluster := testCtx.GetHostedCluster()
-			if hostedCluster == nil || hostedCluster.CreationTimestamp.IsZero() || time.Since(hostedCluster.CreationTimestamp.Time) > 4*time.Hour {
+			hostedCluster, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			if hostedCluster.CreationTimestamp.IsZero() || time.Since(hostedCluster.CreationTimestamp.Time) > 4*time.Hour {
 				Skip("Deployment generation test is only for recently created hosted clusters")
 			}
 		})
@@ -76,13 +77,14 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should not indicate rapid rollouts", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
 
 					deployment := &appsv1.Deployment{}
-					err := testCtx.MgmtClient.Get(testCtx.Context, crclient.ObjectKey{
+					err = testCtx.MgmtClient.Get(testCtx.Context, crclient.ObjectKey{
 						Namespace: testCtx.ControlPlaneNamespace,
 						Name:      workload.Name,
 					}, deployment)
@@ -105,7 +107,7 @@ func SafeToEvictAnnotationsTest(getTestCtx internal.TestContextGetter) {
 	Context("Safe-to-evict annotations", func() {
 
 		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version420)
+			getTestCtx().SkipIfVersionBelow(e2eutil.Version420)
 		})
 
 		// TODO: Fix these in their corresponding repositories
@@ -129,7 +131,8 @@ func SafeToEvictAnnotationsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should exist for pods with emptyDir or hostPath volumes", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -185,7 +188,7 @@ func SafeToEvictAnnotationsTest(getTestCtx internal.TestContextGetter) {
 func ReadOnlyRootFilesystemTest(getTestCtx internal.TestContextGetter) {
 	Context("Read-only root filesystem", func() {
 		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version420)
+			getTestCtx().SkipIfVersionBelow(e2eutil.Version420)
 		})
 
 		// EnsureReadOnlyRootFilesystem
@@ -224,7 +227,8 @@ func ReadOnlyRootFilesystemTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have read-only root filesystem for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -259,7 +263,7 @@ func ReadOnlyRootFilesystemTest(getTestCtx internal.TestContextGetter) {
 func ReadOnlyRootFilesystemTmpDirMountTest(getTestCtx internal.TestContextGetter) {
 	Context("Read-only root filesystem tmp dir mount", func() {
 		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version420)
+			getTestCtx().SkipIfVersionBelow(e2eutil.Version420)
 		})
 
 		// EnsureReadOnlyRootFilesystemTmpDirMount
@@ -297,7 +301,8 @@ func ReadOnlyRootFilesystemTmpDirMountTest(getTestCtx internal.TestContextGetter
 			Context(workload.Name, func() {
 				It("should have /tmp mounted for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -339,7 +344,8 @@ func ContainerImagePullPolicyTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have IfNotPresent pull policy for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -369,7 +375,7 @@ func ContainerImagePullPolicyTest(getTestCtx internal.TestContextGetter) {
 func ContainerTerminationMessagePolicyTest(getTestCtx internal.TestContextGetter) {
 	Context("Container termination message policy", func() {
 		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version419)
+			getTestCtx().SkipIfVersionBelow(e2eutil.Version419)
 		})
 
 		// EnsureAllContainersHaveTerminationMessagePolicyFallbackToLogsOnError
@@ -389,7 +395,8 @@ func ContainerTerminationMessagePolicyTest(getTestCtx internal.TestContextGetter
 			Context(workload.Name, func() {
 				It("should have FallbackToLogsOnError termination message policy for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -431,7 +438,8 @@ func ContainerResourceRequestsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have resource requests for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -468,7 +476,8 @@ func PodPriorityTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should not have too high priority for pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -492,10 +501,6 @@ func PodPriorityTest(getTestCtx internal.TestContextGetter) {
 // ServiceAccountTokenMountingTest registers tests for service account token mounting validation
 func ServiceAccountTokenMountingTest(getTestCtx internal.TestContextGetter) {
 	Context("Service account token mounting", func() {
-		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version416)
-		})
-
 		// EnsureSATokenNotMountedUnlessNecessary
 		// Build expected components list based on platform
 		exemptions := []string{
@@ -543,24 +548,22 @@ func ServiceAccountTokenMountingTest(getTestCtx internal.TestContextGetter) {
 			"kubevirt-csi-controller",
 		}
 
-		if e2eutil.IsLessThan(e2eutil.Version418) {
-			exemptions = append(exemptions,
-				"csi-snapshot-webhook",
-			)
-		}
-
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
 				It("should not mount service account token unless necessary for pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
+					testCtx.SkipIfVersionBelow(e2eutil.Version416)
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
 
-					// Skip if workload is in exemption list
 					if slices.Contains(exemptions, workload.Name) {
 						Skip(fmt.Sprintf("workload %s is exempt from service account token mounting check", workload.Name))
+					}
+					if workload.Name == "csi-snapshot-webhook" && !testCtx.VersionAtLeast(e2eutil.Version418) {
+						Skip(fmt.Sprintf("workload %s is exempt from service account token mounting check before %s", workload.Name, e2eutil.Version418))
 					}
 
 					pods := getWorkloadPods(testCtx, workload)
@@ -585,18 +588,15 @@ func PodAffinitiesAndTolerationsTest(getTestCtx internal.TestContextGetter) {
 	Context("Pod affinities and tolerations", func() {
 		// EnsureHCPPodsAffinitiesAndTolerations
 		BeforeEach(func() {
-			testCtx := getTestCtx()
-			hostedCluster := testCtx.GetHostedCluster()
-			if hostedCluster == nil || hostedCluster.Spec.Platform.Type != hyperv1.AWSPlatform {
-				Skip("Pod affinities and tolerations test is only for AWS platform")
-			}
+			getTestCtx().SkipIfNotPlatform(hyperv1.AWSPlatform)
 		})
 
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
 				It("should have correct affinities and tolerations for pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -762,10 +762,7 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 
 		BeforeEach(func() {
 			testCtx := getTestCtx()
-			hostedCluster := testCtx.GetHostedCluster()
-			if hostedCluster == nil || hostedCluster.Spec.Platform.Type != hyperv1.AzurePlatform {
-				Skip("Security context UID test is only for Azure platform")
-			}
+			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
 
 			// Get the control plane namespace to check for UID annotation
 			controlPlaneNamespace := &corev1.Namespace{}
@@ -799,7 +796,8 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have expected RunAsUser UID for pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -904,7 +902,8 @@ func NoCrashingPodsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have no crashing pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -968,7 +967,7 @@ func NoCrashingPodsTest(getTestCtx internal.TestContextGetter) {
 func CustomLabelsTest(getTestCtx internal.TestContextGetter) {
 	Context("Custom labels", Label("Informing"), func() {
 		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version419)
+			getTestCtx().SkipIfVersionBelow(e2eutil.Version419)
 		})
 
 		exemptions := []string{
@@ -980,7 +979,8 @@ func CustomLabelsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should propagate custom labels to pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -1007,7 +1007,7 @@ func CustomLabelsTest(getTestCtx internal.TestContextGetter) {
 func CustomTolerationsTest(getTestCtx internal.TestContextGetter) {
 	Context("Custom tolerations", Label("Informing"), func() {
 		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version419)
+			getTestCtx().SkipIfVersionBelow(e2eutil.Version419)
 		})
 
 		exemptions := []string{
@@ -1019,7 +1019,8 @@ func CustomTolerationsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should propagate custom tolerations to pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -1073,8 +1074,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneWorkload
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterControlPlaneWorkloadsTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -59,7 +59,8 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
 	Context("Deployment generation", func() {
 		BeforeEach(func() {
 			testCtx := getTestCtx()
-			hostedCluster := testCtx.MustGetHostedCluster()
+			hostedCluster, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			if hostedCluster.CreationTimestamp.IsZero() || time.Since(hostedCluster.CreationTimestamp.Time) > 4*time.Hour {
 				Skip("Deployment generation test is only for recently created hosted clusters")
 			}
@@ -76,13 +77,14 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should not indicate rapid rollouts", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
 
 					deployment := &appsv1.Deployment{}
-					err := testCtx.MgmtClient.Get(testCtx.Context, crclient.ObjectKey{
+					err = testCtx.MgmtClient.Get(testCtx.Context, crclient.ObjectKey{
 						Namespace: testCtx.ControlPlaneNamespace,
 						Name:      workload.Name,
 					}, deployment)
@@ -129,7 +131,8 @@ func SafeToEvictAnnotationsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should exist for pods with emptyDir or hostPath volumes", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -224,7 +227,8 @@ func ReadOnlyRootFilesystemTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have read-only root filesystem for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -297,7 +301,8 @@ func ReadOnlyRootFilesystemTmpDirMountTest(getTestCtx internal.TestContextGetter
 			Context(workload.Name, func() {
 				It("should have /tmp mounted for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -339,7 +344,8 @@ func ContainerImagePullPolicyTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have IfNotPresent pull policy for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -389,7 +395,8 @@ func ContainerTerminationMessagePolicyTest(getTestCtx internal.TestContextGetter
 			Context(workload.Name, func() {
 				It("should have FallbackToLogsOnError termination message policy for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -431,7 +438,8 @@ func ContainerResourceRequestsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have resource requests for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -468,7 +476,8 @@ func PodPriorityTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should not have too high priority for pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -543,7 +552,8 @@ func ServiceAccountTokenMountingTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should not mount service account token unless necessary for pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					testCtx.SkipIfVersionBelow(e2eutil.Version416)
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
@@ -585,7 +595,8 @@ func PodAffinitiesAndTolerationsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have correct affinities and tolerations for pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -785,7 +796,8 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have expected RunAsUser UID for pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -890,7 +902,8 @@ func NoCrashingPodsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have no crashing pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -966,7 +979,8 @@ func CustomLabelsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should propagate custom labels to pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -1005,7 +1019,8 @@ func CustomTolerationsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should propagate custom tolerations to pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.MustGetHostedCluster()
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred())
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -59,8 +59,8 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
 	Context("Deployment generation", func() {
 		BeforeEach(func() {
 			testCtx := getTestCtx()
-			hostedCluster := testCtx.GetHostedCluster()
-			if hostedCluster == nil || hostedCluster.CreationTimestamp.IsZero() || time.Since(hostedCluster.CreationTimestamp.Time) > 4*time.Hour {
+			hostedCluster := testCtx.MustGetHostedCluster()
+			if hostedCluster.CreationTimestamp.IsZero() || time.Since(hostedCluster.CreationTimestamp.Time) > 4*time.Hour {
 				Skip("Deployment generation test is only for recently created hosted clusters")
 			}
 		})
@@ -76,7 +76,7 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should not indicate rapid rollouts", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -105,7 +105,7 @@ func SafeToEvictAnnotationsTest(getTestCtx internal.TestContextGetter) {
 	Context("Safe-to-evict annotations", func() {
 
 		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version420)
+			getTestCtx().SkipIfVersionBelow(e2eutil.Version420)
 		})
 
 		// TODO: Fix these in their corresponding repositories
@@ -129,7 +129,7 @@ func SafeToEvictAnnotationsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should exist for pods with emptyDir or hostPath volumes", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -185,7 +185,7 @@ func SafeToEvictAnnotationsTest(getTestCtx internal.TestContextGetter) {
 func ReadOnlyRootFilesystemTest(getTestCtx internal.TestContextGetter) {
 	Context("Read-only root filesystem", func() {
 		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version420)
+			getTestCtx().SkipIfVersionBelow(e2eutil.Version420)
 		})
 
 		// EnsureReadOnlyRootFilesystem
@@ -224,7 +224,7 @@ func ReadOnlyRootFilesystemTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have read-only root filesystem for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -259,7 +259,7 @@ func ReadOnlyRootFilesystemTest(getTestCtx internal.TestContextGetter) {
 func ReadOnlyRootFilesystemTmpDirMountTest(getTestCtx internal.TestContextGetter) {
 	Context("Read-only root filesystem tmp dir mount", func() {
 		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version420)
+			getTestCtx().SkipIfVersionBelow(e2eutil.Version420)
 		})
 
 		// EnsureReadOnlyRootFilesystemTmpDirMount
@@ -297,7 +297,7 @@ func ReadOnlyRootFilesystemTmpDirMountTest(getTestCtx internal.TestContextGetter
 			Context(workload.Name, func() {
 				It("should have /tmp mounted for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -339,7 +339,7 @@ func ContainerImagePullPolicyTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have IfNotPresent pull policy for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -369,7 +369,7 @@ func ContainerImagePullPolicyTest(getTestCtx internal.TestContextGetter) {
 func ContainerTerminationMessagePolicyTest(getTestCtx internal.TestContextGetter) {
 	Context("Container termination message policy", func() {
 		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version419)
+			getTestCtx().SkipIfVersionBelow(e2eutil.Version419)
 		})
 
 		// EnsureAllContainersHaveTerminationMessagePolicyFallbackToLogsOnError
@@ -389,7 +389,7 @@ func ContainerTerminationMessagePolicyTest(getTestCtx internal.TestContextGetter
 			Context(workload.Name, func() {
 				It("should have FallbackToLogsOnError termination message policy for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -431,7 +431,7 @@ func ContainerResourceRequestsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have resource requests for containers", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -468,7 +468,7 @@ func PodPriorityTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should not have too high priority for pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -492,10 +492,6 @@ func PodPriorityTest(getTestCtx internal.TestContextGetter) {
 // ServiceAccountTokenMountingTest registers tests for service account token mounting validation
 func ServiceAccountTokenMountingTest(getTestCtx internal.TestContextGetter) {
 	Context("Service account token mounting", func() {
-		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version416)
-		})
-
 		// EnsureSATokenNotMountedUnlessNecessary
 		// Build expected components list based on platform
 		exemptions := []string{
@@ -543,24 +539,21 @@ func ServiceAccountTokenMountingTest(getTestCtx internal.TestContextGetter) {
 			"kubevirt-csi-controller",
 		}
 
-		if e2eutil.IsLessThan(e2eutil.Version418) {
-			exemptions = append(exemptions,
-				"csi-snapshot-webhook",
-			)
-		}
-
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
 				It("should not mount service account token unless necessary for pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
+					testCtx.SkipIfVersionBelow(e2eutil.Version416)
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
 
-					// Skip if workload is in exemption list
 					if slices.Contains(exemptions, workload.Name) {
 						Skip(fmt.Sprintf("workload %s is exempt from service account token mounting check", workload.Name))
+					}
+					if workload.Name == "csi-snapshot-webhook" && !testCtx.VersionAtLeast(e2eutil.Version418) {
+						Skip(fmt.Sprintf("workload %s is exempt from service account token mounting check before %s", workload.Name, e2eutil.Version418))
 					}
 
 					pods := getWorkloadPods(testCtx, workload)
@@ -585,18 +578,14 @@ func PodAffinitiesAndTolerationsTest(getTestCtx internal.TestContextGetter) {
 	Context("Pod affinities and tolerations", func() {
 		// EnsureHCPPodsAffinitiesAndTolerations
 		BeforeEach(func() {
-			testCtx := getTestCtx()
-			hostedCluster := testCtx.GetHostedCluster()
-			if hostedCluster == nil || hostedCluster.Spec.Platform.Type != hyperv1.AWSPlatform {
-				Skip("Pod affinities and tolerations test is only for AWS platform")
-			}
+			getTestCtx().SkipIfNotPlatform(hyperv1.AWSPlatform)
 		})
 
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
 				It("should have correct affinities and tolerations for pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -762,10 +751,7 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 
 		BeforeEach(func() {
 			testCtx := getTestCtx()
-			hostedCluster := testCtx.GetHostedCluster()
-			if hostedCluster == nil || hostedCluster.Spec.Platform.Type != hyperv1.AzurePlatform {
-				Skip("Security context UID test is only for Azure platform")
-			}
+			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
 
 			// Get the control plane namespace to check for UID annotation
 			controlPlaneNamespace := &corev1.Namespace{}
@@ -799,7 +785,7 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have expected RunAsUser UID for pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -904,7 +890,7 @@ func NoCrashingPodsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should have no crashing pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -968,7 +954,7 @@ func NoCrashingPodsTest(getTestCtx internal.TestContextGetter) {
 func CustomLabelsTest(getTestCtx internal.TestContextGetter) {
 	Context("Custom labels", Label("Informing"), func() {
 		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version419)
+			getTestCtx().SkipIfVersionBelow(e2eutil.Version419)
 		})
 
 		exemptions := []string{
@@ -980,7 +966,7 @@ func CustomLabelsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should propagate custom labels to pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -1007,7 +993,7 @@ func CustomLabelsTest(getTestCtx internal.TestContextGetter) {
 func CustomTolerationsTest(getTestCtx internal.TestContextGetter) {
 	Context("Custom tolerations", Label("Informing"), func() {
 		BeforeEach(func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version419)
+			getTestCtx().SkipIfVersionBelow(e2eutil.Version419)
 		})
 
 		exemptions := []string{
@@ -1019,7 +1005,7 @@ func CustomTolerationsTest(getTestCtx internal.TestContextGetter) {
 			Context(workload.Name, func() {
 				It("should propagate custom tolerations to pods", func() {
 					testCtx := getTestCtx()
-					hostedCluster := testCtx.GetHostedCluster()
+					hostedCluster := testCtx.MustGetHostedCluster()
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
@@ -1073,8 +1059,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneWorkload
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterControlPlaneWorkloadsTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/etcd_chaos_test.go
+++ b/test/e2e/v2/tests/etcd_chaos_test.go
@@ -122,11 +122,13 @@ func EtcdSingleMemberRecoveryTest(getTestCtx internal.TestContextGetter) {
 func EtcdKillRandomMembersTest(getTestCtx internal.TestContextGetter) {
 	It("should preserve data when random members are repeatedly killed", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
 
-		hcClient := testCtx.GetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		// Create marker data that should survive the chaos
 		markerCM := createMarkerConfigMap(ctx, hcClient)
@@ -170,11 +172,13 @@ func EtcdKillRandomMembersTest(getTestCtx internal.TestContextGetter) {
 func EtcdKillAllMembersTest(getTestCtx internal.TestContextGetter) {
 	It("should preserve data when all members are killed simultaneously", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
 
-		hcClient := testCtx.GetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		// Create marker data that should survive the chaos
 		markerCM := createMarkerConfigMap(ctx, hcClient)

--- a/test/e2e/v2/tests/etcd_chaos_test.go
+++ b/test/e2e/v2/tests/etcd_chaos_test.go
@@ -122,11 +122,10 @@ func EtcdSingleMemberRecoveryTest(getTestCtx internal.TestContextGetter) {
 func EtcdKillRandomMembersTest(getTestCtx internal.TestContextGetter) {
 	It("should preserve data when random members are repeatedly killed", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
 
-		hcClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		// Create marker data that should survive the chaos
 		markerCM := createMarkerConfigMap(ctx, hcClient)
@@ -170,11 +169,10 @@ func EtcdKillRandomMembersTest(getTestCtx internal.TestContextGetter) {
 func EtcdKillAllMembersTest(getTestCtx internal.TestContextGetter) {
 	It("should preserve data when all members are killed simultaneously", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
 
-		hcClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		// Create marker data that should survive the chaos
 		markerCM := createMarkerConfigMap(ctx, hcClient)

--- a/test/e2e/v2/tests/etcd_chaos_test.go
+++ b/test/e2e/v2/tests/etcd_chaos_test.go
@@ -125,7 +125,10 @@ func EtcdKillRandomMembersTest(getTestCtx internal.TestContextGetter) {
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
 
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		// Create marker data that should survive the chaos
 		markerCM := createMarkerConfigMap(ctx, hcClient)
@@ -172,7 +175,10 @@ func EtcdKillAllMembersTest(getTestCtx internal.TestContextGetter) {
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
 
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		// Create marker data that should survive the chaos
 		markerCM := createMarkerConfigMap(ctx, hcClient)

--- a/test/e2e/v2/tests/hosted_cluster_aws_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_aws_test.go
@@ -50,13 +50,10 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 	When("[Feature:AWSSecurityGroups] a day-2 resource tag is added to the HostedCluster spec", func() {
 		It("should apply the tag to the default worker security group via AWS API", Label("AWS"), func() {
 			tc := getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version420) {
-				Skip("default security group tags test requires version >= 4.20")
-			}
-			hc := tc.GetHostedCluster()
-			if hc.Spec.Platform.Type != hyperv1.AWSPlatform {
-				Skip("default security group tags test is only for AWS platform")
-			}
+			tc.SkipIfVersionBelow(e2eutil.Version420)
+			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(hc.Status.Platform).NotTo(BeNil(),
 				"HostedCluster %s/%s should have platform status", hc.Namespace, hc.Name)
@@ -115,8 +112,8 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to restore HostedCluster AWS resource tags")
 				}
 
-				tc.ValidateHostedClusterClient()
-				hcClient := tc.GetHostedClusterClient()
+				hcClient, err := tc.GetHostedClusterClient(hc)
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(func(g Gomega) {
 					infra := &configv1.Infrastructure{}
 					g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, infra)).To(Succeed())
@@ -145,13 +142,9 @@ func EnsureInfrastructureResourceTagsTest(getTestCtx internal.TestContextGetter)
 	When("a HostedCluster is created with additional AWS resource tags", func() {
 		It("should propagate those tags to the infrastructure resource in the hosted cluster", Label("AWS"), func() {
 			tc := getTestCtx()
-			hc := tc.GetHostedCluster()
-			if hc.Spec.Platform.Type != hyperv1.AWSPlatform {
-				Skip("hosted cluster infrastructure resource tags test is only for AWS platform")
-			}
-			if hc.Spec.Platform.AWS == nil {
-				Skip("HostedCluster does not have AWS platform spec")
-			}
+			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			// Re-fetch to get current server state; the cached hc pointer may be
 			// stale if a prior test mutated it via UpdateObject.
@@ -181,8 +174,8 @@ func EnsureInfrastructureResourceTagsTest(getTestCtx internal.TestContextGetter)
 				Skip("HostedCluster has only kubernetes.io-prefixed tags which are filtered out")
 			}
 
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			infra := &configv1.Infrastructure{}
 			Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, infra)).To(Succeed(),
@@ -211,13 +204,8 @@ func AWSCCMWithCustomizationsTest(getTestCtx internal.TestContextGetter) {
 	Context("[Feature:AWSNLB] AWS CCM NLB Security Group", Label("AWS", "CCM"), func() {
 		BeforeEach(func() {
 			tc := getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version423) {
-				Skip("AWS CCM NLB security group test requires version >= 4.23")
-			}
-			hc := tc.GetHostedCluster()
-			if hc.Spec.Platform.Type != hyperv1.AWSPlatform {
-				Skip("AWS CCM test is only for AWS platform")
-			}
+			tc.SkipIfVersionBelow(e2eutil.Version423)
+			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
 		})
 
 		When("AWSServiceLBNetworkSecurityGroup feature gate is enabled", func() {
@@ -242,9 +230,10 @@ func AWSCCMWithCustomizationsTest(getTestCtx internal.TestContextGetter) {
 		When("a LoadBalancer NLB service is created in the hosted cluster", func() {
 			It("should attach managed security groups to the NLB", func() {
 				tc := getTestCtx()
-				tc.ValidateHostedClusterClient()
-				hcClient := tc.GetHostedClusterClient()
-				hc := tc.GetHostedCluster()
+				hc, err := tc.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
+				hcClient, err := tc.GetHostedClusterClient(hc)
+				Expect(err).NotTo(HaveOccurred())
 
 				awsCredsFile := internal.GetEnvVarValue("AWS_GUEST_INFRA_CREDENTIALS_FILE")
 				Expect(awsCredsFile).NotTo(BeEmpty(), "AWS_GUEST_INFRA_CREDENTIALS_FILE must be set for AWS CCM NLB test")
@@ -362,8 +351,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift] Hosted Cluster AWS", Label("
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterAWSTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_aws_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_aws_test.go
@@ -52,7 +52,8 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version420)
 			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
-			hc := tc.MustGetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(hc.Status.Platform).NotTo(BeNil(),
 				"HostedCluster %s/%s should have platform status", hc.Namespace, hc.Name)
@@ -111,7 +112,8 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to restore HostedCluster AWS resource tags")
 				}
 
-				hcClient := tc.MustGetHostedClusterClient()
+				hcClient, err := tc.GetHostedClusterClient(hc)
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(func(g Gomega) {
 					infra := &configv1.Infrastructure{}
 					g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, infra)).To(Succeed())
@@ -141,7 +143,8 @@ func EnsureInfrastructureResourceTagsTest(getTestCtx internal.TestContextGetter)
 		It("should propagate those tags to the infrastructure resource in the hosted cluster", Label("AWS"), func() {
 			tc := getTestCtx()
 			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
-			hc := tc.MustGetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			specTags := hc.Spec.Platform.AWS.ResourceTags
 			if len(specTags) == 0 {
@@ -165,7 +168,8 @@ func EnsureInfrastructureResourceTagsTest(getTestCtx internal.TestContextGetter)
 				Skip("HostedCluster has only kubernetes.io-prefixed tags which are filtered out")
 			}
 
-			hcClient := tc.MustGetHostedClusterClient()
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			infra := &configv1.Infrastructure{}
 			Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, infra)).To(Succeed(),
@@ -220,8 +224,10 @@ func AWSCCMWithCustomizationsTest(getTestCtx internal.TestContextGetter) {
 		When("a LoadBalancer NLB service is created in the hosted cluster", func() {
 			It("should attach managed security groups to the NLB", func() {
 				tc := getTestCtx()
-				hc := tc.MustGetHostedCluster()
-				hcClient := tc.MustGetHostedClusterClient()
+				hc, err := tc.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
+				hcClient, err := tc.GetHostedClusterClient(hc)
+				Expect(err).NotTo(HaveOccurred())
 
 				awsCredsFile := internal.GetEnvVarValue("AWS_GUEST_INFRA_CREDENTIALS_FILE")
 				Expect(awsCredsFile).NotTo(BeEmpty(), "AWS_GUEST_INFRA_CREDENTIALS_FILE must be set for AWS CCM NLB test")

--- a/test/e2e/v2/tests/hosted_cluster_aws_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_aws_test.go
@@ -50,13 +50,9 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 	When("[Feature:AWSSecurityGroups] a day-2 resource tag is added to the HostedCluster spec", func() {
 		It("should apply the tag to the default worker security group via AWS API", Label("AWS"), func() {
 			tc := getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version420) {
-				Skip("default security group tags test requires version >= 4.20")
-			}
-			hc := tc.GetHostedCluster()
-			if hc.Spec.Platform.Type != hyperv1.AWSPlatform {
-				Skip("default security group tags test is only for AWS platform")
-			}
+			tc.SkipIfVersionBelow(e2eutil.Version420)
+			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
+			hc := tc.MustGetHostedCluster()
 
 			Expect(hc.Status.Platform).NotTo(BeNil(),
 				"HostedCluster %s/%s should have platform status", hc.Namespace, hc.Name)
@@ -114,6 +110,18 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 				if err != nil && !apierrors.IsNotFound(err) {
 					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to restore HostedCluster AWS resource tags")
 				}
+
+				hcClient := tc.MustGetHostedClusterClient()
+				Eventually(func(g Gomega) {
+					infra := &configv1.Infrastructure{}
+					g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, infra)).To(Succeed())
+					g.Expect(infra.Status.PlatformStatus).NotTo(BeNil())
+					g.Expect(infra.Status.PlatformStatus.AWS).NotTo(BeNil())
+					g.Expect(infra.Status.PlatformStatus.AWS.ResourceTags).NotTo(
+						ContainElement(configv1.AWSResourceTag{Key: day2TagKey, Value: day2TagValue}),
+						"cleanup: day-2 tag should be removed from infrastructure resource",
+					)
+				}, 5*time.Minute, 10*time.Second).Should(Succeed())
 			})
 
 			Eventually(func(g Gomega) {
@@ -132,13 +140,8 @@ func EnsureInfrastructureResourceTagsTest(getTestCtx internal.TestContextGetter)
 	When("a HostedCluster is created with additional AWS resource tags", func() {
 		It("should propagate those tags to the infrastructure resource in the hosted cluster", Label("AWS"), func() {
 			tc := getTestCtx()
-			hc := tc.GetHostedCluster()
-			if hc.Spec.Platform.Type != hyperv1.AWSPlatform {
-				Skip("hosted cluster infrastructure resource tags test is only for AWS platform")
-			}
-			if hc.Spec.Platform.AWS == nil {
-				Skip("HostedCluster does not have AWS platform spec")
-			}
+			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
+			hc := tc.MustGetHostedCluster()
 
 			specTags := hc.Spec.Platform.AWS.ResourceTags
 			if len(specTags) == 0 {
@@ -162,8 +165,7 @@ func EnsureInfrastructureResourceTagsTest(getTestCtx internal.TestContextGetter)
 				Skip("HostedCluster has only kubernetes.io-prefixed tags which are filtered out")
 			}
 
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
+			hcClient := tc.MustGetHostedClusterClient()
 
 			infra := &configv1.Infrastructure{}
 			Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, infra)).To(Succeed(),
@@ -192,13 +194,8 @@ func AWSCCMWithCustomizationsTest(getTestCtx internal.TestContextGetter) {
 	Context("[Feature:AWSNLB] AWS CCM NLB Security Group", Label("AWS", "CCM"), func() {
 		BeforeEach(func() {
 			tc := getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version423) {
-				Skip("AWS CCM NLB security group test requires version >= 4.23")
-			}
-			hc := tc.GetHostedCluster()
-			if hc.Spec.Platform.Type != hyperv1.AWSPlatform {
-				Skip("AWS CCM test is only for AWS platform")
-			}
+			tc.SkipIfVersionBelow(e2eutil.Version423)
+			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
 		})
 
 		When("AWSServiceLBNetworkSecurityGroup feature gate is enabled", func() {
@@ -223,9 +220,8 @@ func AWSCCMWithCustomizationsTest(getTestCtx internal.TestContextGetter) {
 		When("a LoadBalancer NLB service is created in the hosted cluster", func() {
 			It("should attach managed security groups to the NLB", func() {
 				tc := getTestCtx()
-				tc.ValidateHostedClusterClient()
-				hcClient := tc.GetHostedClusterClient()
-				hc := tc.GetHostedCluster()
+				hc := tc.MustGetHostedCluster()
+				hcClient := tc.MustGetHostedClusterClient()
 
 				awsCredsFile := internal.GetEnvVarValue("AWS_GUEST_INFRA_CREDENTIALS_FILE")
 				Expect(awsCredsFile).NotTo(BeEmpty(), "AWS_GUEST_INFRA_CREDENTIALS_FILE must be set for AWS CCM NLB test")
@@ -343,8 +339,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift] Hosted Cluster AWS", Label("
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterAWSTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_azure_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_azure_test.go
@@ -50,26 +50,25 @@ func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
 	Context("[Feature:AzureWorkloadIdentity] Azure Public Cluster", Label("Azure", "self-managed-azure-public"), func() {
 		BeforeEach(func() {
 			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
-			if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform {
-				Skip("Azure public cluster tests are only for Azure platform")
-			}
+			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
 		})
 
 		It("should mutate pods with workload identity federated credentials", func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version420)
 			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			testCtx.SkipIfVersionBelow(e2eutil.Version420)
 			e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
-			hostedClusterClient := testCtx.GetHostedClusterClient()
-			Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
+			hostedClusterClient, err := testCtx.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			e2eutil.ValidateAzureWorkloadIdentityWebhookMutation(GinkgoTB(), testCtx.Context, hostedClusterClient)
 		})
 
 		It("should have expected KAS allowed CIDRs", func() {
 			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			kubeconfigData := e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
 			restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
 			Expect(err).NotTo(HaveOccurred(), "failed to create hosted cluster REST config")
@@ -78,12 +77,13 @@ func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should have Ingress Operator configuration applied", func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version421)
 			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			testCtx.SkipIfVersionBelow(e2eutil.Version421)
 			e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
-			hostedClusterClient := testCtx.GetHostedClusterClient()
-			Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
+			hostedClusterClient, err := testCtx.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			e2eutil.ValidateIngressOperatorConfiguration(GinkgoTB(), testCtx.Context, hostedClusterClient, hc)
 		})
@@ -100,10 +100,9 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 
 		BeforeAll(func() {
 			testCtx = getTestCtx()
-			hc := testCtx.GetHostedCluster()
-			if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform {
-				Skip("Azure private topology tests are only for Azure platform")
-			}
+			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			if hc.Spec.Platform.Azure == nil || hc.Spec.Platform.Azure.Topology != hyperv1.AzureTopologyPrivate {
 				Skip("Azure private topology tests require Private topology")
 			}
@@ -223,15 +222,13 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 	Context("[Feature:AzureEndpointAccess] Azure Endpoint Access Transition", Label("Azure", "self-managed-azure-private"), Ordered, func() {
 		var testCtx *internal.TestContext
-		var hc *hyperv1.HostedCluster
 		var controlPlaneNamespace string
 
 		BeforeAll(func() {
 			testCtx = getTestCtx()
-			hc = testCtx.GetHostedCluster()
-			if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform {
-				Skip("Azure endpoint access transition tests are only for Azure platform")
-			}
+			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			if hc.Spec.Platform.Azure == nil || hc.Spec.Platform.Azure.Topology != hyperv1.AzureTopologyPrivate {
 				Skip("Azure endpoint access transition tests require Private topology")
 			}
@@ -241,7 +238,12 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			DeferCleanup(func() {
 				// Use context.Background() because DeferCleanup runs after the test completes,
 				// when testCtx.Context may already be canceled.
-				restoreErr := e2eutil.UpdateObject(GinkgoTB(), context.Background(), testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+				freshHC, err := testCtx.GetHostedCluster()
+				if err != nil {
+					GinkgoTB().Logf("WARNING: failed to fetch HostedCluster for cleanup: %v", err)
+					return
+				}
+				restoreErr := e2eutil.UpdateObject(GinkgoTB(), context.Background(), testCtx.MgmtClient, freshHC, func(obj *hyperv1.HostedCluster) {
 					obj.Spec.Platform.Azure.Topology = hyperv1.AzureTopologyPrivate
 				})
 				if restoreErr != nil {
@@ -252,6 +254,8 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 
 		It("should transition from Private to PublicAndPrivate", func() {
 			ctx := testCtx.Context
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			// Verify ExternalPrivateService resources exist in Private topology before transition.
 			e2eutil.EventuallyObject(GinkgoTB(), ctx, "KAS ExternalPrivateService exists in Private topology",
@@ -278,7 +282,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 				e2eutil.WithTimeout(2*time.Minute),
 			)
 
-			err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+			err = e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.Platform.Azure.Topology = hyperv1.AzureTopologyPublicAndPrivate
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to update topology to PublicAndPrivate")
@@ -298,7 +302,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			Eventually(func() error {
 				route := hcpmanifests.KubeAPIServerExternalPrivateRoute(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, route)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"KAS external private route should be deleted after transition to PublicAndPrivate")
 
 			e2eutil.EventuallyObject(GinkgoTB(), ctx, "OAuth external public route exists after transition to PublicAndPrivate",
@@ -316,7 +320,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			Eventually(func() error {
 				route := hcpmanifests.OauthServerExternalPrivateRoute(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, route)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"OAuth external private route should be deleted after transition to PublicAndPrivate")
 
 			e2eutil.EventuallyObject(GinkgoTB(), ctx, "router-public Service is LoadBalancer after transition to PublicAndPrivate",
@@ -345,13 +349,13 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			Eventually(func() error {
 				svc := hcpmanifests.KubeAPIServerExternalPrivateService(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, svc)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"KAS ExternalPrivateService should be deleted after transition to PublicAndPrivate")
 
 			Eventually(func() error {
 				svc := hcpmanifests.OauthServerExternalPrivateService(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, svc)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"OAuth ExternalPrivateService should be deleted after transition to PublicAndPrivate")
 
 			verifyAPIReachable(testCtx, "after transition to PublicAndPrivate")
@@ -359,8 +363,10 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 
 		It("should transition from PublicAndPrivate back to Private", func() {
 			ctx := testCtx.Context
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
-			err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+			err = e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.Platform.Azure.Topology = hyperv1.AzureTopologyPrivate
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to update topology to Private")
@@ -380,7 +386,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			Eventually(func() error {
 				route := hcpmanifests.KubeAPIServerExternalPublicRoute(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, route)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"KAS external public route should be deleted after restore to Private")
 
 			e2eutil.EventuallyObject(GinkgoTB(), ctx, "OAuth external private route exists after restore to Private",
@@ -398,13 +404,13 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			Eventually(func() error {
 				route := hcpmanifests.OauthServerExternalPublicRoute(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, route)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"OAuth external public route should be deleted after restore to Private")
 
 			Eventually(func() error {
 				svc := hcpmanifests.RouterPublicService(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, svc)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"router-public Service should be deleted after restore to Private")
 
 			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "PLS CRs still exist after restore to Private",
@@ -451,7 +457,10 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			e2eutil.EventuallyObject(GinkgoTB(), testCtx.Context, "HostedCluster is Available and not Degraded after restore to Private",
 				func(ctx context.Context) (*hyperv1.HostedCluster, error) {
 					freshHC := &hyperv1.HostedCluster{}
-					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), freshHC)
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKey{
+						Namespace: testCtx.ClusterNamespace,
+						Name:      testCtx.ClusterName,
+					}, freshHC)
 					return freshHC, err
 				},
 				[]e2eutil.Predicate[*hyperv1.HostedCluster]{
@@ -541,7 +550,12 @@ func verifyAPIReachable(testCtx *internal.TestContext, phase string) {
 	attempts := 0
 	Eventually(func(g Gomega) {
 		attempts++
-		hc := testCtx.GetHostedCluster()
+		hc := &hyperv1.HostedCluster{}
+		err := testCtx.MgmtClient.Get(testCtx.Context, crclient.ObjectKey{
+			Namespace: testCtx.ClusterNamespace,
+			Name:      testCtx.ClusterName,
+		}, hc)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 		g.Expect(hc).NotTo(BeNil(), "hosted cluster is nil %s", phase)
 		g.Expect(hc.Status.KubeConfig).NotTo(BeNil(), "hosted cluster kubeconfig status not set %s", phase)
 
@@ -598,7 +612,7 @@ func verifyAPIReachable(testCtx *internal.TestContext, phase string) {
 		nsList := &corev1.NamespaceList{}
 		g.Expect(freshClient.List(testCtx.Context, nsList)).To(Succeed(), "failed to list namespaces %s", phase)
 		g.Expect(nsList.Items).NotTo(BeEmpty(), "namespace list is empty %s", phase)
-	}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(), "API server not reachable %s", phase)
+	}).WithTimeout(15*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "API server not reachable %s", phase)
 }
 
 func extractHostname(host string) string {
@@ -622,10 +636,9 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 	Context("[Feature:AzureOAuth] Azure OAuth LoadBalancer", Label("Azure", "self-managed-azure-oauth-lb"), func() {
 		BeforeEach(func() {
 			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
-			if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform {
-				Skip("Azure OAuth LB tests are only for Azure platform")
-			}
+			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			strategy := netutil.ServicePublishingStrategyByTypeByHC(hc, hyperv1.OAuthServer)
 			if strategy == nil || strategy.Type != hyperv1.LoadBalancer {
 				Skip("Azure OAuth LB tests require OAuthServer with LoadBalancer publishing strategy")
@@ -671,7 +684,8 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 
 		It("should complete OAuth token flow through LoadBalancer endpoint", func() {
 			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			e2eutil.ValidateOAuthWithIdentityProviderViaLoadBalancer(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
 		})

--- a/test/e2e/v2/tests/hosted_cluster_azure_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_azure_test.go
@@ -50,26 +50,22 @@ func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
 	Context("[Feature:AzureWorkloadIdentity] Azure Public Cluster", Label("Azure", "self-managed-azure-public"), func() {
 		BeforeEach(func() {
 			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
-			if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform {
-				Skip("Azure public cluster tests are only for Azure platform")
-			}
+			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
 		})
 
 		It("should mutate pods with workload identity federated credentials", func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version420)
 			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
+			hc := testCtx.MustGetHostedCluster()
+			testCtx.SkipIfVersionBelow(e2eutil.Version420)
 			e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
-			hostedClusterClient := testCtx.GetHostedClusterClient()
-			Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
+			hostedClusterClient := testCtx.MustGetHostedClusterClient()
 
 			e2eutil.ValidateAzureWorkloadIdentityWebhookMutation(GinkgoTB(), testCtx.Context, hostedClusterClient)
 		})
 
 		It("should have expected KAS allowed CIDRs", func() {
 			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
+			hc := testCtx.MustGetHostedCluster()
 			kubeconfigData := e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
 			restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
 			Expect(err).NotTo(HaveOccurred(), "failed to create hosted cluster REST config")
@@ -78,12 +74,11 @@ func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should have Ingress Operator configuration applied", func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version421)
 			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
+			hc := testCtx.MustGetHostedCluster()
+			testCtx.SkipIfVersionBelow(e2eutil.Version421)
 			e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
-			hostedClusterClient := testCtx.GetHostedClusterClient()
-			Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
+			hostedClusterClient := testCtx.MustGetHostedClusterClient()
 
 			e2eutil.ValidateIngressOperatorConfiguration(GinkgoTB(), testCtx.Context, hostedClusterClient, hc)
 		})
@@ -100,10 +95,8 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 
 		BeforeAll(func() {
 			testCtx = getTestCtx()
-			hc := testCtx.GetHostedCluster()
-			if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform {
-				Skip("Azure private topology tests are only for Azure platform")
-			}
+			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
+			hc := testCtx.MustGetHostedCluster()
 			if hc.Spec.Platform.Azure == nil || hc.Spec.Platform.Azure.Topology != hyperv1.AzureTopologyPrivate {
 				Skip("Azure private topology tests require Private topology")
 			}
@@ -228,10 +221,8 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 
 		BeforeAll(func() {
 			testCtx = getTestCtx()
-			hc = testCtx.GetHostedCluster()
-			if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform {
-				Skip("Azure endpoint access transition tests are only for Azure platform")
-			}
+			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
+			hc := testCtx.MustGetHostedCluster()
 			if hc.Spec.Platform.Azure == nil || hc.Spec.Platform.Azure.Topology != hyperv1.AzureTopologyPrivate {
 				Skip("Azure endpoint access transition tests require Private topology")
 			}
@@ -298,7 +289,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			Eventually(func() error {
 				route := hcpmanifests.KubeAPIServerExternalPrivateRoute(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, route)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"KAS external private route should be deleted after transition to PublicAndPrivate")
 
 			e2eutil.EventuallyObject(GinkgoTB(), ctx, "OAuth external public route exists after transition to PublicAndPrivate",
@@ -316,7 +307,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			Eventually(func() error {
 				route := hcpmanifests.OauthServerExternalPrivateRoute(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, route)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"OAuth external private route should be deleted after transition to PublicAndPrivate")
 
 			e2eutil.EventuallyObject(GinkgoTB(), ctx, "router-public Service is LoadBalancer after transition to PublicAndPrivate",
@@ -345,13 +336,13 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			Eventually(func() error {
 				svc := hcpmanifests.KubeAPIServerExternalPrivateService(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, svc)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"KAS ExternalPrivateService should be deleted after transition to PublicAndPrivate")
 
 			Eventually(func() error {
 				svc := hcpmanifests.OauthServerExternalPrivateService(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, svc)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"OAuth ExternalPrivateService should be deleted after transition to PublicAndPrivate")
 
 			verifyAPIReachable(testCtx, "after transition to PublicAndPrivate")
@@ -380,7 +371,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			Eventually(func() error {
 				route := hcpmanifests.KubeAPIServerExternalPublicRoute(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, route)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"KAS external public route should be deleted after restore to Private")
 
 			e2eutil.EventuallyObject(GinkgoTB(), ctx, "OAuth external private route exists after restore to Private",
@@ -398,13 +389,13 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			Eventually(func() error {
 				route := hcpmanifests.OauthServerExternalPublicRoute(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, route)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"OAuth external public route should be deleted after restore to Private")
 
 			Eventually(func() error {
 				svc := hcpmanifests.RouterPublicService(controlPlaneNamespace)
 				return expectDeleted(ctx, testCtx.MgmtClient, svc)
-			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"router-public Service should be deleted after restore to Private")
 
 			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "PLS CRs still exist after restore to Private",
@@ -541,7 +532,12 @@ func verifyAPIReachable(testCtx *internal.TestContext, phase string) {
 	attempts := 0
 	Eventually(func(g Gomega) {
 		attempts++
-		hc := testCtx.GetHostedCluster()
+		hc := &hyperv1.HostedCluster{}
+		err := testCtx.MgmtClient.Get(testCtx.Context, crclient.ObjectKey{
+			Namespace: testCtx.ClusterNamespace,
+			Name:      testCtx.ClusterName,
+		}, hc)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 		g.Expect(hc).NotTo(BeNil(), "hosted cluster is nil %s", phase)
 		g.Expect(hc.Status.KubeConfig).NotTo(BeNil(), "hosted cluster kubeconfig status not set %s", phase)
 
@@ -598,7 +594,7 @@ func verifyAPIReachable(testCtx *internal.TestContext, phase string) {
 		nsList := &corev1.NamespaceList{}
 		g.Expect(freshClient.List(testCtx.Context, nsList)).To(Succeed(), "failed to list namespaces %s", phase)
 		g.Expect(nsList.Items).NotTo(BeEmpty(), "namespace list is empty %s", phase)
-	}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(), "API server not reachable %s", phase)
+	}).WithTimeout(15*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "API server not reachable %s", phase)
 }
 
 func extractHostname(host string) string {
@@ -622,10 +618,8 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 	Context("[Feature:AzureOAuth] Azure OAuth LoadBalancer", Label("Azure", "self-managed-azure-oauth-lb"), func() {
 		BeforeEach(func() {
 			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
-			if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform {
-				Skip("Azure OAuth LB tests are only for Azure platform")
-			}
+			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
+			hc := testCtx.MustGetHostedCluster()
 			strategy := netutil.ServicePublishingStrategyByTypeByHC(hc, hyperv1.OAuthServer)
 			if strategy == nil || strategy.Type != hyperv1.LoadBalancer {
 				Skip("Azure OAuth LB tests require OAuthServer with LoadBalancer publishing strategy")
@@ -671,7 +665,7 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 
 		It("should complete OAuth token flow through LoadBalancer endpoint", func() {
 			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
+			hc := testCtx.MustGetHostedCluster()
 
 			e2eutil.ValidateOAuthWithIdentityProviderViaLoadBalancer(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
 		})

--- a/test/e2e/v2/tests/hosted_cluster_azure_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_azure_test.go
@@ -55,17 +55,20 @@ func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
 
 		It("should mutate pods with workload identity federated credentials", func() {
 			testCtx := getTestCtx()
-			hc := testCtx.MustGetHostedCluster()
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			testCtx.SkipIfVersionBelow(e2eutil.Version420)
 			e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
-			hostedClusterClient := testCtx.MustGetHostedClusterClient()
+			hostedClusterClient, err := testCtx.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			e2eutil.ValidateAzureWorkloadIdentityWebhookMutation(GinkgoTB(), testCtx.Context, hostedClusterClient)
 		})
 
 		It("should have expected KAS allowed CIDRs", func() {
 			testCtx := getTestCtx()
-			hc := testCtx.MustGetHostedCluster()
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			kubeconfigData := e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
 			restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
 			Expect(err).NotTo(HaveOccurred(), "failed to create hosted cluster REST config")
@@ -75,10 +78,12 @@ func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
 
 		It("should have Ingress Operator configuration applied", func() {
 			testCtx := getTestCtx()
-			hc := testCtx.MustGetHostedCluster()
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			testCtx.SkipIfVersionBelow(e2eutil.Version421)
 			e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
-			hostedClusterClient := testCtx.MustGetHostedClusterClient()
+			hostedClusterClient, err := testCtx.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			e2eutil.ValidateIngressOperatorConfiguration(GinkgoTB(), testCtx.Context, hostedClusterClient, hc)
 		})
@@ -96,7 +101,8 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 		BeforeAll(func() {
 			testCtx = getTestCtx()
 			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
-			hc := testCtx.MustGetHostedCluster()
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			if hc.Spec.Platform.Azure == nil || hc.Spec.Platform.Azure.Topology != hyperv1.AzureTopologyPrivate {
 				Skip("Azure private topology tests require Private topology")
 			}
@@ -222,7 +228,8 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 		BeforeAll(func() {
 			testCtx = getTestCtx()
 			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
-			hc := testCtx.MustGetHostedCluster()
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			if hc.Spec.Platform.Azure == nil || hc.Spec.Platform.Azure.Topology != hyperv1.AzureTopologyPrivate {
 				Skip("Azure endpoint access transition tests require Private topology")
 			}
@@ -619,7 +626,8 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 		BeforeEach(func() {
 			testCtx := getTestCtx()
 			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
-			hc := testCtx.MustGetHostedCluster()
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			strategy := netutil.ServicePublishingStrategyByTypeByHC(hc, hyperv1.OAuthServer)
 			if strategy == nil || strategy.Type != hyperv1.LoadBalancer {
 				Skip("Azure OAuth LB tests require OAuthServer with LoadBalancer publishing strategy")
@@ -665,7 +673,8 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 
 		It("should complete OAuth token flow through LoadBalancer endpoint", func() {
 			testCtx := getTestCtx()
-			hc := testCtx.MustGetHostedCluster()
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			e2eutil.ValidateOAuthWithIdentityProviderViaLoadBalancer(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
 		})

--- a/test/e2e/v2/tests/hosted_cluster_ccm_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ccm_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
@@ -34,11 +35,7 @@ import (
 func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
 	Context("GCP Cloud Controller Manager", Label("GCP", "CCM"), func() {
 		BeforeEach(func() {
-			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
-			if hc == nil || hc.Spec.Platform.Type != hyperv1.GCPPlatform {
-				Skip("GCP Cloud Controller Manager test is only for GCP platform")
-			}
+			getTestCtx().SkipIfNotPlatform(hyperv1.GCPPlatform)
 		})
 
 		When("nodes are initialized by the CCM", func() {
@@ -46,8 +43,11 @@ func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
 
 			BeforeEach(func() {
 				testCtx := getTestCtx()
-				hostedClusterClient := testCtx.GetHostedClusterClient()
-				Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
+				hc, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
+				e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
+				hostedClusterClient, err := testCtx.GetHostedClusterClient(hc)
+				Expect(err).NotTo(HaveOccurred())
 
 				nodes = &corev1.NodeList{}
 				Expect(hostedClusterClient.List(testCtx.Context, nodes)).To(Succeed())
@@ -56,7 +56,8 @@ func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
 
 			It("should set providerID on all nodes", func() {
 				testCtx := getTestCtx()
-				hc := testCtx.GetHostedCluster()
+				hc, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
 				Expect(hc.Spec.Platform.GCP).NotTo(BeNil(), "GCP platform spec must be set for GCP HostedCluster %s/%s", hc.Namespace, hc.Name)
 				gcpProject := hc.Spec.Platform.GCP.Project
 
@@ -111,7 +112,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:CloudControllerManag
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterCCMTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_ccm_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ccm_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
@@ -34,11 +35,7 @@ import (
 func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
 	Context("GCP Cloud Controller Manager", Label("GCP", "CCM"), func() {
 		BeforeEach(func() {
-			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
-			if hc == nil || hc.Spec.Platform.Type != hyperv1.GCPPlatform {
-				Skip("GCP Cloud Controller Manager test is only for GCP platform")
-			}
+			getTestCtx().SkipIfNotPlatform(hyperv1.GCPPlatform)
 		})
 
 		When("nodes are initialized by the CCM", func() {
@@ -46,8 +43,9 @@ func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
 
 			BeforeEach(func() {
 				testCtx := getTestCtx()
-				hostedClusterClient := testCtx.GetHostedClusterClient()
-				Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
+				hc := testCtx.MustGetHostedCluster()
+				e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
+				hostedClusterClient := testCtx.MustGetHostedClusterClient()
 
 				nodes = &corev1.NodeList{}
 				Expect(hostedClusterClient.List(testCtx.Context, nodes)).To(Succeed())
@@ -56,7 +54,7 @@ func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
 
 			It("should set providerID on all nodes", func() {
 				testCtx := getTestCtx()
-				hc := testCtx.GetHostedCluster()
+				hc := testCtx.MustGetHostedCluster()
 				Expect(hc.Spec.Platform.GCP).NotTo(BeNil(), "GCP platform spec must be set for GCP HostedCluster %s/%s", hc.Namespace, hc.Name)
 				gcpProject := hc.Spec.Platform.GCP.Project
 
@@ -111,7 +109,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:CloudControllerManag
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterCCMTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_ccm_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ccm_test.go
@@ -43,9 +43,11 @@ func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
 
 			BeforeEach(func() {
 				testCtx := getTestCtx()
-				hc := testCtx.MustGetHostedCluster()
+				hc, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
 				e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
-				hostedClusterClient := testCtx.MustGetHostedClusterClient()
+				hostedClusterClient, err := testCtx.GetHostedClusterClient(hc)
+				Expect(err).NotTo(HaveOccurred())
 
 				nodes = &corev1.NodeList{}
 				Expect(hostedClusterClient.List(testCtx.Context, nodes)).To(Succeed())
@@ -54,7 +56,8 @@ func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
 
 			It("should set providerID on all nodes", func() {
 				testCtx := getTestCtx()
-				hc := testCtx.MustGetHostedCluster()
+				hc, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
 				Expect(hc.Spec.Platform.GCP).NotTo(BeNil(), "GCP platform spec must be set for GCP HostedCluster %s/%s", hc.Namespace, hc.Name)
 				gcpProject := hc.Spec.Platform.GCP.Project
 

--- a/test/e2e/v2/tests/hosted_cluster_compliance_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_compliance_test.go
@@ -19,7 +19,6 @@ package tests
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/netutil"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
@@ -38,8 +37,8 @@ func EnsureAllRoutesUseHCPRouterTest(getTestCtx internal.TestContextGetter) {
 	When("routes are created in the control plane namespace", func() {
 		It("should label all routes for the per-HCP router", Label("routes"), func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
-			Expect(hostedCluster).NotTo(BeNil(), "hosted cluster must be configured")
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			isRoute := false
 			for _, svc := range hostedCluster.Spec.Services {
@@ -74,8 +73,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Compliance] Hosted C
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterComplianceTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_compliance_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_compliance_test.go
@@ -19,7 +19,6 @@ package tests
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/netutil"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
@@ -38,8 +37,7 @@ func EnsureAllRoutesUseHCPRouterTest(getTestCtx internal.TestContextGetter) {
 	When("routes are created in the control plane namespace", func() {
 		It("should label all routes for the per-HCP router", Label("routes"), func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
-			Expect(hostedCluster).NotTo(BeNil(), "hosted cluster must be configured")
+			hostedCluster := tc.MustGetHostedCluster()
 
 			isRoute := false
 			for _, svc := range hostedCluster.Spec.Services {
@@ -74,8 +72,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Compliance] Hosted C
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterComplianceTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_compliance_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_compliance_test.go
@@ -37,7 +37,8 @@ func EnsureAllRoutesUseHCPRouterTest(getTestCtx internal.TestContextGetter) {
 	When("routes are created in the control plane namespace", func() {
 		It("should label all routes for the per-HCP router", Label("routes"), func() {
 			tc := getTestCtx()
-			hostedCluster := tc.MustGetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			isRoute := false
 			for _, svc := range hostedCluster.Spec.Services {

--- a/test/e2e/v2/tests/hosted_cluster_cpo_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_cpo_test.go
@@ -39,7 +39,8 @@ func VerifyCPOOverrideImageTest(getTestCtx internal.TestContextGetter) {
 	When("a CPO override image is configured for the platform and version", func() {
 		It("should run the control-plane-operator pod with the expected override image", func() {
 			tc := getTestCtx()
-			hc := tc.GetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			releaseImage := hc.Spec.Release.Image
 			Expect(releaseImage).NotTo(BeEmpty(), "HostedCluster release image should be set")
@@ -97,8 +98,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneOperator
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterCPOTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_cpo_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_cpo_test.go
@@ -39,7 +39,7 @@ func VerifyCPOOverrideImageTest(getTestCtx internal.TestContextGetter) {
 	When("a CPO override image is configured for the platform and version", func() {
 		It("should run the control-plane-operator pod with the expected override image", func() {
 			tc := getTestCtx()
-			hc := tc.GetHostedCluster()
+			hc := tc.MustGetHostedCluster()
 
 			releaseImage := hc.Spec.Release.Image
 			Expect(releaseImage).NotTo(BeEmpty(), "HostedCluster release image should be set")
@@ -97,8 +97,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneOperator
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterCPOTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_cpo_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_cpo_test.go
@@ -39,7 +39,8 @@ func VerifyCPOOverrideImageTest(getTestCtx internal.TestContextGetter) {
 	When("a CPO override image is configured for the platform and version", func() {
 		It("should run the control-plane-operator pod with the expected override image", func() {
 			tc := getTestCtx()
-			hc := tc.MustGetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			releaseImage := hc.Spec.Release.Image
 			Expect(releaseImage).NotTo(BeEmpty(), "HostedCluster release image should be set")

--- a/test/e2e/v2/tests/hosted_cluster_dns_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_dns_test.go
@@ -35,13 +35,10 @@ func EnsureKubeAPIDNSNameCustomCertTest(getTestCtx internal.TestContextGetter) {
 	When("KubeAPIDNSName and custom certificate are configured", func() {
 		PIt("should make KAS reachable via the custom DNS endpoint", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
-			if e2eutil.IsLessThan(e2eutil.Version419) {
-				Skip("custom DNS name test requires version >= 4.19")
-			}
-			if hostedCluster.Spec.Platform.Type == hyperv1.KubevirtPlatform {
-				Skip("custom DNS name test not supported on KubeVirt platform")
-			}
+			tc.SkipIfVersionBelow(e2eutil.Version419)
+			tc.SkipIfPlatform(hyperv1.KubevirtPlatform)
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			if !netutil.IsPublicHC(hostedCluster) {
 				Skip("custom DNS name test requires a public hosted cluster")
@@ -74,7 +71,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:DNS] Hosted Cluster 
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterDNSTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_dns_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_dns_test.go
@@ -37,7 +37,8 @@ func EnsureKubeAPIDNSNameCustomCertTest(getTestCtx internal.TestContextGetter) {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version419)
 			tc.SkipIfPlatform(hyperv1.KubevirtPlatform)
-			hostedCluster := tc.MustGetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			if !netutil.IsPublicHC(hostedCluster) {
 				Skip("custom DNS name test requires a public hosted cluster")

--- a/test/e2e/v2/tests/hosted_cluster_dns_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_dns_test.go
@@ -35,13 +35,9 @@ func EnsureKubeAPIDNSNameCustomCertTest(getTestCtx internal.TestContextGetter) {
 	When("KubeAPIDNSName and custom certificate are configured", func() {
 		PIt("should make KAS reachable via the custom DNS endpoint", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
-			if e2eutil.IsLessThan(e2eutil.Version419) {
-				Skip("custom DNS name test requires version >= 4.19")
-			}
-			if hostedCluster.Spec.Platform.Type == hyperv1.KubevirtPlatform {
-				Skip("custom DNS name test not supported on KubeVirt platform")
-			}
+			tc.SkipIfVersionBelow(e2eutil.Version419)
+			tc.SkipIfPlatform(hyperv1.KubevirtPlatform)
+			hostedCluster := tc.MustGetHostedCluster()
 
 			if !netutil.IsPublicHC(hostedCluster) {
 				Skip("custom DNS name test requires a public hosted cluster")
@@ -74,7 +70,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:DNS] Hosted Cluster 
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterDNSTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_external_oidc_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_external_oidc_test.go
@@ -62,7 +62,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ExternalOIDC] Extern
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterExternalOIDCTests(func() *internal.TestContext { return testCtx })
@@ -88,11 +87,14 @@ func skipIfNotOIDC(hc *hyperv1.HostedCluster) {
 func ExternalOIDCClusterConfigTest(getTestCtx internal.TestContextGetter) {
 	Context("Cluster OIDC Configuration", Label("external-oidc"), func() {
 		BeforeEach(func() {
-			skipIfNotOIDC(getTestCtx().GetHostedCluster())
+			hc, err := getTestCtx().GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			skipIfNotOIDC(hc)
 		})
 
 		It("should have authentication type OIDC on the hosted cluster", func() {
-			hc := getTestCtx().GetHostedCluster()
+			hc, err := getTestCtx().GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			Expect(hc.Spec.Configuration).NotTo(BeNil(),
 				"hosted cluster %s/%s should have configuration set", hc.Namespace, hc.Name)
 			Expect(hc.Spec.Configuration.Authentication).NotTo(BeNil(),
@@ -104,7 +106,8 @@ func ExternalOIDCClusterConfigTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should have the hosted cluster Available", func() {
-			hc := getTestCtx().GetHostedCluster()
+			hc, err := getTestCtx().GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			found := false
 			for _, cond := range hc.Status.Conditions {
 				if cond.Type == string(hyperv1.HostedClusterAvailable) {
@@ -126,7 +129,9 @@ func ExternalOIDCClusterConfigTest(getTestCtx internal.TestContextGetter) {
 func ExternalOIDCOAuthNotDeployedTest(getTestCtx internal.TestContextGetter) {
 	Context("OAuth Server Not Deployed", Label("external-oidc"), func() {
 		BeforeEach(func() {
-			skipIfNotOIDC(getTestCtx().GetHostedCluster())
+			hc, err := getTestCtx().GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			skipIfNotOIDC(hc)
 		})
 
 		It("should not have oauth-openshift deployment in the control plane namespace", func() {
@@ -161,12 +166,15 @@ func ExternalOIDCOAuthNotDeployedTest(getTestCtx internal.TestContextGetter) {
 func ExternalOIDCKASConfigTest(getTestCtx internal.TestContextGetter) {
 	Context("KAS Authentication Configuration", Label("external-oidc"), func() {
 		BeforeEach(func() {
-			skipIfNotOIDC(getTestCtx().GetHostedCluster())
+			hc, err := getTestCtx().GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			skipIfNotOIDC(hc)
 		})
 
 		It("should have auth-config ConfigMap with JWT authenticator matching the OIDC provider", func() {
 			tc := getTestCtx()
-			hc := tc.GetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			expectedIssuerURL := hc.Spec.Configuration.Authentication.OIDCProviders[0].Issuer.URL
 			Expect(expectedIssuerURL).NotTo(BeEmpty(),
@@ -205,7 +213,8 @@ func ExternalOIDCKASConfigTest(getTestCtx internal.TestContextGetter) {
 
 		It("should have correct audiences in JWT config", func() {
 			tc := getTestCtx()
-			hc := tc.GetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			expectedAudiences := hc.Spec.Configuration.Authentication.OIDCProviders[0].Issuer.Audiences
 			Expect(expectedAudiences).NotTo(BeEmpty(),
@@ -272,7 +281,8 @@ func ExternalOIDCKeycloakAuthTest(getTestCtx internal.TestContextGetter) {
 
 		BeforeAll(func() {
 			tc := getTestCtx()
-			hc := tc.GetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			skipIfNotOIDC(hc)
 
 			provider := hc.Spec.Configuration.Authentication.OIDCProviders[0]
@@ -310,9 +320,8 @@ func ExternalOIDCKeycloakAuthTest(getTestCtx internal.TestContextGetter) {
 				extOIDCConfig.UserPrefix = provider.ClaimMappings.Username.Prefix.PrefixString
 			}
 
-			restConfig := tc.GetHostedClusterRESTConfig()
-			Expect(restConfig).NotTo(BeNil(),
-				"hosted cluster REST config should be available for %s/%s", hc.Namespace, hc.Name)
+			restConfig, err := tc.GetHostedClusterRESTConfig(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			// KAS may need time to load the OIDC authentication config after the HC
 			// was patched in PostVersionRollout. Retry with a fresh token each attempt
@@ -402,4 +411,3 @@ func obtainKeycloakIDToken(config *e2eutil.ExtOIDCConfig) string {
 	Expect(ok).To(BeTrue(), "id_token not found or not a string in Keycloak response")
 	return idToken
 }
-

--- a/test/e2e/v2/tests/hosted_cluster_external_oidc_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_external_oidc_test.go
@@ -87,11 +87,14 @@ func skipIfNotOIDC(hc *hyperv1.HostedCluster) {
 func ExternalOIDCClusterConfigTest(getTestCtx internal.TestContextGetter) {
 	Context("Cluster OIDC Configuration", Label("external-oidc"), func() {
 		BeforeEach(func() {
-			skipIfNotOIDC(getTestCtx().MustGetHostedCluster())
+			hc, err := getTestCtx().GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			skipIfNotOIDC(hc)
 		})
 
 		It("should have authentication type OIDC on the hosted cluster", func() {
-			hc := getTestCtx().MustGetHostedCluster()
+			hc, err := getTestCtx().GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			Expect(hc.Spec.Configuration).NotTo(BeNil(),
 				"hosted cluster %s/%s should have configuration set", hc.Namespace, hc.Name)
 			Expect(hc.Spec.Configuration.Authentication).NotTo(BeNil(),
@@ -103,7 +106,8 @@ func ExternalOIDCClusterConfigTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should have the hosted cluster Available", func() {
-			hc := getTestCtx().MustGetHostedCluster()
+			hc, err := getTestCtx().GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			found := false
 			for _, cond := range hc.Status.Conditions {
 				if cond.Type == string(hyperv1.HostedClusterAvailable) {
@@ -125,7 +129,9 @@ func ExternalOIDCClusterConfigTest(getTestCtx internal.TestContextGetter) {
 func ExternalOIDCOAuthNotDeployedTest(getTestCtx internal.TestContextGetter) {
 	Context("OAuth Server Not Deployed", Label("external-oidc"), func() {
 		BeforeEach(func() {
-			skipIfNotOIDC(getTestCtx().MustGetHostedCluster())
+			hc, err := getTestCtx().GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			skipIfNotOIDC(hc)
 		})
 
 		It("should not have oauth-openshift deployment in the control plane namespace", func() {
@@ -160,12 +166,15 @@ func ExternalOIDCOAuthNotDeployedTest(getTestCtx internal.TestContextGetter) {
 func ExternalOIDCKASConfigTest(getTestCtx internal.TestContextGetter) {
 	Context("KAS Authentication Configuration", Label("external-oidc"), func() {
 		BeforeEach(func() {
-			skipIfNotOIDC(getTestCtx().MustGetHostedCluster())
+			hc, err := getTestCtx().GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			skipIfNotOIDC(hc)
 		})
 
 		It("should have auth-config ConfigMap with JWT authenticator matching the OIDC provider", func() {
 			tc := getTestCtx()
-			hc := tc.MustGetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			expectedIssuerURL := hc.Spec.Configuration.Authentication.OIDCProviders[0].Issuer.URL
 			Expect(expectedIssuerURL).NotTo(BeEmpty(),
@@ -204,7 +213,8 @@ func ExternalOIDCKASConfigTest(getTestCtx internal.TestContextGetter) {
 
 		It("should have correct audiences in JWT config", func() {
 			tc := getTestCtx()
-			hc := tc.MustGetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			expectedAudiences := hc.Spec.Configuration.Authentication.OIDCProviders[0].Issuer.Audiences
 			Expect(expectedAudiences).NotTo(BeEmpty(),
@@ -271,7 +281,8 @@ func ExternalOIDCKeycloakAuthTest(getTestCtx internal.TestContextGetter) {
 
 		BeforeAll(func() {
 			tc := getTestCtx()
-			hc := tc.MustGetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			skipIfNotOIDC(hc)
 
 			provider := hc.Spec.Configuration.Authentication.OIDCProviders[0]
@@ -309,7 +320,8 @@ func ExternalOIDCKeycloakAuthTest(getTestCtx internal.TestContextGetter) {
 				extOIDCConfig.UserPrefix = provider.ClaimMappings.Username.Prefix.PrefixString
 			}
 
-			restConfig := tc.MustGetHostedClusterRESTConfig()
+			restConfig, err := tc.GetHostedClusterRESTConfig(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			// KAS may need time to load the OIDC authentication config after the HC
 			// was patched in PostVersionRollout. Retry with a fresh token each attempt

--- a/test/e2e/v2/tests/hosted_cluster_external_oidc_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_external_oidc_test.go
@@ -62,7 +62,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ExternalOIDC] Extern
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterExternalOIDCTests(func() *internal.TestContext { return testCtx })
@@ -88,11 +87,11 @@ func skipIfNotOIDC(hc *hyperv1.HostedCluster) {
 func ExternalOIDCClusterConfigTest(getTestCtx internal.TestContextGetter) {
 	Context("Cluster OIDC Configuration", Label("external-oidc"), func() {
 		BeforeEach(func() {
-			skipIfNotOIDC(getTestCtx().GetHostedCluster())
+			skipIfNotOIDC(getTestCtx().MustGetHostedCluster())
 		})
 
 		It("should have authentication type OIDC on the hosted cluster", func() {
-			hc := getTestCtx().GetHostedCluster()
+			hc := getTestCtx().MustGetHostedCluster()
 			Expect(hc.Spec.Configuration).NotTo(BeNil(),
 				"hosted cluster %s/%s should have configuration set", hc.Namespace, hc.Name)
 			Expect(hc.Spec.Configuration.Authentication).NotTo(BeNil(),
@@ -104,7 +103,7 @@ func ExternalOIDCClusterConfigTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should have the hosted cluster Available", func() {
-			hc := getTestCtx().GetHostedCluster()
+			hc := getTestCtx().MustGetHostedCluster()
 			found := false
 			for _, cond := range hc.Status.Conditions {
 				if cond.Type == string(hyperv1.HostedClusterAvailable) {
@@ -126,7 +125,7 @@ func ExternalOIDCClusterConfigTest(getTestCtx internal.TestContextGetter) {
 func ExternalOIDCOAuthNotDeployedTest(getTestCtx internal.TestContextGetter) {
 	Context("OAuth Server Not Deployed", Label("external-oidc"), func() {
 		BeforeEach(func() {
-			skipIfNotOIDC(getTestCtx().GetHostedCluster())
+			skipIfNotOIDC(getTestCtx().MustGetHostedCluster())
 		})
 
 		It("should not have oauth-openshift deployment in the control plane namespace", func() {
@@ -161,12 +160,12 @@ func ExternalOIDCOAuthNotDeployedTest(getTestCtx internal.TestContextGetter) {
 func ExternalOIDCKASConfigTest(getTestCtx internal.TestContextGetter) {
 	Context("KAS Authentication Configuration", Label("external-oidc"), func() {
 		BeforeEach(func() {
-			skipIfNotOIDC(getTestCtx().GetHostedCluster())
+			skipIfNotOIDC(getTestCtx().MustGetHostedCluster())
 		})
 
 		It("should have auth-config ConfigMap with JWT authenticator matching the OIDC provider", func() {
 			tc := getTestCtx()
-			hc := tc.GetHostedCluster()
+			hc := tc.MustGetHostedCluster()
 
 			expectedIssuerURL := hc.Spec.Configuration.Authentication.OIDCProviders[0].Issuer.URL
 			Expect(expectedIssuerURL).NotTo(BeEmpty(),
@@ -205,7 +204,7 @@ func ExternalOIDCKASConfigTest(getTestCtx internal.TestContextGetter) {
 
 		It("should have correct audiences in JWT config", func() {
 			tc := getTestCtx()
-			hc := tc.GetHostedCluster()
+			hc := tc.MustGetHostedCluster()
 
 			expectedAudiences := hc.Spec.Configuration.Authentication.OIDCProviders[0].Issuer.Audiences
 			Expect(expectedAudiences).NotTo(BeEmpty(),
@@ -272,7 +271,7 @@ func ExternalOIDCKeycloakAuthTest(getTestCtx internal.TestContextGetter) {
 
 		BeforeAll(func() {
 			tc := getTestCtx()
-			hc := tc.GetHostedCluster()
+			hc := tc.MustGetHostedCluster()
 			skipIfNotOIDC(hc)
 
 			provider := hc.Spec.Configuration.Authentication.OIDCProviders[0]
@@ -310,9 +309,7 @@ func ExternalOIDCKeycloakAuthTest(getTestCtx internal.TestContextGetter) {
 				extOIDCConfig.UserPrefix = provider.ClaimMappings.Username.Prefix.PrefixString
 			}
 
-			restConfig := tc.GetHostedClusterRESTConfig()
-			Expect(restConfig).NotTo(BeNil(),
-				"hosted cluster REST config should be available for %s/%s", hc.Namespace, hc.Name)
+			restConfig := tc.MustGetHostedClusterRESTConfig()
 
 			// KAS may need time to load the OIDC authentication config after the HC
 			// was patched in PostVersionRollout. Retry with a fresh token each attempt
@@ -402,4 +399,3 @@ func obtainKeycloakIDToken(config *e2eutil.ExtOIDCConfig) string {
 	Expect(ok).To(BeTrue(), "id_token not found or not a string in Keycloak response")
 	return idToken
 }
-

--- a/test/e2e/v2/tests/hosted_cluster_health_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_health_test.go
@@ -51,18 +51,19 @@ func ValidateHostedClusterConditionsTest(getTestCtx internal.TestContextGetter) 
 	When("hosted cluster is operational", func() {
 		It("should have all expected conditions with correct status", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			expectedConditions := conditions.ExpectedHCConditions(hostedCluster)
 			delete(expectedConditions, hyperv1.KubeVirtNodesLiveMigratable)
-			if e2eutil.IsLessThan(e2eutil.Version421) {
+			if !tc.VersionAtLeast(e2eutil.Version421) {
 				delete(expectedConditions, hyperv1.DataPlaneConnectionAvailable)
 			}
-			if e2eutil.IsLessThan(e2eutil.Version422) {
+			if !tc.VersionAtLeast(e2eutil.Version422) {
 				delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
 				delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkPolicyRBAC)
 			}
-			if e2eutil.IsLessThan(e2eutil.Version423) {
+			if !tc.VersionAtLeast(e2eutil.Version423) {
 				delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
 			}
 
@@ -102,11 +103,11 @@ func EnsureFeatureGateStatusTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster version is completed", func() {
 		It("should have feature gate status matching cluster version", func() {
 			tc := getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version419) {
-				Skip("Feature gate status test requires version >= 4.19")
-			}
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
+			tc.SkipIfVersionBelow(e2eutil.Version419)
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			var currentVersion string
 			Eventually(func(g Gomega) {
@@ -137,7 +138,8 @@ func EnsurePayloadArchSetCorrectlyTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster has a release image", func() {
 		It("should set payload arch status correctly", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
+			hostedCluster, err := getTestCtx().GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			imageMetadataProvider := &hyperutil.RegistryClientImageMetadataProvider{}
 			Eventually(func(g Gomega) {
@@ -156,12 +158,12 @@ func ValidateConfigurationStatusTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster authentication is configured", func() {
 		It("should propagate configuration status consistently", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
-			if e2eutil.IsLessThan(e2eutil.Version421) {
-				Skip("Configuration status requires version >= 4.21")
-			}
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			tc.SkipIfVersionBelow(e2eutil.Version421)
+
+			hcClient, err := tc.GetHostedClusterClient(hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
 				var hostedClusterAuth configv1.Authentication
@@ -195,8 +197,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Health] Hosted Clust
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterHealthTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_health_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_health_test.go
@@ -51,7 +51,8 @@ func ValidateHostedClusterConditionsTest(getTestCtx internal.TestContextGetter) 
 	When("hosted cluster is operational", func() {
 		It("should have all expected conditions with correct status", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.MustGetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			expectedConditions := conditions.ExpectedHCConditions(hostedCluster)
 			delete(expectedConditions, hyperv1.KubeVirtNodesLiveMigratable)
@@ -103,7 +104,10 @@ func EnsureFeatureGateStatusTest(getTestCtx internal.TestContextGetter) {
 		It("should have feature gate status matching cluster version", func() {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version419)
-			hcClient := tc.MustGetHostedClusterClient()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			var currentVersion string
 			Eventually(func(g Gomega) {
@@ -134,7 +138,8 @@ func EnsurePayloadArchSetCorrectlyTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster has a release image", func() {
 		It("should set payload arch status correctly", func() {
 			tc := getTestCtx()
-			hostedCluster := getTestCtx().MustGetHostedCluster()
+			hostedCluster, err := getTestCtx().GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			imageMetadataProvider := &hyperutil.RegistryClientImageMetadataProvider{}
 			Eventually(func(g Gomega) {
@@ -153,10 +158,12 @@ func ValidateConfigurationStatusTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster authentication is configured", func() {
 		It("should propagate configuration status consistently", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.MustGetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			tc.SkipIfVersionBelow(e2eutil.Version421)
 
-			hcClient := tc.MustGetHostedClusterClient()
+			hcClient, err := tc.GetHostedClusterClient(hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
 				var hostedClusterAuth configv1.Authentication

--- a/test/e2e/v2/tests/hosted_cluster_health_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_health_test.go
@@ -51,18 +51,18 @@ func ValidateHostedClusterConditionsTest(getTestCtx internal.TestContextGetter) 
 	When("hosted cluster is operational", func() {
 		It("should have all expected conditions with correct status", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
+			hostedCluster := tc.MustGetHostedCluster()
 
 			expectedConditions := conditions.ExpectedHCConditions(hostedCluster)
 			delete(expectedConditions, hyperv1.KubeVirtNodesLiveMigratable)
-			if e2eutil.IsLessThan(e2eutil.Version421) {
+			if !tc.VersionAtLeast(e2eutil.Version421) {
 				delete(expectedConditions, hyperv1.DataPlaneConnectionAvailable)
 			}
-			if e2eutil.IsLessThan(e2eutil.Version422) {
+			if !tc.VersionAtLeast(e2eutil.Version422) {
 				delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
 				delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkPolicyRBAC)
 			}
-			if e2eutil.IsLessThan(e2eutil.Version423) {
+			if !tc.VersionAtLeast(e2eutil.Version423) {
 				delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
 			}
 
@@ -102,11 +102,8 @@ func EnsureFeatureGateStatusTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster version is completed", func() {
 		It("should have feature gate status matching cluster version", func() {
 			tc := getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version419) {
-				Skip("Feature gate status test requires version >= 4.19")
-			}
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
+			tc.SkipIfVersionBelow(e2eutil.Version419)
+			hcClient := tc.MustGetHostedClusterClient()
 
 			var currentVersion string
 			Eventually(func(g Gomega) {
@@ -137,7 +134,7 @@ func EnsurePayloadArchSetCorrectlyTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster has a release image", func() {
 		It("should set payload arch status correctly", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
+			hostedCluster := getTestCtx().MustGetHostedCluster()
 
 			imageMetadataProvider := &hyperutil.RegistryClientImageMetadataProvider{}
 			Eventually(func(g Gomega) {
@@ -156,12 +153,10 @@ func ValidateConfigurationStatusTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster authentication is configured", func() {
 		It("should propagate configuration status consistently", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
-			if e2eutil.IsLessThan(e2eutil.Version421) {
-				Skip("Configuration status requires version >= 4.21")
-			}
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
+			hostedCluster := tc.MustGetHostedCluster()
+			tc.SkipIfVersionBelow(e2eutil.Version421)
+
+			hcClient := tc.MustGetHostedClusterClient()
 
 			Eventually(func(g Gomega) {
 				var hostedClusterAuth configv1.Authentication
@@ -195,8 +190,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Health] Hosted Clust
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterHealthTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_image_registry_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_image_registry_test.go
@@ -47,19 +47,13 @@ func RegisterHostedClusterImageRegistryTests(getTestCtx internal.TestContextGett
 // (waiting for the ClusterOperator to become Available) fails, all subsequent specs are
 // automatically skipped.
 func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
-	var (
-		tc                  *internal.TestContext
-		hc                  *hyperv1.HostedCluster
-		hostedClusterClient crclient.Client
-	)
+	var tc *internal.TestContext
 
 	When("the ImageRegistry capability is enabled", Ordered, func() {
 		BeforeAll(func() {
 			tc = getTestCtx()
-			hc = tc.GetHostedCluster()
-			if hc == nil {
-				Skip("HostedCluster is not available")
-			}
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			if hc.Spec.Capabilities != nil {
 				for _, disabled := range hc.Spec.Capabilities.Disabled {
 					if disabled == hyperv1.ImageRegistryCapability {
@@ -67,11 +61,14 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 					}
 				}
 			}
-			hostedClusterClient = tc.GetHostedClusterClient()
-			Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
 		})
 
 		It("should have a healthy image-registry ClusterOperator", func() {
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hostedClusterClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
+
 			By("waiting for the image-registry ClusterOperator to be Available and not Degraded")
 			Eventually(func(g Gomega) {
 				co := &configv1.ClusterOperator{}
@@ -99,6 +96,11 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should have installer-cloud-credentials in the hosted cluster", func() {
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hostedClusterClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
+
 			secret := &corev1.Secret{}
 			Expect(hostedClusterClient.Get(tc.Context, crclient.ObjectKey{
 				Namespace: "openshift-image-registry",
@@ -109,6 +111,11 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should have storage configured in the registry config", func() {
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hostedClusterClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
+
 			config := &imageregistryv1.Config{}
 			Expect(hostedClusterClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, config)).To(Succeed())
 
@@ -139,9 +146,9 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 			var imageRegistryEmail string
 
 			BeforeEach(func() {
-				if hc == nil || hc.Spec.Platform.Type != hyperv1.GCPPlatform {
-					Skip("image registry GCP tests are only for GCP platform")
-				}
+				tc.SkipIfNotPlatform(hyperv1.GCPPlatform)
+				hc, err := tc.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
 				Expect(hc.Spec.Platform.GCP).NotTo(BeNil(),
 					"GCP platform spec must be set for GCP HostedCluster %s/%s", hc.Namespace, hc.Name)
 				Expect(hc.Spec.Platform.GCP.WorkloadIdentity).NotTo(BeNil(),
@@ -153,6 +160,11 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 			})
 
 			It("should use GCS storage with a bucket name", func() {
+				hc, err := tc.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
+				hostedClusterClient, err := tc.GetHostedClusterClient(hc)
+				Expect(err).NotTo(HaveOccurred())
+
 				config := &imageregistryv1.Config{}
 				Expect(hostedClusterClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, config)).To(Succeed())
 				Expect(config.Spec.Storage.GCS).NotTo(BeNil(),
@@ -162,6 +174,11 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 			})
 
 			It("should have valid WIF credentials in installer-cloud-credentials", func() {
+				hc, err := tc.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
+				hostedClusterClient, err := tc.GetHostedClusterClient(hc)
+				Expect(err).NotTo(HaveOccurred())
+
 				secret := &corev1.Secret{}
 				Expect(hostedClusterClient.Get(tc.Context, crclient.ObjectKey{
 					Namespace: "openshift-image-registry",
@@ -190,10 +207,8 @@ func ImageRegistryCapabilityDisabledTest(getTestCtx internal.TestContextGetter) 
 
 		BeforeEach(func() {
 			tc = getTestCtx()
-			hc := tc.GetHostedCluster()
-			if hc == nil {
-				Skip("HostedCluster is not available")
-			}
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			isDisabled := false
 			if hc.Spec.Capabilities != nil {
@@ -208,8 +223,8 @@ func ImageRegistryCapabilityDisabledTest(getTestCtx internal.TestContextGetter) 
 				Skip("ImageRegistry capability is not disabled on this HostedCluster")
 			}
 
-			hostedClusterClient = tc.GetHostedClusterClient()
-			Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
+			hostedClusterClient, err = tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should not have the image-registry ClusterOperator", func() {
@@ -285,8 +300,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ImageRegistry] Hoste
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterImageRegistryTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_image_registry_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_image_registry_test.go
@@ -56,10 +56,7 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 	When("the ImageRegistry capability is enabled", Ordered, func() {
 		BeforeAll(func() {
 			tc = getTestCtx()
-			hc = tc.GetHostedCluster()
-			if hc == nil {
-				Skip("HostedCluster is not available")
-			}
+			hc = tc.MustGetHostedCluster()
 			if hc.Spec.Capabilities != nil {
 				for _, disabled := range hc.Spec.Capabilities.Disabled {
 					if disabled == hyperv1.ImageRegistryCapability {
@@ -67,8 +64,7 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 					}
 				}
 			}
-			hostedClusterClient = tc.GetHostedClusterClient()
-			Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
+			hostedClusterClient = tc.MustGetHostedClusterClient()
 		})
 
 		It("should have a healthy image-registry ClusterOperator", func() {
@@ -139,9 +135,7 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 			var imageRegistryEmail string
 
 			BeforeEach(func() {
-				if hc == nil || hc.Spec.Platform.Type != hyperv1.GCPPlatform {
-					Skip("image registry GCP tests are only for GCP platform")
-				}
+				tc.SkipIfNotPlatform(hyperv1.GCPPlatform)
 				Expect(hc.Spec.Platform.GCP).NotTo(BeNil(),
 					"GCP platform spec must be set for GCP HostedCluster %s/%s", hc.Namespace, hc.Name)
 				Expect(hc.Spec.Platform.GCP.WorkloadIdentity).NotTo(BeNil(),
@@ -190,10 +184,7 @@ func ImageRegistryCapabilityDisabledTest(getTestCtx internal.TestContextGetter) 
 
 		BeforeEach(func() {
 			tc = getTestCtx()
-			hc := tc.GetHostedCluster()
-			if hc == nil {
-				Skip("HostedCluster is not available")
-			}
+			hc := tc.MustGetHostedCluster()
 
 			isDisabled := false
 			if hc.Spec.Capabilities != nil {
@@ -208,8 +199,7 @@ func ImageRegistryCapabilityDisabledTest(getTestCtx internal.TestContextGetter) 
 				Skip("ImageRegistry capability is not disabled on this HostedCluster")
 			}
 
-			hostedClusterClient = tc.GetHostedClusterClient()
-			Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
+			hostedClusterClient = tc.MustGetHostedClusterClient()
 		})
 
 		It("should not have the image-registry ClusterOperator", func() {
@@ -285,8 +275,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ImageRegistry] Hoste
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterImageRegistryTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_image_registry_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_image_registry_test.go
@@ -56,7 +56,9 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 	When("the ImageRegistry capability is enabled", Ordered, func() {
 		BeforeAll(func() {
 			tc = getTestCtx()
-			hc = tc.MustGetHostedCluster()
+			var err error
+			hc, err = tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			if hc.Spec.Capabilities != nil {
 				for _, disabled := range hc.Spec.Capabilities.Disabled {
 					if disabled == hyperv1.ImageRegistryCapability {
@@ -64,7 +66,8 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 					}
 				}
 			}
-			hostedClusterClient = tc.MustGetHostedClusterClient()
+			hostedClusterClient, err = tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should have a healthy image-registry ClusterOperator", func() {
@@ -184,7 +187,8 @@ func ImageRegistryCapabilityDisabledTest(getTestCtx internal.TestContextGetter) 
 
 		BeforeEach(func() {
 			tc = getTestCtx()
-			hc := tc.MustGetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			isDisabled := false
 			if hc.Spec.Capabilities != nil {
@@ -199,7 +203,8 @@ func ImageRegistryCapabilityDisabledTest(getTestCtx internal.TestContextGetter) 
 				Skip("ImageRegistry capability is not disabled on this HostedCluster")
 			}
 
-			hostedClusterClient = tc.MustGetHostedClusterClient()
+			hostedClusterClient, err = tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should not have the image-registry ClusterOperator", func() {

--- a/test/e2e/v2/tests/hosted_cluster_ingress_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ingress_test.go
@@ -38,10 +38,9 @@ func ValidateIngressOperatorConfigurationTest(getTestCtx internal.TestContextGet
 	When("hosted cluster has IngressOperator EndpointPublishingStrategy configured", func() {
 		It("should reflect the custom strategy in the hosted cluster IngressController", func() {
 			tc := getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version421) {
-				Skip("Ingress operator configuration requires version >= 4.21")
-			}
-			hc := tc.GetHostedCluster()
+			tc.SkipIfVersionBelow(e2eutil.Version421)
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			if hc.Spec.OperatorConfiguration == nil ||
 				hc.Spec.OperatorConfiguration.IngressOperator == nil ||
@@ -51,8 +50,8 @@ func ValidateIngressOperatorConfigurationTest(getTestCtx internal.TestContextGet
 
 			expectedStrategy := hc.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy
 
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
 				ic := &operatorv1.IngressController{}
@@ -82,8 +81,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Ingress] Hosted Clus
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterIngressTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_ingress_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ingress_test.go
@@ -39,7 +39,8 @@ func ValidateIngressOperatorConfigurationTest(getTestCtx internal.TestContextGet
 		It("should reflect the custom strategy in the hosted cluster IngressController", func() {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version421)
-			hc := tc.MustGetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			if hc.Spec.OperatorConfiguration == nil ||
 				hc.Spec.OperatorConfiguration.IngressOperator == nil ||
@@ -49,7 +50,8 @@ func ValidateIngressOperatorConfigurationTest(getTestCtx internal.TestContextGet
 
 			expectedStrategy := hc.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy
 
-			hcClient := tc.MustGetHostedClusterClient()
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
 				ic := &operatorv1.IngressController{}

--- a/test/e2e/v2/tests/hosted_cluster_ingress_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ingress_test.go
@@ -38,10 +38,8 @@ func ValidateIngressOperatorConfigurationTest(getTestCtx internal.TestContextGet
 	When("hosted cluster has IngressOperator EndpointPublishingStrategy configured", func() {
 		It("should reflect the custom strategy in the hosted cluster IngressController", func() {
 			tc := getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version421) {
-				Skip("Ingress operator configuration requires version >= 4.21")
-			}
-			hc := tc.GetHostedCluster()
+			tc.SkipIfVersionBelow(e2eutil.Version421)
+			hc := tc.MustGetHostedCluster()
 
 			if hc.Spec.OperatorConfiguration == nil ||
 				hc.Spec.OperatorConfiguration.IngressOperator == nil ||
@@ -51,8 +49,7 @@ func ValidateIngressOperatorConfigurationTest(getTestCtx internal.TestContextGet
 
 			expectedStrategy := hc.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy
 
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
+			hcClient := tc.MustGetHostedClusterClient()
 
 			Eventually(func(g Gomega) {
 				ic := &operatorv1.IngressController{}
@@ -82,8 +79,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Ingress] Hosted Clus
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterIngressTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_metrics_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_metrics_test.go
@@ -65,10 +65,9 @@ func ValidateMetricsTest(getTestCtx internal.TestContextGetter) {
 	When("HyperShift operator is running", func() {
 		It("should expose expected metrics at the metrics endpoint", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
-			if hostedCluster.Spec.Platform.Type == hyperv1.NonePlatform {
-				Skip("metrics test skipped for None platform")
-			}
+			tc.SkipIfPlatform(hyperv1.NonePlatform)
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			mgmtRestConfig, err := e2eutil.GetConfig()
 			Expect(err).NotTo(HaveOccurred(), "should be able to load management cluster REST config")
@@ -138,10 +137,9 @@ func EnsureMetricsForwarderWorkingTest(getTestCtx internal.TestContextGetter) {
 	When("metrics forwarding is enabled", Label("Informing"), func() {
 		It("should deploy the metrics pipeline and scrape kube-apiserver metrics end-to-end", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
-			if e2eutil.IsLessThan(e2eutil.Version422) {
-				Skip("metrics forwarder requires version >= 4.22")
-			}
+			tc.SkipIfVersionBelow(e2eutil.Version422)
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			if hostedCluster.Spec.Monitoring.MetricsForwarding.Mode != hyperv1.MetricsForwardingModeForward {
 				Skip("metrics forwarding not enabled on hosted cluster; skipping verification test")
@@ -160,10 +158,10 @@ func EnsureMetricsForwarderWorkingTest(getTestCtx internal.TestContextGetter) {
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 
 			By("Waiting for hosted cluster metrics-forwarder deployment")
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
-			hcRestConfig := tc.GetHostedClusterRESTConfig()
-			Expect(hcRestConfig).NotTo(BeNil(), "hosted cluster REST config should be available")
+			hcClient, err := tc.GetHostedClusterClient(hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
+			hcRestConfig, err := tc.GetHostedClusterRESTConfig(hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
 
 			hcClientset, err := kubernetes.NewForConfig(hcRestConfig)
 			Expect(err).NotTo(HaveOccurred(), "should be able to create hosted cluster kubernetes clientset")
@@ -220,9 +218,7 @@ func EnsureNodeTuningOperatorMetricsEndpointTest(getTestCtx internal.TestContext
 	When("cluster has worker nodes", func() {
 		It("should have a functional node-tuning-operator metrics endpoint", func() {
 			tc := getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version422) {
-				Skip("NTO metrics endpoint test requires version >= 4.22")
-			}
+			tc.SkipIfVersionBelow(e2eutil.Version422)
 
 			svc := &corev1.Service{}
 			err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
@@ -314,8 +310,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Metrics] Hosted Clus
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterMetricsTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_metrics_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_metrics_test.go
@@ -65,10 +65,8 @@ func ValidateMetricsTest(getTestCtx internal.TestContextGetter) {
 	When("HyperShift operator is running", func() {
 		It("should expose expected metrics at the metrics endpoint", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
-			if hostedCluster.Spec.Platform.Type == hyperv1.NonePlatform {
-				Skip("metrics test skipped for None platform")
-			}
+			tc.SkipIfPlatform(hyperv1.NonePlatform)
+			hostedCluster := tc.MustGetHostedCluster()
 
 			mgmtRestConfig, err := e2eutil.GetConfig()
 			Expect(err).NotTo(HaveOccurred(), "should be able to load management cluster REST config")
@@ -138,10 +136,8 @@ func EnsureMetricsForwarderWorkingTest(getTestCtx internal.TestContextGetter) {
 	When("metrics forwarding is enabled", Label("Informing"), func() {
 		It("should deploy the metrics pipeline and scrape kube-apiserver metrics end-to-end", func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
-			if e2eutil.IsLessThan(e2eutil.Version422) {
-				Skip("metrics forwarder requires version >= 4.22")
-			}
+			tc.SkipIfVersionBelow(e2eutil.Version422)
+			hostedCluster := tc.MustGetHostedCluster()
 
 			if hostedCluster.Spec.Monitoring.MetricsForwarding.Mode != hyperv1.MetricsForwardingModeForward {
 				Skip("metrics forwarding not enabled on hosted cluster; skipping verification test")
@@ -160,10 +156,8 @@ func EnsureMetricsForwarderWorkingTest(getTestCtx internal.TestContextGetter) {
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 
 			By("Waiting for hosted cluster metrics-forwarder deployment")
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
-			hcRestConfig := tc.GetHostedClusterRESTConfig()
-			Expect(hcRestConfig).NotTo(BeNil(), "hosted cluster REST config should be available")
+			hcClient := tc.MustGetHostedClusterClient()
+			hcRestConfig := tc.MustGetHostedClusterRESTConfig()
 
 			hcClientset, err := kubernetes.NewForConfig(hcRestConfig)
 			Expect(err).NotTo(HaveOccurred(), "should be able to create hosted cluster kubernetes clientset")
@@ -220,9 +214,7 @@ func EnsureNodeTuningOperatorMetricsEndpointTest(getTestCtx internal.TestContext
 	When("cluster has worker nodes", func() {
 		It("should have a functional node-tuning-operator metrics endpoint", func() {
 			tc := getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version422) {
-				Skip("NTO metrics endpoint test requires version >= 4.22")
-			}
+			tc.SkipIfVersionBelow(e2eutil.Version422)
 
 			svc := &corev1.Service{}
 			err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
@@ -314,8 +306,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:Metrics] Hosted Clus
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterMetricsTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_metrics_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_metrics_test.go
@@ -66,7 +66,8 @@ func ValidateMetricsTest(getTestCtx internal.TestContextGetter) {
 		It("should expose expected metrics at the metrics endpoint", func() {
 			tc := getTestCtx()
 			tc.SkipIfPlatform(hyperv1.NonePlatform)
-			hostedCluster := tc.MustGetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			mgmtRestConfig, err := e2eutil.GetConfig()
 			Expect(err).NotTo(HaveOccurred(), "should be able to load management cluster REST config")
@@ -137,7 +138,8 @@ func EnsureMetricsForwarderWorkingTest(getTestCtx internal.TestContextGetter) {
 		It("should deploy the metrics pipeline and scrape kube-apiserver metrics end-to-end", func() {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version422)
-			hostedCluster := tc.MustGetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 
 			if hostedCluster.Spec.Monitoring.MetricsForwarding.Mode != hyperv1.MetricsForwardingModeForward {
 				Skip("metrics forwarding not enabled on hosted cluster; skipping verification test")
@@ -156,8 +158,10 @@ func EnsureMetricsForwarderWorkingTest(getTestCtx internal.TestContextGetter) {
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 
 			By("Waiting for hosted cluster metrics-forwarder deployment")
-			hcClient := tc.MustGetHostedClusterClient()
-			hcRestConfig := tc.MustGetHostedClusterRESTConfig()
+			hcClient, err := tc.GetHostedClusterClient(hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
+			hcRestConfig, err := tc.GetHostedClusterRESTConfig(hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
 
 			hcClientset, err := kubernetes.NewForConfig(hcRestConfig)
 			Expect(err).NotTo(HaveOccurred(), "should be able to create hosted cluster kubernetes clientset")

--- a/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
@@ -37,9 +37,10 @@ func EnsureNodeCommunicationTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster has konnectivity tunnel configured", func() {
 		It("should have konnectivity-agent pods with retrievable logs", func() {
 			tc := getTestCtx()
-			tc.ValidateHostedClusterClient()
-			restConfig := tc.GetHostedClusterRESTConfig()
-			Expect(restConfig).NotTo(BeNil(), "hosted cluster REST config should be available")
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			restConfig, err := tc.GetHostedClusterRESTConfig(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			clientset, err := kubernetes.NewForConfig(restConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to create hosted cluster kubernetes clientset")
@@ -73,8 +74,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodeCommunication] H
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterNodeCommunicationTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
@@ -37,9 +37,7 @@ func EnsureNodeCommunicationTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster has konnectivity tunnel configured", func() {
 		It("should have konnectivity-agent pods with retrievable logs", func() {
 			tc := getTestCtx()
-			tc.ValidateHostedClusterClient()
-			restConfig := tc.GetHostedClusterRESTConfig()
-			Expect(restConfig).NotTo(BeNil(), "hosted cluster REST config should be available")
+			restConfig := tc.MustGetHostedClusterRESTConfig()
 
 			clientset, err := kubernetes.NewForConfig(restConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to create hosted cluster kubernetes clientset")
@@ -73,8 +71,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodeCommunication] H
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterNodeCommunicationTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
@@ -37,7 +37,10 @@ func EnsureNodeCommunicationTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster has konnectivity tunnel configured", func() {
 		It("should have konnectivity-agent pods with retrievable logs", func() {
 			tc := getTestCtx()
-			restConfig := tc.MustGetHostedClusterRESTConfig()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			restConfig, err := tc.GetHostedClusterRESTConfig(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			clientset, err := kubernetes.NewForConfig(restConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to create hosted cluster kubernetes clientset")

--- a/test/e2e/v2/tests/hosted_cluster_psc_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_psc_test.go
@@ -31,11 +31,7 @@ import (
 func GCPPrivateServiceConnectTest(getTestCtx internal.TestContextGetter) {
 	Context("GCP Private Service Connect", Label("GCP", "PSC"), func() {
 		BeforeEach(func() {
-			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
-			if hc == nil || hc.Spec.Platform.Type != hyperv1.GCPPlatform {
-				Skip("GCP Private Service Connect test is only for GCP platform")
-			}
+			getTestCtx().SkipIfNotPlatform(hyperv1.GCPPlatform)
 		})
 
 		// GCP enforces that the NAT subnet and the forwarding rule must belong to the same VPC
@@ -93,7 +89,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:GCPPrivateServiceCon
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterGCPPSCTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
@@ -46,24 +46,19 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 	When("an additional pull secret is created in the hosted cluster", Label("Informing"), func() {
 		It("should propagate it through the global pull secret pipeline and clean up on deletion", func() {
 			tc := getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version419) {
-				Skip("global pull secret test requires version >= 4.19")
-			}
-
-			hc := tc.GetHostedCluster()
-
-			if hc.Spec.Platform.Type != hyperv1.AzurePlatform && hc.Spec.Platform.Type != hyperv1.AWSPlatform {
-				Skip("global pull secret test is only supported on AWS and Azure platforms")
-			}
-			if hc.Spec.Platform.Type == hyperv1.AWSPlatform && e2eutil.IsLessThan(e2eutil.Version421) {
+			tc.SkipIfVersionBelow(e2eutil.Version419)
+			tc.SkipIfNotPlatform(hyperv1.AWSPlatform, hyperv1.AzurePlatform)
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			if hc.Spec.Platform.Type == hyperv1.AWSPlatform && !tc.VersionAtLeast(e2eutil.Version421) {
 				Skip("AWS platform requires version >= 4.21 for global pull secret")
 			}
 			if !netutil.IsPublicHC(hc) {
 				Skip("global pull secret test is only supported on public clusters")
 			}
 
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			np := getDefaultNodePool(tc.Context, tc.MgmtClient, hc)
 			if np == nil ||
@@ -78,7 +73,7 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 			var updatedPullSecretData = []byte(`{"auths": {"registry.example.com": {"auth": "dXNlcjpwYXNzd29yZA=="}}}`)
 
 			By("verifying in-place management-cluster pull secret propagation without rollout")
-			if !e2eutil.IsLessThan(e2eutil.Version422) {
+			if tc.VersionAtLeast(e2eutil.Version422) {
 				verifyPullSecretPropagation(tc, hc, np, hcClient, nodeCount)
 			}
 
@@ -332,8 +327,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:GlobalPullSecret] Gl
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterGlobalPullSecretTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
@@ -46,24 +46,17 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 	When("an additional pull secret is created in the hosted cluster", Label("Informing"), func() {
 		It("should propagate it through the global pull secret pipeline and clean up on deletion", func() {
 			tc := getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version419) {
-				Skip("global pull secret test requires version >= 4.19")
-			}
-
-			hc := tc.GetHostedCluster()
-
-			if hc.Spec.Platform.Type != hyperv1.AzurePlatform && hc.Spec.Platform.Type != hyperv1.AWSPlatform {
-				Skip("global pull secret test is only supported on AWS and Azure platforms")
-			}
-			if hc.Spec.Platform.Type == hyperv1.AWSPlatform && e2eutil.IsLessThan(e2eutil.Version421) {
+			tc.SkipIfVersionBelow(e2eutil.Version419)
+			tc.SkipIfNotPlatform(hyperv1.AWSPlatform, hyperv1.AzurePlatform)
+			hc := tc.MustGetHostedCluster()
+			if hc.Spec.Platform.Type == hyperv1.AWSPlatform && !tc.VersionAtLeast(e2eutil.Version421) {
 				Skip("AWS platform requires version >= 4.21 for global pull secret")
 			}
 			if !netutil.IsPublicHC(hc) {
 				Skip("global pull secret test is only supported on public clusters")
 			}
 
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
+			hcClient := tc.MustGetHostedClusterClient()
 
 			np := getDefaultNodePool(tc.Context, tc.MgmtClient, hc)
 			if np == nil ||
@@ -78,7 +71,7 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 			var updatedPullSecretData = []byte(`{"auths": {"registry.example.com": {"auth": "dXNlcjpwYXNzd29yZA=="}}}`)
 
 			By("verifying in-place management-cluster pull secret propagation without rollout")
-			if !e2eutil.IsLessThan(e2eutil.Version422) {
+			if tc.VersionAtLeast(e2eutil.Version422) {
 				verifyPullSecretPropagation(tc, hc, np, hcClient, nodeCount)
 			}
 
@@ -332,8 +325,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:GlobalPullSecret] Gl
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterGlobalPullSecretTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
@@ -48,7 +48,8 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version419)
 			tc.SkipIfNotPlatform(hyperv1.AWSPlatform, hyperv1.AzurePlatform)
-			hc := tc.MustGetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			if hc.Spec.Platform.Type == hyperv1.AWSPlatform && !tc.VersionAtLeast(e2eutil.Version421) {
 				Skip("AWS platform requires version >= 4.21 for global pull secret")
 			}
@@ -56,7 +57,8 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 				Skip("global pull secret test is only supported on public clusters")
 			}
 
-			hcClient := tc.MustGetHostedClusterClient()
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			np := getDefaultNodePool(tc.Context, tc.MgmtClient, hc)
 			if np == nil ||

--- a/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
@@ -39,18 +39,18 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 	Context("KMS Spec Validation", func() {
 		Context("Azure KMS", func() {
 			BeforeEach(func() {
-				testCtx := getTestCtx()
-				hc := testCtx.GetHostedCluster()
-				if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform ||
-					hc.Spec.SecretEncryption == nil || hc.Spec.SecretEncryption.KMS == nil ||
+				getTestCtx().SkipIfNotPlatform(hyperv1.AzurePlatform)
+				hc, err := getTestCtx().GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
+				if hc.Spec.SecretEncryption == nil || hc.Spec.SecretEncryption.KMS == nil ||
 					hc.Spec.SecretEncryption.KMS.Azure == nil {
-					Skip("Azure KMS spec validation requires Azure platform with KMS configured")
+					Skip("Azure KMS spec validation requires KMS configured")
 				}
 			})
 
 			It("should have ActiveKey fields populated", func() {
-				testCtx := getTestCtx()
-				hc := testCtx.GetHostedCluster()
+				hc, err := getTestCtx().GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
 				azureKMS := hc.Spec.SecretEncryption.KMS.Azure
 
 				Expect(azureKMS.ActiveKey.KeyVaultName).NotTo(BeEmpty(),
@@ -62,8 +62,8 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 			})
 
 			It("should have KMS authentication configured", func() {
-				testCtx := getTestCtx()
-				hc := testCtx.GetHostedCluster()
+				hc, err := getTestCtx().GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
 				azureKMS := hc.Spec.SecretEncryption.KMS.Azure
 
 				hasWorkloadIdentity := azureKMS.WorkloadIdentity.ClientID != ""
@@ -92,13 +92,16 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 func KMSFunctionalValidationTest(getTestCtx internal.TestContextGetter) {
 	Context("KMS Functional Validation", func() {
 		It("should encrypt secrets in etcd using KMSv2", func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version417)
 			testCtx := getTestCtx()
 			ctx := testCtx.Context
 
-			hostedClusterClient := testCtx.GetHostedClusterClient()
-			Expect(hostedClusterClient).NotTo(BeNil(),
-				"hosted cluster client is required; KubeConfig may not be set")
+			testCtx.SkipIfVersionBelow(e2eutil.Version417)
+
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+
+			hostedClusterClient, err := testCtx.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			testSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -156,8 +159,9 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:SecretEncryption] Ho
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
 
-		hc := testCtx.GetHostedCluster()
-		if hc == nil || hc.Spec.SecretEncryption == nil || hc.Spec.SecretEncryption.KMS == nil {
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		if hc.Spec.SecretEncryption == nil || hc.Spec.SecretEncryption.KMS == nil {
 			Skip("SecretEncryption with KMS is not configured on this hosted cluster")
 		}
 	})

--- a/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
@@ -39,18 +39,16 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 	Context("KMS Spec Validation", func() {
 		Context("Azure KMS", func() {
 			BeforeEach(func() {
-				testCtx := getTestCtx()
-				hc := testCtx.GetHostedCluster()
-				if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform ||
-					hc.Spec.SecretEncryption == nil || hc.Spec.SecretEncryption.KMS == nil ||
+				getTestCtx().SkipIfNotPlatform(hyperv1.AzurePlatform)
+				hc := getTestCtx().MustGetHostedCluster()
+				if hc.Spec.SecretEncryption == nil || hc.Spec.SecretEncryption.KMS == nil ||
 					hc.Spec.SecretEncryption.KMS.Azure == nil {
-					Skip("Azure KMS spec validation requires Azure platform with KMS configured")
+					Skip("Azure KMS spec validation requires KMS configured")
 				}
 			})
 
 			It("should have ActiveKey fields populated", func() {
-				testCtx := getTestCtx()
-				hc := testCtx.GetHostedCluster()
+				hc := getTestCtx().MustGetHostedCluster()
 				azureKMS := hc.Spec.SecretEncryption.KMS.Azure
 
 				Expect(azureKMS.ActiveKey.KeyVaultName).NotTo(BeEmpty(),
@@ -62,8 +60,7 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 			})
 
 			It("should have KMS authentication configured", func() {
-				testCtx := getTestCtx()
-				hc := testCtx.GetHostedCluster()
+				hc := getTestCtx().MustGetHostedCluster()
 				azureKMS := hc.Spec.SecretEncryption.KMS.Azure
 
 				hasWorkloadIdentity := azureKMS.WorkloadIdentity.ClientID != ""
@@ -92,13 +89,12 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 func KMSFunctionalValidationTest(getTestCtx internal.TestContextGetter) {
 	Context("KMS Functional Validation", func() {
 		It("should encrypt secrets in etcd using KMSv2", func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version417)
 			testCtx := getTestCtx()
 			ctx := testCtx.Context
 
-			hostedClusterClient := testCtx.GetHostedClusterClient()
-			Expect(hostedClusterClient).NotTo(BeNil(),
-				"hosted cluster client is required; KubeConfig may not be set")
+			testCtx.SkipIfVersionBelow(e2eutil.Version417)
+
+			hostedClusterClient := testCtx.MustGetHostedClusterClient()
 
 			testSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -156,8 +152,8 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:SecretEncryption] Ho
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
 
-		hc := testCtx.GetHostedCluster()
-		if hc == nil || hc.Spec.SecretEncryption == nil || hc.Spec.SecretEncryption.KMS == nil {
+		hc := testCtx.MustGetHostedCluster()
+		if hc.Spec.SecretEncryption == nil || hc.Spec.SecretEncryption.KMS == nil {
 			Skip("SecretEncryption with KMS is not configured on this hosted cluster")
 		}
 	})

--- a/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
@@ -40,7 +40,8 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 		Context("Azure KMS", func() {
 			BeforeEach(func() {
 				getTestCtx().SkipIfNotPlatform(hyperv1.AzurePlatform)
-				hc := getTestCtx().MustGetHostedCluster()
+				hc, err := getTestCtx().GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
 				if hc.Spec.SecretEncryption == nil || hc.Spec.SecretEncryption.KMS == nil ||
 					hc.Spec.SecretEncryption.KMS.Azure == nil {
 					Skip("Azure KMS spec validation requires KMS configured")
@@ -48,7 +49,8 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 			})
 
 			It("should have ActiveKey fields populated", func() {
-				hc := getTestCtx().MustGetHostedCluster()
+				hc, err := getTestCtx().GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
 				azureKMS := hc.Spec.SecretEncryption.KMS.Azure
 
 				Expect(azureKMS.ActiveKey.KeyVaultName).NotTo(BeEmpty(),
@@ -60,7 +62,8 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 			})
 
 			It("should have KMS authentication configured", func() {
-				hc := getTestCtx().MustGetHostedCluster()
+				hc, err := getTestCtx().GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred())
 				azureKMS := hc.Spec.SecretEncryption.KMS.Azure
 
 				hasWorkloadIdentity := azureKMS.WorkloadIdentity.ClientID != ""
@@ -94,7 +97,11 @@ func KMSFunctionalValidationTest(getTestCtx internal.TestContextGetter) {
 
 			testCtx.SkipIfVersionBelow(e2eutil.Version417)
 
-			hostedClusterClient := testCtx.MustGetHostedClusterClient()
+			hc, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+
+			hostedClusterClient, err := testCtx.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			testSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -152,7 +159,8 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:SecretEncryption] Ho
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
 
-		hc := testCtx.MustGetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		if hc.Spec.SecretEncryption == nil || hc.Spec.SecretEncryption.KMS == nil {
 			Skip("SecretEncryption with KMS is not configured on this hosted cluster")
 		}

--- a/test/e2e/v2/tests/hosted_cluster_security_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_security_test.go
@@ -23,13 +23,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/hypershift/support/netutil"
 
 	configv1 "github.com/openshift/api/config/v1"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hccokasvap "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas"
 	suppconfig "github.com/openshift/hypershift/support/config"
-	"github.com/openshift/hypershift/support/netutil"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
@@ -54,8 +54,10 @@ func EnsureHostedClusterWebhooksValidatedTest(getTestCtx internal.TestContextGet
 	When("[Feature:WebhookValidation] a webhook targeting a control plane service is created in the hosted cluster", func() {
 		It("should be automatically deleted", func() {
 			tc := getTestCtx()
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			sideEffectsNone := admissionregistrationv1.SideEffectClassNone
 			webhookConf := &admissionregistrationv1.ValidatingWebhookConfiguration{
@@ -103,23 +105,22 @@ func EnsureHostedClusterWebhooksValidatedTest(getTestCtx internal.TestContextGet
 func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 	When("[Feature:AdmissionPolicies] checking admission policies on a public hosted cluster", Ordered, func() {
 		var tc *internal.TestContext
-		var hcClient crclient.Client
-		var hostedCluster *hyperv1.HostedCluster
 
 		BeforeAll(func() {
 			tc = getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version418) {
-				Skip("Admission policies require version >= 4.18")
-			}
-			hostedCluster = tc.GetHostedCluster()
-			if !netutil.IsPublicHC(hostedCluster) {
+			tc.SkipIfVersionBelow(e2eutil.Version418)
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			if !netutil.IsPublicHC(hc) {
 				Skip("admission policies test requires a public hosted cluster")
 			}
-			tc.ValidateHostedClusterClient()
-			hcClient = tc.GetHostedClusterClient()
 		})
 
 		It("should find all required ValidatingAdmissionPolicies", func() {
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 			Eventually(func(g Gomega) {
 				vapList := &admissionregistrationv1.ValidatingAdmissionPolicyList{}
 				g.Expect(hcClient.List(tc.Context, vapList)).To(Succeed())
@@ -144,6 +145,10 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should deny unauthorized config changes via VAPs", func() {
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 			Eventually(func(g Gomega) {
 				apiServer := &configv1.APIServer{}
 				g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, apiServer)).To(Succeed())
@@ -161,6 +166,10 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should allow status modifications via VAPs", func() {
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 			network := &configv1.Network{}
 			Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, network)).To(Succeed())
 			originalMTU := network.Status.ClusterNetworkMTU
@@ -184,6 +193,10 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should allow OperatorHub config changes with guest OLM placement", func() {
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hcClient, err := tc.GetHostedClusterClient(hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
 			if hostedCluster.Spec.OLMCatalogPlacement != hyperv1.GuestOLMCatalogPlacement {
 				Skip("OperatorHub test requires guest OLM catalog placement")
 			}
@@ -215,10 +228,7 @@ func EnsureNetworkPoliciesTest(getTestCtx internal.TestContextGetter) {
 	When("[Feature:NetworkPolicies] checking network policies on an AWS hosted cluster", func() {
 		BeforeEach(func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
-			if hostedCluster.Spec.Platform.Type != hyperv1.AWSPlatform {
-				Skip("network policies test is only for AWS platform")
-			}
+			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
 		})
 
 		It("should find management KAS access labels on expected components", func() {
@@ -282,7 +292,8 @@ func EnsureNetworkPoliciesTest(getTestCtx internal.TestContextGetter) {
 				), "failure should be a curl connection error, not an exec/setup error; got: %v", err)
 			}, 1*time.Minute, 10*time.Second).Should(Succeed())
 
-			hostedCluster := tc.GetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			if hostedCluster.Spec.Platform.Type == hyperv1.AWSPlatform &&
 				hostedCluster.Spec.Platform.AWS != nil &&
 				hostedCluster.Spec.Platform.AWS.EndpointAccess != hyperv1.Private {
@@ -333,8 +344,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift] Hosted Cluster Security", La
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterSecurityTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_security_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_security_test.go
@@ -23,13 +23,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/hypershift/support/netutil"
 
 	configv1 "github.com/openshift/api/config/v1"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hccokasvap "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas"
 	suppconfig "github.com/openshift/hypershift/support/config"
-	"github.com/openshift/hypershift/support/netutil"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
@@ -54,8 +54,7 @@ func EnsureHostedClusterWebhooksValidatedTest(getTestCtx internal.TestContextGet
 	When("[Feature:WebhookValidation] a webhook targeting a control plane service is created in the hosted cluster", func() {
 		It("should be automatically deleted", func() {
 			tc := getTestCtx()
-			tc.ValidateHostedClusterClient()
-			hcClient := tc.GetHostedClusterClient()
+			hcClient := tc.MustGetHostedClusterClient()
 
 			sideEffectsNone := admissionregistrationv1.SideEffectClassNone
 			webhookConf := &admissionregistrationv1.ValidatingWebhookConfiguration{
@@ -103,23 +102,18 @@ func EnsureHostedClusterWebhooksValidatedTest(getTestCtx internal.TestContextGet
 func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 	When("[Feature:AdmissionPolicies] checking admission policies on a public hosted cluster", Ordered, func() {
 		var tc *internal.TestContext
-		var hcClient crclient.Client
-		var hostedCluster *hyperv1.HostedCluster
 
 		BeforeAll(func() {
 			tc = getTestCtx()
-			if e2eutil.IsLessThan(e2eutil.Version418) {
-				Skip("Admission policies require version >= 4.18")
-			}
-			hostedCluster = tc.GetHostedCluster()
-			if !netutil.IsPublicHC(hostedCluster) {
+			tc.SkipIfVersionBelow(e2eutil.Version418)
+			hc := tc.MustGetHostedCluster()
+			if !netutil.IsPublicHC(hc) {
 				Skip("admission policies test requires a public hosted cluster")
 			}
-			tc.ValidateHostedClusterClient()
-			hcClient = tc.GetHostedClusterClient()
 		})
 
 		It("should find all required ValidatingAdmissionPolicies", func() {
+			hcClient := tc.MustGetHostedClusterClient()
 			Eventually(func(g Gomega) {
 				vapList := &admissionregistrationv1.ValidatingAdmissionPolicyList{}
 				g.Expect(hcClient.List(tc.Context, vapList)).To(Succeed())
@@ -144,6 +138,7 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should deny unauthorized config changes via VAPs", func() {
+			hcClient := tc.MustGetHostedClusterClient()
 			Eventually(func(g Gomega) {
 				apiServer := &configv1.APIServer{}
 				g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, apiServer)).To(Succeed())
@@ -161,6 +156,7 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should allow status modifications via VAPs", func() {
+			hcClient := tc.MustGetHostedClusterClient()
 			network := &configv1.Network{}
 			Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, network)).To(Succeed())
 			originalMTU := network.Status.ClusterNetworkMTU
@@ -184,6 +180,8 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should allow OperatorHub config changes with guest OLM placement", func() {
+			hostedCluster := tc.MustGetHostedCluster()
+			hcClient := tc.MustGetHostedClusterClient()
 			if hostedCluster.Spec.OLMCatalogPlacement != hyperv1.GuestOLMCatalogPlacement {
 				Skip("OperatorHub test requires guest OLM catalog placement")
 			}
@@ -215,10 +213,7 @@ func EnsureNetworkPoliciesTest(getTestCtx internal.TestContextGetter) {
 	When("[Feature:NetworkPolicies] checking network policies on an AWS hosted cluster", func() {
 		BeforeEach(func() {
 			tc := getTestCtx()
-			hostedCluster := tc.GetHostedCluster()
-			if hostedCluster.Spec.Platform.Type != hyperv1.AWSPlatform {
-				Skip("network policies test is only for AWS platform")
-			}
+			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
 		})
 
 		It("should find management KAS access labels on expected components", func() {
@@ -282,7 +277,7 @@ func EnsureNetworkPoliciesTest(getTestCtx internal.TestContextGetter) {
 				), "failure should be a curl connection error, not an exec/setup error; got: %v", err)
 			}, 1*time.Minute, 10*time.Second).Should(Succeed())
 
-			hostedCluster := tc.GetHostedCluster()
+			hostedCluster := tc.MustGetHostedCluster()
 			if hostedCluster.Spec.Platform.Type == hyperv1.AWSPlatform &&
 				hostedCluster.Spec.Platform.AWS != nil &&
 				hostedCluster.Spec.Platform.AWS.EndpointAccess != hyperv1.Private {
@@ -333,8 +328,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift] Hosted Cluster Security", La
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
-
-		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterSecurityTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_security_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_security_test.go
@@ -54,7 +54,10 @@ func EnsureHostedClusterWebhooksValidatedTest(getTestCtx internal.TestContextGet
 	When("[Feature:WebhookValidation] a webhook targeting a control plane service is created in the hosted cluster", func() {
 		It("should be automatically deleted", func() {
 			tc := getTestCtx()
-			hcClient := tc.MustGetHostedClusterClient()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 
 			sideEffectsNone := admissionregistrationv1.SideEffectClassNone
 			webhookConf := &admissionregistrationv1.ValidatingWebhookConfiguration{
@@ -106,14 +109,18 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 		BeforeAll(func() {
 			tc = getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version418)
-			hc := tc.MustGetHostedCluster()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			if !netutil.IsPublicHC(hc) {
 				Skip("admission policies test requires a public hosted cluster")
 			}
 		})
 
 		It("should find all required ValidatingAdmissionPolicies", func() {
-			hcClient := tc.MustGetHostedClusterClient()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 			Eventually(func(g Gomega) {
 				vapList := &admissionregistrationv1.ValidatingAdmissionPolicyList{}
 				g.Expect(hcClient.List(tc.Context, vapList)).To(Succeed())
@@ -138,7 +145,10 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should deny unauthorized config changes via VAPs", func() {
-			hcClient := tc.MustGetHostedClusterClient()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 			Eventually(func(g Gomega) {
 				apiServer := &configv1.APIServer{}
 				g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, apiServer)).To(Succeed())
@@ -156,7 +166,10 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should allow status modifications via VAPs", func() {
-			hcClient := tc.MustGetHostedClusterClient()
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred())
 			network := &configv1.Network{}
 			Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, network)).To(Succeed())
 			originalMTU := network.Status.ClusterNetworkMTU
@@ -180,8 +193,10 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should allow OperatorHub config changes with guest OLM placement", func() {
-			hostedCluster := tc.MustGetHostedCluster()
-			hcClient := tc.MustGetHostedClusterClient()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			hcClient, err := tc.GetHostedClusterClient(hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
 			if hostedCluster.Spec.OLMCatalogPlacement != hyperv1.GuestOLMCatalogPlacement {
 				Skip("OperatorHub test requires guest OLM catalog placement")
 			}
@@ -277,7 +292,8 @@ func EnsureNetworkPoliciesTest(getTestCtx internal.TestContextGetter) {
 				), "failure should be a curl connection error, not an exec/setup error; got: %v", err)
 			}, 1*time.Minute, 10*time.Second).Should(Succeed())
 
-			hostedCluster := tc.MustGetHostedCluster()
+			hostedCluster, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
 			if hostedCluster.Spec.Platform.Type == hyperv1.AWSPlatform &&
 				hostedCluster.Spec.Platform.AWS != nil &&
 				hostedCluster.Spec.Platform.AWS.EndpointAccess != hyperv1.Private {

--- a/test/e2e/v2/tests/nodepool_autoscaling_test.go
+++ b/test/e2e/v2/tests/nodepool_autoscaling_test.go
@@ -44,10 +44,10 @@ import (
 func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 	It("should scale up when workload increases and scale down when workload decreases", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
-
-		hc := testCtx.GetHostedCluster()
-		hcClient := testCtx.GetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 		ctx := testCtx.Context
 
 		// Find the default NodePool to copy platform config
@@ -58,7 +58,7 @@ func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 		// so the workload targets only this NodePool's nodes.
 		autoscalingLabel := map[string]string{"e2e-autoscaling-test": "scale-up-down"}
 		autoscalingNP := buildAutoscalingNodePool(defaultNP, 1, 3, autoscalingLabel)
-		err := testCtx.MgmtClient.Create(ctx, autoscalingNP)
+		err = testCtx.MgmtClient.Create(ctx, autoscalingNP)
 		Expect(err).NotTo(HaveOccurred(), "failed to create autoscaling NodePool")
 		GinkgoWriter.Printf("Created autoscaling NodePool %s with min=1, max=3\n", autoscalingNP.Name)
 
@@ -109,12 +109,13 @@ func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 	It("should balance pods across multiple autoscaling NodePools", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		e2eutil.GinkgoAtLeast(e2eutil.Version420)
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		testCtx.SkipIfVersionBelow(e2eutil.Version420)
 
-		hc := testCtx.GetHostedCluster()
-		hcClient := testCtx.GetHostedClusterClient()
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
 
@@ -131,7 +132,7 @@ func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 			},
 			MaxFreeDifferenceRatioPercent: ptr.To[int32](70),
 		}
-		err := testCtx.MgmtClient.Patch(ctx, hc, crclient.MergeFrom(originalHC))
+		err = testCtx.MgmtClient.Patch(ctx, hc, crclient.MergeFrom(originalHC))
 		Expect(err).NotTo(HaveOccurred(), "failed to configure autoscaler on HostedCluster")
 		GinkgoWriter.Println("Configured HostedCluster autoscaling with Random expander")
 

--- a/test/e2e/v2/tests/nodepool_autoscaling_test.go
+++ b/test/e2e/v2/tests/nodepool_autoscaling_test.go
@@ -44,10 +44,8 @@ import (
 func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 	It("should scale up when workload increases and scale down when workload decreases", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
-
-		hc := testCtx.GetHostedCluster()
-		hcClient := testCtx.GetHostedClusterClient()
+		hc := testCtx.MustGetHostedCluster()
+		hcClient := testCtx.MustGetHostedClusterClient()
 		ctx := testCtx.Context
 
 		// Find the default NodePool to copy platform config
@@ -109,12 +107,11 @@ func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 	It("should balance pods across multiple autoscaling NodePools", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		e2eutil.GinkgoAtLeast(e2eutil.Version420)
+		hc := testCtx.MustGetHostedCluster()
+		testCtx.SkipIfVersionBelow(e2eutil.Version420)
 
-		hc := testCtx.GetHostedCluster()
-		hcClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.MustGetHostedClusterClient()
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
 

--- a/test/e2e/v2/tests/nodepool_autoscaling_test.go
+++ b/test/e2e/v2/tests/nodepool_autoscaling_test.go
@@ -44,8 +44,10 @@ import (
 func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 	It("should scale up when workload increases and scale down when workload decreases", func() {
 		testCtx := getTestCtx()
-		hc := testCtx.MustGetHostedCluster()
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 		ctx := testCtx.Context
 
 		// Find the default NodePool to copy platform config
@@ -56,7 +58,7 @@ func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 		// so the workload targets only this NodePool's nodes.
 		autoscalingLabel := map[string]string{"e2e-autoscaling-test": "scale-up-down"}
 		autoscalingNP := buildAutoscalingNodePool(defaultNP, 1, 3, autoscalingLabel)
-		err := testCtx.MgmtClient.Create(ctx, autoscalingNP)
+		err = testCtx.MgmtClient.Create(ctx, autoscalingNP)
 		Expect(err).NotTo(HaveOccurred(), "failed to create autoscaling NodePool")
 		GinkgoWriter.Printf("Created autoscaling NodePool %s with min=1, max=3\n", autoscalingNP.Name)
 
@@ -108,10 +110,12 @@ func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 	It("should balance pods across multiple autoscaling NodePools", func() {
 		testCtx := getTestCtx()
 
-		hc := testCtx.MustGetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		testCtx.SkipIfVersionBelow(e2eutil.Version420)
 
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
 
@@ -128,7 +132,7 @@ func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 			},
 			MaxFreeDifferenceRatioPercent: ptr.To[int32](70),
 		}
-		err := testCtx.MgmtClient.Patch(ctx, hc, crclient.MergeFrom(originalHC))
+		err = testCtx.MgmtClient.Patch(ctx, hc, crclient.MergeFrom(originalHC))
 		Expect(err).NotTo(HaveOccurred(), "failed to configure autoscaler on HostedCluster")
 		GinkgoWriter.Println("Configured HostedCluster autoscaling with Random expander")
 

--- a/test/e2e/v2/tests/nodepool_lifecycle_test.go
+++ b/test/e2e/v2/tests/nodepool_lifecycle_test.go
@@ -85,14 +85,12 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolLifecycle] N
 func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 	It("should roll out a MachineConfig change via Replace upgrade strategy", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
-
-		hc := testCtx.GetHostedCluster()
-		if hc.Spec.Platform.Type == hyperv1.KubevirtPlatform {
-			Skip("test is skipped for KubeVirt platform until https://issues.redhat.com/browse/CNV-38196 is addressed")
-		}
-
-		hcClient := testCtx.GetHostedClusterClient()
+		// https://issues.redhat.com/browse/CNV-38196
+		testCtx.SkipIfPlatform(hyperv1.KubevirtPlatform)
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -111,7 +109,7 @@ func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
 		DeferCleanup(func() {
@@ -187,17 +185,13 @@ func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 	It("should roll out an NTO Tuned config change via Replace upgrade strategy", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		if hc.Spec.Platform.Type == hyperv1.KubevirtPlatform {
-			Skip("test is skipped for KubeVirt platform until https://issues.redhat.com/browse/CNV-38196 is addressed")
-		}
-		if hc.Spec.Platform.Type == hyperv1.OpenStackPlatform {
-			Skip("test is skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
-		}
-
-		hcClient := testCtx.GetHostedClusterClient()
+		// https://issues.redhat.com/browse/CNV-38196, https://issues.redhat.com/browse/OSASINFRA-3566
+		testCtx.SkipIfPlatform(hyperv1.KubevirtPlatform, hyperv1.OpenStackPlatform)
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -216,7 +210,7 @@ func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
 		DeferCleanup(func() {
@@ -261,17 +255,13 @@ func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 	It("should roll out an NTO Tuned config change via InPlace upgrade strategy", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		if hc.Spec.Platform.Type == hyperv1.KubevirtPlatform {
-			Skip("test is skipped for KubeVirt platform until https://issues.redhat.com/browse/CNV-38196 is addressed")
-		}
-		if hc.Spec.Platform.Type == hyperv1.OpenStackPlatform {
-			Skip("test is skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
-		}
-
-		hcClient := testCtx.GetHostedClusterClient()
+		// https://issues.redhat.com/browse/CNV-38196, https://issues.redhat.com/browse/OSASINFRA-3566
+		testCtx.SkipIfPlatform(hyperv1.KubevirtPlatform, hyperv1.OpenStackPlatform)
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -284,7 +274,7 @@ func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeInPlace
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
 		DeferCleanup(func() {
@@ -330,10 +320,11 @@ func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 	It("should upgrade a NodePool from previous to latest release via Replace strategy", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		hcClient := testCtx.GetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		previousImage := internal.GetEnvVarValue("E2E_PREVIOUS_RELEASE_IMAGE")
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")
@@ -359,7 +350,7 @@ func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s at previous release %s\n", np.Name, previousImage)
 		DeferCleanup(func() {
@@ -417,10 +408,11 @@ func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 	It("should upgrade a NodePool from previous to latest release via InPlace strategy", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		hcClient := testCtx.GetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		previousImage := internal.GetEnvVarValue("E2E_PREVIOUS_RELEASE_IMAGE")
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")
@@ -440,7 +432,7 @@ func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeInPlace
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s at previous release %s\n", np.Name, previousImage)
 		DeferCleanup(func() {
@@ -498,15 +490,13 @@ func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 	It("should perform a rolling upgrade when instance type or VM size changes", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
+		testCtx.SkipIfNotPlatform(hyperv1.AWSPlatform, hyperv1.AzurePlatform)
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 		platform := hc.Spec.Platform.Type
-		if platform != hyperv1.AWSPlatform && platform != hyperv1.AzurePlatform {
-			Skip("rolling upgrade test only supported on AWS and Azure platforms")
-		}
-
-		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -525,7 +515,7 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s with 2 replicas\n", np.Name)
 		DeferCleanup(func() {
@@ -596,16 +586,16 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
 	It("should create a NodePool at N-1 release and have ready nodes", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
-
-		hc := testCtx.GetHostedCluster()
 
 		n1Image := internal.GetEnvVarValue("E2E_N1_RELEASE_IMAGE")
 		if n1Image == "" {
 			Skip("E2E_N1_RELEASE_IMAGE not set, skipping N-1 release test")
 		}
 
-		hcClient := testCtx.GetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -618,7 +608,7 @@ func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Release.Image = n1Image
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s at N-1 release %s\n", np.Name, n1Image)
 		DeferCleanup(func() {
@@ -635,16 +625,16 @@ func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
 func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
 	It("should create a NodePool at N-2 release and have ready nodes", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
-
-		hc := testCtx.GetHostedCluster()
 
 		n2Image := internal.GetEnvVarValue("E2E_N2_RELEASE_IMAGE")
 		if n2Image == "" {
 			Skip("E2E_N2_RELEASE_IMAGE not set, skipping N-2 release test")
 		}
 
-		hcClient := testCtx.GetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -657,7 +647,7 @@ func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Release.Image = n2Image
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s at N-2 release %s\n", np.Name, n2Image)
 		DeferCleanup(func() {
@@ -676,14 +666,13 @@ func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
 func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 	It("should mirror KubeletConfig to the hosted cluster and clean up on removal", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		if e2eutil.IsLessThan(e2eutil.Version418) {
-			Skip("mirror configs test only applicable for 4.18+")
-		}
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		testCtx.SkipIfVersionBelow(e2eutil.Version418)
 
-		hcClient := testCtx.GetHostedClusterClient()
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -695,7 +684,7 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Replicas = &oneReplica
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
 		DeferCleanup(func() {
@@ -811,12 +800,13 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 	It("should propagate and remove additional trust bundle to/from the hosted cluster", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		e2eutil.GinkgoAtLeast(e2eutil.Version418)
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		version := testCtx.SkipIfVersionBelow(e2eutil.Version418)
 
-		hc := testCtx.GetHostedCluster()
-		hcClient := testCtx.GetHostedClusterClient()
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -866,7 +856,14 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 
 		// Defer cleanup: remove trust bundle reference from HostedCluster
 		DeferCleanup(func() {
-			err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, testCtx.GetHostedCluster(), func(obj *hyperv1.HostedCluster) {
+			currentHC := &hyperv1.HostedCluster{}
+			if err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), currentHC); err != nil {
+				if !apierrors.IsNotFound(err) {
+					GinkgoWriter.Printf("Warning: cleanup: failed to get HostedCluster: %v\n", err)
+				}
+				return
+			}
+			err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, currentHC, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.AdditionalTrustBundle = nil
 			})
 			if err != nil && !apierrors.IsNotFound(err) {
@@ -999,7 +996,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 		)
 
 		// Verify user-ca-bundle is deleted from the hosted cluster (4.22+)
-		if e2eutil.IsGreaterThanOrEqualTo(e2eutil.Version422) {
+		if version.GE(e2eutil.Version422) {
 			e2eutil.EventuallyNotFound(GinkgoTB(), ctx, hcClient, userCAConfigMap,
 				e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute),
 			)
@@ -1013,14 +1010,13 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 	It("should create and manage NTO PerformanceProfile via NodePool TuningConfig", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		if hc.Spec.Platform.Type == hyperv1.OpenStackPlatform {
-			Skip("test is skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
-		}
-
-		hcClient := testCtx.GetHostedClusterClient()
+		// https://issues.redhat.com/browse/OSASINFRA-3566
+		testCtx.SkipIfPlatform(hyperv1.OpenStackPlatform)
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -1032,7 +1028,7 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Replicas = &oneReplica
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
 		DeferCleanup(func() {
@@ -1108,7 +1104,7 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 		)
 
 		// Verify status ConfigMap (4.17+)
-		if !e2eutil.IsLessThan(e2eutil.Version417) {
+		if testCtx.VersionAtLeast(e2eutil.Version417) {
 			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "PerformanceProfile status ConfigMap to exist",
 				func(ctx context.Context) ([]*corev1.ConfigMap, error) {
 					list := &corev1.ConfigMapList{}
@@ -1181,15 +1177,15 @@ func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
 		Skip("auto-repair instance termination not yet implemented for v2 framework")
 
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 		platform := hc.Spec.Platform.Type
 		if platform != hyperv1.AWSPlatform && platform != hyperv1.AzurePlatform {
 			Skip("auto-repair test only supported on AWS and Azure platforms")
 		}
-
-		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -1202,7 +1198,7 @@ func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Management.AutoRepair = true
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created auto-repair NodePool %s\n", np.Name)
 		DeferCleanup(func() {
@@ -1224,19 +1220,18 @@ func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
 func NodePoolDiskEncryptionTest(getTestCtx internal.TestContextGetter) {
 	It("should create a NodePool with Azure DiskEncryptionSet and verify it is applied", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		if hc.Spec.Platform.Type != hyperv1.AzurePlatform {
-			Skip("disk encryption test only supported on Azure platform")
-		}
+		testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 
 		diskEncryptionSetID := internal.GetEnvVarValue("E2E_AZURE_DISK_ENCRYPTION_SET_ID")
 		if diskEncryptionSetID == "" {
 			Skip("E2E_AZURE_DISK_ENCRYPTION_SET_ID not set, skipping disk encryption test")
 		}
 
-		hcClient := testCtx.GetHostedClusterClient()
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -1251,7 +1246,7 @@ func NodePoolDiskEncryptionTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created disk encryption NodePool %s\n", np.Name)
 		DeferCleanup(func() {

--- a/test/e2e/v2/tests/nodepool_lifecycle_test.go
+++ b/test/e2e/v2/tests/nodepool_lifecycle_test.go
@@ -85,14 +85,10 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolLifecycle] N
 func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 	It("should roll out a MachineConfig change via Replace upgrade strategy", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
-
-		hc := testCtx.GetHostedCluster()
-		if hc.Spec.Platform.Type == hyperv1.KubevirtPlatform {
-			Skip("test is skipped for KubeVirt platform until https://issues.redhat.com/browse/CNV-38196 is addressed")
-		}
-
-		hcClient := testCtx.GetHostedClusterClient()
+		// https://issues.redhat.com/browse/CNV-38196
+		testCtx.SkipIfPlatform(hyperv1.KubevirtPlatform)
+		hc := testCtx.MustGetHostedCluster()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -187,17 +183,11 @@ func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 	It("should roll out an NTO Tuned config change via Replace upgrade strategy", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		if hc.Spec.Platform.Type == hyperv1.KubevirtPlatform {
-			Skip("test is skipped for KubeVirt platform until https://issues.redhat.com/browse/CNV-38196 is addressed")
-		}
-		if hc.Spec.Platform.Type == hyperv1.OpenStackPlatform {
-			Skip("test is skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
-		}
-
-		hcClient := testCtx.GetHostedClusterClient()
+		// https://issues.redhat.com/browse/CNV-38196, https://issues.redhat.com/browse/OSASINFRA-3566
+		testCtx.SkipIfPlatform(hyperv1.KubevirtPlatform, hyperv1.OpenStackPlatform)
+		hc := testCtx.MustGetHostedCluster()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -261,17 +251,11 @@ func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 	It("should roll out an NTO Tuned config change via InPlace upgrade strategy", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		if hc.Spec.Platform.Type == hyperv1.KubevirtPlatform {
-			Skip("test is skipped for KubeVirt platform until https://issues.redhat.com/browse/CNV-38196 is addressed")
-		}
-		if hc.Spec.Platform.Type == hyperv1.OpenStackPlatform {
-			Skip("test is skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
-		}
-
-		hcClient := testCtx.GetHostedClusterClient()
+		// https://issues.redhat.com/browse/CNV-38196, https://issues.redhat.com/browse/OSASINFRA-3566
+		testCtx.SkipIfPlatform(hyperv1.KubevirtPlatform, hyperv1.OpenStackPlatform)
+		hc := testCtx.MustGetHostedCluster()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -330,10 +314,9 @@ func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 	It("should upgrade a NodePool from previous to latest release via Replace strategy", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		hcClient := testCtx.GetHostedClusterClient()
+		hc := testCtx.MustGetHostedCluster()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		previousImage := internal.GetEnvVarValue("E2E_PREVIOUS_RELEASE_IMAGE")
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")
@@ -417,10 +400,9 @@ func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 	It("should upgrade a NodePool from previous to latest release via InPlace strategy", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		hcClient := testCtx.GetHostedClusterClient()
+		hc := testCtx.MustGetHostedCluster()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		previousImage := internal.GetEnvVarValue("E2E_PREVIOUS_RELEASE_IMAGE")
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")
@@ -498,15 +480,11 @@ func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 	It("should perform a rolling upgrade when instance type or VM size changes", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
+		testCtx.SkipIfNotPlatform(hyperv1.AWSPlatform, hyperv1.AzurePlatform)
+		hc := testCtx.MustGetHostedCluster()
+		hcClient := testCtx.MustGetHostedClusterClient()
 		platform := hc.Spec.Platform.Type
-		if platform != hyperv1.AWSPlatform && platform != hyperv1.AzurePlatform {
-			Skip("rolling upgrade test only supported on AWS and Azure platforms")
-		}
-
-		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -596,16 +574,14 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
 	It("should create a NodePool at N-1 release and have ready nodes", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
-
-		hc := testCtx.GetHostedCluster()
 
 		n1Image := internal.GetEnvVarValue("E2E_N1_RELEASE_IMAGE")
 		if n1Image == "" {
 			Skip("E2E_N1_RELEASE_IMAGE not set, skipping N-1 release test")
 		}
 
-		hcClient := testCtx.GetHostedClusterClient()
+		hc := testCtx.MustGetHostedCluster()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -635,16 +611,14 @@ func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
 func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
 	It("should create a NodePool at N-2 release and have ready nodes", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
-
-		hc := testCtx.GetHostedCluster()
 
 		n2Image := internal.GetEnvVarValue("E2E_N2_RELEASE_IMAGE")
 		if n2Image == "" {
 			Skip("E2E_N2_RELEASE_IMAGE not set, skipping N-2 release test")
 		}
 
-		hcClient := testCtx.GetHostedClusterClient()
+		hc := testCtx.MustGetHostedCluster()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -676,14 +650,11 @@ func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
 func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 	It("should mirror KubeletConfig to the hosted cluster and clean up on removal", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		if e2eutil.IsLessThan(e2eutil.Version418) {
-			Skip("mirror configs test only applicable for 4.18+")
-		}
+		hc := testCtx.MustGetHostedCluster()
+		testCtx.SkipIfVersionBelow(e2eutil.Version418)
 
-		hcClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -811,12 +782,11 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 	It("should propagate and remove additional trust bundle to/from the hosted cluster", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		e2eutil.GinkgoAtLeast(e2eutil.Version418)
+		hc := testCtx.MustGetHostedCluster()
+		version := testCtx.SkipIfVersionBelow(e2eutil.Version418)
 
-		hc := testCtx.GetHostedCluster()
-		hcClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -866,7 +836,14 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 
 		// Defer cleanup: remove trust bundle reference from HostedCluster
 		DeferCleanup(func() {
-			err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, testCtx.GetHostedCluster(), func(obj *hyperv1.HostedCluster) {
+			currentHC := &hyperv1.HostedCluster{}
+			if err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), currentHC); err != nil {
+				if !apierrors.IsNotFound(err) {
+					GinkgoWriter.Printf("Warning: cleanup: failed to get HostedCluster: %v\n", err)
+				}
+				return
+			}
+			err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, currentHC, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.AdditionalTrustBundle = nil
 			})
 			if err != nil && !apierrors.IsNotFound(err) {
@@ -999,7 +976,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 		)
 
 		// Verify user-ca-bundle is deleted from the hosted cluster (4.22+)
-		if e2eutil.IsGreaterThanOrEqualTo(e2eutil.Version422) {
+		if version.GE(e2eutil.Version422) {
 			e2eutil.EventuallyNotFound(GinkgoTB(), ctx, hcClient, userCAConfigMap,
 				e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute),
 			)
@@ -1013,14 +990,11 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 	It("should create and manage NTO PerformanceProfile via NodePool TuningConfig", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		if hc.Spec.Platform.Type == hyperv1.OpenStackPlatform {
-			Skip("test is skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
-		}
-
-		hcClient := testCtx.GetHostedClusterClient()
+		// https://issues.redhat.com/browse/OSASINFRA-3566
+		testCtx.SkipIfPlatform(hyperv1.OpenStackPlatform)
+		hc := testCtx.MustGetHostedCluster()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -1108,7 +1082,7 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 		)
 
 		// Verify status ConfigMap (4.17+)
-		if !e2eutil.IsLessThan(e2eutil.Version417) {
+		if testCtx.VersionAtLeast(e2eutil.Version417) {
 			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "PerformanceProfile status ConfigMap to exist",
 				func(ctx context.Context) ([]*corev1.ConfigMap, error) {
 					list := &corev1.ConfigMapList{}
@@ -1181,15 +1155,13 @@ func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
 		Skip("auto-repair instance termination not yet implemented for v2 framework")
 
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
+		hc := testCtx.MustGetHostedCluster()
+		hcClient := testCtx.MustGetHostedClusterClient()
 		platform := hc.Spec.Platform.Type
 		if platform != hyperv1.AWSPlatform && platform != hyperv1.AzurePlatform {
 			Skip("auto-repair test only supported on AWS and Azure platforms")
 		}
-
-		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -1224,19 +1196,16 @@ func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
 func NodePoolDiskEncryptionTest(getTestCtx internal.TestContextGetter) {
 	It("should create a NodePool with Azure DiskEncryptionSet and verify it is applied", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		if hc.Spec.Platform.Type != hyperv1.AzurePlatform {
-			Skip("disk encryption test only supported on Azure platform")
-		}
+		testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
+		hc := testCtx.MustGetHostedCluster()
 
 		diskEncryptionSetID := internal.GetEnvVarValue("E2E_AZURE_DISK_ENCRYPTION_SET_ID")
 		if diskEncryptionSetID == "" {
 			Skip("E2E_AZURE_DISK_ENCRYPTION_SET_ID not set, skipping disk encryption test")
 		}
 
-		hcClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		ctx := testCtx.Context
 

--- a/test/e2e/v2/tests/nodepool_lifecycle_test.go
+++ b/test/e2e/v2/tests/nodepool_lifecycle_test.go
@@ -87,8 +87,10 @@ func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 		testCtx := getTestCtx()
 		// https://issues.redhat.com/browse/CNV-38196
 		testCtx.SkipIfPlatform(hyperv1.KubevirtPlatform)
-		hc := testCtx.MustGetHostedCluster()
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -107,7 +109,7 @@ func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
 		DeferCleanup(func() {
@@ -186,8 +188,10 @@ func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 
 		// https://issues.redhat.com/browse/CNV-38196, https://issues.redhat.com/browse/OSASINFRA-3566
 		testCtx.SkipIfPlatform(hyperv1.KubevirtPlatform, hyperv1.OpenStackPlatform)
-		hc := testCtx.MustGetHostedCluster()
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -206,7 +210,7 @@ func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
 		DeferCleanup(func() {
@@ -254,8 +258,10 @@ func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 
 		// https://issues.redhat.com/browse/CNV-38196, https://issues.redhat.com/browse/OSASINFRA-3566
 		testCtx.SkipIfPlatform(hyperv1.KubevirtPlatform, hyperv1.OpenStackPlatform)
-		hc := testCtx.MustGetHostedCluster()
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -268,7 +274,7 @@ func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeInPlace
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
 		DeferCleanup(func() {
@@ -315,8 +321,10 @@ func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 	It("should upgrade a NodePool from previous to latest release via Replace strategy", func() {
 		testCtx := getTestCtx()
 
-		hc := testCtx.MustGetHostedCluster()
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		previousImage := internal.GetEnvVarValue("E2E_PREVIOUS_RELEASE_IMAGE")
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")
@@ -342,7 +350,7 @@ func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s at previous release %s\n", np.Name, previousImage)
 		DeferCleanup(func() {
@@ -401,8 +409,10 @@ func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 	It("should upgrade a NodePool from previous to latest release via InPlace strategy", func() {
 		testCtx := getTestCtx()
 
-		hc := testCtx.MustGetHostedCluster()
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		previousImage := internal.GetEnvVarValue("E2E_PREVIOUS_RELEASE_IMAGE")
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")
@@ -422,7 +432,7 @@ func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeInPlace
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s at previous release %s\n", np.Name, previousImage)
 		DeferCleanup(func() {
@@ -482,8 +492,10 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 		testCtx := getTestCtx()
 
 		testCtx.SkipIfNotPlatform(hyperv1.AWSPlatform, hyperv1.AzurePlatform)
-		hc := testCtx.MustGetHostedCluster()
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 		platform := hc.Spec.Platform.Type
 
 		ctx := testCtx.Context
@@ -503,7 +515,7 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s with 2 replicas\n", np.Name)
 		DeferCleanup(func() {
@@ -580,8 +592,10 @@ func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
 			Skip("E2E_N1_RELEASE_IMAGE not set, skipping N-1 release test")
 		}
 
-		hc := testCtx.MustGetHostedCluster()
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -594,7 +608,7 @@ func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Release.Image = n1Image
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s at N-1 release %s\n", np.Name, n1Image)
 		DeferCleanup(func() {
@@ -617,8 +631,10 @@ func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
 			Skip("E2E_N2_RELEASE_IMAGE not set, skipping N-2 release test")
 		}
 
-		hc := testCtx.MustGetHostedCluster()
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -631,7 +647,7 @@ func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Release.Image = n2Image
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s at N-2 release %s\n", np.Name, n2Image)
 		DeferCleanup(func() {
@@ -651,10 +667,12 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 	It("should mirror KubeletConfig to the hosted cluster and clean up on removal", func() {
 		testCtx := getTestCtx()
 
-		hc := testCtx.MustGetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		testCtx.SkipIfVersionBelow(e2eutil.Version418)
 
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -666,7 +684,7 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Replicas = &oneReplica
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
 		DeferCleanup(func() {
@@ -783,10 +801,12 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 	It("should propagate and remove additional trust bundle to/from the hosted cluster", func() {
 		testCtx := getTestCtx()
 
-		hc := testCtx.MustGetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		version := testCtx.SkipIfVersionBelow(e2eutil.Version418)
 
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -993,8 +1013,10 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 
 		// https://issues.redhat.com/browse/OSASINFRA-3566
 		testCtx.SkipIfPlatform(hyperv1.OpenStackPlatform)
-		hc := testCtx.MustGetHostedCluster()
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -1006,7 +1028,7 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Replicas = &oneReplica
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
 		DeferCleanup(func() {
@@ -1156,8 +1178,10 @@ func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
 
 		testCtx := getTestCtx()
 
-		hc := testCtx.MustGetHostedCluster()
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 		platform := hc.Spec.Platform.Type
 		if platform != hyperv1.AWSPlatform && platform != hyperv1.AzurePlatform {
 			Skip("auto-repair test only supported on AWS and Azure platforms")
@@ -1174,7 +1198,7 @@ func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
 			pool.Spec.Management.AutoRepair = true
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created auto-repair NodePool %s\n", np.Name)
 		DeferCleanup(func() {
@@ -1198,14 +1222,16 @@ func NodePoolDiskEncryptionTest(getTestCtx internal.TestContextGetter) {
 		testCtx := getTestCtx()
 
 		testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
-		hc := testCtx.MustGetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 
 		diskEncryptionSetID := internal.GetEnvVarValue("E2E_AZURE_DISK_ENCRYPTION_SET_ID")
 		if diskEncryptionSetID == "" {
 			Skip("E2E_AZURE_DISK_ENCRYPTION_SET_ID not set, skipping disk encryption test")
 		}
 
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		ctx := testCtx.Context
 
@@ -1220,7 +1246,7 @@ func NodePoolDiskEncryptionTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		err := testCtx.MgmtClient.Create(ctx, np)
+		err = testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created disk encryption NodePool %s\n", np.Name)
 		DeferCleanup(func() {

--- a/test/e2e/v2/tests/nodepool_osimagestream_test.go
+++ b/test/e2e/v2/tests/nodepool_osimagestream_test.go
@@ -31,8 +31,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -107,13 +107,12 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolOSImageStrea
 func NodePoolOSImageStreamRHEL10RejectionTest(getTestCtx internal.TestContextGetter) {
 	It("When osImageStream is set to rhel-10 on OCP < 5.0, it should set ValidMachineConfig to False", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedCluster()
-
-		if !e2eutil.IsLessThan(e2eutil.Version50) {
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		if testCtx.VersionAtLeast(e2eutil.Version50) {
 			Skip("test only applies to OCP < 5.0; rhel-10 is valid on OCP >= 5.0")
 		}
 
-		hc := testCtx.GetHostedCluster()
 		ctx := testCtx.Context
 
 		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
@@ -165,13 +164,11 @@ func NodePoolOSImageStreamRHEL10RejectionTest(getTestCtx internal.TestContextGet
 func NodePoolOSImageStreamRHEL10RuncRejectionTest(getTestCtx internal.TestContextGetter) {
 	It("When osImageStream is set to rhel-10 with runc ContainerRuntimeConfig, it should set ValidMachineConfig to False", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedCluster()
 
-		if e2eutil.IsLessThan(e2eutil.Version50) {
-			Skip("test only applies to OCP >= 5.0; on < 5.0 rhel-10 is rejected for version reasons")
-		}
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		testCtx.SkipIfVersionBelow(e2eutil.Version50)
 
-		hc := testCtx.GetHostedCluster()
 		ctx := testCtx.Context
 
 		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
@@ -249,9 +246,9 @@ spec:
 func NodePoolOSImageStreamDefaultStatusTest(getTestCtx internal.TestContextGetter) {
 	It("When no osImageStream is set, it should report a recognized RHEL stream in status", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedCluster()
 
-		hc := testCtx.GetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		ctx := testCtx.Context
 
 		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
@@ -370,9 +367,9 @@ func conditionMessageContains(condType string, substring string) e2eutil.Predica
 func NodePoolOSImageStreamExplicitDefaultNoRolloutTest(getTestCtx internal.TestContextGetter) {
 	It("When osImageStream is set to the version-derived default, it should not trigger a rollout", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedCluster()
 
-		hc := testCtx.GetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		ctx := testCtx.Context
 
 		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
@@ -462,10 +459,11 @@ func NodePoolOSImageStreamExplicitDefaultNoRolloutTest(getTestCtx internal.TestC
 func NodePoolOSImageStreamUpgradeVerificationTest(getTestCtx internal.TestContextGetter) {
 	It("When a NodePool is upgraded, it should report the correct osImageStream in status", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		hcClient := testCtx.GetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		previousImage := internal.GetEnvVarValue("E2E_PREVIOUS_RELEASE_IMAGE")
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")

--- a/test/e2e/v2/tests/nodepool_osimagestream_test.go
+++ b/test/e2e/v2/tests/nodepool_osimagestream_test.go
@@ -107,7 +107,8 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolOSImageStrea
 func NodePoolOSImageStreamRHEL10RejectionTest(getTestCtx internal.TestContextGetter) {
 	It("When osImageStream is set to rhel-10 on OCP < 5.0, it should set ValidMachineConfig to False", func() {
 		testCtx := getTestCtx()
-		hc := testCtx.MustGetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		if testCtx.VersionAtLeast(e2eutil.Version50) {
 			Skip("test only applies to OCP < 5.0; rhel-10 is valid on OCP >= 5.0")
 		}
@@ -164,7 +165,8 @@ func NodePoolOSImageStreamRHEL10RuncRejectionTest(getTestCtx internal.TestContex
 	It("When osImageStream is set to rhel-10 with runc ContainerRuntimeConfig, it should set ValidMachineConfig to False", func() {
 		testCtx := getTestCtx()
 
-		hc := testCtx.MustGetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		testCtx.SkipIfVersionBelow(e2eutil.Version50)
 
 		ctx := testCtx.Context
@@ -245,7 +247,8 @@ func NodePoolOSImageStreamDefaultStatusTest(getTestCtx internal.TestContextGette
 	It("When no osImageStream is set, it should report a recognized RHEL stream in status", func() {
 		testCtx := getTestCtx()
 
-		hc := testCtx.MustGetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		ctx := testCtx.Context
 
 		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
@@ -365,7 +368,8 @@ func NodePoolOSImageStreamExplicitDefaultNoRolloutTest(getTestCtx internal.TestC
 	It("When osImageStream is set to the version-derived default, it should not trigger a rollout", func() {
 		testCtx := getTestCtx()
 
-		hc := testCtx.MustGetHostedCluster()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
 		ctx := testCtx.Context
 
 		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
@@ -456,8 +460,10 @@ func NodePoolOSImageStreamUpgradeVerificationTest(getTestCtx internal.TestContex
 	It("When a NodePool is upgraded, it should report the correct osImageStream in status", func() {
 		testCtx := getTestCtx()
 
-		hc := testCtx.MustGetHostedCluster()
-		hcClient := testCtx.MustGetHostedClusterClient()
+		hc, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred())
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
 		previousImage := internal.GetEnvVarValue("E2E_PREVIOUS_RELEASE_IMAGE")
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")

--- a/test/e2e/v2/tests/nodepool_osimagestream_test.go
+++ b/test/e2e/v2/tests/nodepool_osimagestream_test.go
@@ -31,8 +31,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -107,13 +107,11 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolOSImageStrea
 func NodePoolOSImageStreamRHEL10RejectionTest(getTestCtx internal.TestContextGetter) {
 	It("When osImageStream is set to rhel-10 on OCP < 5.0, it should set ValidMachineConfig to False", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedCluster()
-
-		if !e2eutil.IsLessThan(e2eutil.Version50) {
+		hc := testCtx.MustGetHostedCluster()
+		if testCtx.VersionAtLeast(e2eutil.Version50) {
 			Skip("test only applies to OCP < 5.0; rhel-10 is valid on OCP >= 5.0")
 		}
 
-		hc := testCtx.GetHostedCluster()
 		ctx := testCtx.Context
 
 		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
@@ -165,13 +163,10 @@ func NodePoolOSImageStreamRHEL10RejectionTest(getTestCtx internal.TestContextGet
 func NodePoolOSImageStreamRHEL10RuncRejectionTest(getTestCtx internal.TestContextGetter) {
 	It("When osImageStream is set to rhel-10 with runc ContainerRuntimeConfig, it should set ValidMachineConfig to False", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedCluster()
 
-		if e2eutil.IsLessThan(e2eutil.Version50) {
-			Skip("test only applies to OCP >= 5.0; on < 5.0 rhel-10 is rejected for version reasons")
-		}
+		hc := testCtx.MustGetHostedCluster()
+		testCtx.SkipIfVersionBelow(e2eutil.Version50)
 
-		hc := testCtx.GetHostedCluster()
 		ctx := testCtx.Context
 
 		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
@@ -249,9 +244,8 @@ spec:
 func NodePoolOSImageStreamDefaultStatusTest(getTestCtx internal.TestContextGetter) {
 	It("When no osImageStream is set, it should report a recognized RHEL stream in status", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedCluster()
 
-		hc := testCtx.GetHostedCluster()
+		hc := testCtx.MustGetHostedCluster()
 		ctx := testCtx.Context
 
 		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
@@ -370,9 +364,8 @@ func conditionMessageContains(condType string, substring string) e2eutil.Predica
 func NodePoolOSImageStreamExplicitDefaultNoRolloutTest(getTestCtx internal.TestContextGetter) {
 	It("When osImageStream is set to the version-derived default, it should not trigger a rollout", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedCluster()
 
-		hc := testCtx.GetHostedCluster()
+		hc := testCtx.MustGetHostedCluster()
 		ctx := testCtx.Context
 
 		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
@@ -462,10 +455,9 @@ func NodePoolOSImageStreamExplicitDefaultNoRolloutTest(getTestCtx internal.TestC
 func NodePoolOSImageStreamUpgradeVerificationTest(getTestCtx internal.TestContextGetter) {
 	It("When a NodePool is upgraded, it should report the correct osImageStream in status", func() {
 		testCtx := getTestCtx()
-		testCtx.ValidateHostedClusterClient()
 
-		hc := testCtx.GetHostedCluster()
-		hcClient := testCtx.GetHostedClusterClient()
+		hc := testCtx.MustGetHostedCluster()
+		hcClient := testCtx.MustGetHostedClusterClient()
 
 		previousImage := internal.GetEnvVarValue("E2E_PREVIOUS_RELEASE_IMAGE")
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")


### PR DESCRIPTION
Before this commit, v2 tests relied on cached, shared mutable hostedcluster state via TestContext (and indirectly through version.releaseVersion which was derived from the shared hostedcluster). This contradicts our goals to move tests towards full process isolation at the test case granularity and is a vector for tricky bugs as tests can easily mutate the shared hostedcluster pointer or get a stale view.

This commit removes all caching of the hostedcluster and releaseVersion from the v2 path, and refactors dependent code to use a variety of new test helpers for uniform access and consistent patterns.

A significant amount of boilerplate is reduced, and the helpers make it easy to do the right thing and hard to do the wrong thing (i.e. access shared mutable state).

The primary implication of these changes is that tests which access the hostedcluster will fetch through the client every time, but in the e2e context this overhead is negligable (and if we wanted to it could be addressed in other, safer ways than sharing a cached pointer to a snapshot).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end test setup across backup/restore, control plane, etcd chaos, security, networking/storage, and lifecycle scenarios.
  - Standardized hosted-cluster and client access to provide clearer failures.
  - Consolidated version- and platform-based skip logic for consistent behavior across suites.
  - Removed redundant validation steps while retaining existing assertions and cleanup checks, including day-2 tag removal verification.
- **Chores**
  - Simplified internal version-gating utilities and removed legacy helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->