### PR TITLE
feat(gcp): add GCP PSC conditions to metrics and credential gauge

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -459,6 +459,40 @@ func (p GCP) DeleteCredentials(ctx context.Context, c client.Client, hcluster *h
 	return nil
 }
 
+type CredentialStatus int
+
+const (
+	CredentialStatusValid   CredentialStatus = 0
+	CredentialStatusInvalid CredentialStatus = 1
+	CredentialStatusUnknown CredentialStatus = 2
+)
+
+func GetCredentialStatus(hc *hyperv1.HostedCluster) CredentialStatus {
+	var wifStatus metav1.ConditionStatus
+	validWIF := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPWorkloadIdentity))
+	if validWIF == nil {
+		wifStatus = metav1.ConditionUnknown
+	} else {
+		wifStatus = validWIF.Status
+	}
+
+	var credsStatus metav1.ConditionStatus
+	validCreds := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPCredentials))
+	if validCreds == nil {
+		credsStatus = metav1.ConditionUnknown
+	} else {
+		credsStatus = validCreds.Status
+	}
+
+	if wifStatus == metav1.ConditionFalse || credsStatus == metav1.ConditionFalse {
+		return CredentialStatusInvalid
+	}
+	if wifStatus == metav1.ConditionTrue && credsStatus == metav1.ConditionTrue {
+		return CredentialStatusValid
+	}
+	return CredentialStatusUnknown
+}
+
 // ValidCredentials checks if GCP credentials are valid and ready for use.
 // This function validates Workload Identity Federation configuration and status.
 func ValidCredentials(hc *hyperv1.HostedCluster) bool {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
@@ -206,7 +206,7 @@ func TestGetCredentialStatus(t *testing.T) {
 			}
 
 			result := GetCredentialStatus(hc)
-			g.Expect(result).To(Equal(tt.expected))
+			g.Expect(result).To(Equal(tt.expected), tt.name)
 		})
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
@@ -128,6 +128,89 @@ func TestValidCredentials(t *testing.T) {
 	}
 }
 
+func TestGetCredentialStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		expected   CredentialStatus
+	}{
+		{
+			name: "When both conditions are true, status is valid",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
+			},
+			expected: CredentialStatusValid,
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is false, status is invalid",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
+			},
+			expected: CredentialStatusInvalid,
+		},
+		{
+			name: "When ValidGCPCredentials is false, status is invalid",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+			},
+			expected: CredentialStatusInvalid,
+		},
+		{
+			name: "When both conditions are false, status is invalid",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+			},
+			expected: CredentialStatusInvalid,
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is missing, status is unknown",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
+			},
+			expected: CredentialStatusUnknown,
+		},
+		{
+			name: "When ValidGCPCredentials is missing, status is unknown",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
+			},
+			expected: CredentialStatusUnknown,
+		},
+		{
+			name:       "When no conditions exist, status is unknown",
+			conditions: []metav1.Condition{},
+			expected:   CredentialStatusUnknown,
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is unknown, status is unknown",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionUnknown},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
+			},
+			expected: CredentialStatusUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hc := &hyperv1.HostedCluster{
+				Status: hyperv1.HostedClusterStatus{
+					Conditions: tt.conditions,
+				},
+			}
+
+			result := GetCredentialStatus(hc)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
 // TestWorkloadIdentityValidationScenarios tests additional edge cases for WIF validation.
 // This expands on the existing TestValidateWorkloadIdentityConfiguration with more comprehensive coverage.
 func TestWorkloadIdentityValidationScenarios(t *testing.T) {

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -356,7 +356,7 @@ func collectFailureConditionCounts(hcluster *hyperv1.HostedCluster, platform hyp
 }
 
 func (c *hostedClustersMetricsCollector) collectTransitionDurationMetrics(hcluster *hyperv1.HostedCluster, currentCollectTime time.Time) {
-	for _, conditionType := range []hyperv1.ConditionType{hyperv1.EtcdAvailable, hyperv1.InfrastructureReady, hyperv1.ExternalDNSReachable, hyperv1.AWSEndpointServiceAvailable, hyperv1.AWSEndpointAvailable} {
+	for _, conditionType := range []hyperv1.ConditionType{hyperv1.EtcdAvailable, hyperv1.InfrastructureReady, hyperv1.ExternalDNSReachable, hyperv1.AWSEndpointServiceAvailable, hyperv1.AWSEndpointAvailable, hyperv1.GCPEndpointAvailable, hyperv1.GCPServiceAttachmentAvailable} {
 		condition := meta.FindStatusCondition(hcluster.Status.Conditions, string(conditionType))
 		if condition != nil && condition.Status == metav1.ConditionTrue {
 			t := condition.LastTransitionTime.Time

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	platformaws "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/aws"
+	platformgcp "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/gcp"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/proxy"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/conditions"
@@ -74,6 +75,9 @@ const (
 
 	InvalidAwsCredsMetricName = "hypershift_cluster_invalid_aws_creds"
 	invalidAwsCredsMetricHelp = "AWS credential status for the HostedCluster: 0=valid, 1=invalid, 2=unknown"
+
+	InvalidGcpCredsMetricName = "hypershift_cluster_invalid_gcp_creds"
+	invalidGcpCredsMetricHelp = "GCP credential status for the HostedCluster: 0=valid, 1=invalid, 2=unknown"
 
 	DeletingDurationMetricName = "hypershift_cluster_deleting_duration_seconds"
 	deletingDurationMetricHelp = "Time in seconds it is taking to delete the HostedCluster since the beginning of the delete. " +
@@ -175,6 +179,10 @@ var (
 
 	invalidAwsCredsMetricDesc = prometheus.NewDesc(
 		InvalidAwsCredsMetricName, invalidAwsCredsMetricHelp,
+		hclusterLabels, nil)
+
+	invalidGcpCredsMetricDesc = prometheus.NewDesc(
+		InvalidGcpCredsMetricName, invalidGcpCredsMetricHelp,
 		hclusterLabels, nil)
 
 	deletingDurationMetricDesc = prometheus.NewDesc(
@@ -378,6 +386,7 @@ func (c *hostedClustersMetricsCollector) collectPerClusterMetrics(ch chan<- prom
 	collectAzureInfoMetrics(ch, hcluster, hclusterLabelValues)
 	collectAcrPullIdentityMetric(ch, hcluster, hclusterLabelValues)
 	collectAwsCredsMetric(ch, hcluster, hclusterLabelValues)
+	collectGcpCredsMetric(ch, hcluster, hclusterLabelValues)
 	collectDeletingMetrics(ch, c.clock, hcluster, hclusterLabelValues)
 }
 
@@ -592,6 +601,16 @@ func collectAwsCredsMetric(ch chan<- prometheus.Metric, hcluster *hyperv1.Hosted
 	credStatus := platformaws.GetCredentialStatus(hcluster)
 	ch <- prometheus.MustNewConstMetric(
 		invalidAwsCredsMetricDesc,
+		prometheus.GaugeValue,
+		float64(credStatus),
+		hclusterLabelValues...,
+	)
+}
+
+func collectGcpCredsMetric(ch chan<- prometheus.Metric, hcluster *hyperv1.HostedCluster, hclusterLabelValues []string) {
+	credStatus := platformgcp.GetCredentialStatus(hcluster)
+	ch <- prometheus.MustNewConstMetric(
+		invalidGcpCredsMetricDesc,
 		prometheus.GaugeValue,
 		float64(credStatus),
 		hclusterLabelValues...,

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -638,6 +638,94 @@ func TestReportInvalidAwsCreds(t *testing.T) {
 	}
 }
 
+func TestReportInvalidGcpCreds(t *testing.T) {
+	wrapExpectedValueAsMetric := func(expectedValue float64) *dto.MetricFamily {
+		return createMetricValue(
+			InvalidGcpCredsMetricName,
+			invalidGcpCredsMetricHelp,
+			expectedValue)
+	}
+
+	testCases := []struct {
+		name                                      string
+		ValidGCPWorkloadIdentityConditionStatus   metav1.ConditionStatus
+		ValidGCPCredentialsConditionStatus         metav1.ConditionStatus
+		expected                                  *dto.MetricFamily
+	}{
+		{
+			name:                                    "When both conditions are true, metric is reported with a value set to 0 (valid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
+			ValidGCPCredentialsConditionStatus:       metav1.ConditionTrue,
+			expected:                                wrapExpectedValueAsMetric(0),
+		},
+		{
+			name:                                    "When ValidGCPWorkloadIdentity is false, metric is reported with a value set to 1 (invalid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionFalse,
+			ValidGCPCredentialsConditionStatus:       metav1.ConditionTrue,
+			expected:                                wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                                    "When ValidGCPCredentials is false, metric is reported with a value set to 1 (invalid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
+			ValidGCPCredentialsConditionStatus:       metav1.ConditionFalse,
+			expected:                                wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                                    "When both conditions are false, metric is reported with a value set to 1 (invalid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionFalse,
+			ValidGCPCredentialsConditionStatus:       metav1.ConditionFalse,
+			expected:                                wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                                    "When ValidGCPWorkloadIdentity is unknown, metric is reported with a value set to 2 (unknown)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionUnknown,
+			ValidGCPCredentialsConditionStatus:       metav1.ConditionTrue,
+			expected:                                wrapExpectedValueAsMetric(2),
+		},
+		{
+			name:                                    "When ValidGCPCredentials is unknown, metric is reported with a value set to 2 (unknown)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
+			ValidGCPCredentialsConditionStatus:       metav1.ConditionUnknown,
+			expected:                                wrapExpectedValueAsMetric(2),
+		},
+		{
+			name:                                    "When both conditions are unknown, metric is reported with a value set to 2 (unknown)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionUnknown,
+			ValidGCPCredentialsConditionStatus:       metav1.ConditionUnknown,
+			expected:                                wrapExpectedValueAsMetric(2),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcluster := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hc",
+					Namespace: "any",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					ClusterID: "id",
+				},
+			}
+
+			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
+				Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+				Status: tc.ValidGCPWorkloadIdentityConditionStatus,
+			})
+			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
+				Type:   string(hyperv1.ValidGCPCredentials),
+				Status: tc.ValidGCPCredentialsConditionStatus,
+			})
+
+			checkMetric(t,
+				fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(hcluster).Build(),
+				clock.RealClock{},
+				InvalidGcpCredsMetricName,
+				tc.expected)
+		})
+	}
+}
+
 func TestReportGuestCloudResourcesDeletionDuration(t *testing.T) {
 	wrapExpectedValueAsMetric := func(expectedValue float64) *dto.MetricFamily {
 		return createMetricValue(

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -1509,6 +1509,135 @@ func TestReportTransitionDurationForAWSEndpointConditions(t *testing.T) {
 	}
 }
 
+func TestReportTransitionDurationForGCPEndpointConditions(t *testing.T) {
+	testCases := []struct {
+		name               string
+		conditions         []metav1.Condition
+		expectedConditions []string
+	}{
+		{
+			name:               "When no GCP endpoint conditions are set, no transition duration is recorded",
+			conditions:         nil,
+			expectedConditions: nil,
+		},
+		{
+			name: "When GCPServiceAttachmentAvailable is true, it should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPServiceAttachmentAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{string(hyperv1.GCPServiceAttachmentAvailable)},
+		},
+		{
+			name: "When GCPEndpointAvailable is true, it should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPEndpointAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(3 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{string(hyperv1.GCPEndpointAvailable)},
+		},
+		{
+			name: "When both GCP endpoint conditions are true, both should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPServiceAttachmentAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+				{
+					Type:               string(hyperv1.GCPEndpointAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(5 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{
+				string(hyperv1.GCPServiceAttachmentAvailable),
+				string(hyperv1.GCPEndpointAvailable),
+			},
+		},
+		{
+			name: "When GCPServiceAttachmentAvailable is false, it should not be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPServiceAttachmentAvailable),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+			},
+			expectedConditions: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcluster := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "hc",
+					Namespace:         "any",
+					CreationTimestamp: metav1.Time{Time: now},
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					ClusterID: "id",
+				},
+				Status: hyperv1.HostedClusterStatus{
+					Conditions: tc.conditions,
+				},
+			}
+
+			collectTime := now.Add(10 * time.Minute)
+
+			reg := prometheus.NewPedanticRegistry()
+			reg.MustRegister(createHostedClustersMetricsCollector(
+				fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(hcluster).Build(),
+				clocktesting.NewFakeClock(collectTime),
+			))
+
+			result, err := reg.Gather()
+			if err != nil {
+				t.Fatalf("gathering metrics failed: %v", err)
+			}
+
+			metricFamily := findMetricValue(&result, TransitionDurationMetricName)
+			observedConditions := map[string]bool{}
+			if metricFamily != nil {
+				for _, m := range metricFamily.Metric {
+					for _, label := range m.Label {
+						if label.GetName() == "condition" && m.Histogram != nil && m.Histogram.GetSampleCount() > 0 {
+							observedConditions[label.GetValue()] = true
+						}
+					}
+				}
+			}
+
+			for _, expected := range tc.expectedConditions {
+				if !observedConditions[expected] {
+					t.Errorf("expected condition %q to be observed in transition duration metric, but it was not", expected)
+				}
+			}
+
+			gcpConditions := map[string]bool{
+				string(hyperv1.GCPEndpointAvailable):        true,
+				string(hyperv1.GCPServiceAttachmentAvailable): true,
+			}
+			expectedSet := map[string]bool{}
+			for _, c := range tc.expectedConditions {
+				expectedSet[c] = true
+			}
+			for condition := range observedConditions {
+				if gcpConditions[condition] && !expectedSet[condition] {
+					t.Errorf("unexpected GCP condition %q was observed in transition duration metric", condition)
+				}
+			}
+		})
+	}
+}
+
 func createCa(notBefore, notAfter time.Time) (*x509.Certificate, string, error) {
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(2019),

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -647,51 +647,51 @@ func TestReportInvalidGcpCreds(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name                                      string
-		ValidGCPWorkloadIdentityConditionStatus   metav1.ConditionStatus
-		ValidGCPCredentialsConditionStatus         metav1.ConditionStatus
-		expected                                  *dto.MetricFamily
+		name                                    string
+		ValidGCPWorkloadIdentityConditionStatus metav1.ConditionStatus
+		ValidGCPCredentialsConditionStatus      metav1.ConditionStatus
+		expected                                *dto.MetricFamily
 	}{
 		{
 			name:                                    "When both conditions are true, metric is reported with a value set to 0 (valid)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
-			ValidGCPCredentialsConditionStatus:       metav1.ConditionTrue,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionTrue,
 			expected:                                wrapExpectedValueAsMetric(0),
 		},
 		{
 			name:                                    "When ValidGCPWorkloadIdentity is false, metric is reported with a value set to 1 (invalid)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionFalse,
-			ValidGCPCredentialsConditionStatus:       metav1.ConditionTrue,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionTrue,
 			expected:                                wrapExpectedValueAsMetric(1),
 		},
 		{
 			name:                                    "When ValidGCPCredentials is false, metric is reported with a value set to 1 (invalid)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
-			ValidGCPCredentialsConditionStatus:       metav1.ConditionFalse,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionFalse,
 			expected:                                wrapExpectedValueAsMetric(1),
 		},
 		{
 			name:                                    "When both conditions are false, metric is reported with a value set to 1 (invalid)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionFalse,
-			ValidGCPCredentialsConditionStatus:       metav1.ConditionFalse,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionFalse,
 			expected:                                wrapExpectedValueAsMetric(1),
 		},
 		{
 			name:                                    "When ValidGCPWorkloadIdentity is unknown, metric is reported with a value set to 2 (unknown)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionUnknown,
-			ValidGCPCredentialsConditionStatus:       metav1.ConditionTrue,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionTrue,
 			expected:                                wrapExpectedValueAsMetric(2),
 		},
 		{
 			name:                                    "When ValidGCPCredentials is unknown, metric is reported with a value set to 2 (unknown)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
-			ValidGCPCredentialsConditionStatus:       metav1.ConditionUnknown,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionUnknown,
 			expected:                                wrapExpectedValueAsMetric(2),
 		},
 		{
 			name:                                    "When both conditions are unknown, metric is reported with a value set to 2 (unknown)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionUnknown,
-			ValidGCPCredentialsConditionStatus:       metav1.ConditionUnknown,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionUnknown,
 			expected:                                wrapExpectedValueAsMetric(2),
 		},
 	}
@@ -1710,7 +1710,7 @@ func TestReportTransitionDurationForGCPEndpointConditions(t *testing.T) {
 			}
 
 			gcpConditions := map[string]bool{
-				string(hyperv1.GCPEndpointAvailable):        true,
+				string(hyperv1.GCPEndpointAvailable):          true,
 				string(hyperv1.GCPServiceAttachmentAvailable): true,
 			}
 			expectedSet := map[string]bool{}

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -63,17 +63,10 @@ func ExpectedHCConditions(hostedCluster *hyperv1.HostedCluster) map[hyperv1.Cond
 			conditions[hyperv1.ValidAzureKMSConfig] = metav1.ConditionTrue
 		}
 	case hyperv1.GCPPlatform:
-		// GCP Workload Identity Federation validation - always required
 		conditions[hyperv1.ValidGCPWorkloadIdentity] = metav1.ConditionTrue
-
-		// GCP credentials validation - indicates WIF readiness
 		conditions[hyperv1.ValidGCPCredentials] = metav1.ConditionTrue
-
-		// GCP KMS validation - future support for GCP KMS secret encryption
-		// Following the same pattern as AWS and Azure
-		// Note: GCP KMS integration is not yet implemented but prepared for future use
-		// When GCP KMS is implemented, we'll check for hostedCluster.Spec.SecretEncryption.KMS.GCP
-		// conditions[hyperv1.ValidGCPKMSConfig] = metav1.ConditionUnknown
+		conditions[hyperv1.GCPEndpointAvailable] = metav1.ConditionTrue
+		conditions[hyperv1.GCPServiceAttachmentAvailable] = metav1.ConditionTrue
 	case hyperv1.KubevirtPlatform:
 		if hostedCluster.Spec.Networking.NetworkType == hyperv1.OVNKubernetes {
 			if hostedCluster.Annotations[hyperv1.ManagementPlatformAnnotation] == string(hyperv1.AWSPlatform) {

--- a/support/conditions/conditions_test.go
+++ b/support/conditions/conditions_test.go
@@ -1,0 +1,105 @@
+package conditions
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExpectedHCConditions(t *testing.T) {
+	tests := []struct {
+		name               string
+		hostedCluster      *hyperv1.HostedCluster
+		expectedConditions map[hyperv1.ConditionType]metav1.ConditionStatus
+		unexpectedTypes    []hyperv1.ConditionType
+	}{
+		{
+			name: "When platform is GCP, it should include GCP credential and PSC conditions",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.GCPPlatform,
+					},
+					Etcd: hyperv1.EtcdSpec{
+						ManagementType: hyperv1.Managed,
+					},
+				},
+			},
+			expectedConditions: map[hyperv1.ConditionType]metav1.ConditionStatus{
+				hyperv1.ValidGCPWorkloadIdentity:      metav1.ConditionTrue,
+				hyperv1.ValidGCPCredentials:           metav1.ConditionTrue,
+				hyperv1.GCPEndpointAvailable:          metav1.ConditionTrue,
+				hyperv1.GCPServiceAttachmentAvailable: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "When platform is AWS with private endpoint, it should include AWS endpoint conditions",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Private,
+						},
+					},
+					Etcd: hyperv1.EtcdSpec{
+						ManagementType: hyperv1.Managed,
+					},
+				},
+			},
+			expectedConditions: map[hyperv1.ConditionType]metav1.ConditionStatus{
+				hyperv1.ValidOIDCConfiguration:         metav1.ConditionTrue,
+				hyperv1.ValidAWSIdentityProvider:       metav1.ConditionTrue,
+				hyperv1.AWSDefaultSecurityGroupCreated: metav1.ConditionTrue,
+				hyperv1.AWSEndpointAvailable:           metav1.ConditionTrue,
+				hyperv1.AWSEndpointServiceAvailable:    metav1.ConditionTrue,
+				hyperv1.ValidAWSKMSConfig:              metav1.ConditionUnknown,
+			},
+			unexpectedTypes: []hyperv1.ConditionType{
+				hyperv1.ValidGCPWorkloadIdentity,
+				hyperv1.GCPEndpointAvailable,
+			},
+		},
+		{
+			name: "When platform is GCP, it should not include AWS-specific conditions",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.GCPPlatform,
+					},
+					Etcd: hyperv1.EtcdSpec{
+						ManagementType: hyperv1.Managed,
+					},
+				},
+			},
+			unexpectedTypes: []hyperv1.ConditionType{
+				hyperv1.ValidOIDCConfiguration,
+				hyperv1.ValidAWSIdentityProvider,
+				hyperv1.AWSEndpointAvailable,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result := ExpectedHCConditions(tt.hostedCluster)
+
+			for condType, expectedStatus := range tt.expectedConditions {
+				status, exists := result[condType]
+				g.Expect(exists).To(BeTrue(), "condition %s should be present", condType)
+				g.Expect(status).To(Equal(expectedStatus), "condition %s should have status %s", condType, expectedStatus)
+			}
+
+			for _, condType := range tt.unexpectedTypes {
+				_, exists := result[condType]
+				g.Expect(exists).To(BeFalse(), "condition %s should not be present", condType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `GCPEndpointAvailable` and `GCPServiceAttachmentAvailable` to `ExpectedHCConditions()` so PSC failures surface in `hypershift_hostedclusters_failure_conditions`
- Track GCP PSC conditions in the `hypershift_hosted_cluster_transition_seconds` histogram for latency visibility
- Add `hypershift_cluster_invalid_gcp_creds` gauge metric (0=valid, 1=invalid, 2=unknown) mirroring the AWS credential gauge pattern
- Add `GetCredentialStatus()` tri-state function to the GCP platform package

## Test plan

- [x] `TestGetCredentialStatus` — 8 cases covering valid/invalid/unknown/missing combinations
- [x] `TestReportInvalidGcpCreds` — 7 cases validating gauge metric values
- [x] `TestReportTransitionDurationForGCPEndpointConditions` — 5 cases validating histogram observations
- [x] All existing tests pass with no regressions

Refs: [GCP-959](https://redhat.atlassian.net/browse/GCP-959)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring for GCP credential status, including valid, invalid, and unknown states.
  * Added GCP endpoint and service attachment availability to transition-duration metrics.
* **Bug Fixes**
  * GCP hosted clusters now correctly report endpoint and service attachment availability conditions.
* **Tests**
  * Added coverage for GCP credential status, availability metrics, and expected platform conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->