### PR TITLE
CNTRLPLANE-3997: correct wrangler pages deploy flags for docs publish

### DIFF
--- a/.github/workflows/docs-deploy-reusable.yaml
+++ b/.github/workflows/docs-deploy-reusable.yaml
@@ -37,15 +37,17 @@ jobs:
         if: inputs.production
         env:
           npm_config_cache: ${{ runner.temp }}/.npm
+          HOME: ${{ runner.temp }}
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy site --project-name=hypershift --production --commit-dirty=true
+          command: pages deploy site --project-name=hypershift --branch=main --commit-dirty=true
       - name: Deploy to Cloudflare Pages (Preview)
         if: ${{ !inputs.production && inputs.branch != '' }}
         env:
           npm_config_cache: ${{ runner.temp }}/.npm
+          HOME: ${{ runner.temp }}
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -37,6 +37,7 @@ jobs:
       - name: Deploy to Cloudflare Pages
         env:
           npm_config_cache: ${{ runner.temp }}/.npm
+          HOME: ${{ runner.temp }}
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the [failing "Deploy Production" job](https://github.com/openshift/hypershift/actions/runs/31171749781/job/92845178194) in the new docs production publishing workflow.

- `wrangler pages deploy` (v4) has no `--production` flag — it never existed in any wrangler version. It only classifies a deployment as production by comparing `--branch` against the Cloudflare project's configured production branch (`isProduction = project.production_branch === branch`, confirmed by inspecting the bundled wrangler CLI). Passing `--production` made the command fail with `Unknown argument: production`, exit code 1. Replaced it with `--branch=main`, matching the project's configured production branch, consistent with how the preview job already passes `--branch`.
- The ARC runners have no `$HOME` set, so Wrangler was failing with `EACCES: permission denied, mkdir '/.config'` trying to write its debug log (non-fatal here, but noisy and worth fixing). Set `HOME` to `${{ runner.temp }}` for the `wrangler-action` steps in both the reusable deploy workflow and the PR-preview deploy workflow.

Ref: [CNTRLPLANE-3997](https://redhat.atlassian.net/browse/CNTRLPLANE-3997)

## Test plan

- [ ] Merge and confirm `Docs Publish` / `Deploy Production` succeeds and `https://hypershift.pages.dev/` updates
- [ ] Open a docs PR and confirm the preview deploy still works and produces `https://pr-<number>.hypershift.pages.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation deployment reliability across production and preview environments.
  * Updated production deployments to use the main branch configuration.
  * Ensured deployment processes use a temporary runner directory for consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->