### PR TITLE
CNTRLPLANE-2775: Expose KAS availability and latency metrics from CPO

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -185,6 +185,7 @@ type HostedControlPlaneReconciler struct {
 	OperateOnReleaseImage                   string
 	DefaultIngressDomain                    string
 	MetricsSet                              metrics.MetricsSet
+	KASHealthMetrics                        *kas.KASHealthMetrics
 	SREConfigHash                           string
 	ec2Client                               awsapi.EC2API
 	awsSession                              *aws.Config
@@ -960,9 +961,9 @@ func (r *HostedControlPlaneReconciler) healthCheckKASLoadBalancers(ctx context.C
 		// When the cluster is private, checking the load balancers will depend on whether the load balancer is
 		// using the right subnets. To avoid uncertainty, we'll limit the check to the service endpoint.
 		if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
-			return healthCheckKASEndpoint(ctx, manifests.KubeAPIServerService("").Name, config.KASSVCIBMCloudPort)
+			return healthCheckKASEndpoint(ctx, manifests.KubeAPIServerService("").Name, config.KASSVCIBMCloudPort, r.KASHealthMetrics)
 		}
-		return healthCheckKASEndpoint(ctx, manifests.KubeAPIServerService("").Name, config.KASSVCPort)
+		return healthCheckKASEndpoint(ctx, manifests.KubeAPIServerService("").Name, config.KASSVCPort, r.KASHealthMetrics)
 	case serviceStrategy.Type == hyperv1.Route:
 		if hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform {
 			externalRoute := manifests.KubeAPIServerExternalPublicRoute(hcp.Namespace)
@@ -974,7 +975,7 @@ func (r *HostedControlPlaneReconciler) healthCheckKASLoadBalancers(ctx context.C
 			if err != nil {
 				return err
 			}
-			return healthCheckKASEndpoint(ctx, endpoint, port)
+			return healthCheckKASEndpoint(ctx, endpoint, port, r.KASHealthMetrics)
 		}
 	case serviceStrategy.Type == hyperv1.LoadBalancer:
 		svc := manifests.KubeAPIServerService(hcp.Namespace)
@@ -1010,25 +1011,41 @@ func (r *HostedControlPlaneReconciler) healthCheckKASLoadBalancers(ctx context.C
 		} else if LBIngress.IP != "" {
 			ingressPoint = LBIngress.IP
 		}
-		return healthCheckKASEndpoint(ctx, ingressPoint, port)
+		return healthCheckKASEndpoint(ctx, ingressPoint, port, r.KASHealthMetrics)
 	}
 	return nil
 }
 
-func healthCheckKASEndpoint(ctx context.Context, ingressPoint string, port int) error {
+func healthCheckKASEndpoint(ctx context.Context, ingressPoint string, port int, metrics *kas.KASHealthMetrics) error {
 	healthEndpoint := fmt.Sprintf("https://%s:%d/healthz?verbose", ingressPoint, port)
 
 	httpClient := util.InsecureHTTPClient()
 	httpClient.Timeout = 10 * time.Second
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthEndpoint, nil)
 	if err != nil {
 		return err
 	}
+
+	start := time.Now()
 	resp, err := httpClient.Do(req)
+	duration := time.Since(start).Seconds()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	if metrics != nil {
+		metrics.RequestDuration.Observe(duration)
+		if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
+			metrics.Available.Set(1)
+		} else {
+			metrics.Available.Set(0)
+		}
+	}
+
 	if err != nil {
 		return fmt.Errorf("health check to APIServer endpoint %s failed: %w", ingressPoint, err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		failingChecks := parseFailingHealthChecks(resp.Body)

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -19,6 +20,7 @@ import (
 	"github.com/openshift/hypershift/api/util/ipnet"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/infra"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	endpointresolverv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/endpoint_resolver"
 	etcdv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/etcd"
@@ -82,6 +84,8 @@ import (
 	"github.com/docker/distribution"
 	"github.com/go-logr/zapr"
 	"github.com/opencontainers/go-digest"
+	"github.com/prometheus/client_golang/prometheus"
+	prometheustestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap/zaptest"
 )
@@ -4922,7 +4926,7 @@ func TestHealthCheckKASEndpoint(t *testing.T) {
 				cancel()
 			}
 
-			err = healthCheckKASEndpoint(ctx, host, port)
+			err = healthCheckKASEndpoint(ctx, host, port, nil)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				if tt.errSubstr != "" {
@@ -4936,7 +4940,7 @@ func TestHealthCheckKASEndpoint(t *testing.T) {
 
 	t.Run("When the ingress point contains invalid characters, it should return a request creation error", func(t *testing.T) {
 		g := NewWithT(t)
-		err := healthCheckKASEndpoint(t.Context(), "host\x7f", 443)
+		err := healthCheckKASEndpoint(t.Context(), "host\x7f", 443, nil)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("invalid control character"))
 	})
@@ -5116,3 +5120,82 @@ var _ util.ImageMetadataProvider = &fakeVersionImageMetadataProvider{}
 
 // Compile-time assertion for clock interface used by tests.
 var _ clock.Clock = &testingclock.FakeClock{}
+
+func TestHealthCheckKASEndpointMetrics(t *testing.T) {
+	t.Run("When KAS endpoint returns 200, it should set available to 1 and record duration", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		m := newTestKASHealthMetrics(t)
+		host, port := parseHostPort(t, server)
+
+		err := healthCheckKASEndpoint(t.Context(), host, port, m)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(prometheustestutil.ToFloat64(m.Available)).To(Equal(float64(1)))
+		g.Expect(prometheustestutil.CollectAndCount(m.RequestDuration)).To(Equal(1))
+	})
+
+	t.Run("When KAS endpoint returns 503, it should set available to 0", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+
+		m := newTestKASHealthMetrics(t)
+		host, port := parseHostPort(t, server)
+
+		err := healthCheckKASEndpoint(t.Context(), host, port, m)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(prometheustestutil.ToFloat64(m.Available)).To(Equal(float64(0)))
+		g.Expect(prometheustestutil.CollectAndCount(m.RequestDuration)).To(Equal(1))
+	})
+
+	t.Run("When KAS endpoint is unreachable, it should set available to 0", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		m := newTestKASHealthMetrics(t)
+
+		err := healthCheckKASEndpoint(t.Context(), "192.0.2.1", 1, m)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(prometheustestutil.ToFloat64(m.Available)).To(Equal(float64(0)))
+		g.Expect(prometheustestutil.CollectAndCount(m.RequestDuration)).To(Equal(1))
+	})
+
+	t.Run("When metrics is nil, it should not panic", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		host, port := parseHostPort(t, server)
+		err := healthCheckKASEndpoint(t.Context(), host, port, nil)
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+}
+
+func newTestKASHealthMetrics(t *testing.T) *kas.KASHealthMetrics {
+	t.Helper()
+	return kas.NewKASHealthMetrics(prometheus.NewRegistry())
+}
+
+func parseHostPort(t *testing.T, server *httptest.Server) (string, int) {
+	t.Helper()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse server URL: %v", err)
+	}
+	host := u.Hostname()
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("failed to parse port: %v", err)
+	}
+	return host, port
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/metrics.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/metrics.go
@@ -1,0 +1,42 @@
+package kas
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	KASAvailableMetricName       = "hypershift_kube_apiserver_available"
+	KASRequestDurationMetricName = "hypershift_kube_apiserver_request_duration_seconds"
+)
+
+// kasRequestDurationBuckets defines the histogram bucket boundaries for KAS
+// health check latency measurements, ranging from 10ms to 10s.
+var kasRequestDurationBuckets = []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+// KASHealthMetrics holds Prometheus metrics for KAS health check probes.
+// Each CPO pod runs in its own HCP namespace, so metrics are naturally
+// scoped per hosted cluster without needing additional labels.
+type KASHealthMetrics struct {
+	Available       prometheus.Gauge
+	RequestDuration prometheus.Histogram
+}
+
+// NewKASHealthMetrics creates and registers KAS health metrics with the
+// controller-runtime metrics registry. The existing PodMonitor for the
+// control-plane-operator will automatically scrape these metrics.
+func NewKASHealthMetrics(reg prometheus.Registerer) *KASHealthMetrics {
+	m := &KASHealthMetrics{
+		Available: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: KASAvailableMetricName,
+			Help: "1 if the KAS /healthz endpoint returns HTTP 200, 0 otherwise.",
+		}),
+		RequestDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    KASRequestDurationMetricName,
+			Help:    "Latency of the KAS /healthz health check probe in seconds.",
+			Buckets: kasRequestDurationBuckets,
+		}),
+	}
+
+	reg.MustRegister(m.Available, m.RequestDuration)
+	return m
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/metrics_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/metrics_test.go
@@ -1,0 +1,48 @@
+package kas
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestKASHealthMetricsOperations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When creating KAS health metrics, it should register both metrics", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		registry := prometheus.NewRegistry()
+		m := NewKASHealthMetrics(registry)
+
+		g.Expect(testutil.ToFloat64(m.Available)).To(Equal(0.0))
+
+		mfs, err := registry.Gather()
+		g.Expect(err).NotTo(HaveOccurred())
+		names := make([]string, 0, len(mfs))
+		for _, mf := range mfs {
+			names = append(names, mf.GetName())
+		}
+		g.Expect(names).To(ConsistOf(KASAvailableMetricName, KASRequestDurationMetricName))
+	})
+
+	t.Run("When setting availability to 1, it should reflect the new value", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		registry := prometheus.NewRegistry()
+		m := NewKASHealthMetrics(registry)
+
+		m.Available.Set(1)
+		g.Expect(testutil.ToFloat64(m.Available)).To(Equal(1.0))
+	})
+
+	t.Run("When observing a request duration, it should be counted", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		registry := prometheus.NewRegistry()
+		m := NewKASHealthMetrics(registry)
+
+		m.RequestDuration.Observe(0.5)
+		g.Expect(testutil.CollectAndCount(m.RequestDuration)).To(Equal(1))
+	})
+}

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/gcpprivateserviceconnect"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/healthcheck"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	endpointresolver "github.com/openshift/hypershift/control-plane-operator/endpoint-resolver"
 	"github.com/openshift/hypershift/control-plane-operator/featuregates"
@@ -67,6 +68,7 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -530,6 +532,7 @@ func NewStartCommand() *cobra.Command {
 			OperateOnReleaseImage:                   os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
 			DefaultIngressDomain:                    defaultIngressDomain,
 			MetricsSet:                              metricsSet,
+			KASHealthMetrics:                        kas.NewKASHealthMetrics(crmetrics.Registry),
 			CertRotationScale:                       certRotationScale,
 			EnableCVOManagementClusterMetricsAccess: enableCVOManagementClusterMetricsAccess,
 			ImageMetadataProvider:                   imageMetaDataProvider,

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -124,6 +124,7 @@ func TestCreateCluster(t *testing.T) {
 		}
 
 		e2eutil.EnsureMetricsForwarderWorking(t, ctx, mgtClient, hostedCluster)
+		e2eutil.ValidateCPOMetrics(t, ctx, mgtClient, hostedCluster)
 
 		// Verify CPO override image if TEST_CPO_OVERRIDE=1 is set
 		if os.Getenv("TEST_CPO_OVERRIDE") == "1" {

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -25,6 +25,7 @@ import (
 	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	awsprivatelink "github.com/openshift/hypershift/control-plane-operator/controllers/awsprivatelink"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	cpomanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	hccokasvap "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas"
 	hccomanifests "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
@@ -2827,6 +2828,8 @@ const (
 	// TODO (jparrill): We need to separate the metrics.go from the main pkg in the hypershift-operator.
 	//     Delete these references when it's done and import it from there
 	HypershiftOperatorInfoName = "hypershift_operator_info"
+
+	cpoMetricsPort = "8080"
 )
 
 func extractDataFromFamilies(metricFamilies map[string]*dto.MetricFamily, metric, labelKey, labelValue string) []*dto.LabelPair {
@@ -2919,6 +2922,44 @@ func ValidateMetrics(t *testing.T, ctx context.Context, client crclient.Client, 
 		})
 		if err != nil {
 			t.Errorf("Failed to validate all metrics: %v", err)
+		}
+	})
+}
+
+// ValidateCPOMetrics verifies that KAS health metrics are exposed from the
+// control-plane-operator pod in the HCP namespace.
+func ValidateCPOMetrics(t *testing.T, ctx context.Context, c crclient.Client, hc *hyperv1.HostedCluster) {
+	t.Run("When KAS health metrics are exposed, it should contain availability and latency data", func(t *testing.T) {
+		AtLeast(t, Version51)
+		if hc.Spec.Platform.Type == hyperv1.NonePlatform {
+			t.Skip("skipping on None platform")
+		}
+
+		kasMetrics := []string{
+			kas.KASAvailableMetricName,
+			kas.KASRequestDurationMetricName,
+		}
+		hcpNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name)
+
+		err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+			mf, err := GetMetricsFromPod(ctx, c, "control-plane-operator", "control-plane-operator", hcpNamespace, cpoMetricsPort)
+			if err != nil {
+				t.Logf("unable to get CPO metrics: %v", err)
+				return false, nil
+			}
+			for _, metricName := range kasMetrics {
+				// These metrics are emitted without labels, so check family presence directly
+				// rather than using ValidateMetricPresence which relies on label iteration.
+				family, ok := mf[metricName]
+				if !ok || len(family.Metric) == 0 {
+					t.Logf("Expected results for metric %q, found none", metricName)
+					return false, nil
+				}
+			}
+			return true, nil
+		})
+		if err != nil {
+			t.Errorf("failed to validate KAS health metrics: %v", err)
 		}
 	})
 }

--- a/test/e2e/v2/tests/hosted_cluster_metrics_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_metrics_test.go
@@ -32,6 +32,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hcmetrics "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/metrics"
 	npmetrics "github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/metrics"
+	kasmetrics "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	azureutil "github.com/openshift/hypershift/support/azureutil"
 	supportforwarder "github.com/openshift/hypershift/support/forwarder"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
@@ -67,6 +68,7 @@ func RegisterHostedClusterMetricsTests(getTestCtx internal.TestContextGetter) {
 	EnsureMetricsForwarderWorkingTest(getTestCtx)
 	EnsureNodeTuningOperatorMetricsEndpointTest(getTestCtx)
 	EnsureKubeSchedulerMetricsEndpointTest(getTestCtx)
+	ValidateCPOMetricsTest(getTestCtx)
 }
 
 func ValidateMetricsTest(getTestCtx internal.TestContextGetter) {
@@ -378,6 +380,56 @@ func EnsureKubeSchedulerMetricsEndpointTest(getTestCtx internal.TestContextGette
 						"metrics response should contain Prometheus format data")
 				}, 3*time.Minute, 10*time.Second).Should(Succeed())
 			}
+		})
+	})
+}
+
+func ValidateCPOMetricsTest(getTestCtx internal.TestContextGetter) {
+	When("KAS health metrics are exposed", func() {
+		var tc *internal.TestContext
+
+		BeforeEach(func() {
+			tc = getTestCtx()
+			tc.SkipIfPlatform(hyperv1.NonePlatform)
+			tc.SkipIfVersionBelow(e2eutil.Version51)
+		})
+
+		It("should contain availability and latency data from CPO", func() {
+			kasMetricNames := []string{
+				kasmetrics.KASAvailableMetricName,
+				kasmetrics.KASRequestDurationMetricName,
+			}
+
+			mgmtRestConfig, err := e2eutil.GetConfig()
+			Expect(err).NotTo(HaveOccurred(), "should be able to load management cluster REST config")
+			clientset, err := kubernetes.NewForConfig(mgmtRestConfig)
+			Expect(err).NotTo(HaveOccurred(), "should be able to create kubernetes clientset")
+
+			Eventually(func(g Gomega) {
+				cpoPods := &corev1.PodList{}
+				g.Expect(tc.MgmtClient.List(tc.Context, cpoPods,
+					crclient.InNamespace(tc.ControlPlaneNamespace),
+					crclient.MatchingLabels{"app": "control-plane-operator"},
+				)).To(Succeed(), "should be able to list control-plane-operator pods")
+				g.Expect(cpoPods.Items).NotTo(BeEmpty(), "control-plane-operator pod should exist")
+
+				var runningPodName string
+				for _, p := range cpoPods.Items {
+					if p.Status.Phase == corev1.PodRunning {
+						runningPodName = p.Name
+						break
+					}
+				}
+				g.Expect(runningPodName).NotTo(BeEmpty(), "a running control-plane-operator pod should exist")
+
+				mf, err := v2util.GetMetricsFromPod(tc.Context, clientset, mgmtRestConfig, tc.ControlPlaneNamespace, runningPodName, "control-plane-operator", 8080)
+				g.Expect(err).NotTo(HaveOccurred(), "should be able to get CPO metrics")
+				for _, metricName := range kasMetricNames {
+					family, ok := mf[metricName]
+					g.Expect(ok).To(BeTrue(), "metric %s should be present in CPO metrics", metricName)
+					g.Expect(family.Metric).NotTo(BeEmpty(), "metric %s should have at least one data point", metricName)
+				}
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 	})
 }


### PR DESCRIPTION
## What this PR does / why we need it:
Picks up #7749 by @enxebre which was closed due to inactivity (`lifecycle/rotten`) with `maintainerCanModify: false`, making it impossible to push a rebase.
  
Cherry-picked the 3 commits onto current main, resolved merge conflicts from the `noctx` linter enforcement (#d22f557d) that landed after the original branch was written.
  
Ref: [CNTRLPLANE-2775](https://issues.redhat.com/browse/CNTRLPLANE-2775)
Closes #7749

## Special notes for your reviewer:
**Merge conflict resolution** — `hostedcontrolplane_controller.go`:

- The original branch used `httpClient.Get()` (no context) because it predated the `noctx` linter enforcement landed in  d22f557d (2026-05-21). Main's version had already changed `healthCheckKASEndpoint` to take `ctx context.Context` and use  `http.NewRequestWithContext`.

-   Resolution: merged both signatures into `(ctx context.Context, ingressPoint string, port int, m *kas.KASHealthMetrics)`,  kept `NewRequestWithContext` + `Do` for context propagation, and inserted the metrics recording block between `Do` and the existing error check. All 4 call sites updated accordingly.

**`hostedcontrolplane_controller_test.go`**:

- Existing tests (pre-cherry-pick) were missing the new `m` parameter — passed `nil` since they test context/error behavior, not metrics. New metrics tests were missing `ctx` — added `t.Context()`.

- `go test ./control-plane-operator/controllers/hostedcontrolplane/... -v -run "TestHealthCheck" 2>&1` - PASS
- `make test - PASS`

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for KAS endpoint availability and health-check request duration.
  * Exposed these metrics through the operator’s Prometheus endpoint.
  * Extended end-to-end validation for supported clusters.
* **Bug Fixes**
  * KAS availability is reported only after a successful HTTP 200 response.
* **Tests**
  * Added coverage for successful, unhealthy, unreachable, and metrics-disabled scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->