### PR TITLE
[Project Darkstar] ACM-39656: Remediate 2 Go stdlib CVEs in hypershift

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -2,6 +2,8 @@ module github.com/openshift/hypershift/api
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	github.com/openshift/api v0.0.0-20260715165912-72066cc9718b
 	k8s.io/api v0.36.2

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openshift/hypershift
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,6 +2,8 @@ module github.com/openshift/hypershift/hack/tools
 
 go 1.25.7
 
+toolchain go1.25.12
+
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
 	github.com/go-git/go-git/v5 v5.19.1


### PR DESCRIPTION
## [Project Darkstar] [ACM-39656](https://redhat.atlassian.net/browse/ACM-39656): Remediate CVEs in hypershift

### Changes
- Add `toolchain go1.26.5` to go.mod and api/go.mod (Go 1.26 modules)
- Add `toolchain go1.25.12` to hack/tools/go.mod (Go 1.25 module)

### Fixed — Go stdlib (2 CVEs)
- CVE-2026-39822 (stdlib, CVSS 7.5) — fix: Go 1.26.5+ / 1.25.12+
- CVE-2026-42505 (stdlib, CVSS 5.3) — fix: Go 1.26.5+ / 1.25.12+

### Already Fixed (44 CVEs)
Covered by existing PR #8944 (Go 1.26.4 + UBI 9.8 base image) — merge to resolve:
- 14 Important stdlib CVEs (fixed in Go 1.26.3/1.26.4)
- 29 Moderate CVEs (RPM-level, fixed in UBI 9.8)
- 1 golang.org/x/text CVE

Note: PR #8944 targets Go 1.26.4 but CVE-2026-39822 requires 1.26.5 — this Darkstar PR closes that gap.

### No Fix Available
- 53 CVEs (curl-minimal, libarchive, libxml2, glib2, libgcrypt) — no upstream fix

> **FedRAMP SLA**: Critical/Important CVEs must be remediated within 30 days of detection.

[About Project Darkstar](https://source.redhat.com/departments/products_and_global_engineering/hybridplatforms/hybrid_platforms_blog/introducing_darkstar_an_experiment_in_ai_assisted_cve_remediation_for_rosa)

[ACM-39656]: https://redhat.atlassian.net/browse/ACM-39656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated required Go toolchain versions for the main project and development tooling.
  * Retained the existing Go language compatibility versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->