### PR TITLE
OCPBUGS-98467: fix(konnectivity): enable sync-force-reconnect to prevent stale agent connections

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/AROSwift/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/AROSwift/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -98,6 +98,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-force-reconnect
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/GCP/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/GCP/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -98,6 +98,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-force-reconnect
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/IBMCloud/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/IBMCloud/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -98,6 +98,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-force-reconnect
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/ModernTLS/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/ModernTLS/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -98,6 +98,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-force-reconnect
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -98,6 +98,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-force-reconnect
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -98,6 +98,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-force-reconnect
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/konnectivity-agent/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/konnectivity-agent/deployment.yaml
@@ -39,6 +39,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-force-reconnect
         - --v
         - "3"
         command:

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
@@ -159,6 +159,7 @@ func buildKonnectivityWorkerAgentContainer(image, host string, port int32, proxy
 			"5s",
 			"--sync-interval-cap",
 			"30s",
+			"--sync-force-reconnect",
 			"--v",
 			"3",
 		}


### PR DESCRIPTION
## What this PR does / why we need it:

Enables `--sync-force-reconnect` on both konnectivity-agent deployments (data-plane DaemonSet and control-plane Deployment) to prevent intermittent communication breakdowns caused by silently stale gRPC connections.

### Root cause

When gRPC connections between konnectivity-agents and the konnectivity-server silently break (e.g. due to load balancer timeouts, route flaps, or transient network partitions), the agents' `/healthz` endpoint still reports healthy because it only checks process liveness — not connection state. The server continues routing traffic to these dead connections, causing:

- Webhook failures
- `oc` command timeouts
- VM console access failures
- VM restart failures

Recovery currently requires manually restarting **all** konnectivity-agent pods (restarting a single pod doesn't help because multiple agents hold stale connections simultaneously).

### Fix

Adding `--sync-force-reconnect` causes agents to periodically tear down and re-establish their server connections during each sync cycle (every 5–30s based on `--sync-interval` / `--sync-interval-cap`). This prevents stale connections from accumulating and ensures the server's routing table stays fresh — eliminating the need for manual intervention.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-98467

## Special notes for your reviewer:

- The `--sync-force-reconnect` flag is available in apiserver-network-proxy since v0.28.0 (we vendor konnectivity-client v0.34.0)
- This is a boolean flag — no value needed, presence enables it
- During reconnection windows (milliseconds per agent every 5–30s), traffic through that specific agent briefly fails; with multiple agents across nodes on different sync schedules, impact is negligible
- No NodePool config hash impact — the DaemonSet is reconciled by HCCO directly
- All CPOv2 fixture tests pass and have been regenerated

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Konnectivity agent reliability by enabling forced reconnection synchronization.
  * Helps maintain connectivity more consistently when connection state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->