### PR TITLE
OCPBUGS-105434: [release-4.21] fix router component ordering to prevent missing HAProxy backends

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -239,7 +239,6 @@ func (r *HostedControlPlaneReconciler) registerComponents(hcp *hyperv1.HostedCon
 		kcmv2.NewComponent(),
 		schedulerv2.NewComponent(),
 		oapiv2.NewComponent(),
-		routerv2.NewComponent(),
 		oauthapiv2.NewComponent(),
 		autoscalerv2.NewComponent(),
 		cvov2.NewComponent(r.EnableCVOManagementClusterMetricsAccess),
@@ -266,6 +265,7 @@ func (r *HostedControlPlaneReconciler) registerComponents(hcp *hyperv1.HostedCon
 		konnectivityv2.NewComponent(),
 		ignitionserverv2.NewComponent(r.ReleaseProvider, r.DefaultIngressDomain),
 		ignitionproxyv2.NewComponent(r.DefaultIngressDomain),
+		routerv2.NewComponent(),
 	)
 	r.components = append(r.components,
 		olmv2.NewComponents(r.ManagementClusterCapabilities.Has(capabilities.CapabilityImageStream))...,

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -22,6 +22,7 @@ import (
 	ignitionproxyv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy"
 	kasv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/kas"
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
+	routerv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/router"
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/capabilities"
@@ -2171,5 +2172,65 @@ func TestRemoveHCPIngressFromRoutes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+
+func TestRouterComponentComesAfterRouteCreatingComponents(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &HostedControlPlaneReconciler{
+		ReleaseProvider:               &fakereleaseprovider.FakeReleaseProvider{},
+		ManagementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
+	}
+
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-hcp",
+			Namespace: "test-ns",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.AWSPlatform,
+			},
+			Etcd: hyperv1.EtcdSpec{
+				ManagementType: hyperv1.Managed,
+			},
+			Services: []hyperv1.ServicePublishingStrategyMapping{
+				{
+					Service: hyperv1.Ignition,
+					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+						Type: hyperv1.Route,
+					},
+				},
+			},
+		},
+	}
+
+	reconciler.registerComponents(hcp)
+
+	positions := make(map[string]int, len(reconciler.components))
+	for i, c := range reconciler.components {
+		positions[c.Name()] = i
+	}
+
+	routerPos, ok := positions[routerv2.ComponentName]
+	if !ok {
+		t.Fatal("router component not found in registered components")
+	}
+
+	routeCreatingComponents := []string{
+		ignitionserverv2.ComponentName,
+	}
+	for _, name := range routeCreatingComponents {
+		pos, ok := positions[name]
+		if !ok {
+			t.Fatalf("route-creating component %q not found in registered components", name)
+		}
+		if routerPos < pos {
+			t.Errorf("router component (position %d) must be registered after %s (position %d) "+
+				"so that the HAProxy config includes %s's route on the first reconcile pass",
+				routerPos, name, pos, name)
+		}
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -2175,7 +2175,6 @@ func TestRemoveHCPIngressFromRoutes(t *testing.T) {
 	}
 }
 
-
 func TestRouterComponentComesAfterRouteCreatingComponents(t *testing.T) {
 	t.Parallel()
 

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/AROSwift/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/AROSwift/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
@@ -8,14 +8,13 @@ spec: {}
 status:
   conditions:
   - lastTransitionTime: null
-    message: router Deployment Available condition not found
+    message: deployments.apps "router" not found
     reason: NotFound
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for deployment router rollout to finish: 0 out of 3 new replicas
-      have been updated'
-    reason: WaitingForRolloutComplete
+    message: 'Waiting for Dependencies: ignition-server, metrics-proxy'
+    reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/AROSwift/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/AROSwift/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
@@ -13,7 +13,7 @@ status:
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for Dependencies: ignition-server, metrics-proxy'
+    message: 'Waiting for Dependencies: ignition-server'
     reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/GCP/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/GCP/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
@@ -8,14 +8,13 @@ spec: {}
 status:
   conditions:
   - lastTransitionTime: null
-    message: router Deployment Available condition not found
+    message: deployments.apps "router" not found
     reason: NotFound
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for deployment router rollout to finish: 0 out of 3 new replicas
-      have been updated'
-    reason: WaitingForRolloutComplete
+    message: 'Waiting for Dependencies: ignition-server, metrics-proxy'
+    reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/GCP/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/GCP/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
@@ -13,7 +13,7 @@ status:
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for Dependencies: ignition-server, metrics-proxy'
+    message: 'Waiting for Dependencies: ignition-server'
     reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/IBMCloud/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/IBMCloud/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
@@ -8,14 +8,13 @@ spec: {}
 status:
   conditions:
   - lastTransitionTime: null
-    message: router Deployment Available condition not found
+    message: deployments.apps "router" not found
     reason: NotFound
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for deployment router rollout to finish: 0 out of 3 new replicas
-      have been updated'
-    reason: WaitingForRolloutComplete
+    message: 'Waiting for Dependencies: ignition-server, metrics-proxy'
+    reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/IBMCloud/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/IBMCloud/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
@@ -13,7 +13,7 @@ status:
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for Dependencies: ignition-server, metrics-proxy'
+    message: 'Waiting for Dependencies: ignition-server'
     reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
@@ -8,14 +8,13 @@ spec: {}
 status:
   conditions:
   - lastTransitionTime: null
-    message: router Deployment Available condition not found
+    message: deployments.apps "router" not found
     reason: NotFound
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for deployment router rollout to finish: 0 out of 3 new replicas
-      have been updated'
-    reason: WaitingForRolloutComplete
+    message: 'Waiting for Dependencies: ignition-server, metrics-proxy'
+    reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
@@ -13,7 +13,7 @@ status:
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for Dependencies: ignition-server, metrics-proxy'
+    message: 'Waiting for Dependencies: ignition-server'
     reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
@@ -8,14 +8,13 @@ spec: {}
 status:
   conditions:
   - lastTransitionTime: null
-    message: router Deployment Available condition not found
+    message: deployments.apps "router" not found
     reason: NotFound
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for deployment router rollout to finish: 0 out of 3 new replicas
-      have been updated'
-    reason: WaitingForRolloutComplete
+    message: 'Waiting for Dependencies: ignition-server, metrics-proxy'
+    reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_router_controlplanecomponent.yaml
@@ -13,7 +13,7 @@ status:
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for Dependencies: ignition-server, metrics-proxy'
+    message: 'Waiting for Dependencies: ignition-server'
     reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/netutil"
+	supportutil "github.com/openshift/hypershift/support/util"
 
 	routev1 "github.com/openshift/api/route/v1"
 
@@ -104,7 +105,6 @@ func ensureHCPRouterRoutesExist(cpContext component.WorkloadContext) error {
 var aroBaseHCPRouterRouteNames = []string{
 	"kube-apiserver-internal",
 	"konnectivity-server",
-	"oauth-internal",
 	"ignition-server",
 }
 
@@ -114,6 +114,9 @@ func aroExpectedHCPRouterRouteNames(hcp *hyperv1.HostedControlPlane) []string {
 	}
 
 	names := append([]string(nil), aroBaseHCPRouterRouteNames...)
+	if supportutil.HCPOAuthEnabled(hcp) {
+		names = append(names, "oauth-internal")
+	}
 	if metricsProxyRouteRequired(hcp) {
 		names = append(names, "metrics-proxy")
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -1,8 +1,21 @@
 package router
 
 import (
+	"fmt"
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	endpointresolverv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/endpoint_resolver"
+	ignitionserverv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver"
+	metricsproxyv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/metrics_proxy"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/router/util"
+	"github.com/openshift/hypershift/support/azureutil"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/netutil"
+
+	routev1 "github.com/openshift/api/route/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -31,9 +44,7 @@ func (k *router) NeedsManagementKASAccess() bool {
 
 func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &router{}).
-		WithPredicate(func(cpContext component.WorkloadContext) (bool, error) {
-			return util.UseHCPRouter(cpContext.HCP), nil
-		}).
+		WithPredicate(routerPredicate).
 		WithAdaptFunction(adaptDeployment).
 		WithManifestAdapter(
 			"config.yaml",
@@ -43,5 +54,81 @@ func NewComponent() component.ControlPlaneComponent {
 			"pdb.yaml",
 			component.AdaptPodDisruptionBudget(),
 		).
+		WithDependencies(ignitionserverv2.ComponentName, metricsproxyv2.ComponentName).
 		Build()
+}
+
+func routerPredicate(cpContext component.WorkloadContext) (bool, error) {
+	if !util.UseHCPRouter(cpContext.HCP) {
+		return false, nil
+	}
+	if azureutil.IsAroHCPByHCP(cpContext.HCP) {
+		if err := ensureHCPRouterRoutesExist(cpContext); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// TODO: introduce live reloading like in shared proxy so the router config
+// is updated when routes change after the initial reconcile.
+
+func ensureHCPRouterRoutesExist(cpContext component.WorkloadContext) error {
+	expected := aroExpectedHCPRouterRouteNames(cpContext.HCP)
+	if len(expected) == 0 {
+		return nil
+	}
+
+	routeList := &routev1.RouteList{}
+	if err := cpContext.Client.List(cpContext, routeList, client.InNamespace(cpContext.HCP.Namespace)); err != nil {
+		return fmt.Errorf("failed to list routes: %w", err)
+	}
+
+	routesByName := make(map[string]routev1.Route, len(routeList.Items))
+	for _, route := range routeList.Items {
+		routesByName[route.Name] = route
+	}
+
+	var missing []string
+	for _, name := range expected {
+		route, ok := routesByName[name]
+		if !ok || !hcpRouterRouteReady(&route) {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("waiting for HCP router routes: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+var aroBaseHCPRouterRouteNames = []string{
+	"kube-apiserver-internal",
+	"konnectivity-server",
+	"oauth-internal",
+	"ignition-server",
+}
+
+func aroExpectedHCPRouterRouteNames(hcp *hyperv1.HostedControlPlane) []string {
+	if !azureutil.IsAroHCPByHCP(hcp) {
+		return nil
+	}
+
+	names := append([]string(nil), aroBaseHCPRouterRouteNames...)
+	if metricsProxyRouteRequired(hcp) {
+		names = append(names, "metrics-proxy")
+	}
+	return names
+}
+
+func metricsProxyRouteRequired(hcp *hyperv1.HostedControlPlane) bool {
+	enabled, err := endpointresolverv2.Predicate(component.WorkloadContext{HCP: hcp})
+	if err != nil || !enabled {
+		return false
+	}
+	return netutil.LabelHCPRoutes(hcp) || netutil.IsPrivateHCP(hcp)
+}
+
+func hcpRouterRouteReady(route *routev1.Route) bool {
+	return route.Spec.Host != ""
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -7,7 +7,6 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	endpointresolverv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/endpoint_resolver"
 	ignitionserverv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver"
-	metricsproxyv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/metrics_proxy"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/router/util"
 	"github.com/openshift/hypershift/support/azureutil"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -54,7 +53,7 @@ func NewComponent() component.ControlPlaneComponent {
 			"pdb.yaml",
 			component.AdaptPodDisruptionBudget(),
 		).
-		WithDependencies(ignitionserverv2.ComponentName, metricsproxyv2.ComponentName).
+		WithDependencies(ignitionserverv2.ComponentName).
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -5,12 +5,10 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	endpointresolverv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/endpoint_resolver"
 	ignitionserverv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/router/util"
 	"github.com/openshift/hypershift/support/azureutil"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/netutil"
 	supportutil "github.com/openshift/hypershift/support/util"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -62,7 +60,7 @@ func routerPredicate(cpContext component.WorkloadContext) (bool, error) {
 	if !util.UseHCPRouter(cpContext.HCP) {
 		return false, nil
 	}
-	if azureutil.IsAroHCPByHCP(cpContext.HCP) {
+	if azureutil.IsAroHCP() {
 		if err := ensureHCPRouterRoutesExist(cpContext); err != nil {
 			return false, err
 		}
@@ -109,7 +107,7 @@ var aroBaseHCPRouterRouteNames = []string{
 }
 
 func aroExpectedHCPRouterRouteNames(hcp *hyperv1.HostedControlPlane) []string {
-	if !azureutil.IsAroHCPByHCP(hcp) {
+	if !azureutil.IsAroHCP() {
 		return nil
 	}
 
@@ -117,18 +115,7 @@ func aroExpectedHCPRouterRouteNames(hcp *hyperv1.HostedControlPlane) []string {
 	if supportutil.HCPOAuthEnabled(hcp) {
 		names = append(names, "oauth-internal")
 	}
-	if metricsProxyRouteRequired(hcp) {
-		names = append(names, "metrics-proxy")
-	}
 	return names
-}
-
-func metricsProxyRouteRequired(hcp *hyperv1.HostedControlPlane) bool {
-	enabled, err := endpointresolverv2.Predicate(component.WorkloadContext{HCP: hcp})
-	if err != nil || !enabled {
-		return false
-	}
-	return netutil.LabelHCPRoutes(hcp) || netutil.IsPrivateHCP(hcp)
 }
 
 func hcpRouterRouteReady(route *routev1.Route) bool {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
@@ -1,13 +1,22 @@
 package router
 
 import (
+	"context"
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/router/util"
 	"github.com/openshift/hypershift/support/azureutil"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	routev1 "github.com/openshift/api/route/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestUseHCPRouter(t *testing.T) {
@@ -316,6 +325,395 @@ func TestUseHCPRouter(t *testing.T) {
 			if got := util.UseHCPRouter(tt.hcp); got != tt.want {
 				t.Errorf("UseHCPRouter() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func aroHCP() *hyperv1.HostedControlPlane {
+	return &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.AzurePlatform,
+				Azure: &hyperv1.AzurePlatformSpec{
+					Topology: hyperv1.AzureTopologyPrivate,
+					AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+						AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeManagedIdentities,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestAroExpectedHCPRouterRouteNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		hcp      *hyperv1.HostedControlPlane
+		expected []string
+	}{
+		{
+			name: "When HCP is not ARO, it should return nil",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "When ARO HCP has no metrics forwarding, it should return base routes",
+			hcp:  aroHCP(),
+			expected: []string{
+				"kube-apiserver-internal",
+				"konnectivity-server",
+				"oauth-internal",
+				"ignition-server",
+			},
+		},
+		{
+			name: "When ARO HCP has metrics forwarding enabled, it should include metrics-proxy",
+			hcp: func() *hyperv1.HostedControlPlane {
+				hcp := aroHCP()
+				hcp.Spec.Monitoring.MetricsForwarding.Mode = hyperv1.MetricsForwardingModeForward
+				return hcp
+			}(),
+			expected: []string{
+				"kube-apiserver-internal",
+				"konnectivity-server",
+				"oauth-internal",
+				"ignition-server",
+				"metrics-proxy",
+			},
+		},
+		{
+			name: "When ARO HCP has disabled monitoring, it should exclude metrics-proxy",
+			hcp: func() *hyperv1.HostedControlPlane {
+				hcp := aroHCP()
+				hcp.Annotations = map[string]string{
+					hyperv1.DisableMonitoringServices: "true",
+				}
+				hcp.Spec.Monitoring.MetricsForwarding.Mode = hyperv1.MetricsForwardingModeForward
+				return hcp
+			}(),
+			expected: []string{
+				"kube-apiserver-internal",
+				"konnectivity-server",
+				"oauth-internal",
+				"ignition-server",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := aroExpectedHCPRouterRouteNames(tc.hcp)
+			if tc.expected == nil {
+				g.Expect(got).To(BeNil())
+			} else {
+				g.Expect(got).To(Equal(tc.expected))
+			}
+		})
+	}
+}
+
+func TestMetricsProxyRouteRequired(t *testing.T) {
+	tests := []struct {
+		name     string
+		hcp      *hyperv1.HostedControlPlane
+		expected bool
+	}{
+		{
+			name: "When platform is not Azure, it should return false",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "When ARO HCP has no metrics forwarding, it should return false",
+			hcp:      aroHCP(),
+			expected: false,
+		},
+		{
+			name: "When ARO HCP has metrics forwarding enabled, it should return true",
+			hcp: func() *hyperv1.HostedControlPlane {
+				hcp := aroHCP()
+				hcp.Spec.Monitoring.MetricsForwarding.Mode = hyperv1.MetricsForwardingModeForward
+				return hcp
+			}(),
+			expected: true,
+		},
+		{
+			name: "When ARO HCP has disabled monitoring, it should return false",
+			hcp: func() *hyperv1.HostedControlPlane {
+				hcp := aroHCP()
+				hcp.Annotations = map[string]string{
+					hyperv1.DisableMonitoringServices: "true",
+				}
+				hcp.Spec.Monitoring.MetricsForwarding.Mode = hyperv1.MetricsForwardingModeForward
+				return hcp
+			}(),
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(metricsProxyRouteRequired(tc.hcp)).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestHcpRouterRouteReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		route    *routev1.Route
+		expected bool
+	}{
+		{
+			name: "When route has a host, it should be ready",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					Host: "test.example.com",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "When route has no host, it should not be ready",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{},
+			},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(hcpRouterRouteReady(tc.route)).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestEnsureHCPRouterRoutesExist(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := routev1.Install(scheme); err != nil {
+		t.Fatalf("install Route scheme: %v", err)
+	}
+
+	readyRoute := func(name string) *routev1.Route {
+		return &routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "test-ns",
+			},
+			Spec: routev1.RouteSpec{
+				Host: name + ".example.com",
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		hcp         *hyperv1.HostedControlPlane
+		routes      []runtime.Object
+		expectedErr string
+	}{
+		{
+			name: "When all base routes are present and ready, it should succeed",
+			hcp:  aroHCP(),
+			routes: []runtime.Object{
+				readyRoute("kube-apiserver-internal"),
+				readyRoute("konnectivity-server"),
+				readyRoute("oauth-internal"),
+				readyRoute("ignition-server"),
+			},
+		},
+		{
+			name: "When ignition-server route is missing, it should return an error",
+			hcp:  aroHCP(),
+			routes: []runtime.Object{
+				readyRoute("kube-apiserver-internal"),
+				readyRoute("konnectivity-server"),
+				readyRoute("oauth-internal"),
+			},
+			expectedErr: "waiting for HCP router routes: ignition-server",
+		},
+		{
+			name: "When route exists but has no host, it should return an error",
+			hcp:  aroHCP(),
+			routes: []runtime.Object{
+				readyRoute("kube-apiserver-internal"),
+				readyRoute("konnectivity-server"),
+				readyRoute("oauth-internal"),
+				&routev1.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ignition-server",
+						Namespace: "test-ns",
+					},
+				},
+			},
+			expectedErr: "waiting for HCP router routes: ignition-server",
+		},
+		{
+			name:        "When all routes are missing, it should return an error listing all",
+			hcp:         aroHCP(),
+			routes:      []runtime.Object{},
+			expectedErr: "waiting for HCP router routes: kube-apiserver-internal, konnectivity-server, oauth-internal, ignition-server",
+		},
+		{
+			name: "When metrics forwarding is enabled and metrics-proxy is missing, it should return an error",
+			hcp: func() *hyperv1.HostedControlPlane {
+				hcp := aroHCP()
+				hcp.Spec.Monitoring.MetricsForwarding.Mode = hyperv1.MetricsForwardingModeForward
+				return hcp
+			}(),
+			routes: []runtime.Object{
+				readyRoute("kube-apiserver-internal"),
+				readyRoute("konnectivity-server"),
+				readyRoute("oauth-internal"),
+				readyRoute("ignition-server"),
+			},
+			expectedErr: "waiting for HCP router routes: metrics-proxy",
+		},
+		{
+			name: "When metrics forwarding is enabled and all routes are present, it should succeed",
+			hcp: func() *hyperv1.HostedControlPlane {
+				hcp := aroHCP()
+				hcp.Spec.Monitoring.MetricsForwarding.Mode = hyperv1.MetricsForwardingModeForward
+				return hcp
+			}(),
+			routes: []runtime.Object{
+				readyRoute("kube-apiserver-internal"),
+				readyRoute("konnectivity-server"),
+				readyRoute("oauth-internal"),
+				readyRoute("ignition-server"),
+				readyRoute("metrics-proxy"),
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tc.routes...).
+				Build()
+			cpContext := component.WorkloadContext{
+				Context: context.Background(),
+				Client:  fakeClient,
+				HCP:     tc.hcp,
+			}
+			err := ensureHCPRouterRoutesExist(cpContext)
+			if tc.expectedErr == "" {
+				g.Expect(err).ToNot(HaveOccurred())
+			} else {
+				g.Expect(err).To(MatchError(tc.expectedErr))
+			}
+		})
+	}
+}
+
+func TestRouterPredicate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := routev1.Install(scheme); err != nil {
+		t.Fatalf("install Route scheme: %v", err)
+	}
+
+	readyRoute := func(name string) *routev1.Route {
+		return &routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "test-ns",
+			},
+			Spec: routev1.RouteSpec{
+				Host: name + ".example.com",
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		hcp       *hyperv1.HostedControlPlane
+		routes    []runtime.Object
+		expected  bool
+		expectErr bool
+	}{
+		{
+			name: "When platform does not use HCP router, it should return false",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.IBMCloudPlatform,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "When ARO HCP has all routes ready, it should return true",
+			hcp:  aroHCP(),
+			routes: []runtime.Object{
+				readyRoute("kube-apiserver-internal"),
+				readyRoute("konnectivity-server"),
+				readyRoute("oauth-internal"),
+				readyRoute("ignition-server"),
+			},
+			expected: true,
+		},
+		{
+			name:      "When ARO HCP has missing routes, it should return false with error",
+			hcp:       aroHCP(),
+			routes:    []runtime.Object{},
+			expected:  false,
+			expectErr: true,
+		},
+		{
+			name: "When AWS has private endpoint access, it should return true without route checks",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Private,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tc.routes...).
+				Build()
+			cpContext := component.WorkloadContext{
+				Context: context.Background(),
+				Client:  fakeClient,
+				HCP:     tc.hcp,
+			}
+			got, err := routerPredicate(cpContext)
+			if tc.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(got).To(Equal(tc.expected))
 		})
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 
+	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -319,12 +320,11 @@ func TestUseHCPRouter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			if tt.setupEnv != nil {
 				tt.setupEnv(t)
 			}
-			if got := util.UseHCPRouter(tt.hcp); got != tt.want {
-				t.Errorf("UseHCPRouter() = %v, want %v", got, tt.want)
-			}
+			g.Expect(util.UseHCPRouter(tt.hcp)).To(Equal(tt.want))
 		})
 	}
 }
@@ -366,13 +366,30 @@ func TestAroExpectedHCPRouterRouteNames(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "When ARO HCP has no metrics forwarding, it should return base routes",
+			name: "When ARO HCP has OAuth disabled via OIDC, it should exclude oauth-internal",
+			hcp: func() *hyperv1.HostedControlPlane {
+				hcp := aroHCP()
+				hcp.Spec.Configuration = &hyperv1.ClusterConfiguration{
+					Authentication: &configv1.AuthenticationSpec{
+						Type: configv1.AuthenticationTypeOIDC,
+					},
+				}
+				return hcp
+			}(),
+			expected: []string{
+				"kube-apiserver-internal",
+				"konnectivity-server",
+				"ignition-server",
+			},
+		},
+		{
+			name: "When ARO HCP has no metrics forwarding, it should return base routes plus oauth",
 			hcp:  aroHCP(),
 			expected: []string{
 				"kube-apiserver-internal",
 				"konnectivity-server",
-				"oauth-internal",
 				"ignition-server",
+				"oauth-internal",
 			},
 		},
 		{
@@ -385,8 +402,8 @@ func TestAroExpectedHCPRouterRouteNames(t *testing.T) {
 			expected: []string{
 				"kube-apiserver-internal",
 				"konnectivity-server",
-				"oauth-internal",
 				"ignition-server",
+				"oauth-internal",
 				"metrics-proxy",
 			},
 		},
@@ -403,8 +420,8 @@ func TestAroExpectedHCPRouterRouteNames(t *testing.T) {
 			expected: []string{
 				"kube-apiserver-internal",
 				"konnectivity-server",
-				"oauth-internal",
 				"ignition-server",
+				"oauth-internal",
 			},
 		},
 	}
@@ -568,7 +585,7 @@ func TestEnsureHCPRouterRoutesExist(t *testing.T) {
 			name:        "When all routes are missing, it should return an error listing all",
 			hcp:         aroHCP(),
 			routes:      []runtime.Object{},
-			expectedErr: "waiting for HCP router routes: kube-apiserver-internal, konnectivity-server, oauth-internal, ignition-server",
+			expectedErr: "waiting for HCP router routes: kube-apiserver-internal, konnectivity-server, ignition-server, oauth-internal",
 		},
 		{
 			name: "When metrics forwarding is enabled and metrics-proxy is missing, it should return an error",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
@@ -333,12 +333,14 @@ func aroHCP() *hyperv1.HostedControlPlane {
 	return &hyperv1.HostedControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-ns",
+			Annotations: map[string]string{
+				hyperv1.SwiftPodNetworkInstanceAnnotation: "test-instance",
+			},
 		},
 		Spec: hyperv1.HostedControlPlaneSpec{
 			Platform: hyperv1.PlatformSpec{
 				Type: hyperv1.AzurePlatform,
 				Azure: &hyperv1.AzurePlatformSpec{
-					Topology: hyperv1.AzureTopologyPrivate,
 					AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
 						AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeManagedIdentities,
 					},
@@ -352,6 +354,7 @@ func TestAroExpectedHCPRouterRouteNames(t *testing.T) {
 	tests := []struct {
 		name     string
 		hcp      *hyperv1.HostedControlPlane
+		setupEnv func(t *testing.T)
 		expected []string
 	}{
 		{
@@ -376,6 +379,9 @@ func TestAroExpectedHCPRouterRouteNames(t *testing.T) {
 				}
 				return hcp
 			}(),
+			setupEnv: func(t *testing.T) {
+				azureutil.SetAsAroHCPTest(t)
+			},
 			expected: []string{
 				"kube-apiserver-internal",
 				"konnectivity-server",
@@ -383,40 +389,11 @@ func TestAroExpectedHCPRouterRouteNames(t *testing.T) {
 			},
 		},
 		{
-			name: "When ARO HCP has no metrics forwarding, it should return base routes plus oauth",
+			name: "When ARO HCP has OAuth enabled, it should return base routes plus oauth",
 			hcp:  aroHCP(),
-			expected: []string{
-				"kube-apiserver-internal",
-				"konnectivity-server",
-				"ignition-server",
-				"oauth-internal",
+			setupEnv: func(t *testing.T) {
+				azureutil.SetAsAroHCPTest(t)
 			},
-		},
-		{
-			name: "When ARO HCP has metrics forwarding enabled, it should include metrics-proxy",
-			hcp: func() *hyperv1.HostedControlPlane {
-				hcp := aroHCP()
-				hcp.Spec.Monitoring.MetricsForwarding.Mode = hyperv1.MetricsForwardingModeForward
-				return hcp
-			}(),
-			expected: []string{
-				"kube-apiserver-internal",
-				"konnectivity-server",
-				"ignition-server",
-				"oauth-internal",
-				"metrics-proxy",
-			},
-		},
-		{
-			name: "When ARO HCP has disabled monitoring, it should exclude metrics-proxy",
-			hcp: func() *hyperv1.HostedControlPlane {
-				hcp := aroHCP()
-				hcp.Annotations = map[string]string{
-					hyperv1.DisableMonitoringServices: "true",
-				}
-				hcp.Spec.Monitoring.MetricsForwarding.Mode = hyperv1.MetricsForwardingModeForward
-				return hcp
-			}(),
 			expected: []string{
 				"kube-apiserver-internal",
 				"konnectivity-server",
@@ -428,64 +405,15 @@ func TestAroExpectedHCPRouterRouteNames(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
+			if tc.setupEnv != nil {
+				tc.setupEnv(t)
+			}
 			got := aroExpectedHCPRouterRouteNames(tc.hcp)
 			if tc.expected == nil {
 				g.Expect(got).To(BeNil())
 			} else {
 				g.Expect(got).To(Equal(tc.expected))
 			}
-		})
-	}
-}
-
-func TestMetricsProxyRouteRequired(t *testing.T) {
-	tests := []struct {
-		name     string
-		hcp      *hyperv1.HostedControlPlane
-		expected bool
-	}{
-		{
-			name: "When platform is not Azure, it should return false",
-			hcp: &hyperv1.HostedControlPlane{
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{
-						Type: hyperv1.AWSPlatform,
-					},
-				},
-			},
-			expected: false,
-		},
-		{
-			name:     "When ARO HCP has no metrics forwarding, it should return false",
-			hcp:      aroHCP(),
-			expected: false,
-		},
-		{
-			name: "When ARO HCP has metrics forwarding enabled, it should return true",
-			hcp: func() *hyperv1.HostedControlPlane {
-				hcp := aroHCP()
-				hcp.Spec.Monitoring.MetricsForwarding.Mode = hyperv1.MetricsForwardingModeForward
-				return hcp
-			}(),
-			expected: true,
-		},
-		{
-			name: "When ARO HCP has disabled monitoring, it should return false",
-			hcp: func() *hyperv1.HostedControlPlane {
-				hcp := aroHCP()
-				hcp.Annotations = map[string]string{
-					hyperv1.DisableMonitoringServices: "true",
-				}
-				hcp.Spec.Monitoring.MetricsForwarding.Mode = hyperv1.MetricsForwardingModeForward
-				return hcp
-			}(),
-			expected: false,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewWithT(t)
-			g.Expect(metricsProxyRouteRequired(tc.hcp)).To(Equal(tc.expected))
 		})
 	}
 }
@@ -542,12 +470,16 @@ func TestEnsureHCPRouterRoutesExist(t *testing.T) {
 	tests := []struct {
 		name        string
 		hcp         *hyperv1.HostedControlPlane
+		setupEnv    func(t *testing.T)
 		routes      []runtime.Object
 		expectedErr string
 	}{
 		{
 			name: "When all base routes are present and ready, it should succeed",
 			hcp:  aroHCP(),
+			setupEnv: func(t *testing.T) {
+				azureutil.SetAsAroHCPTest(t)
+			},
 			routes: []runtime.Object{
 				readyRoute("kube-apiserver-internal"),
 				readyRoute("konnectivity-server"),
@@ -558,6 +490,9 @@ func TestEnsureHCPRouterRoutesExist(t *testing.T) {
 		{
 			name: "When ignition-server route is missing, it should return an error",
 			hcp:  aroHCP(),
+			setupEnv: func(t *testing.T) {
+				azureutil.SetAsAroHCPTest(t)
+			},
 			routes: []runtime.Object{
 				readyRoute("kube-apiserver-internal"),
 				readyRoute("konnectivity-server"),
@@ -568,6 +503,9 @@ func TestEnsureHCPRouterRoutesExist(t *testing.T) {
 		{
 			name: "When route exists but has no host, it should return an error",
 			hcp:  aroHCP(),
+			setupEnv: func(t *testing.T) {
+				azureutil.SetAsAroHCPTest(t)
+			},
 			routes: []runtime.Object{
 				readyRoute("kube-apiserver-internal"),
 				readyRoute("konnectivity-server"),
@@ -582,45 +520,21 @@ func TestEnsureHCPRouterRoutesExist(t *testing.T) {
 			expectedErr: "waiting for HCP router routes: ignition-server",
 		},
 		{
-			name:        "When all routes are missing, it should return an error listing all",
-			hcp:         aroHCP(),
+			name: "When all routes are missing, it should return an error listing all",
+			hcp:  aroHCP(),
+			setupEnv: func(t *testing.T) {
+				azureutil.SetAsAroHCPTest(t)
+			},
 			routes:      []runtime.Object{},
 			expectedErr: "waiting for HCP router routes: kube-apiserver-internal, konnectivity-server, ignition-server, oauth-internal",
-		},
-		{
-			name: "When metrics forwarding is enabled and metrics-proxy is missing, it should return an error",
-			hcp: func() *hyperv1.HostedControlPlane {
-				hcp := aroHCP()
-				hcp.Spec.Monitoring.MetricsForwarding.Mode = hyperv1.MetricsForwardingModeForward
-				return hcp
-			}(),
-			routes: []runtime.Object{
-				readyRoute("kube-apiserver-internal"),
-				readyRoute("konnectivity-server"),
-				readyRoute("oauth-internal"),
-				readyRoute("ignition-server"),
-			},
-			expectedErr: "waiting for HCP router routes: metrics-proxy",
-		},
-		{
-			name: "When metrics forwarding is enabled and all routes are present, it should succeed",
-			hcp: func() *hyperv1.HostedControlPlane {
-				hcp := aroHCP()
-				hcp.Spec.Monitoring.MetricsForwarding.Mode = hyperv1.MetricsForwardingModeForward
-				return hcp
-			}(),
-			routes: []runtime.Object{
-				readyRoute("kube-apiserver-internal"),
-				readyRoute("konnectivity-server"),
-				readyRoute("oauth-internal"),
-				readyRoute("ignition-server"),
-				readyRoute("metrics-proxy"),
-			},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
+			if tc.setupEnv != nil {
+				tc.setupEnv(t)
+			}
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithRuntimeObjects(tc.routes...).
@@ -661,6 +575,7 @@ func TestRouterPredicate(t *testing.T) {
 	tests := []struct {
 		name      string
 		hcp       *hyperv1.HostedControlPlane
+		setupEnv  func(t *testing.T)
 		routes    []runtime.Object
 		expected  bool
 		expectErr bool
@@ -679,6 +594,9 @@ func TestRouterPredicate(t *testing.T) {
 		{
 			name: "When ARO HCP has all routes ready, it should return true",
 			hcp:  aroHCP(),
+			setupEnv: func(t *testing.T) {
+				azureutil.SetAsAroHCPTest(t)
+			},
 			routes: []runtime.Object{
 				readyRoute("kube-apiserver-internal"),
 				readyRoute("konnectivity-server"),
@@ -688,8 +606,11 @@ func TestRouterPredicate(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:      "When ARO HCP has missing routes, it should return false with error",
-			hcp:       aroHCP(),
+			name: "When ARO HCP has missing routes, it should return false with error",
+			hcp:  aroHCP(),
+			setupEnv: func(t *testing.T) {
+				azureutil.SetAsAroHCPTest(t)
+			},
 			routes:    []runtime.Object{},
 			expected:  false,
 			expectErr: true,
@@ -715,6 +636,9 @@ func TestRouterPredicate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
+			if tc.setupEnv != nil {
+				tc.setupEnv(t)
+			}
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithRuntimeObjects(tc.routes...).

--- a/support/controlplane-component/status.go
+++ b/support/controlplane-component/status.go
@@ -36,6 +36,7 @@ var (
 		"karpenter-operator",
 		"karpenter",
 		"router",
+		"ignition-server",
 	)
 )
 

--- a/support/controlplane-component/status.go
+++ b/support/controlplane-component/status.go
@@ -37,6 +37,7 @@ var (
 		"karpenter",
 		"router",
 		"ignition-server",
+		"ignition-server-proxy",
 	)
 )
 


### PR DESCRIPTION
## Summary
Cherry-pick of PR #8971 to release-4.21 with manual conflict resolution and adaptation fixes.

- Moves router component registration after all route-creating components (ignition-server) so the HAProxy config includes every route on the first reconcile pass
- Adds router predicate on ARO-HCP to wait for expected routes before reconciling
- Excludes ignition-server and ignition-server-proxy from implicit KAS dependency
- Conditionally includes oauth-internal in ARO route predicate

## Commits
- `77e577f6c4`: fix(control-plane-operator): ensure router component runs after route-creating components
- `c995ad02f6`: fix(control-plane-operator): drop metrics-proxy from router WithDependencies
- `2b9df60b2f`: fix(control-plane-component): exclude ignition-server from implicit KAS dependency
- `00e36f3406`: fix(router): conditionally include oauth-internal in ARO route predicate
- `d565a6ed5b`: fix(control-plane-component): exclude ignition-server-proxy from implicit KAS dependency

## Fixes Applied
- Resolved merge conflict in `hostedcontrolplane_controller.go` (router positioned after ignitionproxyv2; endpoint_resolver, metrics_proxy, kubestorageversionmigrator components do not exist on release-4.21)
- Resolved merge conflict in `hostedcontrolplane_controller_test.go` (test functions present on main but not on release-4.21)
- Removed `endpointresolverv2` and `metricsProxyRouteRequired` (endpoint_resolver package and MetricsForwarding API do not exist on release-4.21)
- Replaced `azureutil.IsAroHCPByHCP` with `azureutil.IsAroHCP` (ByHCP variant does not exist on release-4.21)
- Removed `AzureTopologyPrivate` from test helper (type does not exist on release-4.21)
- Added `SwiftPodNetworkInstanceAnnotation` and `SetAsAroHCPTest` to ARO test cases (IsPrivateHCP/IsAroHCP are env-var based on release-4.21)
- Used `FakeReleaseProvider` instead of gomock-generated mock (mock file not generated on release-4.21)

## References
- Original PR: #8971
- release-4.22 cherry-pick: #9212
- JIRA: OCPBUGS-98213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>