### PR TITLE
OCPBUGS-97811: fix Tenant API downtime during a management worker node

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 4ca0d704026c94e734c2c4514011697e920716c4aff00c27f9f27566b3980613
+    hypershift.openshift.io/desired-state-hash: 4bcd8dd5b1ada207b56fa8b52351b0280d609bc9bf99afea1bf6f7b74d2561da
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: etcd
@@ -378,6 +378,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 60
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 60
       volumes:
       - name: peer-tls
         secret:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: f8a281d73df6f9dc538f5021e708302e0b5ceff3d7a77011511e61172afcf358
+    hypershift.openshift.io/desired-state-hash: 08dd594f94c6bc2b581c4ba553f1a435b60c0cdb8c373c84c7827bb4a8446fd4
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: etcd
@@ -405,6 +405,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 60
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 60
       volumes:
       - name: peer-tls
         secret:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 4ca0d704026c94e734c2c4514011697e920716c4aff00c27f9f27566b3980613
+    hypershift.openshift.io/desired-state-hash: 4bcd8dd5b1ada207b56fa8b52351b0280d609bc9bf99afea1bf6f7b74d2561da
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: etcd
@@ -378,6 +378,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 60
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 60
       volumes:
       - name: peer-tls
         secret:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/ModernTLS/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/ModernTLS/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: e71ae1cadf703e5e9db11f5cb5754cf8b0cc3a14efac7a12424802aebcc97cb5
+    hypershift.openshift.io/desired-state-hash: 7682082642290dc5a9785672850020a97150256be9af7345dcc081056acb8819
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: etcd
@@ -374,6 +374,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 60
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 60
       volumes:
       - name: peer-tls
         secret:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 4ca0d704026c94e734c2c4514011697e920716c4aff00c27f9f27566b3980613
+    hypershift.openshift.io/desired-state-hash: 4bcd8dd5b1ada207b56fa8b52351b0280d609bc9bf99afea1bf6f7b74d2561da
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: etcd
@@ -378,6 +378,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 60
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 60
       volumes:
       - name: peer-tls
         secret:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 4ca0d704026c94e734c2c4514011697e920716c4aff00c27f9f27566b3980613
+    hypershift.openshift.io/desired-state-hash: 4bcd8dd5b1ada207b56fa8b52351b0280d609bc9bf99afea1bf6f7b74d2561da
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: etcd
@@ -378,6 +378,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 60
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 60
       volumes:
       - name: peer-tls
         secret:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 4cb036d6ed829a02ee5f48dc20d55004072e533aa19f345605a9d696f54698cd
+    hypershift.openshift.io/desired-state-hash: df6148036ab90734cd9f0fa75bea03751f4576a60c0de24120583abedc59f98d
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kube-apiserver
@@ -99,22 +99,21 @@ spec:
         image: hyperkube
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 6
+          failureThreshold: 3
           httpGet:
             path: livez?exclude=etcd
             port: client
             scheme: HTTPS
-          initialDelaySeconds: 300
-          periodSeconds: 180
+          periodSeconds: 60
           successThreshold: 1
-          timeoutSeconds: 160
+          timeoutSeconds: 30
         name: kube-apiserver
         ports:
         - containerPort: 6443
           name: client
           protocol: TCP
         readinessProbe:
-          failureThreshold: 18
+          failureThreshold: 6
           httpGet:
             path: readyz
             port: client
@@ -128,6 +127,14 @@ spec:
             memory: 2Gi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 36
+          httpGet:
+            path: readyz
+            port: client
+            scheme: HTTPS
+          periodSeconds: 10
+          timeoutSeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/certs/aggregator-ca
@@ -580,6 +587,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: bootstrap-manifests

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/GCP/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/GCP/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 4ebf64b31c31573e58e5dbd769e79a650471da90a0cca5058025860488bc8744
+    hypershift.openshift.io/desired-state-hash: 61f47c215f0276b07bde516c88099af27c900fea0a33c734b5b1e5a05d2f715b
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kube-apiserver
@@ -96,22 +96,21 @@ spec:
         image: hyperkube
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 6
+          failureThreshold: 3
           httpGet:
             path: livez?exclude=etcd
             port: client
             scheme: HTTPS
-          initialDelaySeconds: 300
-          periodSeconds: 180
+          periodSeconds: 60
           successThreshold: 1
-          timeoutSeconds: 160
+          timeoutSeconds: 30
         name: kube-apiserver
         ports:
         - containerPort: 6443
           name: client
           protocol: TCP
         readinessProbe:
-          failureThreshold: 18
+          failureThreshold: 6
           httpGet:
             path: readyz
             port: client
@@ -130,6 +129,14 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 36
+          httpGet:
+            path: readyz
+            port: client
+            scheme: HTTPS
+          periodSeconds: 10
+          timeoutSeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/certs/aggregator-ca
@@ -510,6 +517,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: bootstrap-manifests

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: d7ee46882658d6e7c58176261a22f4405958b4da8c7b7badc589966d54ea3bc4
+    hypershift.openshift.io/desired-state-hash: 15731acff6d1dc8d8484d846ed943f4823676dc3d3f47b6ece4c65a80a711054
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kube-apiserver
@@ -96,22 +96,21 @@ spec:
         image: hyperkube
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 6
+          failureThreshold: 3
           httpGet:
             path: livez?exclude=etcd
             port: client
             scheme: HTTPS
-          initialDelaySeconds: 300
-          periodSeconds: 180
+          periodSeconds: 60
           successThreshold: 1
-          timeoutSeconds: 160
+          timeoutSeconds: 30
         name: kube-apiserver
         ports:
         - containerPort: 2040
           name: client
           protocol: TCP
         readinessProbe:
-          failureThreshold: 18
+          failureThreshold: 6
           httpGet:
             path: readyz
             port: client
@@ -125,6 +124,14 @@ spec:
             memory: 2Gi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 36
+          httpGet:
+            path: readyz
+            port: client
+            scheme: HTTPS
+          periodSeconds: 10
+          timeoutSeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/certs/aggregator-ca
@@ -464,6 +471,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: bootstrap-manifests

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 273c2f5612a3e827296388f5cdba5ccdc6e7c1d37443659e6114f7b715838c08
+    hypershift.openshift.io/desired-state-hash: aa002a20e51608264ac0da9bb982da2883cf8a95a53266ec219d9361edbea95c
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kube-apiserver
@@ -96,22 +96,21 @@ spec:
         image: hyperkube
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 6
+          failureThreshold: 3
           httpGet:
             path: livez?exclude=etcd
             port: client
             scheme: HTTPS
-          initialDelaySeconds: 300
-          periodSeconds: 180
+          periodSeconds: 60
           successThreshold: 1
-          timeoutSeconds: 160
+          timeoutSeconds: 30
         name: kube-apiserver
         ports:
         - containerPort: 6443
           name: client
           protocol: TCP
         readinessProbe:
-          failureThreshold: 18
+          failureThreshold: 6
           httpGet:
             path: readyz
             port: client
@@ -125,6 +124,14 @@ spec:
             memory: 2Gi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 36
+          httpGet:
+            path: readyz
+            port: client
+            scheme: HTTPS
+          periodSeconds: 10
+          timeoutSeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/certs/aggregator-ca
@@ -492,6 +499,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: bootstrap-manifests

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 33e473d21500f85f0a5f9811f68b2f28da18c75f836bf74bc5ba466341669dce
+    hypershift.openshift.io/desired-state-hash: 8156037aa6470d1020585eb8b84d4c49691b677314f0857a5c1b6f28674060c3
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kube-apiserver
@@ -96,22 +96,21 @@ spec:
         image: hyperkube
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 6
+          failureThreshold: 3
           httpGet:
             path: livez?exclude=etcd
             port: client
             scheme: HTTPS
-          initialDelaySeconds: 300
-          periodSeconds: 180
+          periodSeconds: 60
           successThreshold: 1
-          timeoutSeconds: 160
+          timeoutSeconds: 30
         name: kube-apiserver
         ports:
         - containerPort: 6443
           name: client
           protocol: TCP
         readinessProbe:
-          failureThreshold: 18
+          failureThreshold: 6
           httpGet:
             path: readyz
             port: client
@@ -125,6 +124,14 @@ spec:
             memory: 2Gi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 36
+          httpGet:
+            path: readyz
+            port: client
+            scheme: HTTPS
+          periodSeconds: 10
+          timeoutSeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/certs/aggregator-ca
@@ -496,6 +503,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: bootstrap-manifests

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 6e13377f72cb9a3fd80c51767045b8ba2818c47e400411767bd6a30c12eb3fd8
+    hypershift.openshift.io/desired-state-hash: a12a8fec89319ac09d4d325cd610ef12573e8de0db86a8f4726d662a121c49c2
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kube-apiserver
@@ -96,22 +96,21 @@ spec:
         image: hyperkube
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 6
+          failureThreshold: 3
           httpGet:
             path: livez?exclude=etcd
             port: client
             scheme: HTTPS
-          initialDelaySeconds: 300
-          periodSeconds: 180
+          periodSeconds: 60
           successThreshold: 1
-          timeoutSeconds: 160
+          timeoutSeconds: 30
         name: kube-apiserver
         ports:
         - containerPort: 6443
           name: client
           protocol: TCP
         readinessProbe:
-          failureThreshold: 18
+          failureThreshold: 6
           httpGet:
             path: readyz
             port: client
@@ -125,6 +124,14 @@ spec:
             memory: 2Gi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 36
+          httpGet:
+            path: readyz
+            port: client
+            scheme: HTTPS
+          periodSeconds: 10
+          timeoutSeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/certs/aggregator-ca
@@ -494,6 +501,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: bootstrap-manifests

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/AROSwift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/AROSwift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: b98d8b345118262fb6106f751e1ca8e192726572deee514af399b98d9a5c5e2d
+    hypershift.openshift.io/desired-state-hash: 712327b4062a1792c31620f1cd42fd90c0e214cc42e75f82b9afe6aa32f256c8
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: oauth-openshift
@@ -261,6 +261,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - configMap:
           defaultMode: 420

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/GCP/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/GCP/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: a59a2f4ce83d76d56ba500c91e789486df291511020151103605845ef3c878ac
+    hypershift.openshift.io/desired-state-hash: 75c3b5d89dacd96470083900bf97acc49dfc9e0f20ef786343547dfe132d6c49
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: oauth-openshift
@@ -287,6 +287,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - configMap:
           defaultMode: 420

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/IBMCloud/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/IBMCloud/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 87a653ee680eb490436f9b222ce933ce355cb4890ac91dcbecb420fa72e1af0c
+    hypershift.openshift.io/desired-state-hash: 0d7734ceb94860de0a00c9f4ce4f93dfa4ba13222e2789f6578efa5bdaf853d8
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: oauth-openshift
@@ -261,6 +261,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - configMap:
           defaultMode: 420

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/ModernTLS/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/ModernTLS/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 3797ff3610487bd48f7512e90f72b3cdbf6eb1b3b6bf93dd9c3a134ff9c1927c
+    hypershift.openshift.io/desired-state-hash: 3db0e1e51777f6e54c81986405a87d9b8044350590933cc106efb63e45365f90
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: oauth-openshift
@@ -261,6 +261,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - configMap:
           defaultMode: 420

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: b98d8b345118262fb6106f751e1ca8e192726572deee514af399b98d9a5c5e2d
+    hypershift.openshift.io/desired-state-hash: 712327b4062a1792c31620f1cd42fd90c0e214cc42e75f82b9afe6aa32f256c8
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: oauth-openshift
@@ -261,6 +261,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - configMap:
           defaultMode: 420

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: b98d8b345118262fb6106f751e1ca8e192726572deee514af399b98d9a5c5e2d
+    hypershift.openshift.io/desired-state-hash: 712327b4062a1792c31620f1cd42fd90c0e214cc42e75f82b9afe6aa32f256c8
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: oauth-openshift
@@ -261,6 +261,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - configMap:
           defaultMode: 420

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 9dc15fba8b7768bf1022f38f84f9fdf43efef88123716a9adf709536ed87280a
+    hypershift.openshift.io/desired-state-hash: f9e91c4e722c3828cedcb10e93b1a6232d7d1f91617c4a0e16fd05e70199b9bf
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openshift-apiserver
@@ -302,6 +302,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: work-logs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/GCP/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/GCP/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: a9ae96c559e42f4c9cac2875b6c7742a0406edcc680ed224fce23b4b24f13daf
+    hypershift.openshift.io/desired-state-hash: 67a55799453d0db21bc806c6421400ce35281c13633e36605a3103db50f19ba5
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openshift-apiserver
@@ -334,6 +334,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: work-logs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 0a12b52c0d35fc5dc84c61b1873e33cfdb4f23415fb2c6e876d1db472167f8a6
+    hypershift.openshift.io/desired-state-hash: b1a01666eb335fd1aaca82d5d47e2980c5300cdb7f0edc28bd1b9b1fdf8f2413
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openshift-apiserver
@@ -302,6 +302,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: work-logs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 8b4d4dd3cdef37834397cf14a0d96b36ca2bb2ae4eea5884c159167b7fb9d6c2
+    hypershift.openshift.io/desired-state-hash: f6b8c103dbbebfed12567046813a86296e6002f1875e5ac3a00184db2073f572
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openshift-apiserver
@@ -302,6 +302,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: work-logs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 6f5ad47a0764d74396d7e431e793212cc950944199b46310aafe13f07febbcee
+    hypershift.openshift.io/desired-state-hash: d6a0f42814688537b0e03bc99673597b6d9d3204ae452d087bd3d61f457f51f7
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openshift-apiserver
@@ -302,6 +302,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: work-logs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 9dc15fba8b7768bf1022f38f84f9fdf43efef88123716a9adf709536ed87280a
+    hypershift.openshift.io/desired-state-hash: f9e91c4e722c3828cedcb10e93b1a6232d7d1f91617c4a0e16fd05e70199b9bf
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openshift-apiserver
@@ -302,6 +302,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: work-logs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: c9d1e51b806e5a345f8b5c0e49d5117bddf2d8a7961bbf70a0e2aab22f85dea4
+    hypershift.openshift.io/desired-state-hash: 84f5cf3d05f378f7afa66b68bc42503dcab3148ea4908b381bfa7346ecf2721d
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openshift-oauth-apiserver
@@ -292,6 +292,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: work-logs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/GCP/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/GCP/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 95a5168abfd56d0f67f064e441b8065123cbbc1efcd317537bf83725e0bc6af3
+    hypershift.openshift.io/desired-state-hash: cfbd1dc1c356cd8e0254e016fca3f7ae8027fa05404f51d6a7140e4b4069c21d
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openshift-oauth-apiserver
@@ -324,6 +324,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: work-logs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: bdac2010893f5b3b4bbab2e7d136891c34c0b3a75777f8b52b4247a3172653de
+    hypershift.openshift.io/desired-state-hash: 1f7a869189567df1391f23c77db0d649fec1e2ca58bdc080e3a4a6a833aa7df6
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openshift-oauth-apiserver
@@ -292,6 +292,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: work-logs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 07b7498ba387b63b345f1687e4fe2fdad2b456be08dd31370f6659c714ae3ce8
+    hypershift.openshift.io/desired-state-hash: 68e309c7c4649820fa1bd628e787aa704e39e235ce1c4521a1c3c0fd370a1789
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openshift-oauth-apiserver
@@ -291,6 +291,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: work-logs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: c9d1e51b806e5a345f8b5c0e49d5117bddf2d8a7961bbf70a0e2aab22f85dea4
+    hypershift.openshift.io/desired-state-hash: 84f5cf3d05f378f7afa66b68bc42503dcab3148ea4908b381bfa7346ecf2721d
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openshift-oauth-apiserver
@@ -292,6 +292,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: work-logs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: c9d1e51b806e5a345f8b5c0e49d5117bddf2d8a7961bbf70a0e2aab22f85dea4
+    hypershift.openshift.io/desired-state-hash: 84f5cf3d05f378f7afa66b68bc42503dcab3148ea4908b381bfa7346ecf2721d
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: openshift-oauth-apiserver
@@ -292,6 +292,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: work-logs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 5e7e081d174d58ff9ff7566eea66866dee4a5a72a89970b5bb56f23bf9a1a073
+    hypershift.openshift.io/desired-state-hash: 2bf9a9bd1eea1169cec6f2ae99779253664d5580d212fbc4ad0aa9756fc6ce0f
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: packageserver
@@ -225,6 +225,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: tmpfs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 11d6d9bcdb91203ea9e43666010fb664c07083fe43dff7534543289466c644d4
+    hypershift.openshift.io/desired-state-hash: d326c84933c46c1010742567fff2973eb53f4a79441253895f4ca1c86d9d4864
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: packageserver
@@ -246,6 +246,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: tmpfs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 519ba2de42af93621ca1c33c8c84f12837e1eb279c87aff235a8c31861093304
+    hypershift.openshift.io/desired-state-hash: 8d9ffe3e76cd82a8b930e37d7b4d7d605a6e62209dae115ebc1bafc2a59c6d7d
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: packageserver
@@ -225,6 +225,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: tmpfs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/ModernTLS/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/ModernTLS/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 10fa2454ae6399596c1c4a66109d9d25ce924685939bb70c83c2e30d6b726648
+    hypershift.openshift.io/desired-state-hash: 5e1b2b035ce10d04740a2674030a5cece0ec197873f264b5f3fde6201192234e
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: packageserver
@@ -224,6 +224,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: tmpfs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 5e7e081d174d58ff9ff7566eea66866dee4a5a72a89970b5bb56f23bf9a1a073
+    hypershift.openshift.io/desired-state-hash: 2bf9a9bd1eea1169cec6f2ae99779253664d5580d212fbc4ad0aa9756fc6ce0f
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: packageserver
@@ -225,6 +225,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: tmpfs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 5e7e081d174d58ff9ff7566eea66866dee4a5a72a89970b5bb56f23bf9a1a073
+    hypershift.openshift.io/desired-state-hash: 2bf9a9bd1eea1169cec6f2ae99779253664d5580d212fbc4ad0aa9756fc6ce0f
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: packageserver
@@ -225,6 +225,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - emptyDir: {}
         name: tmpfs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/AROSwift/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/AROSwift/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
@@ -132,6 +132,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - configMap:
           defaultMode: 420

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/GCP/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/GCP/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
@@ -133,6 +133,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - configMap:
           defaultMode: 420

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/IBMCloud/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/IBMCloud/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
@@ -129,6 +129,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - configMap:
           defaultMode: 420

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/ModernTLS/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/ModernTLS/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
@@ -127,6 +127,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - configMap:
           defaultMode: 420

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
@@ -129,6 +129,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - configMap:
           defaultMode: 420

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
@@ -129,6 +129,14 @@ spec:
         key: hypershift.openshift.io/cluster
         operator: Equal
         value: hcp-namespace
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 10
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 10
       volumes:
       - configMap:
           defaultMode: 420

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/deployment.yaml
@@ -33,23 +33,42 @@ spec:
               fieldPath: status.podIP
         image: hyperkube
         imagePullPolicy: IfNotPresent
+        # livenessProbe restarts a wedged-but-alive KAS. It uses livez?exclude=etcd so a
+        # slow/unavailable etcd does not trigger restart storms. The startupProbe gates
+        # this probe until KAS has started, so no initialDelaySeconds is needed.
+        # Budget to restart = failureThreshold(3) x periodSeconds(60) = 180s of sustained
+        # livez failure, with a 30s per-probe timeout for headroom under load.
         livenessProbe:
-          failureThreshold: 6
+          failureThreshold: 3
           httpGet:
             path: livez?exclude=etcd
             port: client
             scheme: HTTPS
-          initialDelaySeconds: 300
-          periodSeconds: 180
+          periodSeconds: 60
           successThreshold: 1
-          timeoutSeconds: 160
+          timeoutSeconds: 30
         name: kube-apiserver
         ports:
         - containerPort: 6443
           name: client
           protocol: TCP
+        # startupProbe gates liveness/readiness until KAS has finished starting.
+        # Budget = failureThreshold(36) x periodSeconds(10) = 360s, covering the previous
+        # livenessProbe initialDelaySeconds(300s) plus headroom for slow starts at scale.
+        startupProbe:
+          failureThreshold: 36
+          httpGet:
+            path: readyz
+            port: client
+            scheme: HTTPS
+          periodSeconds: 10
+          timeoutSeconds: 10
+        # readinessProbe ejects a healthy-but-slow KAS from Service endpoints without
+        # killing it. Budget = failureThreshold(6) x periodSeconds(10) = ~60s of sustained
+        # slow /readyz, tuned to avoid flapping healthy pods under load while still ejecting
+        # far faster than the previous 180s.
         readinessProbe:
-          failureThreshold: 18
+          failureThreshold: 6
           httpGet:
             path: readyz
             port: client

--- a/support/controlplane-component/defaults.go
+++ b/support/controlplane-component/defaults.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,7 +44,54 @@ const (
 	// podSafeToEvictLocalVolumesAnnotation is an annotation denoting the local volumes of a pod that can be safely evicted.
 	// This is needed for the CA operator to make sure it can properly drain the nodes with those volumes.
 	podSafeToEvictLocalVolumesAnnotation = "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes"
+
+	// defaultNodeFailureTolerationSeconds is the TolerationSeconds applied to the
+	// well-known node.kubernetes.io/not-ready and node.kubernetes.io/unreachable
+	// NoExecute taints for API-critical components. When a management node fails,
+	// this evicts and replaces those (stateless, highly-available) pods quickly
+	// instead of waiting for the 300s default that the DefaultTolerationSeconds
+	// admission plugin would otherwise inject, reducing HA recovery time. Users can
+	// override this per-key via HostedControlPlane.spec.tolerations.
+	defaultNodeFailureTolerationSeconds int64 = 10
+
+	// etcdNodeFailureTolerationSeconds is the TolerationSeconds applied to the same
+	// node-failure taints for etcd. etcd is a quorum-based StatefulSet, so evicting a
+	// member too aggressively on a transient node partition forces unnecessary member
+	// churn and data re-sync. This value is still far below the 300s default (so full
+	// redundancy is restored faster after a genuine node loss) while long enough to
+	// ride out brief blips.
+	etcdNodeFailureTolerationSeconds int64 = 60
 )
+
+// shortNodeFailureToleration returns a NoExecute toleration for the given
+// well-known node-failure taint key (node.kubernetes.io/not-ready or
+// node.kubernetes.io/unreachable) with the provided short TolerationSeconds.
+func shortNodeFailureToleration(key string, seconds int64) corev1.Toleration {
+	return corev1.Toleration{
+		Key:               key,
+		Operator:          corev1.TolerationOpExists,
+		Effect:            corev1.TaintEffectNoExecute,
+		TolerationSeconds: ptr.To(seconds),
+	}
+}
+
+// tolerationsTolerateTaint reports whether any of the given tolerations tolerates
+// the provided taint using Kubernetes taint-matching semantics. This is used to
+// decide whether a user-specified toleration already covers a node-failure taint,
+// so we don't inject our short default. It correctly handles cases that a naive
+// key/effect comparison would get wrong, e.g. an empty-Effect toleration (which
+// matches all effects) or an Operator=Equal toleration with a non-empty Value
+// (which does NOT tolerate the empty-valued node-failure taints).
+func tolerationsTolerateTaint(tolerations []corev1.Toleration, taint *corev1.Taint) bool {
+	for i := range tolerations {
+		// enableComparisonOperators=false: the Lt/Gt operators are irrelevant for the
+		// empty-valued node-failure taints and are treated as non-matching.
+		if tolerations[i].ToleratesTaint(klog.Background(), taint, false) {
+			return true
+		}
+	}
+	return false
+}
 
 var (
 	apiCriticalComponents = sets.New(
@@ -252,6 +300,29 @@ func (c *controlPlaneWorkload[T]) setControlPlaneIsolation(podTemplate *corev1.P
 			Effect:   corev1.TaintEffectNoSchedule,
 		})
 	}
+	// For API-critical and etcd components, default to short NoExecute tolerations
+	// so pods are evicted and replaced quickly, reducing HA recovery time after a
+	// management node failure. User-specified tolerations for the same keys take
+	// precedence and are applied unfiltered below.
+	if apiCriticalComponents.Has(c.Name()) || isEtcdComponent(c.Name()) {
+		tolerationSeconds := defaultNodeFailureTolerationSeconds
+		if isEtcdComponent(c.Name()) {
+			// etcd uses a longer value to avoid quorum churn on transient partitions.
+			tolerationSeconds = etcdNodeFailureTolerationSeconds
+		}
+		for _, key := range []string{corev1.TaintNodeNotReady, corev1.TaintNodeUnreachable} {
+			// Only inject our short default if the user hasn't already provided a
+			// toleration that actually tolerates this node-failure taint. The taints
+			// are added by the node-lifecycle-controller with NoExecute and an empty
+			// value, so we match against that exact taint.
+			taint := &corev1.Taint{Key: key, Effect: corev1.TaintEffectNoExecute}
+			if !tolerationsTolerateTaint(hcp.Spec.Tolerations, taint) {
+				podTemplate.Spec.Tolerations = append(podTemplate.Spec.Tolerations,
+					shortNodeFailureToleration(key, tolerationSeconds))
+			}
+		}
+	}
+
 	// set additional Tolerations
 	if len(hcp.Spec.Tolerations) != 0 {
 		podTemplate.Spec.Tolerations = append(podTemplate.Spec.Tolerations, hcp.Spec.Tolerations...)

--- a/support/controlplane-component/defaults_test.go
+++ b/support/controlplane-component/defaults_test.go
@@ -287,6 +287,166 @@ func generateResources() (map[string]*corev1.Secret, map[string]*corev1.ConfigMa
 	return secrets, configMaps
 }
 
+func TestSetControlPlaneIsolationNodeFailureTolerations(t *testing.T) {
+	// expectNotReady and expectUnreachable capture the presence of the short default
+	// NoExecute toleration per taint key. They are separate because a user override for
+	// one key suppresses only that key's default, leaving the other key's default intact.
+	tests := []struct {
+		name              string
+		componentName     string
+		hcpTolerations    []corev1.Toleration
+		expectNotReady    bool
+		expectUnreachable bool
+		// expectSeconds is the TolerationSeconds the default(s) should carry when present.
+		expectSeconds int64
+	}{
+		{
+			name:              "When component is API-critical, it should get default short NoExecute tolerations",
+			componentName:     "kube-apiserver",
+			expectNotReady:    true,
+			expectUnreachable: true,
+			expectSeconds:     defaultNodeFailureTolerationSeconds,
+		},
+		{
+			name:              "When component is etcd, it should get longer NoExecute tolerations",
+			componentName:     "etcd",
+			expectNotReady:    true,
+			expectUnreachable: true,
+			expectSeconds:     etcdNodeFailureTolerationSeconds,
+		},
+		{
+			name:              "When component is neither API-critical nor etcd, it should not get short NoExecute tolerations",
+			componentName:     "kube-controller-manager",
+			expectNotReady:    false,
+			expectUnreachable: false,
+		},
+		{
+			name:          "When a user sets a not-ready NoExecute toleration, it should suppress only the not-ready default",
+			componentName: "kube-apiserver",
+			hcpTolerations: []corev1.Toleration{
+				{
+					Key:               corev1.TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: ptr.To[int64](120),
+				},
+			},
+			expectNotReady:    false,
+			expectUnreachable: true,
+			expectSeconds:     defaultNodeFailureTolerationSeconds,
+		},
+		{
+			name:          "When a user sets an unreachable NoExecute toleration, it should suppress only the unreachable default",
+			componentName: "kube-apiserver",
+			hcpTolerations: []corev1.Toleration{
+				{
+					Key:               corev1.TaintNodeUnreachable,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: ptr.To[int64](60),
+				},
+			},
+			expectNotReady:    true,
+			expectUnreachable: false,
+			expectSeconds:     defaultNodeFailureTolerationSeconds,
+		},
+		{
+			name:          "When a user sets a NoSchedule toleration on the same key, it should not suppress the NoExecute default",
+			componentName: "kube-apiserver",
+			hcpTolerations: []corev1.Toleration{
+				{
+					Key:      corev1.TaintNodeNotReady,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			expectNotReady:    true,
+			expectUnreachable: true,
+			expectSeconds:     defaultNodeFailureTolerationSeconds,
+		},
+		{
+			// An Operator=Equal toleration with a non-empty value does NOT tolerate the
+			// empty-valued node-failure taint, so it must not suppress our default.
+			name:          "When a user sets an Equal NoExecute toleration with a non-empty value, it should not suppress the default",
+			componentName: "kube-apiserver",
+			hcpTolerations: []corev1.Toleration{
+				{
+					Key:               corev1.TaintNodeNotReady,
+					Operator:          corev1.TolerationOpEqual,
+					Value:             "true",
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: ptr.To[int64](120),
+				},
+			},
+			expectNotReady:    true,
+			expectUnreachable: true,
+			expectSeconds:     defaultNodeFailureTolerationSeconds,
+		},
+		{
+			// An empty Effect matches all effects (including NoExecute), so an Exists
+			// toleration for the key tolerates the taint and suppresses that key's default.
+			name:          "When a user sets an empty-effect Exists toleration for not-ready, it should suppress only the not-ready default",
+			componentName: "kube-apiserver",
+			hcpTolerations: []corev1.Toleration{
+				{
+					Key:      corev1.TaintNodeNotReady,
+					Operator: corev1.TolerationOpExists,
+				},
+			},
+			expectNotReady:    false,
+			expectUnreachable: true,
+			expectSeconds:     defaultNodeFailureTolerationSeconds,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			workload := &controlPlaneWorkload[*appsv1.Deployment]{
+				name:             test.componentName,
+				workloadProvider: &deploymentProvider{},
+				ComponentOptions: &testComponent{},
+			}
+
+			hcp := &hyperv1.HostedControlPlane{}
+			hcp.Spec.Tolerations = test.hcpTolerations
+
+			podTemplate := &corev1.PodTemplateSpec{}
+			workload.setControlPlaneIsolation(podTemplate, hcp)
+
+			hasNotReady := false
+			hasUnreachable := false
+			for _, tol := range podTemplate.Spec.Tolerations {
+				if tol.Effect != corev1.TaintEffectNoExecute {
+					continue
+				}
+				if tol.TolerationSeconds == nil || *tol.TolerationSeconds != test.expectSeconds {
+					continue
+				}
+				switch tol.Key {
+				case corev1.TaintNodeNotReady:
+					hasNotReady = true
+				case corev1.TaintNodeUnreachable:
+					hasUnreachable = true
+				}
+			}
+
+			g.Expect(hasNotReady).To(Equal(test.expectNotReady),
+				"unexpected presence of default not-ready NoExecute toleration")
+			g.Expect(hasUnreachable).To(Equal(test.expectUnreachable),
+				"unexpected presence of default unreachable NoExecute toleration")
+
+			// User tolerations are always passed through unfiltered.
+			for _, expected := range test.hcpTolerations {
+				g.Expect(podTemplate.Spec.Tolerations).To(ContainElement(expected),
+					"user toleration should be passed through unfiltered")
+			}
+		})
+	}
+}
+
 func TestApplyRequestsOverrides(t *testing.T) {
 	tests := []struct {
 		name                   string


### PR DESCRIPTION


<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

### Root Cause
When a management worker node is power-cycled, the Kubernetes node controller takes ~40 seconds (`node-monitor-grace-period`) to detect the failure. During that window, the kube-apiserver Service retains stale endpoints pointing to the dead pod's IP. kube-proxy randomly routes ~33% of new connections to the dead endpoint, causing timeouts for those requests. This explains the 26-37% cluster failure rate (roughly matching the 1/3 probability of hitting the dead endpoint).

After detection, the default `DefaultTolerationSeconds` admission plugin adds 300-second tolerations, so pods aren't evicted and replaced for 5 full minutes, extending the degraded-HA window.

### Fix 1: Fast pod eviction via short `NoExecute` tolerations
File: [defaults.go:255-271](vscode-webview://1t3lus1e6qmfbo2e14o6e3il9pdjsdga6cknf1sf49bg4bkdkmhl/support/controlplane-component/defaults.go#L255-L271)

Added explicit `node.kubernetes.io/not-ready:NoExecute` and `node.kubernetes.io/unreachable:NoExecute` tolerations with 10-second `TolerationSeconds` for all API-critical components (`kube-apiserver`, `openshift-apiserver`, `openshift-oauth-apiserver`, `oauth-openshift`, `router`, `packageserver`) and etcd. This overrides the default 300s, so once the node controller marks a node NotReady:

- T+0s: Stale endpoint removed (pod Ready condition -> Unknown)
- T+10s: Pod evicted (deleted), replacement scheduled
- T+40-60s: New pod ready and serving
vs. the old behavior where replacement didn't start until T+300s.

### Fix 2: Startup probe + responsive readiness probe
File: [deployment.yaml:51-60](vscode-webview://1t3lus1e6qmfbo2e14o6e3il9pdjsdga6cknf1sf49bg4bkdkmhl/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/deployment.yaml#L51-L60)

- Added `startupProbe` with `failureThreshold: 36` (360s startup budget) — handles the slow-start case that the old high readiness threshold was covering.
- Reduced readiness `failureThreshold` from 18 to 3 — unhealthy pods are now removed from endpoints in 30 seconds instead of 180 seconds. This helps when a kube-apiserver pod becomes unhealthy while the node itself is fine (a separate failure mode from node crashes).

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/OCPBUGS-97811

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kube-apiserver startup, liveness, and readiness detection using HTTPS health checks.
  * Reduced the time required to identify kube-apiserver readiness failures.
  * Improved API-critical and etcd component resilience during temporary node readiness or reachability issues.
  * Added default 10-second toleration handling for API-critical components and 60-second handling for etcd.
  * Preserved compatible custom toleration settings and ensured non-critical components remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->