### PR TITLE
OCPBUGS-105282: Add proxy env vars to cluster-storage-operator deployment

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
+	"github.com/openshift/hypershift/support/proxy"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +15,7 @@ import (
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		proxy.SetEnvVars(&c.Env)
 		envReplacer := newEnvironmentReplacer(cpContext.ReleaseImageProvider, cpContext.UserReleaseImageProvider)
 		envReplacer.replaceEnvVars(c.Env)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment_test.go
@@ -1,0 +1,130 @@
+package storage
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAdaptDeployment(t *testing.T) {
+	testCases := []struct {
+		name       string
+		httpProxy  string
+		httpsProxy string
+		noProxy    string
+		validate   func(*WithT, *corev1.Container)
+	}{
+		{
+			name:       "When proxy environment variables are set, it should add proxy env vars to container",
+			httpProxy:  "http://proxy.example.com:8080",
+			httpsProxy: "https://proxy.example.com:8443",
+			noProxy:    "localhost,127.0.0.1",
+			validate: func(g *WithT, container *corev1.Container) {
+				httpProxy := podspec.FindEnvVar("HTTP_PROXY", container.Env)
+				g.Expect(httpProxy).ToNot(BeNil())
+				g.Expect(httpProxy.Value).To(Equal("http://proxy.example.com:8080"))
+
+				httpsProxy := podspec.FindEnvVar("HTTPS_PROXY", container.Env)
+				g.Expect(httpsProxy).ToNot(BeNil())
+				g.Expect(httpsProxy.Value).To(Equal("https://proxy.example.com:8443"))
+
+				noProxy := podspec.FindEnvVar("NO_PROXY", container.Env)
+				g.Expect(noProxy).ToNot(BeNil())
+				g.Expect(noProxy.Value).To(ContainSubstring("localhost"))
+				g.Expect(noProxy.Value).To(ContainSubstring("127.0.0.1"))
+				g.Expect(noProxy.Value).To(ContainSubstring("kube-apiserver"))
+
+				g.Expect(podspec.FindEnvVar("OPERATOR_IMAGE_VERSION", container.Env)).ToNot(BeNil())
+				g.Expect(podspec.FindEnvVar("AWS_EBS_DRIVER_OPERATOR_IMAGE", container.Env)).ToNot(BeNil())
+				g.Expect(podspec.FindEnvVar("HYPERSHIFT_IMAGE", container.Env)).ToNot(BeNil())
+			},
+		},
+		{
+			name:      "When only HTTP_PROXY is set, it should add HTTP_PROXY and NO_PROXY but not HTTPS_PROXY",
+			httpProxy: "http://proxy.example.com:8080",
+			noProxy:   "localhost,127.0.0.1",
+			validate: func(g *WithT, container *corev1.Container) {
+				httpProxy := podspec.FindEnvVar("HTTP_PROXY", container.Env)
+				g.Expect(httpProxy).ToNot(BeNil())
+				g.Expect(httpProxy.Value).To(Equal("http://proxy.example.com:8080"))
+
+				g.Expect(podspec.FindEnvVar("HTTPS_PROXY", container.Env)).To(BeNil())
+
+				noProxy := podspec.FindEnvVar("NO_PROXY", container.Env)
+				g.Expect(noProxy).ToNot(BeNil())
+				g.Expect(noProxy.Value).To(ContainSubstring("localhost"))
+				g.Expect(noProxy.Value).To(ContainSubstring("127.0.0.1"))
+				g.Expect(noProxy.Value).To(ContainSubstring("kube-apiserver"))
+			},
+		},
+		{
+			name:       "When only HTTPS_PROXY is set, it should add HTTPS_PROXY and NO_PROXY but not HTTP_PROXY",
+			httpsProxy: "https://proxy.example.com:8443",
+			noProxy:    "localhost,127.0.0.1",
+			validate: func(g *WithT, container *corev1.Container) {
+				g.Expect(podspec.FindEnvVar("HTTP_PROXY", container.Env)).To(BeNil())
+
+				httpsProxy := podspec.FindEnvVar("HTTPS_PROXY", container.Env)
+				g.Expect(httpsProxy).ToNot(BeNil())
+				g.Expect(httpsProxy.Value).To(Equal("https://proxy.example.com:8443"))
+
+				noProxy := podspec.FindEnvVar("NO_PROXY", container.Env)
+				g.Expect(noProxy).ToNot(BeNil())
+				g.Expect(noProxy.Value).To(ContainSubstring("localhost"))
+				g.Expect(noProxy.Value).To(ContainSubstring("127.0.0.1"))
+				g.Expect(noProxy.Value).To(ContainSubstring("kube-apiserver"))
+			},
+		},
+		{
+			name: "When no proxy is set, it should not add proxy env vars",
+			validate: func(g *WithT, container *corev1.Container) {
+				g.Expect(podspec.FindEnvVar("HTTP_PROXY", container.Env)).To(BeNil())
+				g.Expect(podspec.FindEnvVar("HTTPS_PROXY", container.Env)).To(BeNil())
+				g.Expect(podspec.FindEnvVar("NO_PROXY", container.Env)).To(BeNil())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			t.Setenv("HTTP_PROXY", tc.httpProxy)
+			t.Setenv("HTTPS_PROXY", tc.httpsProxy)
+			t.Setenv("NO_PROXY", tc.noProxy)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-namespace",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{},
+			}
+
+			cpContext := component.WorkloadContext{
+				HCP:                      hcp,
+				ReleaseImageProvider:     &fakeReleaseImageProvider{images: map[string]string{}, version: "4.18.0"},
+				UserReleaseImageProvider: &fakeReleaseImageProvider{images: map[string]string{}, version: "4.18.0"},
+			}
+
+			deployment, err := assets.LoadDeploymentManifest(ComponentName)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			err = adaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+			g.Expect(container).ToNot(BeNil(), "cluster-storage-operator container should exist")
+
+			tc.validate(g, container)
+		})
+	}
+}


### PR DESCRIPTION
 ## Summary

  - Add `proxy.SetEnvVars(&c.Env)` to the cluster-storage-operator's `adaptDeployment` to inject management cluster proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) into the CSO container
  - Add unit tests covering full proxy, partial proxy (HTTP-only, HTTPS-only), and no-proxy scenarios

  ## Problem

 When the management cluster requires a proxy for external access, the cluster-storage-operator deployment created by CPO does not receive proxy environment variables. This is the first link in a broken chain that ultimately prevents the `aws-ebs-csi-driver-controller` from reaching AWS APIs (e.g. `sts.us-east-1.amazonaws.com`), causing STS token timeouts and failing all PVC provisioning — 26+ conformance tests break.

Guest cluster proxy injection was correctly removed in OCPBUGS-7331/OCPBUGS-7837 because the guest cluster's Proxy CR should not be injected into management cluster components. However, management cluster proxy injection via `os.Getenv()` was never added to replace it.

  ## Fix
`proxy.SetEnvVars(&c.Env)` reads `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` from the CPO process environment (which inherits them from the management cluster) and sets them on the CSO container. This is a no-op when no proxy is configured. 

  This is step 1 of a 3-repo fix:
  1. **HyperShift CPO** (this PR) — Inject proxy env vars into CSO deployment
  2. **cluster-storage-operator** (OCPBUGS-105391) — Pass proxy env vars from `os.Getenv()` to operand deployments
  3. **csi-operator** (OCPBUGS-105392) — Add `withHyperShiftProxy` hook to inject proxy into CSI driver controller containers

  ## Test plan

  - [x]  Unit tests pass: `go test -race ./control-plane-operator/controllers/hostedcontrolplane/v2/storage/... -v`
  - [x] `make test` passes
  - [x] `make verify` passes
  - [x] Full end-to-end validation requires all 3 repos fixed and tested on a proxy-required management cluster

## Identified as a part of :

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/80204/rehearse-80204-periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aws-ovn-proxy-conformance/2085242112562958336

  ## JIRA
  - [OCPBUGS-105282](https://redhat.atlassian.net/browse/OCPBUGS-105282)
  
 Related: 
  1 . [OCPBUGS-105391](https://redhat.atlassian.net/browse/OCPBUGS-105391)
  2.  [OCPBUGS-105392](https://redhat.atlassian.net/browse/OCPBUGS-105392)

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage deployments now support HTTP and HTTPS proxy configurations.
  * Proxy settings are automatically applied to storage components, including appropriate `NO_PROXY` values.
* **Bug Fixes**
  * Existing required environment settings are preserved when proxy configuration is applied.
  * Unset proxy variables are no longer added to storage deployments.
  * Proxy configuration is consistently handled across supported deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->