### PR TITLE
OCPBUGS-105597: fix(ci): update GHA runner base image to unblock CI

### DIFF
--- a/Dockerfile.github-actions-runner
+++ b/Dockerfile.github-actions-runner
@@ -1,4 +1,4 @@
-FROM ghcr.io/actions/actions-runner@sha256:b6614fce332517f74d0a76e7c762fb08e4f2ff13dcf333183397c8a5725b6e8e
+FROM ghcr.io/actions/actions-runner@sha256:0cfdcc701ce933c6d243c6b0b2da767366dc9f2e99961d4c3754b0b78084cdda
 
 USER root
 


### PR DESCRIPTION
## What this PR does / why we need it:

Updates the `ghcr.io/actions/actions-runner` base image digest in `Dockerfile.github-actions-runner`. The previous digest contained runner v2.334.0, which GitHub has deprecated. Runner pods connect to GitHub successfully but immediately exit with:

```
Runner version v2.334.0 is deprecated and cannot receive messages.
```

All real CI jobs (unit tests, lint, verify, envtest) have been queued since 2026-08-10 18:42 UTC with no jobs completing. Only `issue_comment`-triggered workflows (Rebase PR, Restructure Commits) complete because GitHub evaluates their `if` conditions server-side without needing a runner.

## Which issue(s) this PR fixes:

OCPBUGS-105597

## Special notes for your reviewer:

This only changes the base image digest. Once merged, Konflux will rebuild the runner image with the updated base and publish to `quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-gh-actions-runner:latest`. New runner pods will pick up the updated image. A Helm upgrade (`helm upgrade arc-runner-set ...`) may be needed to force an immediate rollout of existing pods.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions runner image to a newer pinned version.
  * Build steps and configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->