### PR TITLE
NO-JIRA: fix: separate gci-only pre-commit hooks from full lint-fix targets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,15 +37,15 @@ repos:
         stages: [pre-commit]
       - id: api-lint-fix
         name: Sort API imports
-        description: Runs `make api-lint-fix` to sort imports in the api/ module.
-        entry: make api-lint-fix PULL_BASE_SHA=HEAD
+        description: Runs `make precommit-api-lint-fix` to sort imports in the api/ module.
+        entry: bash -c 'make precommit-api-lint-fix FILES="$*"' --
         language: system
         stages: [pre-commit]
         files: '^api/.*\.go$'
       - id: main-lint-fix
         name: Sort imports
-        description: Runs `make main-lint-fix` to sort imports in the main module.
-        entry: make main-lint-fix PULL_BASE_SHA=HEAD
+        description: Runs `make precommit-main-lint-fix` to sort imports in the main module.
+        entry: bash -c 'make precommit-main-lint-fix FILES="$*"' --
         language: system
         stages: [pre-commit]
         files: '\.go$'

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,10 @@ api-lint: $(GOLANGCI_LINT) $(KUBEAPILINTER_PLUGIN)
 api-lint-fix: $(GOLANGCI_LINT) $(KUBEAPILINTER_PLUGIN)
 	cd api && $(GOLANGCI_LINT) run --config ./.golangci.yml --fix -v --new-from-rev=${PULL_BASE_SHA}
 
+.PHONY: precommit-api-lint-fix
+precommit-api-lint-fix: $(GOLANGCI_LINT)
+	cd api && $(GOLANGCI_LINT) fmt --config ./.golangci.yml --enable gci $(patsubst api/%,%,$(FILES))
+
 .PHONY: lint
 lint: generate
 	$(MAKE) api-lint; api_rc=$$?; \
@@ -122,6 +126,10 @@ lint: generate
 .PHONY: main-lint-fix
 main-lint-fix: generate $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) run --config ./.golangci.yml --fix -v $(if $(PULL_BASE_SHA),--new-from-rev=$(PULL_BASE_SHA) --whole-files)
+
+.PHONY: precommit-main-lint-fix
+precommit-main-lint-fix: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) fmt --config ./.golangci.yml --enable gci $(FILES)
 
 .PHONY: lint-fix
 lint-fix: generate
@@ -392,7 +400,7 @@ test: generate
 test-changed:
 	@CHANGED_DIRS=$$(git diff --name-only $(PULL_BASE_SHA)...HEAD -- '*.go' | \
 		while IFS= read -r file; do dirname "$$file"; done | \
-		sort -u | sed 's|^|./|' | grep -v '^\./vendor/' | grep -v '^\./api/vendor/' | grep -v '^\./hack/tools/' | grep -vE '^\./test/e2e(/|$$)'); \
+		sort -u | sed 's|^|./|' | grep -v '^\./vendor/' | grep -vE '^\./api(/|$$)' | grep -v '^\./hack/tools/' | grep -vE '^\./test/e2e(/|$$)'); \
 	if [ -z "$$CHANGED_DIRS" ]; then \
 		echo "No Go files changed relative to $(PULL_BASE_SHA), skipping tests."; \
 	else \


### PR DESCRIPTION
## What this PR does / why we need it:

The `api-lint-fix` and `main-lint-fix` pre-commit hooks run `golangci-lint --fix` with the full linter config, which includes kubeapilinter. In the pre-commit environment, kubeapilinter's structural auto-fixes (e.g. `string` → `*string`) are applied across all ~1025 issues before the `--new-from-rev` diff filter runs. The diff processor passes all issues through instead of filtering them, causing 20+ api/ files to be modified on every commit that touches api/ Go files.

This PR:
1. Adds `api-lint-fix-precommit` and `main-lint-fix-precommit` Makefile targets that use `golangci-lint fmt --enable gci`, scoped to only the files passed by pre-commit. This runs only gci import sorting on the changed files, avoiding kubeapilinter structural fixes entirely.
2. Filters `api/` directories from `test-changed`, since `api/` is a separate Go module that cannot be listed from the root module.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

The existing `api-lint-fix` and `main-lint-fix` targets are unchanged and still available for manual use / CI.

Tested end-to-end (commit + push all hooks passing) with both api/ and main module Go file changes.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pre-commit formatting checks for API and main Go code.
  * Limited automatic formatting to selected changed files.
  * Updated changed-file testing to properly exclude the API directory.
  * Added dedicated commands for applying lint-based formatting fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->