### PR TITLE
CNTRLPLANE-3997: add manual trigger and fix path filter for docs publish

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/docs-publish.yaml'
+      - '.github/workflows/docs-build-reusable.yaml'
+      - '.github/workflows/docs-deploy-reusable.yaml'
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
## What this PR does / why we need it:

`Docs Publish` only runs on pushes to `main` that touch `docs/**` or the workflow file itself. #9252 fixed a bug in `docs-deploy.yaml` / `docs-deploy-reusable.yaml` (the workflows `Docs Publish` calls to actually deploy to Cloudflare Pages), but merging it didn't trigger a production deploy because those files weren't in the path filter.

This PR:
- Adds `docs-build-reusable.yaml` and `docs-deploy-reusable.yaml` to the `Docs Publish` path filter, so changes to the reusable workflows it depends on trigger a deploy on merge.
- Adds a `workflow_dispatch` trigger so the production docs deploy can be re-run manually (e.g. via `gh workflow run docs-publish.yaml`) without needing an unrelated docs change to force it.

Ref: [CNTRLPLANE-3997](https://redhat.atlassian.net/browse/CNTRLPLANE-3997)

## Which issue(s) this PR fixes:
Fixes [CNTRLPLANE-3997](https://redhat.atlassian.net/browse/CNTRLPLANE-3997)

## Special notes for your reviewer:
No functional docs content changes — CI workflow triggers only.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation publishing now runs when reusable documentation build or deployment workflows are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->