### PR TITLE
NO-JIRA: fix: Make pre-commit hooks work in git worktrees

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,8 @@ The following guidelines will help ensure a smooth contribution process for both
 
 > **Tip: Install pre-commit hooks**
 >
-> Install `pre-commit` to automatically catch issues before committing. This helps catch spelling mistakes, formatting issues, and test failures early in your development process.
+> Install `pre-commit` ([installation instructions](https://pre-commit.com/#install)) and run `make setup-hooks` to automatically catch issues before committing. This helps catch spelling mistakes, formatting issues, and test failures early in your development process.
 >
-> * [Installation instructions](https://pre-commit.com/#install)
 > * [HyperShift-specific tips](docs/content/contribute/precommit-hook-help.md)
 
 ## Creating a Pull Request

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,11 @@ build: hypershift-operator control-plane-operator control-plane-pki-operator kar
 .PHONY: update
 update: api-deps workspace-sync deps api api-docs clients docs-aggregate
 
+.PHONY: setup-hooks
+setup-hooks:
+	git config core.hooksPath hack/tools/git-hooks
+	@echo "Git hooks configured. Hooks in hack/tools/git-hooks/ will run for all worktrees."
+
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/golangci-lint)
 $(GOLANGCI_LINT): $(TOOLS_DIR)/go.mod # Build golangci-lint from tools folder.
 	cd $(TOOLS_DIR); $(GO) build -tags=tools -o $(GOLANGCI_LINT) github.com/golangci/golangci-lint/v2/cmd/golangci-lint

--- a/docs/content/contribute/precommit-hook-help.md
+++ b/docs/content/contribute/precommit-hook-help.md
@@ -5,15 +5,21 @@ that catches the most common CI failures. Full verification (staticcheck, lintin
 Actions. The following sections walk you through how to install the hooks, what they do, and how to bypass them.
 
 ## Installing precommit hooks
-Once you have precommit installed on your machine([see this for more info](https://pre-commit.com/#install)), it's quite simple to install the precommit hooks.
+
+First, ensure you have `pre-commit` installed on your machine ([see this for more info](https://pre-commit.com/#install)).
+
+To install the hooks, run:
 
 ```shell
-% pre-commit install
-pre-commit installed at .git/hooks/pre-commit
-pre-commit installed at .git/hooks/pre-push
+% make setup-hooks
+Git hooks configured. Hooks in hack/tools/git-hooks/ will run for all worktrees.
 ```
 
-The hooks for each stage are defined in the `.pre-commit-config.yaml` file at the base of the HyperShift repo.
+This sets up hooks that work across all git worktrees. If you work in multiple worktrees, you only need to run this command once — it applies to the main checkout and all worktrees.
+
+The hooks for each stage are defined in the `.pre-commit-config.yaml` file at the base of the HyperShift repo. The wrapper scripts that delegate to `pre-commit` live in `hack/tools/git-hooks/`.
+
+**Note:** Do not use `pre-commit install` directly — it writes hooks to `.git/hooks/`, which won't work in worktrees. Use `make setup-hooks` instead.
 
 ## What runs on commit (pre-commit stage)
 
@@ -39,13 +45,14 @@ Full verification (staticcheck, golangci-lint, go vet, CRD schema checks, etc.) 
 run in GitHub Actions on your pull request.
 
 ## Uninstalling precommit hooks
-Sometimes it might be useful to turn off the precommit hooks briefly.
+
+To disable hooks, unset the `core.hooksPath` config:
 
 ```shell
-% pre-commit uninstall
-pre-commit uninstalled
-pre-push uninstalled
+% git config --unset core.hooksPath
 ```
+
+To re-enable them later, run `make setup-hooks` again.
 
 ## Bypassing precommit hooks
 Sometimes you may want to bypass the precommit hooks on a `git push` command, for example, if you just updated something really minor, updating your local `main` branch, or just needed to rerun a `go mod tidy` command, etc. To ignore the `pre-push` hooks, just add the `--no-verify` flag to your command.

--- a/hack/tools/git-hooks/post-checkout
+++ b/hack/tools/git-hooks/post-checkout
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Wrapper for post-checkout hook — tracked in-repo so hooks work in all worktrees.
+#
+# Git resolves hooks from $GIT_DIR/hooks/, which for worktrees is per-worktree.
+# By setting core.hooksPath to this tracked directory, all worktrees share hooks.
+#
+# See docs/content/contribute/precommit-hook-help.md for setup info.
+
+HOOK_TYPE="post-checkout"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+if command -v pre-commit > /dev/null; then
+    exec pre-commit hook-impl --config=.pre-commit-config.yaml \
+      --hook-type="$HOOK_TYPE" --hook-dir "$HERE" -- "$@"
+else
+    echo '`pre-commit` not found. Install it: https://pre-commit.com/#install' 1>&2
+    exit 1
+fi

--- a/hack/tools/git-hooks/pre-commit
+++ b/hack/tools/git-hooks/pre-commit
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Wrapper for pre-commit hook — tracked in-repo so hooks work in all worktrees.
+#
+# Git resolves hooks from $GIT_DIR/hooks/, which for worktrees is per-worktree.
+# By setting core.hooksPath to this tracked directory, all worktrees share hooks.
+#
+# See docs/content/contribute/precommit-hook-help.md for setup info.
+
+HOOK_TYPE="pre-commit"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+if command -v pre-commit > /dev/null; then
+    exec pre-commit hook-impl --config=.pre-commit-config.yaml \
+      --hook-type="$HOOK_TYPE" --hook-dir "$HERE" -- "$@"
+else
+    echo '`pre-commit` not found. Install it: https://pre-commit.com/#install' 1>&2
+    exit 1
+fi

--- a/hack/tools/git-hooks/pre-push
+++ b/hack/tools/git-hooks/pre-push
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Wrapper for pre-push hook — tracked in-repo so hooks work in all worktrees.
+#
+# Git resolves hooks from $GIT_DIR/hooks/, which for worktrees is per-worktree.
+# By setting core.hooksPath to this tracked directory, all worktrees share hooks.
+#
+# See docs/content/contribute/precommit-hook-help.md for setup info.
+
+HOOK_TYPE="pre-push"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+if command -v pre-commit > /dev/null; then
+    exec pre-commit hook-impl --config=.pre-commit-config.yaml \
+      --hook-type="$HOOK_TYPE" --hook-dir "$HERE" -- "$@"
+else
+    echo '`pre-commit` not found. Install it: https://pre-commit.com/#install' 1>&2
+    exit 1
+fi


### PR DESCRIPTION
## What this PR does / why we need it:

This PR fixes pre-commit hooks to work correctly in git worktrees. Previously, hooks only worked in the main checkout because git resolves hooks from `$GIT_DIR/hooks/`, which for worktrees points to `.git/worktrees/<name>/hooks/` (not the shared `.git/hooks/` where `pre-commit install` writes them).

The fix adds tracked hook wrapper scripts in `hack/tools/git-hooks/` and configures `core.hooksPath` to point there. Since this config is stored in `.git/config` (shared via `$GIT_COMMON_DIR`), all worktrees automatically inherit it.

**Changes:**
- Add hook wrapper scripts (pre-commit, pre-push, post-checkout) to `hack/tools/git-hooks/` that delegate to `pre-commit hook-impl`
- Add `make setup-hooks` target to configure `core.hooksPath`
- Update documentation to use `make setup-hooks` instead of `pre-commit install`

Developers run `make setup-hooks` once; hooks then work in all worktrees.

## Which issue(s) this PR fixes:

Fixes NO-JIRA (developer tooling improvement)

## Special notes for your reviewer:

- The hook scripts follow the same pattern as what `pre-commit install` generates, but without hardcoded Python paths
- Only documentation and hook setup changed — no code changes
- Hooks verified working in both main checkout and worktrees

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [x] This change includes unit tests. (N/A - tooling change)

---

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setup command for configuring repository Git hooks.
  * Added pre-commit checks for checkout, commit, and push operations.
  * Added clear error guidance when pre-commit is unavailable.

* **Documentation**
  * Streamlined contributor setup instructions.
  * Documented worktree support, hook configuration, and safe uninstall steps.
  * Clarified that direct pre-commit installation is not recommended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->