### PR TITLE
feat(gcp): add GCP PSC conditions to metrics and add platform-specific gauges

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -42,6 +42,18 @@ import (
 	"github.com/blang/semver"
 )
 
+// CredentialStatus represents the status of GCP credentials.
+type CredentialStatus int
+
+const (
+	// CredentialStatusValid indicates that GCP credentials are valid.
+	CredentialStatusValid CredentialStatus = 0
+	// CredentialStatusInvalid indicates that GCP credentials are invalid.
+	CredentialStatusInvalid CredentialStatus = 1
+	// CredentialStatusUnknown indicates that GCP credential status is unknown.
+	CredentialStatusUnknown CredentialStatus = 2
+)
+
 // GCP implements the Platform interface for Google Cloud Platform.
 //
 // This implementation enables HostedCluster reconciliation for GCP platform
@@ -475,6 +487,40 @@ func ValidCredentials(hc *hyperv1.HostedCluster) bool {
 	}
 
 	return true
+}
+
+// GetCredentialStatus returns the GCP credential status (valid/invalid/unknown).
+// It checks both ValidGCPWorkloadIdentity and ValidGCPCredentials conditions:
+//   - If either is explicitly False → CredentialStatusInvalid (1)
+//   - If both are True → CredentialStatusValid (0)
+//   - Otherwise (missing or unknown) → CredentialStatusUnknown (2)
+//
+// Non-GCP clusters naturally return CredentialStatusUnknown because neither condition
+// will be present on their HostedCluster status.
+func GetCredentialStatus(hc *hyperv1.HostedCluster) CredentialStatus {
+	var wifStatus metav1.ConditionStatus
+	validWIF := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPWorkloadIdentity))
+	if validWIF == nil {
+		wifStatus = metav1.ConditionUnknown
+	} else {
+		wifStatus = validWIF.Status
+	}
+
+	var credStatus metav1.ConditionStatus
+	validCreds := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPCredentials))
+	if validCreds == nil {
+		credStatus = metav1.ConditionUnknown
+	} else {
+		credStatus = validCreds.Status
+	}
+
+	if wifStatus == metav1.ConditionFalse || credStatus == metav1.ConditionFalse {
+		return CredentialStatusInvalid
+	}
+	if wifStatus == metav1.ConditionTrue && credStatus == metav1.ConditionTrue {
+		return CredentialStatusValid
+	}
+	return CredentialStatusUnknown
 }
 
 // validateWorkloadIdentityConfiguration validates the Workload Identity Federation configuration.

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
@@ -128,6 +128,150 @@ func TestValidCredentials(t *testing.T) {
 	}
 }
 
+// TestGetCredentialStatus tests the tri-state GetCredentialStatus function.
+func TestGetCredentialStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		conditions  []metav1.Condition
+		expected    CredentialStatus
+		description string
+	}{
+		{
+			name: "When both conditions are true, status is valid (0)",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected:    CredentialStatusValid,
+			description: "Both conditions present and true → valid",
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is false, status is invalid (1)",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionFalse,
+				},
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected:    CredentialStatusInvalid,
+			description: "ValidGCPWorkloadIdentity false → invalid",
+		},
+		{
+			name: "When ValidGCPCredentials is false, status is invalid (1)",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionFalse,
+				},
+			},
+			expected:    CredentialStatusInvalid,
+			description: "ValidGCPCredentials false → invalid",
+		},
+		{
+			name: "When both conditions are false, status is invalid (1)",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionFalse,
+				},
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionFalse,
+				},
+			},
+			expected:    CredentialStatusInvalid,
+			description: "Both conditions false → invalid",
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is missing, status is unknown (2)",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected:    CredentialStatusUnknown,
+			description: "ValidGCPWorkloadIdentity missing → unknown",
+		},
+		{
+			name: "When ValidGCPCredentials is missing, status is unknown (2)",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected:    CredentialStatusUnknown,
+			description: "ValidGCPCredentials missing → unknown",
+		},
+		{
+			name:        "When no conditions exist, status is unknown (2)",
+			conditions:  []metav1.Condition{},
+			expected:    CredentialStatusUnknown,
+			description: "No conditions present → unknown (covers non-GCP clusters)",
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is unknown, status is unknown (2)",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionUnknown,
+				},
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected:    CredentialStatusUnknown,
+			description: "ValidGCPWorkloadIdentity unknown → unknown",
+		},
+		{
+			name: "When ValidGCPCredentials is unknown, status is unknown (2)",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionUnknown,
+				},
+			},
+			expected:    CredentialStatusUnknown,
+			description: "ValidGCPCredentials unknown → unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hc := &hyperv1.HostedCluster{
+				Status: hyperv1.HostedClusterStatus{
+					Conditions: tt.conditions,
+				},
+			}
+
+			result := GetCredentialStatus(hc)
+			g.Expect(result).To(Equal(tt.expected), tt.description)
+		})
+	}
+}
+
 // TestWorkloadIdentityValidationScenarios tests additional edge cases for WIF validation.
 // This expands on the existing TestValidateWorkloadIdentityConfiguration with more comprehensive coverage.
 func TestWorkloadIdentityValidationScenarios(t *testing.T) {

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -356,7 +356,7 @@ func collectFailureConditionCounts(hcluster *hyperv1.HostedCluster, platform hyp
 }
 
 func (c *hostedClustersMetricsCollector) collectTransitionDurationMetrics(hcluster *hyperv1.HostedCluster, currentCollectTime time.Time) {
-	for _, conditionType := range []hyperv1.ConditionType{hyperv1.EtcdAvailable, hyperv1.InfrastructureReady, hyperv1.ExternalDNSReachable, hyperv1.AWSEndpointServiceAvailable, hyperv1.AWSEndpointAvailable} {
+	for _, conditionType := range []hyperv1.ConditionType{hyperv1.EtcdAvailable, hyperv1.InfrastructureReady, hyperv1.ExternalDNSReachable, hyperv1.AWSEndpointServiceAvailable, hyperv1.AWSEndpointAvailable, hyperv1.GCPEndpointAvailable, hyperv1.GCPServiceAttachmentAvailable} {
 		condition := meta.FindStatusCondition(hcluster.Status.Conditions, string(conditionType))
 		if condition != nil && condition.Status == metav1.ConditionTrue {
 			t := condition.LastTransitionTime.Time

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	platformaws "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/aws"
+	platformgcp "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/gcp"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/proxy"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/conditions"
@@ -74,6 +75,9 @@ const (
 
 	InvalidAwsCredsMetricName = "hypershift_cluster_invalid_aws_creds"
 	invalidAwsCredsMetricHelp = "AWS credential status for the HostedCluster: 0=valid, 1=invalid, 2=unknown"
+
+	InvalidGcpCredsMetricName = "hypershift_cluster_invalid_gcp_creds"
+	invalidGcpCredsMetricHelp = "GCP credential status for the HostedCluster: 0=valid, 1=invalid, 2=unknown"
 
 	DeletingDurationMetricName = "hypershift_cluster_deleting_duration_seconds"
 	deletingDurationMetricHelp = "Time in seconds it is taking to delete the HostedCluster since the beginning of the delete. " +
@@ -175,6 +179,10 @@ var (
 
 	invalidAwsCredsMetricDesc = prometheus.NewDesc(
 		InvalidAwsCredsMetricName, invalidAwsCredsMetricHelp,
+		hclusterLabels, nil)
+
+	invalidGcpCredsMetricDesc = prometheus.NewDesc(
+		InvalidGcpCredsMetricName, invalidGcpCredsMetricHelp,
 		hclusterLabels, nil)
 
 	deletingDurationMetricDesc = prometheus.NewDesc(
@@ -378,6 +386,7 @@ func (c *hostedClustersMetricsCollector) collectPerClusterMetrics(ch chan<- prom
 	collectAzureInfoMetrics(ch, hcluster, hclusterLabelValues)
 	collectAcrPullIdentityMetric(ch, hcluster, hclusterLabelValues)
 	collectAwsCredsMetric(ch, hcluster, hclusterLabelValues)
+	collectGcpCredsMetric(ch, hcluster, hclusterLabelValues)
 	collectDeletingMetrics(ch, c.clock, hcluster, hclusterLabelValues)
 }
 
@@ -592,6 +601,19 @@ func collectAwsCredsMetric(ch chan<- prometheus.Metric, hcluster *hyperv1.Hosted
 	credStatus := platformaws.GetCredentialStatus(hcluster)
 	ch <- prometheus.MustNewConstMetric(
 		invalidAwsCredsMetricDesc,
+		prometheus.GaugeValue,
+		float64(credStatus),
+		hclusterLabelValues...,
+	)
+}
+
+// collectGcpCredsMetric emits the GCP credential status gauge.
+// Non-GCP clusters will report CredentialStatusUnknown (2) because neither
+// ValidGCPWorkloadIdentity nor ValidGCPCredentials will be set on them.
+func collectGcpCredsMetric(ch chan<- prometheus.Metric, hcluster *hyperv1.HostedCluster, hclusterLabelValues []string) {
+	credStatus := platformgcp.GetCredentialStatus(hcluster)
+	ch <- prometheus.MustNewConstMetric(
+		invalidGcpCredsMetricDesc,
 		prometheus.GaugeValue,
 		float64(credStatus),
 		hclusterLabelValues...,

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -638,6 +638,94 @@ func TestReportInvalidAwsCreds(t *testing.T) {
 	}
 }
 
+func TestReportInvalidGcpCreds(t *testing.T) {
+	wrapExpectedValueAsMetric := func(expectedValue float64) *dto.MetricFamily {
+		return createMetricValue(
+			InvalidGcpCredsMetricName,
+			invalidGcpCredsMetricHelp,
+			expectedValue)
+	}
+
+	testCases := []struct {
+		name                                    string
+		ValidGCPWorkloadIdentityConditionStatus metav1.ConditionStatus
+		ValidGCPCredentialsConditionStatus      metav1.ConditionStatus
+		expected                                *dto.MetricFamily
+	}{
+		{
+			name:                                    "When both conditions are true, metric is reported with a value set to 0 (valid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionTrue,
+			expected:                                wrapExpectedValueAsMetric(0),
+		},
+		{
+			name:                                    "When ValidGCPWorkloadIdentity status is false, metric is reported with a value set to 1 (invalid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionFalse,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionTrue,
+			expected:                                wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                                    "When ValidGCPCredentials status is false, metric is reported with a value set to 1 (invalid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionFalse,
+			expected:                                wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                                    "When both conditions are false, metric is reported with a value set to 1 (invalid)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionFalse,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionFalse,
+			expected:                                wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                                    "When ValidGCPWorkloadIdentity status is unknown, metric is reported with a value set to 2 (unknown)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionUnknown,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionTrue,
+			expected:                                wrapExpectedValueAsMetric(2),
+		},
+		{
+			name:                                    "When ValidGCPCredentials status is unknown, metric is reported with a value set to 2 (unknown)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionTrue,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionUnknown,
+			expected:                                wrapExpectedValueAsMetric(2),
+		},
+		{
+			name:                                    "When both conditions are unknown, metric is reported with a value set to 2 (unknown)",
+			ValidGCPWorkloadIdentityConditionStatus: metav1.ConditionUnknown,
+			ValidGCPCredentialsConditionStatus:      metav1.ConditionUnknown,
+			expected:                                wrapExpectedValueAsMetric(2),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcluster := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hc",
+					Namespace: "any",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					ClusterID: "id",
+				},
+			}
+
+			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
+				Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+				Status: tc.ValidGCPWorkloadIdentityConditionStatus,
+			})
+			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
+				Type:   string(hyperv1.ValidGCPCredentials),
+				Status: tc.ValidGCPCredentialsConditionStatus,
+			})
+
+			checkMetric(t,
+				fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(hcluster).Build(),
+				clock.RealClock{},
+				InvalidGcpCredsMetricName,
+				tc.expected)
+		})
+	}
+}
+
 func TestReportGuestCloudResourcesDeletionDuration(t *testing.T) {
 	wrapExpectedValueAsMetric := func(expectedValue float64) *dto.MetricFamily {
 		return createMetricValue(

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -1509,6 +1509,137 @@ func TestReportTransitionDurationForAWSEndpointConditions(t *testing.T) {
 	}
 }
 
+func TestReportTransitionDurationForGCPEndpointConditions(t *testing.T) {
+	testCases := []struct {
+		name               string
+		conditions         []metav1.Condition
+		expectedConditions []string
+	}{
+		{
+			name:               "When no GCP endpoint conditions are set, no transition duration is recorded",
+			conditions:         nil,
+			expectedConditions: nil,
+		},
+		{
+			name: "When GCPEndpointAvailable is true, it should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPEndpointAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{string(hyperv1.GCPEndpointAvailable)},
+		},
+		{
+			name: "When GCPServiceAttachmentAvailable is true, it should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPServiceAttachmentAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(3 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{string(hyperv1.GCPServiceAttachmentAvailable)},
+		},
+		{
+			name: "When both GCP endpoint conditions are true, both should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPEndpointAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+				{
+					Type:               string(hyperv1.GCPServiceAttachmentAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(4 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{
+				string(hyperv1.GCPEndpointAvailable),
+				string(hyperv1.GCPServiceAttachmentAvailable),
+			},
+		},
+		{
+			name: "When GCPEndpointAvailable is false, it should not be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPEndpointAvailable),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+			},
+			expectedConditions: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcluster := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "hc",
+					Namespace:         "any",
+					CreationTimestamp: metav1.Time{Time: now},
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					ClusterID: "id",
+				},
+				Status: hyperv1.HostedClusterStatus{
+					Conditions: tc.conditions,
+				},
+			}
+
+			// Use a collect time after all transition times so observations fall in the window
+			collectTime := now.Add(10 * time.Minute)
+
+			reg := prometheus.NewPedanticRegistry()
+			reg.MustRegister(createHostedClustersMetricsCollector(
+				fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(hcluster).Build(),
+				clocktesting.NewFakeClock(collectTime),
+			))
+
+			result, err := reg.Gather()
+			if err != nil {
+				t.Fatalf("gathering metrics failed: %v", err)
+			}
+
+			metricFamily := findMetricValue(&result, TransitionDurationMetricName)
+			observedConditions := map[string]bool{}
+			if metricFamily != nil {
+				for _, m := range metricFamily.Metric {
+					for _, label := range m.Label {
+						if label.GetName() == "condition" && m.Histogram != nil && m.Histogram.GetSampleCount() > 0 {
+							observedConditions[label.GetValue()] = true
+						}
+					}
+				}
+			}
+
+			for _, expected := range tc.expectedConditions {
+				if !observedConditions[expected] {
+					t.Errorf("expected condition %q to be observed in transition duration metric, but it was not", expected)
+				}
+			}
+
+			// Verify no unexpected GCP endpoint conditions were observed
+			gcpConditions := map[string]bool{
+				string(hyperv1.GCPEndpointAvailable):          true,
+				string(hyperv1.GCPServiceAttachmentAvailable): true,
+			}
+			expectedSet := map[string]bool{}
+			for _, c := range tc.expectedConditions {
+				expectedSet[c] = true
+			}
+			for condition := range observedConditions {
+				if gcpConditions[condition] && !expectedSet[condition] {
+					t.Errorf("unexpected GCP condition %q was observed in transition duration metric", condition)
+				}
+			}
+		})
+	}
+}
+
 func createCa(notBefore, notAfter time.Time) (*x509.Certificate, string, error) {
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(2019),

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -69,6 +69,12 @@ func ExpectedHCConditions(hostedCluster *hyperv1.HostedCluster) map[hyperv1.Cond
 		// GCP credentials validation - indicates WIF readiness
 		conditions[hyperv1.ValidGCPCredentials] = metav1.ConditionTrue
 
+		// GCP PSC (Private Service Connect) conditions - both GCP endpoint access modes
+		// (GCPEndpointAccessPrivate and GCPEndpointAccessPublicAndPrivate) use PSC, so
+		// no EndpointAccess gate is needed (unlike AWS which has a Public-only mode).
+		conditions[hyperv1.GCPEndpointAvailable] = metav1.ConditionTrue
+		conditions[hyperv1.GCPServiceAttachmentAvailable] = metav1.ConditionTrue
+
 		// GCP KMS validation - future support for GCP KMS secret encryption
 		// Following the same pattern as AWS and Azure
 		// Note: GCP KMS integration is not yet implemented but prepared for future use


### PR DESCRIPTION
## Summary

Implements [GCP-959](https://redhat.atlassian.net/browse/GCP-959) — Add GCP PSC conditions to metrics and add platform-specific gauges (GA checklist items 6.1, 6.2, 6.3).

### Problem

PSC conditions (`GCPEndpointAvailable`, `GCPServiceAttachmentAvailable`) are set on the HostedCluster by `computeGCPPSCCondition` but were not tracked as expected conditions, so PSC failures did not appear in `hypershift_hostedclusters_failure_conditions` or the transition duration histogram. Additionally, there was no GCP equivalent of `hypershift_cluster_invalid_aws_creds`.

### Changes

**Commit 1: `feat(gcp): add CredentialStatus type and GetCredentialStatus function`**
- Adds a tri-state `CredentialStatus` type (Valid=0, Invalid=1, Unknown=2) and `GetCredentialStatus()` to the GCP platform package, mirroring the AWS pattern.
- Non-GCP clusters naturally return `Unknown` since neither GCP condition will be present on their HostedCluster.

**Commit 2: `feat(gcp): add PSC conditions to ExpectedHCConditions`** (GA 6.1)
- Adds `GCPEndpointAvailable` and `GCPServiceAttachmentAvailable` to the GCP case in `ExpectedHCConditions()` unconditionally — no `EndpointAccess` gate needed since both GCP access modes (`Private`, `PublicAndPrivate`) use PSC (unlike AWS which has a `Public`-only mode).
- PSC failures now appear in `hypershift_hostedclusters_failure_conditions`.

**Commit 3: `feat(metrics): add GCP PSC conditions to transition duration metric`** (GA 6.2)
- Adds `GCPEndpointAvailable` and `GCPServiceAttachmentAvailable` to `collectTransitionDurationMetrics()`.
- PSC setup latency is now tracked in `hypershift_hosted_cluster_transition_seconds`.

**Commit 4: `feat(metrics): add hypershift_cluster_invalid_gcp_creds gauge`** (GA 6.3)
- Adds a new `hypershift_cluster_invalid_gcp_creds` Prometheus gauge (0=valid, 1=invalid, 2=unknown) following the `hypershift_cluster_invalid_aws_creds` pattern.
- Emitted unconditionally for all clusters.

### Tests

- `TestGetCredentialStatus` — 9 cases covering all tri-state combinations
- `TestReportInvalidGcpCreds` — 7 cases mirroring `TestReportInvalidAwsCreds`
- `TestReportTransitionDurationForGCPEndpointConditions` — 5 cases mirroring `TestReportTransitionDurationForAWSEndpointConditions`

### Acceptance Criteria

- [x] PSC failures appear in `hypershift_hostedclusters_failure_conditions` metric
- [x] PSC setup latency tracked in `hypershift_hostedclusters_transition_duration` histogram
- [x] GCP credential validity exposed as Prometheus gauge metric
- [x] Metrics are unit tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added monitoring for invalid GCP credentials, including workload identity status.
  - Added transition-duration metrics for GCP endpoint and service-attachment conditions.

- **Bug Fixes**
  - GCP endpoint and service-attachment availability now report correctly for supported endpoint access modes.

- **Tests**
  - Added coverage for valid, invalid, unknown, and missing GCP credential conditions.
  - Added coverage for GCP condition transition metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->