### PR TITLE
CNTRLPLANE-3945: fix(docs): set writable uv cache path for arc-runner-set

### DIFF
--- a/.github/workflows/docs-build-reusable.yaml
+++ b/.github/workflows/docs-build-reusable.yaml
@@ -16,6 +16,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+        with:
+          cache-local-path: ${{ runner.temp }}/.uv-cache
       - name: Build documentation
         run: uv run --frozen zensical build --strict
         working-directory: docs


### PR DESCRIPTION
## Summary
- Fix docs build failure on `arc-runner-set` runners after #9139 merged
- On these runners `HOME=/`, so `setup-uv` resolves its cache to `/.cache/uv` which isn't writable
- Set `cache-local-path: ${{ runner.temp }}/.uv-cache` to use a writable directory

## Test plan
- [ ] `build / Build Docs` CI check passes on this PR


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build configuration to use a temporary local cache directory for tooling, improving build environment isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->