### PR TITLE
feat(gcp): add GCP PSC conditions to metrics and platform-specific gauges

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -459,6 +459,49 @@ func (p GCP) DeleteCredentials(ctx context.Context, c client.Client, hcluster *h
 	return nil
 }
 
+// CredentialStatus represents the status of GCP credentials.
+type CredentialStatus int
+
+const (
+	// CredentialStatusValid indicates that GCP credentials are valid.
+	CredentialStatusValid CredentialStatus = 0
+	// CredentialStatusInvalid indicates that GCP credentials are invalid.
+	CredentialStatusInvalid CredentialStatus = 1
+	// CredentialStatusUnknown indicates that GCP credential status is unknown.
+	CredentialStatusUnknown CredentialStatus = 2
+)
+
+// GetCredentialStatus returns the tri-state credential status for a HostedCluster
+// by inspecting the ValidGCPWorkloadIdentity and ValidGCPCredentials conditions.
+// Returns CredentialStatusInvalid if either condition is False,
+// CredentialStatusValid if both are True,
+// and CredentialStatusUnknown otherwise (missing or Unknown conditions).
+func GetCredentialStatus(hc *hyperv1.HostedCluster) CredentialStatus {
+	var wifStatus metav1.ConditionStatus
+	validWIF := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPWorkloadIdentity))
+	if validWIF == nil {
+		wifStatus = metav1.ConditionUnknown
+	} else {
+		wifStatus = validWIF.Status
+	}
+
+	var credsStatus metav1.ConditionStatus
+	validCredentials := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPCredentials))
+	if validCredentials == nil {
+		credsStatus = metav1.ConditionUnknown
+	} else {
+		credsStatus = validCredentials.Status
+	}
+
+	if wifStatus == metav1.ConditionFalse || credsStatus == metav1.ConditionFalse {
+		return CredentialStatusInvalid
+	}
+	if wifStatus == metav1.ConditionTrue && credsStatus == metav1.ConditionTrue {
+		return CredentialStatusValid
+	}
+	return CredentialStatusUnknown
+}
+
 // ValidCredentials checks if GCP credentials are valid and ready for use.
 // This function validates Workload Identity Federation configuration and status.
 func ValidCredentials(hc *hyperv1.HostedCluster) bool {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
@@ -128,6 +128,109 @@ func TestValidCredentials(t *testing.T) {
 	}
 }
 
+// TestGetCredentialStatus tests the GetCredentialStatus function for all combinations
+// of ValidGCPWorkloadIdentity and ValidGCPCredentials condition states.
+func TestGetCredentialStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		conditions  []metav1.Condition
+		expected    CredentialStatus
+		description string
+	}{
+		{
+			name: "When both conditions are true, status is Valid (0)",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
+			},
+			expected:    CredentialStatusValid,
+			description: "Both conditions present and true → Valid",
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is false, status is Invalid (1)",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
+			},
+			expected:    CredentialStatusInvalid,
+			description: "ValidGCPWorkloadIdentity false → Invalid",
+		},
+		{
+			name: "When ValidGCPCredentials is false, status is Invalid (1)",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+			},
+			expected:    CredentialStatusInvalid,
+			description: "ValidGCPCredentials false → Invalid",
+		},
+		{
+			name: "When both conditions are false, status is Invalid (1)",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+			},
+			expected:    CredentialStatusInvalid,
+			description: "Both false → Invalid",
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is unknown, status is Unknown (2)",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionUnknown},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
+			},
+			expected:    CredentialStatusUnknown,
+			description: "ValidGCPWorkloadIdentity unknown → Unknown",
+		},
+		{
+			name: "When ValidGCPCredentials is unknown, status is Unknown (2)",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionUnknown},
+			},
+			expected:    CredentialStatusUnknown,
+			description: "ValidGCPCredentials unknown → Unknown",
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is missing, status is Unknown (2)",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
+			},
+			expected:    CredentialStatusUnknown,
+			description: "ValidGCPWorkloadIdentity missing → Unknown",
+		},
+		{
+			name: "When ValidGCPCredentials is missing, status is Unknown (2)",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
+			},
+			expected:    CredentialStatusUnknown,
+			description: "ValidGCPCredentials missing → Unknown",
+		},
+		{
+			name:        "When no conditions exist, status is Unknown (2)",
+			conditions:  []metav1.Condition{},
+			expected:    CredentialStatusUnknown,
+			description: "No conditions → Unknown (covers non-GCP clusters)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hc := &hyperv1.HostedCluster{
+				Status: hyperv1.HostedClusterStatus{
+					Conditions: tt.conditions,
+				},
+			}
+
+			result := GetCredentialStatus(hc)
+			g.Expect(result).To(Equal(tt.expected), tt.description)
+		})
+	}
+}
+
 // TestWorkloadIdentityValidationScenarios tests additional edge cases for WIF validation.
 // This expands on the existing TestValidateWorkloadIdentityConfiguration with more comprehensive coverage.
 func TestWorkloadIdentityValidationScenarios(t *testing.T) {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
@@ -138,7 +138,7 @@ func TestGetCredentialStatus(t *testing.T) {
 		description string
 	}{
 		{
-			name: "When both conditions are true, status is Valid (0)",
+			name: "When both conditions are true, it should return Valid (0)",
 			conditions: []metav1.Condition{
 				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
 				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
@@ -147,7 +147,7 @@ func TestGetCredentialStatus(t *testing.T) {
 			description: "Both conditions present and true → Valid",
 		},
 		{
-			name: "When ValidGCPWorkloadIdentity is false, status is Invalid (1)",
+			name: "When ValidGCPWorkloadIdentity is false, it should return Invalid (1)",
 			conditions: []metav1.Condition{
 				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
 				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
@@ -156,7 +156,7 @@ func TestGetCredentialStatus(t *testing.T) {
 			description: "ValidGCPWorkloadIdentity false → Invalid",
 		},
 		{
-			name: "When ValidGCPCredentials is false, status is Invalid (1)",
+			name: "When ValidGCPCredentials is false, it should return Invalid (1)",
 			conditions: []metav1.Condition{
 				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
 				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
@@ -165,7 +165,7 @@ func TestGetCredentialStatus(t *testing.T) {
 			description: "ValidGCPCredentials false → Invalid",
 		},
 		{
-			name: "When both conditions are false, status is Invalid (1)",
+			name: "When both conditions are false, it should return Invalid (1)",
 			conditions: []metav1.Condition{
 				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
 				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
@@ -174,7 +174,25 @@ func TestGetCredentialStatus(t *testing.T) {
 			description: "Both false → Invalid",
 		},
 		{
-			name: "When ValidGCPWorkloadIdentity is unknown, status is Unknown (2)",
+			name: "When ValidGCPWorkloadIdentity is false and ValidGCPCredentials is unknown, it should return Invalid (1)",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionUnknown},
+			},
+			expected:    CredentialStatusInvalid,
+			description: "ValidGCPWorkloadIdentity false overrides ValidGCPCredentials unknown → Invalid",
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is unknown and ValidGCPCredentials is false, it should return Invalid (1)",
+			conditions: []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionUnknown},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+			},
+			expected:    CredentialStatusInvalid,
+			description: "ValidGCPCredentials false overrides ValidGCPWorkloadIdentity unknown → Invalid",
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is unknown, it should return Unknown (2)",
 			conditions: []metav1.Condition{
 				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionUnknown},
 				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
@@ -183,7 +201,7 @@ func TestGetCredentialStatus(t *testing.T) {
 			description: "ValidGCPWorkloadIdentity unknown → Unknown",
 		},
 		{
-			name: "When ValidGCPCredentials is unknown, status is Unknown (2)",
+			name: "When ValidGCPCredentials is unknown, it should return Unknown (2)",
 			conditions: []metav1.Condition{
 				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
 				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionUnknown},
@@ -192,7 +210,7 @@ func TestGetCredentialStatus(t *testing.T) {
 			description: "ValidGCPCredentials unknown → Unknown",
 		},
 		{
-			name: "When ValidGCPWorkloadIdentity is missing, status is Unknown (2)",
+			name: "When ValidGCPWorkloadIdentity is missing, it should return Unknown (2)",
 			conditions: []metav1.Condition{
 				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
 			},
@@ -200,7 +218,7 @@ func TestGetCredentialStatus(t *testing.T) {
 			description: "ValidGCPWorkloadIdentity missing → Unknown",
 		},
 		{
-			name: "When ValidGCPCredentials is missing, status is Unknown (2)",
+			name: "When ValidGCPCredentials is missing, it should return Unknown (2)",
 			conditions: []metav1.Condition{
 				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
 			},
@@ -208,7 +226,7 @@ func TestGetCredentialStatus(t *testing.T) {
 			description: "ValidGCPCredentials missing → Unknown",
 		},
 		{
-			name:        "When no conditions exist, status is Unknown (2)",
+			name:        "When no conditions exist, it should return Unknown (2)",
 			conditions:  []metav1.Condition{},
 			expected:    CredentialStatusUnknown,
 			description: "No conditions → Unknown (covers non-GCP clusters)",

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	platformaws "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/aws"
+	platformgcp "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/gcp"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/proxy"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/conditions"
@@ -74,6 +75,9 @@ const (
 
 	InvalidAwsCredsMetricName = "hypershift_cluster_invalid_aws_creds"
 	invalidAwsCredsMetricHelp = "AWS credential status for the HostedCluster: 0=valid, 1=invalid, 2=unknown"
+
+	InvalidGcpCredsMetricName = "hypershift_cluster_invalid_gcp_creds"
+	invalidGcpCredsMetricHelp = "GCP credential status for the HostedCluster: 0=valid, 1=invalid, 2=unknown"
 
 	DeletingDurationMetricName = "hypershift_cluster_deleting_duration_seconds"
 	deletingDurationMetricHelp = "Time in seconds it is taking to delete the HostedCluster since the beginning of the delete. " +
@@ -175,6 +179,10 @@ var (
 
 	invalidAwsCredsMetricDesc = prometheus.NewDesc(
 		InvalidAwsCredsMetricName, invalidAwsCredsMetricHelp,
+		hclusterLabels, nil)
+
+	invalidGcpCredsMetricDesc = prometheus.NewDesc(
+		InvalidGcpCredsMetricName, invalidGcpCredsMetricHelp,
 		hclusterLabels, nil)
 
 	deletingDurationMetricDesc = prometheus.NewDesc(
@@ -356,7 +364,7 @@ func collectFailureConditionCounts(hcluster *hyperv1.HostedCluster, platform hyp
 }
 
 func (c *hostedClustersMetricsCollector) collectTransitionDurationMetrics(hcluster *hyperv1.HostedCluster, currentCollectTime time.Time) {
-	for _, conditionType := range []hyperv1.ConditionType{hyperv1.EtcdAvailable, hyperv1.InfrastructureReady, hyperv1.ExternalDNSReachable, hyperv1.AWSEndpointServiceAvailable, hyperv1.AWSEndpointAvailable} {
+	for _, conditionType := range []hyperv1.ConditionType{hyperv1.EtcdAvailable, hyperv1.InfrastructureReady, hyperv1.ExternalDNSReachable, hyperv1.AWSEndpointServiceAvailable, hyperv1.AWSEndpointAvailable, hyperv1.GCPEndpointAvailable, hyperv1.GCPServiceAttachmentAvailable} {
 		condition := meta.FindStatusCondition(hcluster.Status.Conditions, string(conditionType))
 		if condition != nil && condition.Status == metav1.ConditionTrue {
 			t := condition.LastTransitionTime.Time
@@ -378,6 +386,7 @@ func (c *hostedClustersMetricsCollector) collectPerClusterMetrics(ch chan<- prom
 	collectAzureInfoMetrics(ch, hcluster, hclusterLabelValues)
 	collectAcrPullIdentityMetric(ch, hcluster, hclusterLabelValues)
 	collectAwsCredsMetric(ch, hcluster, hclusterLabelValues)
+	collectGcpCredsMetric(ch, hcluster, hclusterLabelValues)
 	collectDeletingMetrics(ch, c.clock, hcluster, hclusterLabelValues)
 }
 
@@ -592,6 +601,18 @@ func collectAwsCredsMetric(ch chan<- prometheus.Metric, hcluster *hyperv1.Hosted
 	credStatus := platformaws.GetCredentialStatus(hcluster)
 	ch <- prometheus.MustNewConstMetric(
 		invalidAwsCredsMetricDesc,
+		prometheus.GaugeValue,
+		float64(credStatus),
+		hclusterLabelValues...,
+	)
+}
+
+// collectGcpCredsMetric emits the GCP credential status gauge for every HostedCluster.
+// Non-GCP clusters will report CredentialStatusUnknown (2), matching the AWS pattern.
+func collectGcpCredsMetric(ch chan<- prometheus.Metric, hcluster *hyperv1.HostedCluster, hclusterLabelValues []string) {
+	credStatus := platformgcp.GetCredentialStatus(hcluster)
+	ch <- prometheus.MustNewConstMetric(
+		invalidGcpCredsMetricDesc,
 		prometheus.GaugeValue,
 		float64(credStatus),
 		hclusterLabelValues...,

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -638,6 +638,94 @@ func TestReportInvalidAwsCreds(t *testing.T) {
 	}
 }
 
+func TestReportInvalidGcpCreds(t *testing.T) {
+	wrapExpectedValueAsMetric := func(expectedValue float64) *dto.MetricFamily {
+		return createMetricValue(
+			InvalidGcpCredsMetricName,
+			invalidGcpCredsMetricHelp,
+			expectedValue)
+	}
+
+	testCases := []struct {
+		name                                    string
+		ValidGCPWorkloadIdentityConditionStatus metav1.ConditionStatus
+		ValidGCPCredentialsConditionStatus      metav1.ConditionStatus
+		expected                                *dto.MetricFamily
+	}{
+		{
+			name:                                    "When both conditions are true, metric is reported with a value set to 0 (valid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionTrue,
+			expected:                                wrapExpectedValueAsMetric(0),
+		},
+		{
+			name:                                    "When ValidGCPWorkloadIdentity status is false, metric is reported with a value set to 1 (invalid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionFalse,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionTrue,
+			expected:                                wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                                    "When ValidGCPCredentials status is false, metric is reported with a value set to 1 (invalid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionFalse,
+			expected:                                wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                                    "When both conditions are false, metric is reported with a value set to 1 (invalid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionFalse,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionFalse,
+			expected:                                wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                                    "When ValidGCPWorkloadIdentity status is unknown, metric is reported with a value set to 2 (unknown)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionUnknown,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionTrue,
+			expected:                                wrapExpectedValueAsMetric(2),
+		},
+		{
+			name:                                    "When ValidGCPCredentials status is unknown, metric is reported with a value set to 2 (unknown)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionUnknown,
+			expected:                                wrapExpectedValueAsMetric(2),
+		},
+		{
+			name:                                    "When both conditions are unknown, metric is reported with a value set to 2 (unknown)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionUnknown,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionUnknown,
+			expected:                                wrapExpectedValueAsMetric(2),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcluster := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hc",
+					Namespace: "any",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					ClusterID: "id",
+				},
+			}
+
+			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
+				Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+				Status: tc.ValidGCPWorkloadIdentityConditionStatus,
+			})
+			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
+				Type:   string(hyperv1.ValidGCPCredentials),
+				Status: tc.ValidGCPCredentialsConditionStatus,
+			})
+
+			checkMetric(t,
+				fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(hcluster).Build(),
+				clock.RealClock{},
+				InvalidGcpCredsMetricName,
+				tc.expected)
+		})
+	}
+}
+
 func TestReportGuestCloudResourcesDeletionDuration(t *testing.T) {
 	wrapExpectedValueAsMetric := func(expectedValue float64) *dto.MetricFamily {
 		return createMetricValue(
@@ -1503,6 +1591,137 @@ func TestReportTransitionDurationForAWSEndpointConditions(t *testing.T) {
 			for condition := range observedConditions {
 				if awsConditions[condition] && !expectedSet[condition] {
 					t.Errorf("unexpected AWS condition %q was observed in transition duration metric", condition)
+				}
+			}
+		})
+	}
+}
+
+func TestReportTransitionDurationForGCPEndpointConditions(t *testing.T) {
+	testCases := []struct {
+		name               string
+		conditions         []metav1.Condition
+		expectedConditions []string
+	}{
+		{
+			name:               "When no GCP endpoint conditions are set, no transition duration is recorded",
+			conditions:         nil,
+			expectedConditions: nil,
+		},
+		{
+			name: "When GCPEndpointAvailable is true, it should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPEndpointAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{string(hyperv1.GCPEndpointAvailable)},
+		},
+		{
+			name: "When GCPServiceAttachmentAvailable is true, it should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPServiceAttachmentAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(3 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{string(hyperv1.GCPServiceAttachmentAvailable)},
+		},
+		{
+			name: "When both GCP endpoint conditions are true, both should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPEndpointAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+				{
+					Type:               string(hyperv1.GCPServiceAttachmentAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(5 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{
+				string(hyperv1.GCPEndpointAvailable),
+				string(hyperv1.GCPServiceAttachmentAvailable),
+			},
+		},
+		{
+			name: "When GCPEndpointAvailable is false, it should not be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPEndpointAvailable),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+			},
+			expectedConditions: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcluster := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "hc",
+					Namespace:         "any",
+					CreationTimestamp: metav1.Time{Time: now},
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					ClusterID: "id",
+				},
+				Status: hyperv1.HostedClusterStatus{
+					Conditions: tc.conditions,
+				},
+			}
+
+			// Use a collect time after all transition times so observations fall in the window
+			collectTime := now.Add(10 * time.Minute)
+
+			reg := prometheus.NewPedanticRegistry()
+			reg.MustRegister(createHostedClustersMetricsCollector(
+				fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(hcluster).Build(),
+				clocktesting.NewFakeClock(collectTime),
+			))
+
+			result, err := reg.Gather()
+			if err != nil {
+				t.Fatalf("gathering metrics failed: %v", err)
+			}
+
+			metricFamily := findMetricValue(&result, TransitionDurationMetricName)
+			observedConditions := map[string]bool{}
+			if metricFamily != nil {
+				for _, m := range metricFamily.Metric {
+					for _, label := range m.Label {
+						if label.GetName() == "condition" && m.Histogram != nil && m.Histogram.GetSampleCount() > 0 {
+							observedConditions[label.GetValue()] = true
+						}
+					}
+				}
+			}
+
+			for _, expected := range tc.expectedConditions {
+				if !observedConditions[expected] {
+					t.Errorf("expected condition %q to be observed in transition duration metric, but it was not", expected)
+				}
+			}
+
+			// Verify no unexpected GCP endpoint conditions were observed
+			gcpConditions := map[string]bool{
+				string(hyperv1.GCPEndpointAvailable):          true,
+				string(hyperv1.GCPServiceAttachmentAvailable): true,
+			}
+			expectedSet := map[string]bool{}
+			for _, c := range tc.expectedConditions {
+				expectedSet[c] = true
+			}
+			for condition := range observedConditions {
+				if gcpConditions[condition] && !expectedSet[condition] {
+					t.Errorf("unexpected GCP condition %q was observed in transition duration metric", condition)
 				}
 			}
 		})

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -653,43 +653,55 @@ func TestReportInvalidGcpCreds(t *testing.T) {
 		expected                                *dto.MetricFamily
 	}{
 		{
-			name:                                    "When both conditions are true, metric is reported with a value set to 0 (valid)",
+			name:                                    "When both conditions are true, it should report metric value 0 (valid)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
 			ValidGCPCredentialsConditionStatus:      metav1.ConditionTrue,
 			expected:                                wrapExpectedValueAsMetric(0),
 		},
 		{
-			name:                                    "When ValidGCPWorkloadIdentity status is false, metric is reported with a value set to 1 (invalid)",
+			name:                                    "When ValidGCPWorkloadIdentity status is false, it should report metric value 1 (invalid)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionFalse,
 			ValidGCPCredentialsConditionStatus:      metav1.ConditionTrue,
 			expected:                                wrapExpectedValueAsMetric(1),
 		},
 		{
-			name:                                    "When ValidGCPCredentials status is false, metric is reported with a value set to 1 (invalid)",
+			name:                                    "When ValidGCPCredentials status is false, it should report metric value 1 (invalid)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
 			ValidGCPCredentialsConditionStatus:      metav1.ConditionFalse,
 			expected:                                wrapExpectedValueAsMetric(1),
 		},
 		{
-			name:                                    "When both conditions are false, metric is reported with a value set to 1 (invalid)",
+			name:                                    "When both conditions are false, it should report metric value 1 (invalid)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionFalse,
 			ValidGCPCredentialsConditionStatus:      metav1.ConditionFalse,
 			expected:                                wrapExpectedValueAsMetric(1),
 		},
 		{
-			name:                                    "When ValidGCPWorkloadIdentity status is unknown, metric is reported with a value set to 2 (unknown)",
+			name:                                    "When ValidGCPWorkloadIdentity is false and ValidGCPCredentials is unknown, it should report metric value 1 (invalid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionFalse,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionUnknown,
+			expected:                                wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                                    "When ValidGCPWorkloadIdentity is unknown and ValidGCPCredentials is false, it should report metric value 1 (invalid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionUnknown,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionFalse,
+			expected:                                wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                                    "When ValidGCPWorkloadIdentity status is unknown, it should report metric value 2 (unknown)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionUnknown,
 			ValidGCPCredentialsConditionStatus:      metav1.ConditionTrue,
 			expected:                                wrapExpectedValueAsMetric(2),
 		},
 		{
-			name:                                    "When ValidGCPCredentials status is unknown, metric is reported with a value set to 2 (unknown)",
+			name:                                    "When ValidGCPCredentials status is unknown, it should report metric value 2 (unknown)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
 			ValidGCPCredentialsConditionStatus:      metav1.ConditionUnknown,
 			expected:                                wrapExpectedValueAsMetric(2),
 		},
 		{
-			name:                                    "When both conditions are unknown, metric is reported with a value set to 2 (unknown)",
+			name:                                    "When both conditions are unknown, it should report metric value 2 (unknown)",
 			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionUnknown,
 			ValidGCPCredentialsConditionStatus:      metav1.ConditionUnknown,
 			expected:                                wrapExpectedValueAsMetric(2),
@@ -1604,7 +1616,7 @@ func TestReportTransitionDurationForGCPEndpointConditions(t *testing.T) {
 		expectedConditions []string
 	}{
 		{
-			name:               "When no GCP endpoint conditions are set, no transition duration is recorded",
+			name:               "When no GCP endpoint conditions are set, it should not record any transition duration",
 			conditions:         nil,
 			expectedConditions: nil,
 		},
@@ -1631,7 +1643,7 @@ func TestReportTransitionDurationForGCPEndpointConditions(t *testing.T) {
 			expectedConditions: []string{string(hyperv1.GCPServiceAttachmentAvailable)},
 		},
 		{
-			name: "When both GCP endpoint conditions are true, both should be observed",
+			name: "When both GCP endpoint conditions are true, it should observe both",
 			conditions: []metav1.Condition{
 				{
 					Type:               string(hyperv1.GCPEndpointAvailable),

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -69,6 +69,12 @@ func ExpectedHCConditions(hostedCluster *hyperv1.HostedCluster) map[hyperv1.Cond
 		// GCP credentials validation - indicates WIF readiness
 		conditions[hyperv1.ValidGCPCredentials] = metav1.ConditionTrue
 
+		// GCP PSC conditions - both GCP endpoint access modes (Private and PublicAndPrivate)
+		// use Private Service Connect, so these are included unconditionally.
+		// There is no GCPEndpointAccessPublic constant in GCP (unlike AWS which has a Public-only mode).
+		conditions[hyperv1.GCPEndpointAvailable] = metav1.ConditionTrue
+		conditions[hyperv1.GCPServiceAttachmentAvailable] = metav1.ConditionTrue
+
 		// GCP KMS validation - future support for GCP KMS secret encryption
 		// Following the same pattern as AWS and Azure
 		// Note: GCP KMS integration is not yet implemented but prepared for future use

--- a/support/conditions/conditions_test.go
+++ b/support/conditions/conditions_test.go
@@ -3,10 +3,9 @@ package conditions
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	. "github.com/onsi/gomega"
 )
 
 func TestExpectedHCConditionsGCPPlatform(t *testing.T) {

--- a/support/conditions/conditions_test.go
+++ b/support/conditions/conditions_test.go
@@ -1,0 +1,107 @@
+package conditions
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestExpectedHCConditionsGCPPlatform(t *testing.T) {
+	tests := []struct {
+		name               string
+		hostedCluster      *hyperv1.HostedCluster
+		expectedConditions map[hyperv1.ConditionType]metav1.ConditionStatus
+	}{
+		{
+			name: "When platform is GCP, it should include ValidGCPWorkloadIdentity as True",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.GCPPlatform},
+				},
+			},
+			expectedConditions: map[hyperv1.ConditionType]metav1.ConditionStatus{
+				hyperv1.ValidGCPWorkloadIdentity: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "When platform is GCP, it should include ValidGCPCredentials as True",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.GCPPlatform},
+				},
+			},
+			expectedConditions: map[hyperv1.ConditionType]metav1.ConditionStatus{
+				hyperv1.ValidGCPCredentials: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "When platform is GCP, it should include GCPEndpointAvailable as True",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.GCPPlatform},
+				},
+			},
+			expectedConditions: map[hyperv1.ConditionType]metav1.ConditionStatus{
+				hyperv1.GCPEndpointAvailable: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "When platform is GCP, it should include GCPServiceAttachmentAvailable as True",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.GCPPlatform},
+				},
+			},
+			expectedConditions: map[hyperv1.ConditionType]metav1.ConditionStatus{
+				hyperv1.GCPServiceAttachmentAvailable: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "When platform is GCP, it should include all four GCP-specific conditions as True",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.GCPPlatform},
+				},
+			},
+			expectedConditions: map[hyperv1.ConditionType]metav1.ConditionStatus{
+				hyperv1.ValidGCPWorkloadIdentity:      metav1.ConditionTrue,
+				hyperv1.ValidGCPCredentials:           metav1.ConditionTrue,
+				hyperv1.GCPEndpointAvailable:          metav1.ConditionTrue,
+				hyperv1.GCPServiceAttachmentAvailable: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "When platform is not GCP, it should not include GCP-specific conditions",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform},
+				},
+			},
+			expectedConditions: map[hyperv1.ConditionType]metav1.ConditionStatus{
+				hyperv1.ValidGCPWorkloadIdentity:      "",
+				hyperv1.ValidGCPCredentials:           "",
+				hyperv1.GCPEndpointAvailable:          "",
+				hyperv1.GCPServiceAttachmentAvailable: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := ExpectedHCConditions(tt.hostedCluster)
+			for condType, expectedStatus := range tt.expectedConditions {
+				if expectedStatus == "" {
+					g.Expect(result).NotTo(HaveKey(condType),
+						"condition %q should not be present for non-GCP platform", condType)
+				} else {
+					g.Expect(result).To(HaveKeyWithValue(condType, expectedStatus),
+						"condition %q should be %q", condType, expectedStatus)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements [GCP-959](https://redhat.atlassian.net/browse/GCP-959) (GA checklist items 6.1, 6.2, 6.3): add PSC connectivity conditions to failure metrics and transition duration histograms, and expose a GCP credential validity gauge.

## Changes

### 1. GCP `GetCredentialStatus` foundation (`gcp.go`)
- Add `CredentialStatus` type (Valid=0, Invalid=1, Unknown=2) mirroring the AWS pattern
- Add `GetCredentialStatus()` inspecting `ValidGCPWorkloadIdentity` and `ValidGCPCredentials` conditions

### 2. PSC conditions in `ExpectedHCConditions()` (`support/conditions/conditions.go`)
- Add `GCPEndpointAvailable` and `GCPServiceAttachmentAvailable` to the GCP case unconditionally
- Unlike AWS, GCP has no Public-only endpoint access mode — both GCP modes use PSC, so no gate is needed
- **Impact:** PSC failures now appear in `hypershift_hostedclusters_failure_conditions`

### 3. PSC conditions in transition duration metrics (`metrics.go`)
- Add `GCPEndpointAvailable` and `GCPServiceAttachmentAvailable` to `collectTransitionDurationMetrics()`
- **Impact:** PSC setup latency tracked in `hypershift_hosted_cluster_transition_seconds` histogram

### 4. `hypershift_cluster_invalid_gcp_creds` gauge (`metrics.go`)
- Add metric constant, descriptor, `collectGcpCredsMetric()` function
- Called unconditionally from `collectPerClusterMetrics()` — non-GCP clusters report 2 (unknown)

## Tests
- `TestGetCredentialStatus` — all condition combinations for the GCP tri-state function
- `TestReportInvalidGcpCreds` — gauge metric collection for all credential states
- `TestReportTransitionDurationForGCPEndpointConditions` — histogram observation for PSC conditions
- `TestExpectedHCConditionsGCPPlatform` — expected conditions for GCP platform

Jira: https://redhat.atlassian.net/browse/GCP-959

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GCP credential-status reporting for HostedClusters, distinguishing valid, invalid, and unknown states.
  * Added GCP credential validity metrics.
  * Added transition-duration metrics for GCP endpoint and service-attachment conditions.
  * GCP hosted clusters now report endpoint and service-attachment availability conditions.

* **Bug Fixes**
  * Improved handling of missing, unknown, and mixed credential conditions in status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->