### PR TITLE
GCP-959: Add GCP PSC conditions to metrics and add platform-specific gauges

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -42,6 +42,18 @@ import (
 	"github.com/blang/semver"
 )
 
+// CredentialStatus represents the status of GCP credentials
+type CredentialStatus int
+
+const (
+	// CredentialStatusValid indicates that GCP credentials are valid
+	CredentialStatusValid CredentialStatus = 0
+	// CredentialStatusInvalid indicates that GCP credentials are invalid
+	CredentialStatusInvalid CredentialStatus = 1
+	// CredentialStatusUnknown indicates that GCP credential status is unknown
+	CredentialStatusUnknown CredentialStatus = 2
+)
+
 // GCP implements the Platform interface for Google Cloud Platform.
 //
 // This implementation enables HostedCluster reconciliation for GCP platform
@@ -475,6 +487,39 @@ func ValidCredentials(hc *hyperv1.HostedCluster) bool {
 	}
 
 	return true
+}
+
+// GetCredentialStatus returns the GCP credential status (valid/invalid/unknown)
+func GetCredentialStatus(hc *hyperv1.HostedCluster) CredentialStatus {
+	// Get GCP Workload Identity Federation status
+	var wifStatus metav1.ConditionStatus
+	validWIF := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPWorkloadIdentity))
+	if validWIF == nil {
+		wifStatus = metav1.ConditionUnknown
+	} else {
+		wifStatus = validWIF.Status
+	}
+
+	// Get GCP credentials status
+	var credsStatus metav1.ConditionStatus
+	validCreds := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPCredentials))
+	if validCreds == nil {
+		credsStatus = metav1.ConditionUnknown
+	} else {
+		credsStatus = validCreds.Status
+	}
+
+	// Combine the results:
+	// - If either is explicitly False → Invalid
+	// - If both are True → Valid
+	// - Otherwise → Unknown
+	if wifStatus == metav1.ConditionFalse || credsStatus == metav1.ConditionFalse {
+		return CredentialStatusInvalid
+	}
+	if wifStatus == metav1.ConditionTrue && credsStatus == metav1.ConditionTrue {
+		return CredentialStatusValid
+	}
+	return CredentialStatusUnknown
 }
 
 // validateWorkloadIdentityConfiguration validates the Workload Identity Federation configuration.

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
@@ -128,6 +128,141 @@ func TestValidCredentials(t *testing.T) {
 	}
 }
 
+// TestGetCredentialStatus tests the GetCredentialStatus function for various condition states.
+// This tests the tri-state logic (valid/invalid/unknown) for GCP credential conditions.
+func TestGetCredentialStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		expected   CredentialStatus
+	}{
+		{
+			name: "When both conditions are true, it should return CredentialStatusValid",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: CredentialStatusValid,
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is false, it should return CredentialStatusInvalid",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionFalse,
+				},
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: CredentialStatusInvalid,
+		},
+		{
+			name: "When ValidGCPCredentials is false, it should return CredentialStatusInvalid",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionFalse,
+				},
+			},
+			expected: CredentialStatusInvalid,
+		},
+		{
+			name: "When both conditions are false, it should return CredentialStatusInvalid",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionFalse,
+				},
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionFalse,
+				},
+			},
+			expected: CredentialStatusInvalid,
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is missing, it should return CredentialStatusUnknown",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: CredentialStatusUnknown,
+		},
+		{
+			name: "When ValidGCPCredentials is missing, it should return CredentialStatusUnknown",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: CredentialStatusUnknown,
+		},
+		{
+			name:       "When no conditions exist, it should return CredentialStatusUnknown",
+			conditions: []metav1.Condition{},
+			expected:   CredentialStatusUnknown,
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is unknown and ValidGCPCredentials is true, it should return CredentialStatusUnknown",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionUnknown,
+				},
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: CredentialStatusUnknown,
+		},
+		{
+			name: "When ValidGCPWorkloadIdentity is true and ValidGCPCredentials is unknown, it should return CredentialStatusUnknown",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   string(hyperv1.ValidGCPCredentials),
+					Status: metav1.ConditionUnknown,
+				},
+			},
+			expected: CredentialStatusUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hc := &hyperv1.HostedCluster{
+				Status: hyperv1.HostedClusterStatus{
+					Conditions: tt.conditions,
+				},
+			}
+
+			result := GetCredentialStatus(hc)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
 // TestWorkloadIdentityValidationScenarios tests additional edge cases for WIF validation.
 // This expands on the existing TestValidateWorkloadIdentityConfiguration with more comprehensive coverage.
 func TestWorkloadIdentityValidationScenarios(t *testing.T) {

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -356,7 +356,7 @@ func collectFailureConditionCounts(hcluster *hyperv1.HostedCluster, platform hyp
 }
 
 func (c *hostedClustersMetricsCollector) collectTransitionDurationMetrics(hcluster *hyperv1.HostedCluster, currentCollectTime time.Time) {
-	for _, conditionType := range []hyperv1.ConditionType{hyperv1.EtcdAvailable, hyperv1.InfrastructureReady, hyperv1.ExternalDNSReachable, hyperv1.AWSEndpointServiceAvailable, hyperv1.AWSEndpointAvailable} {
+	for _, conditionType := range []hyperv1.ConditionType{hyperv1.EtcdAvailable, hyperv1.InfrastructureReady, hyperv1.ExternalDNSReachable, hyperv1.AWSEndpointServiceAvailable, hyperv1.AWSEndpointAvailable, hyperv1.GCPEndpointAvailable, hyperv1.GCPServiceAttachmentAvailable} {
 		condition := meta.FindStatusCondition(hcluster.Status.Conditions, string(conditionType))
 		if condition != nil && condition.Status == metav1.ConditionTrue {
 			t := condition.LastTransitionTime.Time

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	platformaws "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/aws"
+	platformgcp "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/gcp"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/proxy"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/conditions"
@@ -74,6 +75,9 @@ const (
 
 	InvalidAwsCredsMetricName = "hypershift_cluster_invalid_aws_creds"
 	invalidAwsCredsMetricHelp = "AWS credential status for the HostedCluster: 0=valid, 1=invalid, 2=unknown"
+
+	InvalidGcpCredsMetricName = "hypershift_cluster_invalid_gcp_creds"
+	invalidGcpCredsMetricHelp = "GCP credential status for the HostedCluster: 0=valid, 1=invalid, 2=unknown"
 
 	DeletingDurationMetricName = "hypershift_cluster_deleting_duration_seconds"
 	deletingDurationMetricHelp = "Time in seconds it is taking to delete the HostedCluster since the beginning of the delete. " +
@@ -175,6 +179,10 @@ var (
 
 	invalidAwsCredsMetricDesc = prometheus.NewDesc(
 		InvalidAwsCredsMetricName, invalidAwsCredsMetricHelp,
+		hclusterLabels, nil)
+
+	invalidGcpCredsMetricDesc = prometheus.NewDesc(
+		InvalidGcpCredsMetricName, invalidGcpCredsMetricHelp,
 		hclusterLabels, nil)
 
 	deletingDurationMetricDesc = prometheus.NewDesc(
@@ -378,6 +386,7 @@ func (c *hostedClustersMetricsCollector) collectPerClusterMetrics(ch chan<- prom
 	collectAzureInfoMetrics(ch, hcluster, hclusterLabelValues)
 	collectAcrPullIdentityMetric(ch, hcluster, hclusterLabelValues)
 	collectAwsCredsMetric(ch, hcluster, hclusterLabelValues)
+	collectGcpCredsMetric(ch, hcluster, hclusterLabelValues)
 	collectDeletingMetrics(ch, c.clock, hcluster, hclusterLabelValues)
 }
 
@@ -592,6 +601,17 @@ func collectAwsCredsMetric(ch chan<- prometheus.Metric, hcluster *hyperv1.Hosted
 	credStatus := platformaws.GetCredentialStatus(hcluster)
 	ch <- prometheus.MustNewConstMetric(
 		invalidAwsCredsMetricDesc,
+		prometheus.GaugeValue,
+		float64(credStatus),
+		hclusterLabelValues...,
+	)
+}
+
+// Use detailed credential status: 0=valid, 1=invalid, 2=unknown
+func collectGcpCredsMetric(ch chan<- prometheus.Metric, hcluster *hyperv1.HostedCluster, hclusterLabelValues []string) {
+	credStatus := platformgcp.GetCredentialStatus(hcluster)
+	ch <- prometheus.MustNewConstMetric(
+		invalidGcpCredsMetricDesc,
 		prometheus.GaugeValue,
 		float64(credStatus),
 		hclusterLabelValues...,

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -1509,6 +1509,137 @@ func TestReportTransitionDurationForAWSEndpointConditions(t *testing.T) {
 	}
 }
 
+func TestReportTransitionDurationForGCPEndpointConditions(t *testing.T) {
+	testCases := []struct {
+		name               string
+		conditions         []metav1.Condition
+		expectedConditions []string
+	}{
+		{
+			name:               "When no GCP endpoint conditions are set, no transition duration is recorded",
+			conditions:         nil,
+			expectedConditions: nil,
+		},
+		{
+			name: "When GCPServiceAttachmentAvailable is true, it should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPServiceAttachmentAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{string(hyperv1.GCPServiceAttachmentAvailable)},
+		},
+		{
+			name: "When GCPEndpointAvailable is true, it should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPEndpointAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(3 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{string(hyperv1.GCPEndpointAvailable)},
+		},
+		{
+			name: "When both GCP endpoint conditions are true, both should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPServiceAttachmentAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+				{
+					Type:               string(hyperv1.GCPEndpointAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(5 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{
+				string(hyperv1.GCPServiceAttachmentAvailable),
+				string(hyperv1.GCPEndpointAvailable),
+			},
+		},
+		{
+			name: "When GCPServiceAttachmentAvailable is false, it should not be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.GCPServiceAttachmentAvailable),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+			},
+			expectedConditions: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcluster := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "hc",
+					Namespace:         "any",
+					CreationTimestamp: metav1.Time{Time: now},
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					ClusterID: "id",
+				},
+				Status: hyperv1.HostedClusterStatus{
+					Conditions: tc.conditions,
+				},
+			}
+
+			// Use a collect time after all transition times so observations fall in the window
+			collectTime := now.Add(10 * time.Minute)
+
+			reg := prometheus.NewPedanticRegistry()
+			reg.MustRegister(createHostedClustersMetricsCollector(
+				fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(hcluster).Build(),
+				clocktesting.NewFakeClock(collectTime),
+			))
+
+			result, err := reg.Gather()
+			if err != nil {
+				t.Fatalf("gathering metrics failed: %v", err)
+			}
+
+			metricFamily := findMetricValue(&result, TransitionDurationMetricName)
+			observedConditions := map[string]bool{}
+			if metricFamily != nil {
+				for _, m := range metricFamily.Metric {
+					for _, label := range m.Label {
+						if label.GetName() == "condition" && m.Histogram != nil && m.Histogram.GetSampleCount() > 0 {
+							observedConditions[label.GetValue()] = true
+						}
+					}
+				}
+			}
+
+			for _, expected := range tc.expectedConditions {
+				if !observedConditions[expected] {
+					t.Errorf("expected condition %q to be observed in transition duration metric, but it was not", expected)
+				}
+			}
+
+			// Verify no unexpected GCP endpoint conditions were observed
+			gcpConditions := map[string]bool{
+				string(hyperv1.GCPServiceAttachmentAvailable): true,
+				string(hyperv1.GCPEndpointAvailable):          true,
+			}
+			expectedSet := map[string]bool{}
+			for _, c := range tc.expectedConditions {
+				expectedSet[c] = true
+			}
+			for condition := range observedConditions {
+				if gcpConditions[condition] && !expectedSet[condition] {
+					t.Errorf("unexpected GCP condition %q was observed in transition duration metric", condition)
+				}
+			}
+		})
+	}
+}
+
 func createCa(notBefore, notAfter time.Time) (*x509.Certificate, string, error) {
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(2019),

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -550,6 +550,94 @@ func TestReportProxy(t *testing.T) {
 	}
 }
 
+func TestReportInvalidGcpCreds(t *testing.T) {
+	wrapExpectedValueAsMetric := func(expectedValue float64) *dto.MetricFamily {
+		return createMetricValue(
+			InvalidGcpCredsMetricName,
+			invalidGcpCredsMetricHelp,
+			expectedValue)
+	}
+
+	testCases := []struct {
+		name                               string
+		ValidGCPWorkloadIdentityCondStatus metav1.ConditionStatus
+		ValidGCPCredentialsCondStatus      metav1.ConditionStatus
+		expected                           *dto.MetricFamily
+	}{
+		{
+			name:                               "When both GCP conditions are true, metric is reported with a value set to 0 (valid)",
+			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionTrue,
+			ValidGCPCredentialsCondStatus:      metav1.ConditionTrue,
+			expected:                           wrapExpectedValueAsMetric(0),
+		},
+		{
+			name:                               "When ValidGCPWorkloadIdentity status is false, metric is reported with a value set to 1 (invalid)",
+			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionFalse,
+			ValidGCPCredentialsCondStatus:      metav1.ConditionTrue,
+			expected:                           wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                               "When ValidGCPCredentials status is false, metric is reported with a value set to 1 (invalid)",
+			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionTrue,
+			ValidGCPCredentialsCondStatus:      metav1.ConditionFalse,
+			expected:                           wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                               "When both GCP conditions are false, metric is reported with a value set to 1 (invalid)",
+			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionFalse,
+			ValidGCPCredentialsCondStatus:      metav1.ConditionFalse,
+			expected:                           wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                               "When ValidGCPWorkloadIdentity status is unknown, metric is reported with a value set to 2 (unknown)",
+			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionUnknown,
+			ValidGCPCredentialsCondStatus:      metav1.ConditionTrue,
+			expected:                           wrapExpectedValueAsMetric(2),
+		},
+		{
+			name:                               "When ValidGCPCredentials status is unknown, metric is reported with a value set to 2 (unknown)",
+			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionTrue,
+			ValidGCPCredentialsCondStatus:      metav1.ConditionUnknown,
+			expected:                           wrapExpectedValueAsMetric(2),
+		},
+		{
+			name:                               "When both GCP conditions are unknown, metric is reported with a value set to 2 (unknown)",
+			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionUnknown,
+			ValidGCPCredentialsCondStatus:      metav1.ConditionUnknown,
+			expected:                           wrapExpectedValueAsMetric(2),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcluster := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hc",
+					Namespace: "any",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					ClusterID: "id",
+				},
+			}
+
+			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
+				Type:   string(hyperv1.ValidGCPWorkloadIdentity),
+				Status: tc.ValidGCPWorkloadIdentityCondStatus,
+			})
+			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
+				Type:   string(hyperv1.ValidGCPCredentials),
+				Status: tc.ValidGCPCredentialsCondStatus,
+			})
+
+			checkMetric(t,
+				fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(hcluster).Build(),
+				clock.RealClock{},
+				InvalidGcpCredsMetricName,
+				tc.expected)
+		})
+	}
+}
+
 func TestReportInvalidAwsCreds(t *testing.T) {
 	wrapExpectedValueAsMetric := func(expectedValue float64) *dto.MetricFamily {
 		return createMetricValue(

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -69,6 +69,11 @@ func ExpectedHCConditions(hostedCluster *hyperv1.HostedCluster) map[hyperv1.Cond
 		// GCP credentials validation - indicates WIF readiness
 		conditions[hyperv1.ValidGCPCredentials] = metav1.ConditionTrue
 
+		// GCP Private Service Connect conditions - both GCP endpoint access modes
+		// (Private and PublicAndPrivate) use PSC, so no EndpointAccess gate is needed.
+		conditions[hyperv1.GCPEndpointAvailable] = metav1.ConditionTrue
+		conditions[hyperv1.GCPServiceAttachmentAvailable] = metav1.ConditionTrue
+
 		// GCP KMS validation - future support for GCP KMS secret encryption
 		// Following the same pattern as AWS and Azure
 		// Note: GCP KMS integration is not yet implemented but prepared for future use


### PR DESCRIPTION
## What this PR does / why we need it:

Adds GCP PSC (Private Service Connect) conditions to HyperShift monitoring metrics and introduces a new GCP credential validity gauge, bringing GCP monitoring to parity with AWS.

**Changes:**

1. **`GetCredentialStatus()` in GCP platform package** — New tri-state function (valid/invalid/unknown) mirroring the AWS pattern, checking `ValidGCPWorkloadIdentity` and `ValidGCPCredentials` conditions.

2. **PSC conditions in `ExpectedHCConditions()`** — Adds `GCPEndpointAvailable` and `GCPServiceAttachmentAvailable` unconditionally (both GCP endpoint access modes use PSC). PSC failures now appear in `hypershift_hostedclusters_failure_conditions`.

3. **PSC conditions in transition duration metrics** — Adds same conditions to `collectTransitionDurationMetrics()`. PSC setup latency is now tracked in `hypershift_hostedclusters_transition_duration`.

4. **`hypershift_cluster_invalid_gcp_creds` gauge** — New Prometheus gauge exposing GCP credential status (0=valid, 1=invalid, 2=unknown), following the `hypershift_cluster_invalid_aws_creds` pattern.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/GCP-959

## Special notes for your reviewer:

- The Jira ticket mentions gating PSC conditions on `EndpointAccess != Public`, but GCP has no `Public`-only endpoint access mode (only `Private` and `PublicAndPrivate`), so conditions are added unconditionally.
- `CredentialStatus` type is intentionally duplicated from the AWS package to avoid cross-platform import dependencies.
- The GCP creds gauge is collected unconditionally for all clusters (non-GCP clusters report `Unknown`=2), consistent with the AWS gauge behavior.
- All unit tests follow the "When ... it should ..." naming convention per TESTING.md.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added monitoring for GCP credential validity, including valid, invalid, and unknown states.
  - Added transition-duration metrics for GCP endpoint and service-attachment availability.
- **Bug Fixes**
  - Improved GCP condition handling so endpoint and service-attachment readiness is accurately recognized across supported endpoint access modes.
- **Tests**
  - Added coverage for GCP credential status, credential metrics, and availability transition metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->