### PR TITLE
OCPBUGS-105207: Revert "OCPBUGS-89689: (karpenter) use completed release image for unpinned NodeClaims during CP upgrade"

### DIFF
--- a/karpenter-operator/controllers/karpenterignition/karpenterignition_controller.go
+++ b/karpenter-operator/controllers/karpenterignition/karpenterignition_controller.go
@@ -126,11 +126,8 @@ func (r *KarpenterIgnitionReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("failed to get HostedCluster: %w", err)
 	}
 
-	releaseImage, version, requeue := currentClusterRelease(hostedCluster)
-	if requeue && openshiftEC2NodeClass.Spec.Version == "" {
-		log.Info("No version history available for unpinned NodeClass, requeueing")
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
+	releaseImage := hcp.Spec.ReleaseImage
+	version := currentClusterVersion(hostedCluster)
 
 	// When the user requests a version for the OpenshiftEC2NodeClass we perform further validation and lookup of the release image.
 	// We only detect skew and if the version is valid in this case, as under normal circumstances we can assume the release image
@@ -345,18 +342,14 @@ func (r *KarpenterIgnitionReconciler) createInMemoryNodePool(
 	}
 }
 
-// currentClusterRelease returns the release image and version of the most recently
-// completed update from the HostedCluster's version history, plus a requeue flag.
-// It searches history entries for the one with state=Completed and the most recent
-// CompletionTime. If no completed entries exist, it falls back to the first Partial
-// entry (the version currently being rolled out). If no history entries exist at all,
-// it signals the caller to requeue.
-// This ensures that during a control plane upgrade, unpinned Karpenter NodeClaims use the
-// completed version's release image rather than the desired version, preventing premature
-// drift detection and worker node replacement before the control plane is ready.
-func currentClusterRelease(hostedCluster *hyperv1.HostedCluster) (string, string, bool) {
+// currentClusterVersion returns the version of the most recently completed update from the
+// HostedCluster's version history. It searches history entries for the one with state=Completed
+// and the most recent CompletionTime. If no completed entries exist and there is exactly one
+// history entry, it falls back to the desired version. This handles the case where a cluster
+// is still rolling out its initial version.
+func currentClusterVersion(hostedCluster *hyperv1.HostedCluster) string {
 	if hostedCluster.Status.Version == nil {
-		return hostedCluster.Spec.Release.Image, "", false
+		return ""
 	}
 
 	var latest *configv1.UpdateHistory
@@ -369,33 +362,22 @@ func currentClusterRelease(hostedCluster *hyperv1.HostedCluster) (string, string
 			latest = entry
 			continue
 		}
-		switch {
-		case entry.CompletionTime == nil:
-			// keep latest; nothing to compare against
-		case latest.CompletionTime == nil:
-			latest = entry
-		case entry.CompletionTime.After(latest.CompletionTime.Time):
+		if entry.CompletionTime != nil && latest.CompletionTime != nil && entry.CompletionTime.After(latest.CompletionTime.Time) {
 			latest = entry
 		}
 	}
 
 	if latest != nil {
-		return latest.Image, latest.Version, false
+		return latest.Version
 	}
 
-	// No completed entries: fall back to the first Partial entry if available.
-	// CVO prepends newest entries, so the first Partial is the currently rolling-out version.
-	// This is safer than Spec.Release.Image which flips to the new (desired) version
-	// immediately on upgrade request.
-	for i := range hostedCluster.Status.Version.History {
-		entry := &hostedCluster.Status.Version.History[i]
-		if entry.State == configv1.PartialUpdate {
-			return entry.Image, entry.Version, false
-		}
+	// If there are no completed entries but exactly one history entry exists, the cluster
+	// is likely still rolling out its first version. Fall back to the desired version.
+	if len(hostedCluster.Status.Version.History) == 1 {
+		return hostedCluster.Status.Version.Desired.Version
 	}
 
-	// Empty history: signal caller to requeue — CVO hasn't reported any version yet.
-	return "", "", true
+	return hostedCluster.Status.Version.Desired.Version
 }
 
 // validateVersion checks whether the requested version is valid for the given HostedCluster.

--- a/karpenter-operator/controllers/karpenterignition/karpenterignition_controller_test.go
+++ b/karpenter-operator/controllers/karpenterignition/karpenterignition_controller_test.go
@@ -122,7 +122,6 @@ func TestReconcile(t *testing.T) {
 					{
 						State:          configv1.CompletedUpdate,
 						Version:        "4.17.0",
-						Image:          "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64",
 						CompletionTime: &metav1.Time{Time: time.Now()},
 					},
 				},
@@ -438,7 +437,6 @@ func TestReconcileVersionResolution(t *testing.T) {
 						{
 							State:          configv1.CompletedUpdate,
 							Version:        "4.17.0",
-							Image:          "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64",
 							CompletionTime: &metav1.Time{Time: time.Now()},
 						},
 					},
@@ -734,7 +732,6 @@ func TestResolveVersion(t *testing.T) {
 						{
 							State:          configv1.CompletedUpdate,
 							Version:        "4.17.0",
-							Image:          "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64",
 							CompletionTime: &metav1.Time{Time: time.Now()},
 						},
 					},
@@ -996,23 +993,18 @@ func TestUpdateVersionStatus(t *testing.T) {
 	})
 }
 
-func TestCurrentClusterRelease(t *testing.T) {
+func TestCurrentClusterVersion(t *testing.T) {
 	completedTime1 := metav1.Now()
 	completedTime2 := metav1.NewTime(completedTime1.Add(time.Hour))
 
 	testCases := []struct {
 		name            string
 		hostedCluster   *hyperv1.HostedCluster
-		expectedImage   string
 		expectedVersion string
-		expectedRequeue bool
 	}{
 		{
-			name: "When there is a single completed entry, it should return that entry's version and image",
+			name: "When there is a single completed history entry it should return that version",
 			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Release: hyperv1.Release{Image: "quay.io/release:4.17.0"},
-				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{Version: "4.17.0"},
@@ -1020,50 +1012,17 @@ func TestCurrentClusterRelease(t *testing.T) {
 							{
 								State:          configv1.CompletedUpdate,
 								Version:        "4.17.0",
-								Image:          "quay.io/release:4.17.0",
 								CompletionTime: &completedTime1,
 							},
 						},
 					},
 				},
 			},
-			expectedImage:   "quay.io/release:4.17.0",
 			expectedVersion: "4.17.0",
 		},
 		{
-			name: "When upgrade is in progress, it should return completed entry, not the partial",
+			name: "When there are multiple completed entries it should return the one with the most recent CompletionTime",
 			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Release: hyperv1.Release{Image: "quay.io/release:4.18.0"},
-				},
-				Status: hyperv1.HostedClusterStatus{
-					Version: &hyperv1.ClusterVersionStatus{
-						Desired: configv1.Release{Version: "4.18.0"},
-						History: []configv1.UpdateHistory{
-							{
-								State:   configv1.PartialUpdate,
-								Version: "",
-								Image:   "quay.io/release:4.18.0",
-							},
-							{
-								State:          configv1.CompletedUpdate,
-								Version:        "4.17.0",
-								Image:          "quay.io/release:4.17.0",
-								CompletionTime: &completedTime1,
-							},
-						},
-					},
-				},
-			},
-			expectedImage:   "quay.io/release:4.17.0",
-			expectedVersion: "4.17.0",
-		},
-		{
-			name: "When there are multiple completed entries, it should return the most recent by CompletionTime",
-			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Release: hyperv1.Release{Image: "quay.io/release:4.18.0"},
-				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{Version: "4.18.0"},
@@ -1071,28 +1030,22 @@ func TestCurrentClusterRelease(t *testing.T) {
 							{
 								State:          configv1.CompletedUpdate,
 								Version:        "4.17.0",
-								Image:          "quay.io/release:4.17.0",
 								CompletionTime: &completedTime1,
 							},
 							{
 								State:          configv1.CompletedUpdate,
 								Version:        "4.18.0",
-								Image:          "quay.io/release:4.18.0",
 								CompletionTime: &completedTime2,
 							},
 						},
 					},
 				},
 			},
-			expectedImage:   "quay.io/release:4.18.0",
 			expectedVersion: "4.18.0",
 		},
 		{
-			name: "When there is a partial entry and a completed entry, it should return the completed entry",
+			name: "When there is a partial entry and a completed entry it should return the completed entry",
 			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Release: hyperv1.Release{Image: "quay.io/release:4.18.0"},
-				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{Version: "4.18.0"},
@@ -1100,27 +1053,21 @@ func TestCurrentClusterRelease(t *testing.T) {
 							{
 								State:   configv1.PartialUpdate,
 								Version: "4.18.0",
-								Image:   "quay.io/release:4.18.0",
 							},
 							{
 								State:          configv1.CompletedUpdate,
 								Version:        "4.17.0",
-								Image:          "quay.io/release:4.17.0",
 								CompletionTime: &completedTime1,
 							},
 						},
 					},
 				},
 			},
-			expectedImage:   "quay.io/release:4.17.0",
 			expectedVersion: "4.17.0",
 		},
 		{
-			name: "When there are no completed entries and exactly one Partial entry, it should fall back to the Partial entry",
+			name: "When there are no completed entries and exactly one history entry it should fall back to Desired.Version",
 			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Release: hyperv1.Release{Image: "quay.io/release:4.17.0"},
-				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{Version: "4.17.0"},
@@ -1128,21 +1075,16 @@ func TestCurrentClusterRelease(t *testing.T) {
 							{
 								State:   configv1.PartialUpdate,
 								Version: "4.17.0",
-								Image:   "quay.io/release:4.17.0",
 							},
 						},
 					},
 				},
 			},
-			expectedImage:   "quay.io/release:4.17.0",
 			expectedVersion: "4.17.0",
 		},
 		{
-			name: "When there are no completed entries and multiple Partial entries, it should return the first Partial entry",
+			name: "When there are no completed entries and multiple history entries it should fall back to Desired.Version",
 			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Release: hyperv1.Release{Image: "quay.io/release:4.18.0"},
-				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{Version: "4.18.0"},
@@ -1150,111 +1092,20 @@ func TestCurrentClusterRelease(t *testing.T) {
 							{
 								State:   configv1.PartialUpdate,
 								Version: "4.18.0",
-								Image:   "quay.io/release:4.18.0",
 							},
 							{
 								State:   configv1.PartialUpdate,
 								Version: "4.17.0",
-								Image:   "quay.io/release:4.17.0",
 							},
 						},
 					},
 				},
 			},
-			expectedImage:   "quay.io/release:4.18.0",
 			expectedVersion: "4.18.0",
 		},
 		{
-			name: "When Spec image differs from only Partial entry during upgrade, it should return Partial image not Spec",
+			name: "When history is empty it should fall back to Desired.Version",
 			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Release: hyperv1.Release{Image: "quay.io/release:4.18.0"},
-				},
-				Status: hyperv1.HostedClusterStatus{
-					Version: &hyperv1.ClusterVersionStatus{
-						Desired: configv1.Release{Version: "4.18.0"},
-						History: []configv1.UpdateHistory{
-							{
-								State:   configv1.PartialUpdate,
-								Version: "4.17.0",
-								Image:   "quay.io/release:4.17.0",
-							},
-						},
-					},
-				},
-			},
-			expectedImage:   "quay.io/release:4.17.0",
-			expectedVersion: "4.17.0",
-		},
-		{
-			name: "When multi-upgrade has 2 Completed and 1 Partial, it should return latest Completed not the Partial",
-			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Release: hyperv1.Release{Image: "quay.io/release:4.19.0"},
-				},
-				Status: hyperv1.HostedClusterStatus{
-					Version: &hyperv1.ClusterVersionStatus{
-						Desired: configv1.Release{Version: "4.19.0"},
-						History: []configv1.UpdateHistory{
-							{
-								State:   configv1.PartialUpdate,
-								Version: "4.19.0",
-								Image:   "quay.io/release:4.19.0",
-							},
-							{
-								State:          configv1.CompletedUpdate,
-								Version:        "4.18.0",
-								Image:          "quay.io/release:4.18.0",
-								CompletionTime: &completedTime2,
-							},
-							{
-								State:          configv1.CompletedUpdate,
-								Version:        "4.17.0",
-								Image:          "quay.io/release:4.17.0",
-								CompletionTime: &completedTime1,
-							},
-						},
-					},
-				},
-			},
-			expectedImage:   "quay.io/release:4.18.0",
-			expectedVersion: "4.18.0",
-		},
-		{
-			name: "When a Completed entry has nil CompletionTime and another has a timestamp, it should prefer the one with a timestamp",
-			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Release: hyperv1.Release{Image: "quay.io/release:4.18.0"},
-				},
-				Status: hyperv1.HostedClusterStatus{
-					Version: &hyperv1.ClusterVersionStatus{
-						Desired: configv1.Release{Version: "4.18.0"},
-						History: []configv1.UpdateHistory{
-							{
-								State:   configv1.CompletedUpdate,
-								Version: "4.17.0",
-								Image:   "quay.io/release:4.17.0",
-								// nil CompletionTime
-							},
-							{
-								State:          configv1.CompletedUpdate,
-								Version:        "4.18.0",
-								Image:          "quay.io/release:4.18.0",
-								CompletionTime: &completedTime1,
-							},
-						},
-					},
-				},
-			},
-			expectedImage:   "quay.io/release:4.18.0",
-			expectedVersion: "4.18.0",
-		},
-		{
-			name: "When history is empty, it should signal requeue",
-			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Release: hyperv1.Release{Image: "quay.io/release:4.17.0"},
-				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{Version: "4.17.0"},
@@ -1262,19 +1113,15 @@ func TestCurrentClusterRelease(t *testing.T) {
 					},
 				},
 			},
-			expectedRequeue: true,
+			expectedVersion: "4.17.0",
 		},
 		{
-			name: "When Version is nil, it should return Spec.Release.Image and empty version",
+			name: "When Version is nil it should return empty string",
 			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Release: hyperv1.Release{Image: "quay.io/release:4.17.0"},
-				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: nil,
 				},
 			},
-			expectedImage:   "quay.io/release:4.17.0",
 			expectedVersion: "",
 		},
 	}
@@ -1282,12 +1129,8 @@ func TestCurrentClusterRelease(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			image, version, requeue := currentClusterRelease(tc.hostedCluster)
-			g.Expect(requeue).To(Equal(tc.expectedRequeue))
-			if !tc.expectedRequeue {
-				g.Expect(image).To(Equal(tc.expectedImage))
-				g.Expect(version).To(Equal(tc.expectedVersion))
-			}
+			version := currentClusterVersion(tc.hostedCluster)
+			g.Expect(version).To(Equal(tc.expectedVersion))
 		})
 	}
 }
@@ -1493,7 +1336,6 @@ func TestReconcileKubeletConfigMapOrphanCleanup(t *testing.T) {
 						{
 							State:          configv1.CompletedUpdate,
 							Version:        "4.17.0",
-							Image:          "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64",
 							CompletionTime: &metav1.Time{Time: time.Now()},
 						},
 					},

--- a/test/e2e/karpenter_control_plane_upgrade_test.go
+++ b/test/e2e/karpenter_control_plane_upgrade_test.go
@@ -81,23 +81,19 @@ func TestKarpenterUpgradeControlPlane(t *testing.T) {
 		})
 		g.Expect(err).NotTo(HaveOccurred(), "failed update hostedcluster image")
 
-		// Assert NO drift during CP upgrade. Unpinned NodeClaims should not detect
-		// drift until the control plane upgrade completes, because the ignition config
-		// hash is derived from the completed release image, not the desired one.
-		noDriftCancel, noDriftDone := assertNodeClaimsNotDrifted(t, ctx, guestClient, nodeClaims, cancel)
+		driftChan := make(chan struct{})
+		go func() {
+			defer close(driftChan)
+			for _, nodeClaim := range nodeClaims.Items {
+				waitForNodeClaimDrifted(t, ctx, guestClient, &nodeClaim)
+			}
+		}()
 
 		e2eutil.WaitForImageRollout(t, ctx, mgtClient, hostedCluster)
-		noDriftCancel()
-		<-noDriftDone
-
 		err = mgtClient.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 
-		// After CP upgrade completes, drift should now be detected.
-		t.Logf("Control plane upgrade complete, waiting for NodeClaim drift detection")
-		for _, nodeClaim := range nodeClaims.Items {
-			waitForNodeClaimDrifted(t, ctx, guestClient, &nodeClaim)
-		}
+		<-driftChan
 		t.Logf("Karpenter Nodes drifted")
 
 		preUpgradeRHCOSVersion := extractRHCOSVersion(preUpgradeOSImage)

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -1641,48 +1641,6 @@ func waitForNodeClaimDrifted(t *testing.T, ctx context.Context, client crclient.
 	)
 }
 
-// assertNodeClaimsNotDrifted starts a background goroutine that polls NodeClaims every
-// 10 seconds and fails the test if any NodeClaim has the Drifted condition set to True.
-// When premature drift is detected, it calls cancelOnDrift (if non-nil) to abort the
-// parent context, avoiding wasted e2e time on a known-failed run.
-// Returns a cancel function to stop polling and a channel that closes when the goroutine exits.
-func assertNodeClaimsNotDrifted(t *testing.T, ctx context.Context, client crclient.Client, nodeClaims *karpenterv1.NodeClaimList, cancelOnDrift context.CancelFunc) (context.CancelFunc, <-chan struct{}) {
-	noDriftCtx, noDriftCancel := context.WithCancel(ctx)
-	noDriftDone := make(chan struct{})
-	go func() {
-		defer close(noDriftDone)
-		ticker := time.NewTicker(10 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-noDriftCtx.Done():
-				return
-			case <-ticker.C:
-				for i := range nodeClaims.Items {
-					current := &karpenterv1.NodeClaim{}
-					if err := client.Get(noDriftCtx, crclient.ObjectKeyFromObject(&nodeClaims.Items[i]), current); err != nil {
-						continue
-					}
-					conditions, err := e2eutil.Conditions(current)
-					if err != nil {
-						continue
-					}
-					for _, c := range conditions {
-						if c.Type == karpenterv1.ConditionTypeDrifted && c.Status == metav1.ConditionTrue {
-							t.Errorf("NodeClaim %s detected drift BEFORE CP upgrade completed", nodeClaims.Items[i].Name)
-							if cancelOnDrift != nil {
-								cancelOnDrift()
-							}
-							return
-						}
-					}
-				}
-			}
-		}
-	}()
-	return noDriftCancel, noDriftDone
-}
-
 // waitForAutoNodeStatusVCPUs polls until HostedCluster.Status.AutoNode.VCPUs
 // converges to the expected value. This checks only the status field (Karpenter-only vCPUs),
 // not the billing metric.


### PR DESCRIPTION
Reverts openshift/hypershift#8957

Justification: https://redhat.atlassian.net/browse/OCPBUGS-105207

>PR [#8957](https://github.com/openshift/hypershift/pull/8957) (merged [fff9961de5](https://github.com/openshift/hypershift/commit/fff9961de573ba7d983eaabce0c36b49cad5f93d), Aug 4 11:10 UTC) introduced a new assertNodeClaimsNotDrifted test assertion in TestKarpenterUpgradeControlPlane. Before this PR, the test passed 13 consecutive runs. After the merge, 3 of 7 runs failed, all triggered by the new assertion.

This impacts the blocking merge path as well as the release controller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved control plane upgrades by using the configured release image directly.
  * Node configuration versions now track the most recent completed cluster version, with safer fallback behavior during initial rollout.

* **Bug Fixes**
  * Improved handling when version information is temporarily unavailable.
  * Node configuration drift is now detected alongside control plane image rollouts, enabling updated nodes to be recognized more reliably.

* **Tests**
  * Expanded upgrade coverage for completed, partial, initial, and unavailable version states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->