### PR TITLE
OCPBUGS-77781: fix(certs): normalize IP SANs to stop dual-stack KAS cert churn

### DIFF
--- a/support/certs/tls.go
+++ b/support/certs/tls.go
@@ -316,7 +316,11 @@ func ValidateKeyPair(pemKey, pemCertificate []byte, cfg *CertCfg, minimumRemaini
 		errs = append(errs, fmt.Errorf("actual extended key usages differ from expected: %s", extUsageDiff))
 	}
 
-	ipAddressDiff := cmp.Diff(cert.IPAddresses, cfg.IPAddresses, cmpopts.SortSlices(func(a, b []byte) bool { return bytes.Compare(a, b) == -1 }))
+	ipAddressDiff := cmp.Diff(
+		normalizedIPAddresses(cert.IPAddresses),
+		normalizedIPAddresses(cfg.IPAddresses),
+		cmpopts.SortSlices(func(a, b []byte) bool { return bytes.Compare(a, b) == -1 }),
+	)
 	if ipAddressDiff != "" {
 		errs = append(errs, fmt.Errorf("actual ip addresses differ from expected: %s", ipAddressDiff))
 	}
@@ -340,6 +344,21 @@ func ValidateKeyPair(pemKey, pemCertificate []byte, cfg *CertCfg, minimumRemaini
 	}
 
 	return utilerrors.NewAggregate(errs)
+}
+
+// normalizedIPAddresses expands IPs to 16-byte form for comparison so 4-byte
+// X.509 IPv4 SANs match net.ParseIP's IPv4-mapped form. Entries where To16
+// returns nil are kept as-is to avoid silently dropping them from the diff.
+func normalizedIPAddresses(ips []net.IP) []net.IP {
+	normalizedIPs := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		if ip16 := ip.To16(); ip16 != nil {
+			normalizedIPs = append(normalizedIPs, ip16)
+		} else {
+			normalizedIPs = append(normalizedIPs, ip)
+		}
+	}
+	return normalizedIPs
 }
 
 // ReconcileSignedCert reconciles a certificate secret using the provided config. It will

--- a/support/certs/tls_test.go
+++ b/support/certs/tls_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -146,6 +147,37 @@ func fuzzer() *fuzz.Fuzzer {
 		)
 }
 
+func TestValidateKeyPairRejectsMalformedIP(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When config has a malformed IP address, it should fail validation", func(t *testing.T) {
+		caCfg := certs.CertCfg{IsCA: true, Subject: pkix.Name{CommonName: "root-ca", OrganizationalUnit: []string{"ou"}}}
+		caKey, caCert, err := certs.GenerateSelfSignedCertificate(&caCfg)
+		if err != nil {
+			t.Fatalf("failed to generate CA: %v", err)
+		}
+
+		cfg := &certs.CertCfg{
+			Subject:     pkix.Name{CommonName: "test", OrganizationalUnit: []string{"ou"}},
+			IPAddresses: []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("10.0.0.1")},
+		}
+		key, cert, err := certs.GenerateSignedCertificate(caKey, caCert, cfg)
+		if err != nil {
+			t.Fatalf("GenerateSignedCertificate failed: %v", err)
+		}
+
+		cfg.IPAddresses = append(cfg.IPAddresses, net.IP{1, 2, 3})
+
+		err = certs.ValidateKeyPair(certs.PrivateKeyToPem(key), certs.CertToPem(cert), cfg, 0)
+		if err == nil {
+			t.Fatal("ValidateKeyPair returned a nil error, should have detected the malformed IP")
+		}
+		if !strings.Contains(err.Error(), "ip addresses") {
+			t.Fatalf("expected error about ip addresses, got: %v", err)
+		}
+	})
+}
+
 func TestValidateKeyPairItempotency(t *testing.T) {
 	t.Parallel()
 	caCfg := certs.CertCfg{IsCA: true, Subject: pkix.Name{CommonName: "root-ca", OrganizationalUnit: []string{"ou"}}}
@@ -167,6 +199,87 @@ func TestValidateKeyPairItempotency(t *testing.T) {
 
 			if err := certs.ValidateKeyPair(certs.PrivateKeyToPem(key), certs.CertToPem(cert), cfg, 0); err != nil {
 				t.Errorf("validation failed when config was unchanged: %v", err)
+			}
+		})
+	}
+}
+
+// TestReconcileSignedCertIdempotentWithDualStackIPs asserts that repeated
+// ReconcileSignedCert calls with the same ipv4-only or dual-stack IPs leave
+// tls.crt unchanged.
+func TestReconcileSignedCertIdempotentWithDualStackIPs(t *testing.T) {
+	t.Parallel()
+
+	ca := &corev1.Secret{Type: corev1.SecretTypeTLS}
+	if err := certs.ReconcileSelfSignedCA(ca, "root-ca", "ou"); err != nil {
+		t.Fatalf("failed to reconcile CA: %v", err)
+	}
+
+	dnsNames := []string{
+		"localhost",
+		"kubernetes",
+		"kubernetes.default",
+		"kubernetes.default.svc",
+		"kubernetes.default.svc.cluster.local",
+	}
+
+	testCases := []struct {
+		name string
+		ips  []string
+	}{
+		{
+			name: "When IPs are IPv4-only, it should not regenerate the certificate",
+			ips:  []string{"127.0.0.1", "172.31.0.1", "172.20.0.1"},
+		},
+		{
+			// Mirrors dual-stack serviceNetwork SANs that trigger KAS cert churn.
+			name: "When IPs are dual-stack, it should not regenerate the certificate",
+			ips:  []string{"127.0.0.1", "0:0:0:0:0:0:0:1", "172.31.0.1", "2001:780:1c6:601::1", "172.20.0.1"},
+		},
+	}
+
+	const reconcileIterations = 2
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			secret := &corev1.Secret{Type: corev1.SecretTypeTLS}
+			var firstCert, firstKey []byte
+
+			for i := 0; i < reconcileIterations; i++ {
+				if err := certs.ReconcileSignedCert(
+					secret,
+					ca,
+					"kubernetes",
+					[]string{"kubernetes"},
+					pki.X509UsageServerAuth,
+					corev1.TLSCertKey,
+					corev1.TLSPrivateKeyKey,
+					"",
+					dnsNames,
+					tc.ips,
+				); err != nil {
+					t.Fatalf("ReconcileSignedCert iteration %d failed: %v", i, err)
+				}
+
+				cert := secret.Data[corev1.TLSCertKey]
+				key := secret.Data[corev1.TLSPrivateKeyKey]
+				if len(cert) == 0 || len(key) == 0 {
+					t.Fatalf("iteration %d did not populate tls.crt/tls.key", i)
+				}
+
+				if i == 0 {
+					firstCert = append([]byte(nil), cert...)
+					firstKey = append([]byte(nil), key...)
+					continue
+				}
+
+				// Later iterations revalidate; they must be a no-op.
+				if !bytes.Equal(firstCert, cert) {
+					t.Fatalf("iteration %d regenerated tls.crt for %s (revalidation should have been a no-op)", i, tc.name)
+				}
+				if !bytes.Equal(firstKey, key) {
+					t.Fatalf("iteration %d regenerated tls.key for %s (revalidation should have been a no-op)", i, tc.name)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## What this PR does / why we need it

On dual-stack HostedClusters, `ValidateKeyPair` compared certificate IP SANs with `cmp.Diff` + `SortSlices(bytes.Compare)` on raw `net.IP` byte slices.

After an X.509 round-trip, IPv4 SANs are stored as **4-byte** values, while desired IPs from `net.ParseIP` are **16-byte** IPv4-mapped. Mixed lengths change sort order for some IPv6 service CIDRs (e.g. `2001:db8:…`), so validation falsely reports that IP addresses differ even when the logical set is unchanged.

CPO then resigns `kas-server-crt` every reconcile → kube-apiserver Deployment `config-hash` / generation churn → ReplicaSet pile-up.

**Fix:** normalize both sides with `net.IP.To16()` before comparing.

**Test:** unit test reconciles twice for ipv4-only and dual-stack IPs and asserts `tls.crt` is not regenerated.

## Which issue(s) this PR fixes

Fixes OCPBUGS-77781

## Special notes for your reviewer

### Manual verification (kubevirt HCP, stock CPO → fixed CPO)

Dual-stack HC with `serviceNetwork` including `2001:db8:2::/112` (ULA `fd02::/112` alone often does **not** trigger the sort mismatch).

**Before (stock CPO):** between two samples, RS count and Deployment generation climb while SANs stay identical:

```text
# --- sample 1 ---

# Number of kube-apiserver ReplicaSets right now.
root@hitchhiker-02:~# oc get rs -n $NS -l app=kube-apiserver --no-headers | wc -l
5484

# Current Deployment generation (bumps when the Deployment spec changes).
root@hitchhiker-02:~# oc get deploy kube-apiserver -n $NS -o jsonpath='{.metadata.generation}{"\n"}'
5556

# kas-server-crt has dual-stack IP SANs (IPv4 + 2001:db8:2::1) — the condition that triggers the bug.
root@hitchhiker-02:~# oc get secret kas-server-crt -n $NS -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -text | grep -A2 'Subject Alternative Name'
            X509v3 Subject Alternative Name: 
                DNS:localhost, DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.cluster.local, DNS:openshift, DNS:openshift.default, DNS:openshift.default.svc, DNS:openshift.default.svc.cluster.local, DNS:api.ocpbugs-77781.hypershift.local, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1, IP Address:172.31.0.1, IP Address:2001:DB8:2:0:0:0:0:1, IP Address:172.20.0.1, IP Address:192.168.122.240
    Signature Algorithm: sha256WithRSAEncryption

# --- sample 2 (same checks, shortly after) ---
# RS count increased (5484 → 5502) without any intentional rollout from us.
root@hitchhiker-02:~# oc get rs -n $NS -l app=kube-apiserver --no-headers | wc -l
5502

# Generation increased (5556 → 5563) — Deployment spec is still being rewritten.
root@hitchhiker-02:~# oc get deploy kube-apiserver -n $NS -o jsonpath='{.metadata.generation}{"\n"}'
5563

# Same SAN set as sample 1. Desired names/IPs did not change, yet the Deployment keeps rolling.
root@hitchhiker-02:~# oc get secret kas-server-crt -n $NS -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -text | grep -A2 'Subject Alternative Name'
            X509v3 Subject Alternative Name: 
                DNS:localhost, DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.cluster.local, DNS:openshift, DNS:openshift.default, DNS:openshift.default.svc, DNS:openshift.default.svc.cluster.local, DNS:api.ocpbugs-77781.hypershift.local, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1, IP Address:172.31.0.1, IP Address:2001:DB8:2:0:0:0:0:1, IP Address:172.20.0.1, IP Address:192.168.122.240
    Signature Algorithm: sha256WithRSAEncryption
```

**After (CPO image with this fix):** over 60s, metrics stay flat:

```text
root@hitchhiker-02:~# oc get rs -n $NS -l app=kube-apiserver --no-headers | wc -l
4
root@hitchhiker-02:~# oc get deploy kube-apiserver -n $NS -o jsonpath='{.metadata.generation}{"\n"}'
5721
root@hitchhiker-02:~# oc get secret kas-server-crt -n $NS -o jsonpath='{.metadata.resourceVersion}{"\n"}'
2141595
root@hitchhiker-02:~# sleep 60
root@hitchhiker-02:~# oc get rs -n $NS -l app=kube-apiserver --no-headers | wc -l
4
root@hitchhiker-02:~# oc get deploy kube-apiserver -n $NS -o jsonpath='{.metadata.generation}{"\n"}'
5721
root@hitchhiker-02:~# oc get secret kas-server-crt -n $NS -o jsonpath='{.metadata.resourceVersion}{"\n"}'
2141595
```

## Checklist

- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate validation for IPv4 and IPv6 address configurations.
  * Prevented unnecessary certificate and key changes during repeated reconciliation.
  * Added clearer errors for malformed IP addresses.

* **Tests**
  * Added coverage confirming certificate reconciliation remains stable for IPv4-only and dual-stack configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->