### PR TITLE
OCPBUGS-105602: fix broken relative reference

### DIFF
--- a/docs/content/getting-started/quick-setup.md
+++ b/docs/content/getting-started/quick-setup.md
@@ -24,7 +24,7 @@ you should adjust to your own environment.
 2. Admin access to an OpenShift cluster (version 4.12+) specified by the `KUBECONFIG` environment variable.
 3. The OpenShift CLI (`oc`) or Kubernetes CLI (`kubectl`). 
 4. A valid [pull secret](https://cloud.redhat.com/openshift/install/aws/installer-provisioned) file for the `quay.io/openshift-release-dev` repository. 
-5. AWS credentials with [permissions](/reference/infrastructure/aws.md) to create infrastructure for the cluster. You will need:
+5. AWS credentials with [permissions](../reference/infrastructure/aws.md) to create infrastructure for the cluster. You will need:
      - An IAM role ARN with the required permissions
      - STS credentials (session token) that can be generated using `aws sts get-session-token` 
 6. A Route53 public zone for cluster DNS records. To create a public zone:


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes a broken docs relative reference. It is needed so docs navigation works well and we can build the docs in strict mode.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-105602

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the AWS permissions reference link in the quick setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->