### PR TITLE
OCPBUGS-98467: fix(konnectivity): enable --sync-forever to restore lost agent-server tunnels

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/AROSwift/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/AROSwift/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 12905ab0076d334392ac03961f017375c5b825ce48143a439114d045a392b54f
+    hypershift.openshift.io/desired-state-hash: de36575be3d464cfd2dbc3740388589bab3c302f2fb6cba4d5442f251f4ada26
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: konnectivity-agent
@@ -100,6 +100,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-forever
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/GCP/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/GCP/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 899eca11e0ecf38e53d71dd11dfed3baf50f339b47d559c7c2afc8a1b1795492
+    hypershift.openshift.io/desired-state-hash: 7be4bbfe10bcc0e28780ffc6c06d0f425cd78d7e921a43f190627a42d257c3f1
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: konnectivity-agent
@@ -100,6 +100,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-forever
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/IBMCloud/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/IBMCloud/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 12905ab0076d334392ac03961f017375c5b825ce48143a439114d045a392b54f
+    hypershift.openshift.io/desired-state-hash: de36575be3d464cfd2dbc3740388589bab3c302f2fb6cba4d5442f251f4ada26
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: konnectivity-agent
@@ -100,6 +100,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-forever
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/ModernTLS/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/ModernTLS/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 12905ab0076d334392ac03961f017375c5b825ce48143a439114d045a392b54f
+    hypershift.openshift.io/desired-state-hash: de36575be3d464cfd2dbc3740388589bab3c302f2fb6cba4d5442f251f4ada26
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: konnectivity-agent
@@ -100,6 +100,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-forever
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 12905ab0076d334392ac03961f017375c5b825ce48143a439114d045a392b54f
+    hypershift.openshift.io/desired-state-hash: de36575be3d464cfd2dbc3740388589bab3c302f2fb6cba4d5442f251f4ada26
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: konnectivity-agent
@@ -100,6 +100,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-forever
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 12905ab0076d334392ac03961f017375c5b825ce48143a439114d045a392b54f
+    hypershift.openshift.io/desired-state-hash: de36575be3d464cfd2dbc3740388589bab3c302f2fb6cba4d5442f251f4ada26
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: konnectivity-agent
@@ -100,6 +100,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-forever
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/konnectivity-agent/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/konnectivity-agent/deployment.yaml
@@ -39,6 +39,10 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        # --sync-forever is a stopgap until the OCP fork rebases upstream PR
+        # https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/643,
+        # which adds lease-based server counting (--count-server-leases).
+        - --sync-forever
         - --v
         - "3"
         command:

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
@@ -159,6 +159,10 @@ func buildKonnectivityWorkerAgentContainer(image, host string, port int32, proxy
 			"5s",
 			"--sync-interval-cap",
 			"30s",
+			// --sync-forever is a stopgap until the OCP fork rebases upstream PR
+			// https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/643,
+			// which adds lease-based server counting (--count-server-leases).
+			"--sync-forever",
 			"--v",
 			"3",
 		}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile_test.go
@@ -1,0 +1,39 @@
+package konnectivity
+
+import (
+	"slices"
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestReconcileAgentDaemonSet(t *testing.T) {
+	testCases := []struct {
+		name string
+	}{
+		{
+			name: "When ReconcileAgentDaemonSet is called, it should include --sync-forever in the agent args",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			daemonset := &appsv1.DaemonSet{}
+			params := &KonnectivityParams{
+				Image:           "konnectivity-agent-image",
+				ExternalAddress: "konnectivity-server",
+				ExternalPort:    8091,
+			}
+
+			ReconcileAgentDaemonSet(daemonset, params, hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform}, configv1.ProxyStatus{})
+
+			args := daemonset.Spec.Template.Spec.Containers[0].Args
+			if !slices.Contains(args, "--sync-forever") {
+				t.Errorf("expected konnectivity-agent container args to contain --sync-forever, got: %v", args)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Enables `--sync-forever` on konnectivity-agents (both control-plane Deployment and data-plane DaemonSet) so agents continuously sync and reconnect lost server tunnels.

Without this flag (the default `SyncForever=false`), agents connect to proxy servers at startup and never re-sync. When a server pod is replaced (e.g. during rollout or crash), agents permanently lose that tunnel and never redial. The `readyz` endpoint only checks "connected to at least 1 server" — agents with 1/3 or 2/3 connections stay `Ready=true`, masking the degradation. With enough degraded agents, all konnectivity routing paths exhaust, causing webhook timeouts, `oc exec/logs` failures, and VM console breakage. Recovery currently requires manually restarting **all** konnectivity-agent pods.

Reference: [upstream PR #285](https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/285) introduced `--sync-forever` specifically for this.

Supersedes #9249 (closed — used non-existent `--sync-force-reconnect` flag).

## Which issue(s) this PR fixes:

Fixes OCPBUGS-98467

## Special notes for your reviewer:

### Alternatives Considered

**1. Lease-based server counting** (`--count-server-leases` + `--enable-lease-controller`)
[Upstream PR #643](https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/643) uses Kubernetes Lease objects for server count detection — cleaner than Connect() polling. However, **OCP's fork of apiserver-network-proxy does not include these flags** (verified on `release-4.19` branch and running binary). Requires rebasing the OCP fork — separate effort.

**2. Sidecar watcher that kills degraded agent pods**
Viable on multi-node clusters (other agents absorb traffic via `defaultRoute` failover), but pod kill drops ALL connections vs `--sync-forever` which reconnects only the missing tunnel with zero disruption. Also requires new container image, RBAC, and reconciliation in both CPO and HCCO.

**`--sync-forever` chosen because it's the simplest fix available in the current OCP binary** — one flag, zero new containers, zero RBAC.

### Upstream Issue Validation

Tested with `--sync-forever` enabled on live HCP cluster (OCP 4.19, 3 KAS pods, 3 CP agents, 2 DP agents):

| Test | Upstream Issue | Result |
|------|---------------|--------|
| Connect() polling noise | [#349](https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/349), [#358](https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/358) | **PASS** — ~5 cancel msgs/min, Info level. Minimal noise. |
| Reconnection after tunnel loss | Core fix | **PASS** — Agents reconnected to replacement server in ~30-50s. |
| Reconnection delay regression | [PR #817](https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/817) | **PASS** — No excessive delay from DuplicateServerError. |
| Rolling update / stale server count | [#739](https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/739) | **PASS** — Full KAS rollout, agents never below 2/3 connections. |
| Steady-state stability | [#588](https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/588) | **PASS** — Stable 3/3 for 5 min. Zero restarts. No churn growth. |

### Reproduction Results

**Defect 1 — agents never reconnect:** Killed KAS pod, agents stayed at 2/3 indefinitely. With `--sync-forever`: reconnected in ~30-50s.

**Defect 2 — server channel overflow:** 2000 concurrent `oc exec` (5MB each) produced 54,119 `"Receive channel from agent is full"` errors. During overflow: `oc get` worked (0.3s), `oc exec` hung >2min, `oc logs` timed out at 10s.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Konnectivity agent synchronization by enabling continuous sync behavior.
  * Applied the synchronization setting consistently across supported deployment configurations.
  * Reduced the risk of connectivity interruptions by ensuring agents remain synchronized during operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->