### PR TITLE
GCP-916: allow goog-partner-solution label key in GCP resourceLabels

### DIFF
--- a/api/hypershift/v1beta1/gcp.go
+++ b/api/hypershift/v1beta1/gcp.go
@@ -24,14 +24,15 @@ type GCPResourceLabel struct {
 	// - Contain only lowercase letters, digits, underscores, or hyphens
 	// - End with a lowercase letter or digit (not a hyphen or underscore)
 	// - Be 1-63 characters long
-	// GCP reserves the 'goog' prefix for system labels.
+	// GCP reserves the 'goog' prefix for system labels, with the exception of
+	// 'goog-partner-solution' which Google requires for partner attribution tracking.
 	// See https://cloud.google.com/compute/docs/labeling-resources for Compute Engine label requirements.
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z]([_a-z0-9-]{0,61}[a-z0-9])?$')",message="key must start with a lowercase letter, contain only lowercase letters, digits, underscores, or hyphens, and end with a letter or digit"
-	// +kubebuilder:validation:XValidation:rule="!self.startsWith('goog')",message="Label keys starting with the reserved 'goog' prefix are not allowed"
+	// +kubebuilder:validation:XValidation:rule="!self.startsWith('goog') || self == 'goog-partner-solution'",message="Label keys starting with the reserved 'goog' prefix are not allowed (exception: 'goog-partner-solution')"
 	Key string `json:"key,omitempty"`
 
 	// value is the value part of the label. A label value can have a maximum of 63 characters.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -5869,7 +5869,8 @@ spec:
                                 - Contain only lowercase letters, digits, underscores, or hyphens
                                 - End with a lowercase letter or digit (not a hyphen or underscore)
                                 - Be 1-63 characters long
-                                GCP reserves the 'goog' prefix for system labels.
+                                GCP reserves the 'goog' prefix for system labels, with the exception of
+                                'goog-partner-solution' which Google requires for partner attribution tracking.
                                 See https://cloud.google.com/compute/docs/labeling-resources for Compute Engine label requirements.
                               maxLength: 63
                               minLength: 1
@@ -5879,9 +5880,9 @@ spec:
                                   only lowercase letters, digits, underscores, or
                                   hyphens, and end with a letter or digit
                                 rule: self.matches('^[a-z]([_a-z0-9-]{0,61}[a-z0-9])?$')
-                              - message: Label keys starting with the reserved 'goog'
-                                  prefix are not allowed
-                                rule: '!self.startsWith(''goog'')'
+                              - message: 'Label keys starting with the reserved ''goog''
+                                  prefix are not allowed (exception: ''goog-partner-solution'')'
+                                rule: '!self.startsWith(''goog'') || self == ''goog-partner-solution'''
                             value:
                               description: |-
                                 value is the value part of the label. A label value can have a maximum of 63 characters.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -5747,7 +5747,8 @@ spec:
                                 - Contain only lowercase letters, digits, underscores, or hyphens
                                 - End with a lowercase letter or digit (not a hyphen or underscore)
                                 - Be 1-63 characters long
-                                GCP reserves the 'goog' prefix for system labels.
+                                GCP reserves the 'goog' prefix for system labels, with the exception of
+                                'goog-partner-solution' which Google requires for partner attribution tracking.
                                 See https://cloud.google.com/compute/docs/labeling-resources for Compute Engine label requirements.
                               maxLength: 63
                               minLength: 1
@@ -5757,9 +5758,9 @@ spec:
                                   only lowercase letters, digits, underscores, or
                                   hyphens, and end with a letter or digit
                                 rule: self.matches('^[a-z]([_a-z0-9-]{0,61}[a-z0-9])?$')
-                              - message: Label keys starting with the reserved 'goog'
-                                  prefix are not allowed
-                                rule: '!self.startsWith(''goog'')'
+                              - message: 'Label keys starting with the reserved ''goog''
+                                  prefix are not allowed (exception: ''goog-partner-solution'')'
+                                rule: '!self.startsWith(''goog'') || self == ''goog-partner-solution'''
                             value:
                               description: |-
                                 value is the value part of the label. A label value can have a maximum of 63 characters.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -1211,7 +1211,8 @@ spec:
                                 - Contain only lowercase letters, digits, underscores, or hyphens
                                 - End with a lowercase letter or digit (not a hyphen or underscore)
                                 - Be 1-63 characters long
-                                GCP reserves the 'goog' prefix for system labels.
+                                GCP reserves the 'goog' prefix for system labels, with the exception of
+                                'goog-partner-solution' which Google requires for partner attribution tracking.
                                 See https://cloud.google.com/compute/docs/labeling-resources for Compute Engine label requirements.
                               maxLength: 63
                               minLength: 1
@@ -1221,9 +1222,9 @@ spec:
                                   only lowercase letters, digits, underscores, or
                                   hyphens, and end with a letter or digit
                                 rule: self.matches('^[a-z]([_a-z0-9-]{0,61}[a-z0-9])?$')
-                              - message: Label keys starting with the reserved 'goog'
-                                  prefix are not allowed
-                                rule: '!self.startsWith(''goog'')'
+                              - message: 'Label keys starting with the reserved ''goog''
+                                  prefix are not allowed (exception: ''goog-partner-solution'')'
+                                rule: '!self.startsWith(''goog'') || self == ''goog-partner-solution'''
                             value:
                               description: |-
                                 value is the value part of the label. A label value can have a maximum of 63 characters.

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/techpreview.hostedclusters.gcp.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/techpreview.hostedclusters.gcp.testsuite.yaml
@@ -960,6 +960,124 @@ tests:
             route: {}
     expectedError: "imageRegistry service account must belong to the same project"
 
+  # --- GCP resourceLabels validation ---
+  - name: When GCP resourceLabels key starts with goog it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: GCP
+          gcp:
+            project: my-project-123
+            region: us-central1
+            networkConfig:
+              network:
+                name: my-network
+              privateServiceConnectSubnet:
+                name: my-psc-subnet
+            workloadIdentity:
+              projectNumber: "123456789012"
+              poolID: my-wif-pool
+              providerID: my-wif-provider
+              serviceAccountsEmails:
+                nodePool: nodepool@my-project-123.iam.gserviceaccount.com
+                controlPlane: controlplane@my-project-123.iam.gserviceaccount.com
+                cloudController: cloudcontroller@my-project-123.iam.gserviceaccount.com
+                storage: storage@my-project-123.iam.gserviceaccount.com
+                imageRegistry: imageregistry@my-project-123.iam.gserviceaccount.com
+                network: cnccsa@my-project-123.iam.gserviceaccount.com
+            resourceLabels:
+              - key: googfoo
+                value: bar
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "Label keys starting with the reserved 'goog' prefix are not allowed"
+
+  - name: When GCP resourceLabels key is goog-partner-solution it should succeed
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: GCP
+          gcp:
+            project: my-project-123
+            region: us-central1
+            networkConfig:
+              network:
+                name: my-network
+              privateServiceConnectSubnet:
+                name: my-psc-subnet
+            workloadIdentity:
+              projectNumber: "123456789012"
+              poolID: my-wif-pool
+              providerID: my-wif-provider
+              serviceAccountsEmails:
+                nodePool: nodepool@my-project-123.iam.gserviceaccount.com
+                controlPlane: controlplane@my-project-123.iam.gserviceaccount.com
+                cloudController: cloudcontroller@my-project-123.iam.gserviceaccount.com
+                storage: storage@my-project-123.iam.gserviceaccount.com
+                imageRegistry: imageregistry@my-project-123.iam.gserviceaccount.com
+                network: cnccsa@my-project-123.iam.gserviceaccount.com
+            resourceLabels:
+              - key: goog-partner-solution
+                value: isol_psn_0014m00001h31bnqaq_openshift
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
   onUpdate:
   # --- GCP network service account immutability ---
   - name: When GCP network service account is changed it should fail

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/techpreview.hostedclusters.gcp.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/techpreview.hostedclusters.gcp.testsuite.yaml
@@ -1020,6 +1020,65 @@ tests:
             route: {}
     expectedError: "Label keys starting with the reserved 'goog' prefix are not allowed"
 
+  - name: When GCP resourceLabels key is goog-partner-solution-foo it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: GCP
+          gcp:
+            project: my-project-123
+            region: us-central1
+            networkConfig:
+              network:
+                name: my-network
+              privateServiceConnectSubnet:
+                name: my-psc-subnet
+            workloadIdentity:
+              projectNumber: "123456789012"
+              poolID: my-wif-pool
+              providerID: my-wif-provider
+              serviceAccountsEmails:
+                nodePool: nodepool@my-project-123.iam.gserviceaccount.com
+                controlPlane: controlplane@my-project-123.iam.gserviceaccount.com
+                cloudController: cloudcontroller@my-project-123.iam.gserviceaccount.com
+                storage: storage@my-project-123.iam.gserviceaccount.com
+                imageRegistry: imageregistry@my-project-123.iam.gserviceaccount.com
+                network: cnccsa@my-project-123.iam.gserviceaccount.com
+            resourceLabels:
+              - key: goog-partner-solution-foo
+                value: bar
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "Label keys starting with the reserved 'goog' prefix are not allowed"
+
   - name: When GCP resourceLabels key is goog-partner-solution it should succeed
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -7980,7 +7980,8 @@ spec:
                                 - Contain only lowercase letters, digits, underscores, or hyphens
                                 - End with a lowercase letter or digit (not a hyphen or underscore)
                                 - Be 1-63 characters long
-                                GCP reserves the 'goog' prefix for system labels.
+                                GCP reserves the 'goog' prefix for system labels, with the exception of
+                                'goog-partner-solution' which Google requires for partner attribution tracking.
                                 See https://cloud.google.com/compute/docs/labeling-resources for Compute Engine label requirements.
                               maxLength: 63
                               minLength: 1
@@ -7990,9 +7991,9 @@ spec:
                                   only lowercase letters, digits, underscores, or
                                   hyphens, and end with a letter or digit
                                 rule: self.matches('^[a-z]([_a-z0-9-]{0,61}[a-z0-9])?$')
-                              - message: Label keys starting with the reserved 'goog'
-                                  prefix are not allowed
-                                rule: '!self.startsWith(''goog'')'
+                              - message: 'Label keys starting with the reserved ''goog''
+                                  prefix are not allowed (exception: ''goog-partner-solution'')'
+                                rule: '!self.startsWith(''goog'') || self == ''goog-partner-solution'''
                             value:
                               description: |-
                                 value is the value part of the label. A label value can have a maximum of 63 characters.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -7102,7 +7102,8 @@ spec:
                                 - Contain only lowercase letters, digits, underscores, or hyphens
                                 - End with a lowercase letter or digit (not a hyphen or underscore)
                                 - Be 1-63 characters long
-                                GCP reserves the 'goog' prefix for system labels.
+                                GCP reserves the 'goog' prefix for system labels, with the exception of
+                                'goog-partner-solution' which Google requires for partner attribution tracking.
                                 See https://cloud.google.com/compute/docs/labeling-resources for Compute Engine label requirements.
                               maxLength: 63
                               minLength: 1
@@ -7112,9 +7113,9 @@ spec:
                                   only lowercase letters, digits, underscores, or
                                   hyphens, and end with a letter or digit
                                 rule: self.matches('^[a-z]([_a-z0-9-]{0,61}[a-z0-9])?$')
-                              - message: Label keys starting with the reserved 'goog'
-                                  prefix are not allowed
-                                rule: '!self.startsWith(''goog'')'
+                              - message: 'Label keys starting with the reserved ''goog''
+                                  prefix are not allowed (exception: ''goog-partner-solution'')'
+                                rule: '!self.startsWith(''goog'') || self == ''goog-partner-solution'''
                             value:
                               description: |-
                                 value is the value part of the label. A label value can have a maximum of 63 characters.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -7858,7 +7858,8 @@ spec:
                                 - Contain only lowercase letters, digits, underscores, or hyphens
                                 - End with a lowercase letter or digit (not a hyphen or underscore)
                                 - Be 1-63 characters long
-                                GCP reserves the 'goog' prefix for system labels.
+                                GCP reserves the 'goog' prefix for system labels, with the exception of
+                                'goog-partner-solution' which Google requires for partner attribution tracking.
                                 See https://cloud.google.com/compute/docs/labeling-resources for Compute Engine label requirements.
                               maxLength: 63
                               minLength: 1
@@ -7868,9 +7869,9 @@ spec:
                                   only lowercase letters, digits, underscores, or
                                   hyphens, and end with a letter or digit
                                 rule: self.matches('^[a-z]([_a-z0-9-]{0,61}[a-z0-9])?$')
-                              - message: Label keys starting with the reserved 'goog'
-                                  prefix are not allowed
-                                rule: '!self.startsWith(''goog'')'
+                              - message: 'Label keys starting with the reserved ''goog''
+                                  prefix are not allowed (exception: ''goog-partner-solution'')'
+                                rule: '!self.startsWith(''goog'') || self == ''goog-partner-solution'''
                             value:
                               description: |-
                                 value is the value part of the label. A label value can have a maximum of 63 characters.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -6980,7 +6980,8 @@ spec:
                                 - Contain only lowercase letters, digits, underscores, or hyphens
                                 - End with a lowercase letter or digit (not a hyphen or underscore)
                                 - Be 1-63 characters long
-                                GCP reserves the 'goog' prefix for system labels.
+                                GCP reserves the 'goog' prefix for system labels, with the exception of
+                                'goog-partner-solution' which Google requires for partner attribution tracking.
                                 See https://cloud.google.com/compute/docs/labeling-resources for Compute Engine label requirements.
                               maxLength: 63
                               minLength: 1
@@ -6990,9 +6991,9 @@ spec:
                                   only lowercase letters, digits, underscores, or
                                   hyphens, and end with a letter or digit
                                 rule: self.matches('^[a-z]([_a-z0-9-]{0,61}[a-z0-9])?$')
-                              - message: Label keys starting with the reserved 'goog'
-                                  prefix are not allowed
-                                rule: '!self.startsWith(''goog'')'
+                              - message: 'Label keys starting with the reserved ''goog''
+                                  prefix are not allowed (exception: ''goog-partner-solution'')'
+                                rule: '!self.startsWith(''goog'') || self == ''goog-partner-solution'''
                             value:
                               description: |-
                                 value is the value part of the label. A label value can have a maximum of 63 characters.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -1247,7 +1247,8 @@ spec:
                                 - Contain only lowercase letters, digits, underscores, or hyphens
                                 - End with a lowercase letter or digit (not a hyphen or underscore)
                                 - Be 1-63 characters long
-                                GCP reserves the 'goog' prefix for system labels.
+                                GCP reserves the 'goog' prefix for system labels, with the exception of
+                                'goog-partner-solution' which Google requires for partner attribution tracking.
                                 See https://cloud.google.com/compute/docs/labeling-resources for Compute Engine label requirements.
                               maxLength: 63
                               minLength: 1
@@ -1257,9 +1258,9 @@ spec:
                                   only lowercase letters, digits, underscores, or
                                   hyphens, and end with a letter or digit
                                 rule: self.matches('^[a-z]([_a-z0-9-]{0,61}[a-z0-9])?$')
-                              - message: Label keys starting with the reserved 'goog'
-                                  prefix are not allowed
-                                rule: '!self.startsWith(''goog'')'
+                              - message: 'Label keys starting with the reserved ''goog''
+                                  prefix are not allowed (exception: ''goog-partner-solution'')'
+                                rule: '!self.startsWith(''goog'') || self == ''goog-partner-solution'''
                             value:
                               description: |-
                                 value is the value part of the label. A label value can have a maximum of 63 characters.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -1247,7 +1247,8 @@ spec:
                                 - Contain only lowercase letters, digits, underscores, or hyphens
                                 - End with a lowercase letter or digit (not a hyphen or underscore)
                                 - Be 1-63 characters long
-                                GCP reserves the 'goog' prefix for system labels.
+                                GCP reserves the 'goog' prefix for system labels, with the exception of
+                                'goog-partner-solution' which Google requires for partner attribution tracking.
                                 See https://cloud.google.com/compute/docs/labeling-resources for Compute Engine label requirements.
                               maxLength: 63
                               minLength: 1
@@ -1257,9 +1258,9 @@ spec:
                                   only lowercase letters, digits, underscores, or
                                   hyphens, and end with a letter or digit
                                 rule: self.matches('^[a-z]([_a-z0-9-]{0,61}[a-z0-9])?$')
-                              - message: Label keys starting with the reserved 'goog'
-                                  prefix are not allowed
-                                rule: '!self.startsWith(''goog'')'
+                              - message: 'Label keys starting with the reserved ''goog''
+                                  prefix are not allowed (exception: ''goog-partner-solution'')'
+                                rule: '!self.startsWith(''goog'') || self == ''goog-partner-solution'''
                             value:
                               description: |-
                                 value is the value part of the label. A label value can have a maximum of 63 characters.

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -47491,7 +47491,8 @@ For Compute Engine resources (VMs, disks, networks created by CAPG), keys must:
 - Contain only lowercase letters, digits, underscores, or hyphens
 - End with a lowercase letter or digit (not a hyphen or underscore)
 - Be 1-63 characters long
-GCP reserves the &lsquo;goog&rsquo; prefix for system labels.
+GCP reserves the &lsquo;goog&rsquo; prefix for system labels, with the exception of
+&lsquo;goog-partner-solution&rsquo; which Google requires for partner attribution tracking.
 See <a href="https://cloud.google.com/compute/docs/labeling-resources">https://cloud.google.com/compute/docs/labeling-resources</a> for Compute Engine label requirements.</p>
 </td>
 </tr>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -8387,7 +8387,8 @@ For Compute Engine resources (VMs, disks, networks created by CAPG), keys must:
 - Contain only lowercase letters, digits, underscores, or hyphens
 - End with a lowercase letter or digit (not a hyphen or underscore)
 - Be 1-63 characters long
-GCP reserves the &lsquo;goog&rsquo; prefix for system labels.
+GCP reserves the &lsquo;goog&rsquo; prefix for system labels, with the exception of
+&lsquo;goog-partner-solution&rsquo; which Google requires for partner attribution tracking.
 See <a href="https://cloud.google.com/compute/docs/labeling-resources">https://cloud.google.com/compute/docs/labeling-resources</a> for Compute Engine label requirements.</p>
 </td>
 </tr>

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/gcp.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/gcp.go
@@ -24,14 +24,15 @@ type GCPResourceLabel struct {
 	// - Contain only lowercase letters, digits, underscores, or hyphens
 	// - End with a lowercase letter or digit (not a hyphen or underscore)
 	// - Be 1-63 characters long
-	// GCP reserves the 'goog' prefix for system labels.
+	// GCP reserves the 'goog' prefix for system labels, with the exception of
+	// 'goog-partner-solution' which Google requires for partner attribution tracking.
 	// See https://cloud.google.com/compute/docs/labeling-resources for Compute Engine label requirements.
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z]([_a-z0-9-]{0,61}[a-z0-9])?$')",message="key must start with a lowercase letter, contain only lowercase letters, digits, underscores, or hyphens, and end with a letter or digit"
-	// +kubebuilder:validation:XValidation:rule="!self.startsWith('goog')",message="Label keys starting with the reserved 'goog' prefix are not allowed"
+	// +kubebuilder:validation:XValidation:rule="!self.startsWith('goog') || self == 'goog-partner-solution'",message="Label keys starting with the reserved 'goog' prefix are not allowed (exception: 'goog-partner-solution')"
 	Key string `json:"key,omitempty"`
 
 	// value is the value part of the label. A label value can have a maximum of 63 characters.


### PR DESCRIPTION
## What this PR does / why we need it:

Google requires the \`goog-partner-solution\` partner attribution label on all OpenShift-related GCP resources for consumption tracking. The label must flow from \`HostedCluster.spec.platform.gcp.resourceLabels\` through the HyperShift operator to CAPG and onto GCP resources (VMs, disks).

The existing CEL validation rule on \`GCPResourceLabel.Key\` blocks all label keys starting with the \`goog\` prefix, including \`goog-partner-solution\`. This PR relaxes the rule to add a specific exception for \`goog-partner-solution\`, which is a Google-mandated key — not a system-reserved one.

**Before:**
\`\`\`
rule: !self.startsWith('goog')
\`\`\`

**After:**
\`\`\`
rule: !self.startsWith('goog') || self == 'goog-partner-solution'
\`\`\`

## Which issue(s) this PR fixes:

Fixes [GCP-916](https://redhat.atlassian.net/browse/GCP-916)

## Related work:

- openshift-online/gecko#107 — companion change in the Gecko operator that consumes the label and passes it through to CAPG

## Special notes for your reviewer:

- Only the CEL validation rule and its accompanying comment are changed — no logic changes in the operator itself.
- The label propagation path (\`HostedCluster.spec.platform.gcp.resourceLabels\` → \`GCPMachineTemplate.spec.template.spec.additionalLabels\` → CAPG → VMs/disks) was already working and has been validated on a dev cluster.
- Two envtest cases are added: one confirming other \`goog*\` keys are still rejected, and one confirming \`goog-partner-solution\` is now accepted.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GCP label validation to allow the reserved `goog-partner-solution` label key.
  * Continued rejecting other label keys beginning with `goog`.
  * Clarified the related label-key documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->