### PR TITLE
AUTOSCALE-166: feat(karpenter): deploy NodeOverlay CRD to guest cluster

### DIFF
--- a/karpenter-operator/controllers/karpenter/karpenter_controller.go
+++ b/karpenter-operator/controllers/karpenter/karpenter_controller.go
@@ -59,6 +59,7 @@ var (
 	crdEC2NodeClass = supportassets.MustCRD(assets.ReadFile, "karpenter.k8s.aws_ec2nodeclasses.yaml")
 	crdNodePool     = supportassets.MustCRD(assets.ReadFile, "karpenter.sh_nodepools.yaml")
 	crdNodeClaim    = supportassets.MustCRD(assets.ReadFile, "karpenter.sh_nodeclaims.yaml")
+	crdNodeOverlay  = supportassets.MustCRD(assets.ReadFile, "karpenter.sh_nodeoverlays.yaml")
 )
 
 type Reconciler struct {
@@ -96,7 +97,8 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, man
 			switch o.GetName() {
 			case "ec2nodeclasses.karpenter.k8s.aws",
 				"nodepools.karpenter.sh",
-				"nodeclaims.karpenter.sh":
+				"nodeclaims.karpenter.sh",
+				"nodeoverlays.karpenter.sh":
 				return []ctrl.Request{{NamespacedName: client.ObjectKey{Namespace: r.Namespace}}}
 			}
 			return nil
@@ -402,6 +404,7 @@ func (r *Reconciler) reconcileCRDs(ctx context.Context, onlyCreate bool) error {
 		crdEC2NodeClass,
 		crdNodePool,
 		crdNodeClaim,
+		crdNodeOverlay,
 	} {
 		crd := desired.DeepCopy()
 		if onlyCreate {

--- a/karpenter-operator/controllers/karpenter/karpenter_controller_test.go
+++ b/karpenter-operator/controllers/karpenter/karpenter_controller_test.go
@@ -405,15 +405,17 @@ func TestReconcileCRDsConcurrentAccess(t *testing.T) {
 		crdEC2NodeClass.Name: *crdEC2NodeClass.Spec.DeepCopy(),
 		crdNodePool.Name:     *crdNodePool.Spec.DeepCopy(),
 		crdNodeClaim.Name:    *crdNodeClaim.Spec.DeepCopy(),
+		crdNodeOverlay.Name:  *crdNodeOverlay.Spec.DeepCopy(),
 	}
 
 	// Pre-create the CRDs in the fake client so that CreateOrUpdate's
 	// internal Get() succeeds and overwrites the passed object with server state.
-	existingCRDs := make([]client.Object, 0, 3)
+	existingCRDs := make([]client.Object, 0, 4)
 	for _, crd := range []*apiextensionsv1.CustomResourceDefinition{
 		crdEC2NodeClass,
 		crdNodePool,
 		crdNodeClaim,
+		crdNodeOverlay,
 	} {
 		serverCopy := crd.DeepCopy()
 		serverCopy.ResourceVersion = "999"
@@ -458,6 +460,7 @@ func TestReconcileCRDsConcurrentAccess(t *testing.T) {
 		crdEC2NodeClass,
 		crdNodePool,
 		crdNodeClaim,
+		crdNodeOverlay,
 	} {
 		g.Expect(equality.Semantic.DeepEqual(crd.Spec, originalSpecs[crd.Name])).To(BeTrue(),
 			"global CRD %q spec was corrupted by concurrent reconcileCRDs calls", crd.Name)


### PR DESCRIPTION
## What this PR does / why we need it:
Adds the NodeOverlay CRD (karpenter.sh_nodeoverlays.yaml) to the hypershift karpenter controller so it gets deployed to guest clusters alongside EC2NodeClass, NodePool, and NodeClaim.

The upstream karpenter core regression e2e tests expect the NodeOverlay CRD to exist in the cluster. Without this, tests fail with no matches for kind "NodeOverlay".

## Which issue(s) this PR fixes:
A part of [AUTOSCALE-166](https://redhat.atlassian.net/browse/AUTOSCALE-166?focusedCommentId=16851181)

## Special notes for your reviewer:
The standalone karpenter-operator repo already has NodeOverlay wired up via CoreCRDs in pkg/assets/assets.go.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing and reconciling NodeOverlay custom resources.

* **Tests**
  * Expanded reconciliation coverage to verify NodeOverlay resources are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->