### PR TITLE
AUTOSCALE-871: add deployment path for standalone karpenter-operator

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -17,6 +17,7 @@ import (
 	controlplaneoperatoroverrides "github.com/openshift/hypershift/hypershift-operator/controlplaneoperator-overrides"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
+	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
@@ -548,6 +549,7 @@ type HyperShiftOperatorDeployment struct {
 	EnableSizeTagging                       bool
 	EnableEtcdRecovery                      bool
 	EnableCPOOverrides                      bool
+	EnableKarpenterOperator                 bool
 	AdditionalOperatorEnvVars               map[string]string
 	AROHCPKeyVaultUsersClientID             string
 	TechPreviewNoUpgrade                    bool
@@ -864,6 +866,9 @@ func (o HyperShiftOperatorDeployment) buildEnvVars() []corev1.EnvVar {
 	}
 	if o.EnableCPOOverrides {
 		envVars = append(envVars, corev1.EnvVar{Name: controlplaneoperatoroverrides.CPOOverridesEnvVar, Value: "1"})
+	}
+	if o.EnableKarpenterOperator {
+		envVars = append(envVars, corev1.EnvVar{Name: karpenterutil.EnableStandaloneKarpenterOperatorEnvVar, Value: "1"})
 	}
 	if len(o.PlatformsInstalled) > 0 {
 		envVars = append(envVars, corev1.EnvVar{Name: "PLATFORMS_INSTALLED", Value: o.PlatformsInstalled})

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -149,6 +149,7 @@ type Options struct {
 	EnableSizeTagging                         bool
 	EnableEtcdRecovery                        bool
 	EnableCPOOverrides                        bool
+	EnableStandaloneKarpenterOperator         bool
 	AroHCPKeyVaultUsersClientID               string
 	TechPreviewNoUpgrade                      bool
 	RegistryOverrides                         string
@@ -499,6 +500,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.EnableSizeTagging, "enable-size-tagging", opts.EnableSizeTagging, "If true, HyperShift will tag the HostedCluster with a size label corresponding to the number of worker nodes")
 	cmd.PersistentFlags().BoolVar(&opts.EnableEtcdRecovery, "enable-etcd-recovery", opts.EnableEtcdRecovery, "If true, the HyperShift operator checks for failed etcd pods and attempts a recovery if possible")
 	cmd.PersistentFlags().BoolVar(&opts.EnableCPOOverrides, "enable-cpo-overrides", opts.EnableCPOOverrides, "If true, the HyperShift operator uses a set of static overrides for the CPO image given specific release versions")
+	cmd.PersistentFlags().BoolVar(&opts.EnableStandaloneKarpenterOperator, "enable-standalone-karpenter-operator", opts.EnableStandaloneKarpenterOperator, "If true, the HyperShift operator deploys the standalone karpenter-operator binary instead of the karpenter-operator embedded in the HO image (default false)")
 	cmd.PersistentFlags().StringVar(&opts.AroHCPKeyVaultUsersClientID, "aro-hcp-key-vault-users-client-id", opts.AroHCPKeyVaultUsersClientID, "The client ID of the managed identity which can access the Azure Key Vaults, in an AKS management cluster, to retrieve secrets and certificates.")
 	// TODO: Would it make sense to deprecate this flag in favor of a new flag like `--feature-set=TechPreviewNoUpgrade`
 	// and make it so that setting this flag is essentially equivalent to that?
@@ -1383,6 +1385,7 @@ func setupOperatorResources(opts Options, userCABundleCM *corev1.ConfigMap, trus
 		EnableSizeTagging:                       opts.EnableSizeTagging,
 		EnableEtcdRecovery:                      opts.EnableEtcdRecovery,
 		EnableCPOOverrides:                      opts.EnableCPOOverrides,
+		EnableKarpenterOperator:                 opts.EnableStandaloneKarpenterOperator,
 		AdditionalOperatorEnvVars:               opts.AdditionalOperatorEnvVars,
 		AROHCPKeyVaultUsersClientID:             opts.AroHCPKeyVaultUsersClientID,
 		TechPreviewNoUpgrade:                    opts.TechPreviewNoUpgrade,

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/component.go
@@ -18,9 +18,10 @@ const (
 var _ component.ComponentOptions = &KarpenterOperatorOptions{}
 
 type KarpenterOperatorOptions struct {
-	HyperShiftOperatorImage   string
-	ControlPlaneOperatorImage string
-	IgnitionEndpoint          string
+	HyperShiftOperatorImage            string
+	ControlPlaneOperatorImage          string
+	IgnitionEndpoint                   string
+	StandaloneKarpenterOperatorEnabled bool
 }
 
 // IsRequestServing implements controlplanecomponent.ComponentOptions.

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
@@ -1,6 +1,7 @@
 package karpenteroperator
 
 import (
+	"fmt"
 	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -13,7 +14,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	// ManagementClusterEnvVar signals to Karpenter Operator that it should run in management cluster mode.
+	ManagementClusterEnvVar = "MANAGEMENT_CLUSTER"
+	// KarpenterImageAWSEnvVar is the environment variable that sets the Karpenter image for AWS.
+	KarpenterImageAWSEnvVar = "KARPENTER_IMAGE_AWS"
+	// KarpenterImageAzureEnvVar is the environment variable that sets the Karpenter image for Azure.
+	KarpenterImageAzureEnvVar = "KARPENTER_IMAGE_AZURE"
+)
+
 func (karp *KarpenterOperatorOptions) adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	if karp.StandaloneKarpenterOperatorEnabled {
+		return adaptStandaloneDeployment(cpContext, deployment)
+	}
+
 	hcp := cpContext.HCP
 
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
@@ -71,6 +85,99 @@ func (karp *KarpenterOperatorOptions) adaptDeployment(cpContext component.Worklo
 			}
 		})
 	}
+
+	return nil
+}
+
+// adaptStandaloneDeployment configures the deployment for the standalone karpenter-operator binary.
+func adaptStandaloneDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
+
+	platformType := string(hcp.Spec.Platform.Type)
+
+	var region string
+	var extraEnvVars []corev1.EnvVar
+	switch platformType {
+	case string(hyperv1.AWSPlatform):
+		region = hcp.Spec.Platform.AWS.Region
+		extraEnvVars = append(extraEnvVars,
+			corev1.EnvVar{
+				Name:  KarpenterImageAWSEnvVar,
+				Value: cpContext.ReleaseImageProvider.GetImage("aws-karpenter-provider-aws"),
+			},
+			corev1.EnvVar{
+				Name:  "AWS_SHARED_CREDENTIALS_FILE",
+				Value: "/etc/provider/credentials",
+			},
+			corev1.EnvVar{
+				Name:  "AWS_SDK_LOAD_CONFIG",
+				Value: "true",
+			},
+		)
+	case string(hyperv1.AzurePlatform):
+		region = hcp.Spec.Platform.Azure.Location
+		extraEnvVars = append(extraEnvVars, corev1.EnvVar{
+			Name:  KarpenterImageAzureEnvVar,
+			Value: cpContext.ReleaseImageProvider.GetImage("azure-karpenter-provider-azure"),
+		})
+	}
+
+	extraEnvVars = append(extraEnvVars, corev1.EnvVar{
+		Name:  ManagementClusterEnvVar,
+		Value: "true",
+	})
+
+	proxy.SetEnvVars(&extraEnvVars)
+
+	if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" {
+		extraEnvVars = append(extraEnvVars,
+			corev1.EnvVar{
+				Name:  rhobsmonitoring.EnvironmentVariable,
+				Value: "1",
+			},
+		)
+	}
+
+	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes,
+		corev1.Volume{
+			Name: "provider-creds",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "karpenter-credentials",
+				},
+			},
+		},
+	)
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		c.Image = cpContext.ReleaseImageProvider.GetImage("karpenter-operator")
+		c.VolumeMounts = append(c.VolumeMounts,
+			corev1.VolumeMount{
+				Name:      "provider-creds",
+				MountPath: "/etc/provider",
+			},
+		)
+		c.Env = append(c.Env,
+			corev1.EnvVar{
+				Name:  "CLUSTER_NAME",
+				Value: hcp.Spec.InfraID,
+			},
+			corev1.EnvVar{
+				Name:  "CLUSTER_ENDPOINT",
+				Value: fmt.Sprintf("https://%s:%d", hcp.Status.ControlPlaneEndpoint.Host, hcp.Status.ControlPlaneEndpoint.Port),
+			},
+			corev1.EnvVar{
+				Name:  "PLATFORM",
+				Value: platformType,
+			},
+			corev1.EnvVar{
+				Name:  "REGION",
+				Value: region,
+			},
+		)
+		c.Env = append(c.Env,
+			extraEnvVars...,
+		)
+	})
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment_test.go
@@ -15,6 +15,31 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type fakeReleaseImageProvider struct {
+	images map[string]string
+}
+
+func (f *fakeReleaseImageProvider) GetImage(name string) string {
+	return f.images[name]
+}
+
+func (f *fakeReleaseImageProvider) ImageExist(name string) (string, bool) {
+	img, ok := f.images[name]
+	return img, ok
+}
+
+func (f *fakeReleaseImageProvider) Version() string {
+	return "4.18.0"
+}
+
+func (f *fakeReleaseImageProvider) ComponentVersions() (map[string]string, error) {
+	return nil, nil
+}
+
+func (f *fakeReleaseImageProvider) ComponentImages() map[string]string {
+	return f.images
+}
+
 func TestAdaptDeployment(t *testing.T) {
 	testCases := []struct {
 		name                      string
@@ -228,6 +253,190 @@ func TestAdaptDeployment(t *testing.T) {
 			}
 
 			tc.validateFunc(t, g, opts, cpContext)
+		})
+	}
+}
+
+func TestAdaptStandaloneDeployment(t *testing.T) {
+	testCases := []struct {
+		name          string
+		platformType  hyperv1.PlatformType
+		awsRegion     string
+		azureLocation string
+		infraID       string
+		rhobsEnabled  bool
+		images        map[string]string
+		validateFunc  func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext)
+	}{
+		{
+			name:         "When platform is AWS, it should configure AWS-specific env vars and karpenter image",
+			platformType: hyperv1.AWSPlatform,
+			awsRegion:    "us-west-2",
+			infraID:      "test-infra-123",
+			images: map[string]string{
+				"aws-karpenter-provider-aws": "quay.io/openshift/karpenter-aws:latest",
+			},
+			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
+				t.Helper()
+				deploymentObj, err := assets.LoadDeploymentManifest(ComponentName)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				err = adaptStandaloneDeployment(cpContext, deploymentObj)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				g.Expect(container).ToNot(BeNil())
+
+				g.Expect(container.Env).To(ContainElements(
+					corev1.EnvVar{Name: "CLUSTER_NAME", Value: "test-infra-123"},
+					corev1.EnvVar{Name: "CLUSTER_ENDPOINT", Value: "https://api.test-cluster.example.com:6443"},
+					corev1.EnvVar{Name: "PLATFORM", Value: "AWS"},
+					corev1.EnvVar{Name: "REGION", Value: "us-west-2"},
+					corev1.EnvVar{Name: "AWS_SHARED_CREDENTIALS_FILE", Value: "/etc/provider/credentials"},
+					corev1.EnvVar{Name: "AWS_SDK_LOAD_CONFIG", Value: "true"},
+					corev1.EnvVar{Name: KarpenterImageAWSEnvVar, Value: "quay.io/openshift/karpenter-aws:latest"},
+					corev1.EnvVar{Name: ManagementClusterEnvVar, Value: "true"},
+				))
+
+				g.Expect(container.Args).To(ContainElement(ContainSubstring("--target-kubeconfig=")))
+
+				g.Expect(container.VolumeMounts).To(ContainElement(
+					corev1.VolumeMount{Name: "provider-creds", MountPath: "/etc/provider"},
+				))
+
+				providerCredsVolume := podspec.FindVolume("provider-creds", deploymentObj.Spec.Template.Spec.Volumes)
+				g.Expect(providerCredsVolume).ToNot(BeNil())
+				g.Expect(providerCredsVolume.VolumeSource.Secret.SecretName).To(Equal("karpenter-credentials"))
+			},
+		},
+		{
+			name:          "When platform is Azure, it should configure Azure-specific env vars and karpenter image",
+			platformType:  hyperv1.AzurePlatform,
+			azureLocation: "eastus",
+			infraID:       "test-azure-456",
+			images: map[string]string{
+				"azure-karpenter-provider-azure": "quay.io/openshift/karpenter-azure:latest",
+			},
+			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
+				t.Helper()
+				deploymentObj, err := assets.LoadDeploymentManifest(ComponentName)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				err = adaptStandaloneDeployment(cpContext, deploymentObj)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				g.Expect(container).ToNot(BeNil())
+
+				g.Expect(container.Env).To(ContainElements(
+					corev1.EnvVar{Name: "CLUSTER_NAME", Value: "test-azure-456"},
+					corev1.EnvVar{Name: "PLATFORM", Value: "Azure"},
+					corev1.EnvVar{Name: "REGION", Value: "eastus"},
+					corev1.EnvVar{Name: KarpenterImageAzureEnvVar, Value: "quay.io/openshift/karpenter-azure:latest"},
+					corev1.EnvVar{Name: ManagementClusterEnvVar, Value: "true"},
+				))
+
+				// Azure should not have AWS-specific env vars
+				g.Expect(podspec.FindEnvVar(KarpenterImageAWSEnvVar, container.Env)).To(BeNil())
+				g.Expect(podspec.FindEnvVar("AWS_SHARED_CREDENTIALS_FILE", container.Env)).To(BeNil())
+				g.Expect(podspec.FindEnvVar("AWS_SDK_LOAD_CONFIG", container.Env)).To(BeNil())
+			},
+		},
+		{
+			name:         "When RHOBS monitoring is enabled, it should set the env var",
+			platformType: hyperv1.AWSPlatform,
+			awsRegion:    "us-east-1",
+			infraID:      "test-rhobs",
+			rhobsEnabled: true,
+			images: map[string]string{
+				"aws-karpenter-provider-aws": "quay.io/openshift/karpenter-aws:latest",
+			},
+			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
+				t.Helper()
+				deploymentObj, err := assets.LoadDeploymentManifest(ComponentName)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				err = adaptStandaloneDeployment(cpContext, deploymentObj)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				g.Expect(container).ToNot(BeNil())
+				g.Expect(container.Env).To(ContainElement(
+					corev1.EnvVar{Name: rhobsmonitoring.EnvironmentVariable, Value: "1"},
+				))
+			},
+		},
+		{
+			name:         "When RHOBS monitoring is disabled, it should not set the env var",
+			platformType: hyperv1.AWSPlatform,
+			awsRegion:    "us-east-1",
+			infraID:      "test-no-rhobs",
+			rhobsEnabled: false,
+			images: map[string]string{
+				"aws-karpenter-provider-aws": "quay.io/openshift/karpenter-aws:latest",
+			},
+			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
+				t.Helper()
+				deploymentObj, err := assets.LoadDeploymentManifest(ComponentName)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				err = adaptStandaloneDeployment(cpContext, deploymentObj)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				g.Expect(container).ToNot(BeNil())
+				g.Expect(podspec.FindEnvVar(rhobsmonitoring.EnvironmentVariable, container.Env)).To(BeNil())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			if tc.rhobsEnabled {
+				t.Setenv(rhobsmonitoring.EnvironmentVariable, "1")
+			} else {
+				t.Setenv(rhobsmonitoring.EnvironmentVariable, "")
+			}
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-namespace",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					InfraID: tc.infraID,
+					Platform: hyperv1.PlatformSpec{
+						Type: tc.platformType,
+					},
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					ControlPlaneEndpoint: hyperv1.APIEndpoint{
+						Host: "api.test-cluster.example.com",
+						Port: 6443,
+					},
+				},
+			}
+
+			if tc.platformType == hyperv1.AWSPlatform {
+				hcp.Spec.Platform.AWS = &hyperv1.AWSPlatformSpec{
+					Region: tc.awsRegion,
+				}
+			}
+			if tc.platformType == hyperv1.AzurePlatform {
+				hcp.Spec.Platform.Azure = &hyperv1.AzurePlatformSpec{
+					Location: tc.azureLocation,
+				}
+			}
+
+			cpContext := controlplanecomponent.WorkloadContext{
+				Context:              t.Context(),
+				HCP:                  hcp,
+				ReleaseImageProvider: &fakeReleaseImageProvider{images: tc.images},
+			}
+
+			tc.validateFunc(t, g, cpContext)
 		})
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/karpenter.go
+++ b/hypershift-operator/controllers/hostedcluster/karpenter.go
@@ -71,9 +71,10 @@ func (r *HostedClusterReconciler) reconcileKarpenterOperator(cpContext controlpl
 	}
 
 	karpenteroperator := karpenteroperatorv2.NewComponent(&karpenteroperatorv2.KarpenterOperatorOptions{
-		HyperShiftOperatorImage:   hypershiftOperatorImage,
-		ControlPlaneOperatorImage: controlPlaneOperatorImage,
-		IgnitionEndpoint:          hcluster.Status.IgnitionEndpoint,
+		HyperShiftOperatorImage:            hypershiftOperatorImage,
+		ControlPlaneOperatorImage:          controlPlaneOperatorImage,
+		IgnitionEndpoint:                   hcluster.Status.IgnitionEndpoint,
+		StandaloneKarpenterOperatorEnabled: karpenterutil.IsStandaloneKarpenterOperatorEnabled(),
 	})
 
 	// Always reconcile the Karpenter Operator so it has a chance to clean up, the predicate on

--- a/support/karpenter/karpenter.go
+++ b/support/karpenter/karpenter.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1"
+	"github.com/openshift/hypershift/hypershift-operator/featuregate"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -127,4 +129,16 @@ func ArchToAMILabelKey(arch string) string {
 		return hyperkarpenterv1.UserDataAMILabel
 	}
 	return fmt.Sprintf("%s-%s", hyperkarpenterv1.UserDataAMILabel, arch)
+}
+
+const EnableStandaloneKarpenterOperatorEnvVar = "ENABLE_STANDALONE_KARPENTER_OPERATOR"
+
+// IsStandaloneKarpenterOperatorEnabled returns true if the standalone karpenter-operator
+// should be deployed instead of the embedded karpenter controller.
+// Requires both:
+// - the KarpenterOperator feature gate is on (via TechPreviewNoUpgrade), and
+// - the ENABLE_STANDALONE_KARPENTER_OPERATOR env var is set to "1" (via --enable-standalone-karpenter-operator install flag).
+func IsStandaloneKarpenterOperatorEnabled() bool {
+	return featuregate.Gate().Enabled(featuregate.KarpenterOperator) &&
+		os.Getenv(EnableStandaloneKarpenterOperatorEnvVar) == "1"
 }

--- a/support/karpenter/karpenter_test.go
+++ b/support/karpenter/karpenter_test.go
@@ -8,6 +8,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/featuregate"
+
+	configv1 "github.com/openshift/api/config/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -208,6 +211,62 @@ func TestKarpenterTaintConfigManifest(t *testing.T) {
 		g.Expect(taint["value"]).To(Equal(KarpenterBaseTaints[0].Value))
 		g.Expect(taint["effect"]).To(Equal(string(KarpenterBaseTaints[0].Effect)))
 	})
+}
+
+func TestIsStandaloneKarpenterOperatorEnabled(t *testing.T) {
+	testCases := []struct {
+		name       string
+		featureSet configv1.FeatureSet
+		envValue   string
+		expected   bool
+	}{
+		{
+			name:       "When both feature gate and env var are enabled, it should return true",
+			featureSet: configv1.TechPreviewNoUpgrade,
+			envValue:   "1",
+			expected:   true,
+		},
+		{
+			name:       "When feature gate is enabled but env var is unset, it should return false",
+			featureSet: configv1.TechPreviewNoUpgrade,
+			envValue:   "",
+			expected:   false,
+		},
+		{
+			name:       "When feature gate is enabled but env var is set to 0, it should return false",
+			featureSet: configv1.TechPreviewNoUpgrade,
+			envValue:   "0",
+			expected:   false,
+		},
+		{
+			name:       "When feature gate is disabled but env var is set to 1, it should return false",
+			featureSet: configv1.Default,
+			envValue:   "1",
+			expected:   false,
+		},
+		{
+			name:       "When both feature gate and env var are disabled, it should return false",
+			featureSet: configv1.Default,
+			envValue:   "",
+			expected:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			previousFeatureSet := featuregate.FeatureSet()
+			featuregate.ConfigureFeatureSet(string(tc.featureSet))
+			t.Cleanup(func() {
+				featuregate.ConfigureFeatureSet(string(previousFeatureSet))
+			})
+
+			t.Setenv(EnableStandaloneKarpenterOperatorEnvVar, tc.envValue)
+
+			g.Expect(IsStandaloneKarpenterOperatorEnabled()).To(Equal(tc.expected))
+		})
+	}
 }
 
 func TestKarpenterBaseTaintMap(t *testing.T) {


### PR DESCRIPTION
## What this PR does / why we need it:

This is part of the overall work to refactor karpenter-operator out of the hypershift repo and into the standalone openshift/karpenter-operator repository which is tracked by https://redhat.atlassian.net/browse/AUTOSCALE-522.

Gate the standalone karpenter-operator behind
`--enable-standalone-karpenter-operator` (hypershift install flag) AND the `KarpenterOperator` feature gate. When both are set, the CPO uses `adaptStandaloneDeployment` which sets `MANAGEMENT_CLUSTER` and deploys the standalone Karpenter Operator instead of the karpenter-operator which exists currently embedded in hypershift.

- Wire `--enable-standalone-karpenter-operator` through install.go to `ENABLE_STANDALONE_KARPENTER_OPERATOR` env var on the HO deployment
- Add `IsStandaloneKarpenterOperatorEnabled()` in support/karpenter
- Add `StandaloneKarpenterOperatorEnabled` to KarpenterOperatorOptions
- Add standalone KO deployment tests (AWS, Azure, RHOBS on/off)

Currently, if you enable this workflow, the karpenter-operator will not run any controllers and not deploy karpenter, so tests will not work but this will not "fail" the overall guest cluster creation. 

A followup PR will be done to enable an optional,  `always-run: false` e2e-aws-autonode-v2 presubmit in hypershift to validate the refactor. This job will run the current hypershift autonode tests that exist in the repo, but only if enabled for it. By default at the start of this refactor, none of the tests will run (since they will fail). As we move more controllers over to the standalone repo, we will slowly enable these tests which will serve as regression signal. 

Builds off of the work done in https://github.com/openshift/karpenter-operator/pull/19

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/AUTOSCALE-871

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for deploying the standalone Karpenter Operator v2.
  - Added the `--enable-karpenter-operator` installation option.
  - Added AWS and Azure configuration, credentials, monitoring, proxy, and cluster metadata support.
  - Added feature-gate and environment-variable controls for enabling Karpenter Operator v2.

- **Tests**
  - Added coverage for AWS and Azure deployments, configuration, credentials, monitoring, image selection, and enablement controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->