### PR TITLE
NO-JIRA: test(e2e/v2): add upsert desired-state-hash E2E tests

### DIFF
--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -31,6 +32,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/podspec"
+	"github.com/openshift/hypershift/support/upsert"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 
@@ -44,7 +46,10 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var workloads = internal.GetControlPlaneWorkloads()
+var (
+	workloads             = internal.GetControlPlaneWorkloads()
+	desiredStateHashHexRE = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
 
 func getWorkloadPods(testCtx *internal.TestContext, workload internal.WorkloadSpec) []corev1.Pod {
 	GinkgoHelper()
@@ -1089,6 +1094,38 @@ func CustomTolerationsTest(getTestCtx internal.TestContextGetter) {
 }
 
 // RegisterControlPlaneWorkloadsTests registers all control plane workloads tests
+func DesiredStateHashAnnotationTest(getTestCtx internal.TestContextGetter) {
+	Context("Desired state hash annotation", func() {
+		for _, w := range workloads {
+			workload := w
+			Context(workload.Name, func() {
+				It("should carry desired-state-hash annotation if managed by control-plane-operator", func() {
+					tc := getTestCtx()
+
+					deploy := &appsv1.Deployment{}
+					err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{Namespace: tc.ControlPlaneNamespace, Name: workload.Name}, deploy)
+					if apierrors.IsNotFound(err) {
+						Skip(fmt.Sprintf("Deployment %s not found in %s", workload.Name, tc.ControlPlaneNamespace))
+					}
+					Expect(err).NotTo(HaveOccurred(), "failed to get Deployment %s/%s", tc.ControlPlaneNamespace, workload.Name)
+
+					if deploy.Labels["hypershift.openshift.io/managed-by"] != "control-plane-operator" {
+						Skip(fmt.Sprintf("Deployment %s/%s is not managed by control-plane-operator", deploy.Namespace, deploy.Name))
+					}
+
+					hash, ok := deploy.Annotations[upsert.DesiredStateHashAnnotation]
+					Expect(ok).To(BeTrue(),
+						"Deployment %s/%s is missing the %s annotation",
+						deploy.Namespace, deploy.Name, upsert.DesiredStateHashAnnotation)
+					Expect(desiredStateHashHexRE.MatchString(hash)).To(BeTrue(),
+						"Deployment %s/%s has invalid desired-state-hash %q (expected 64 hex chars)",
+						deploy.Namespace, deploy.Name, hash)
+				})
+			})
+		}
+	})
+}
+
 func RegisterControlPlaneWorkloadsTests(getTestCtx internal.TestContextGetter) {
 	WorkloadRegistryValidationTest(getTestCtx)
 	DeploymentGenerationTest(getTestCtx)
@@ -1105,6 +1142,7 @@ func RegisterControlPlaneWorkloadsTests(getTestCtx internal.TestContextGetter) {
 	CustomLabelsTest(getTestCtx)
 	CustomTolerationsTest(getTestCtx)
 	SecurityContextUIDTest(getTestCtx)
+	DesiredStateHashAnnotationTest(getTestCtx)
 }
 
 var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:ControlPlaneWorkloads] Control Plane Workloads", Label("control-plane-workloads"), func() {


### PR DESCRIPTION
## What this PR does / why we need it:

Add E2E v2 test covering the desired-state-hash annotation introduced in support/upsert.ApplyManifest (PR #7713):

- DesiredStateHashAnnotationTest: asserts every managed Deployment in the control plane namespace carries a valid 64-char hex desired-state-hash annotation

Picking one test from https://github.com/openshift/hypershift/pull/9236 which was used to verify the feature.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->


## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end validation for deployment desired-state hash annotations.
  * Deployments managed by the control-plane operator must include a valid 64-character lowercase hexadecimal hash.
  * Unmanaged deployments and deployments without the annotation are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->