### PR TITLE
OCPBUGS-105865: fix(nodepool): include only TLSSecurityProfile in config hash instead of full APIServer

### DIFF
--- a/hypershift-operator/controllers/nodepool/config.go
+++ b/hypershift-operator/controllers/nodepool/config.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	coreerrors "errors"
 	"fmt"
 	"io"
@@ -416,19 +417,23 @@ func conditionallyAddToGlobalConfigString(
 	if err != nil {
 		return fmt.Errorf("failed to parse release image version: %w", err)
 	}
+	version.Pre = nil
 
-	// Starting on v4.23.0 we support TLS Profile configuration. The
-	// expected TLS Profile is part of the HostedCluster config.
+	// Starting on v4.23.0 we support TLS Profile configuration.
+	// Only TLSSecurityProfile affects worker node configuration; other
+	// APIServer fields are control-plane-only and must not be included
+	// in the hash to avoid unnecessary NodePool rollouts.
 	if version.GTE(semver.MustParse("4.23.0")) {
-		apiServer := globalconfig.APIServerConfiguration()
-		if err := globalconfig.ReconcileAPIServerConfiguration(apiServer, hcluster.Spec.Configuration); err != nil {
-			return fmt.Errorf("failed to reconcile apiserver global config: %w", err)
+		var tlsProfile *configv1.TLSSecurityProfile
+		if hcluster.Spec.Configuration != nil && hcluster.Spec.Configuration.APIServer != nil {
+			tlsProfile = hcluster.Spec.Configuration.APIServer.TLSSecurityProfile
 		}
-		apiServerBytes, err := api.CompatibleJSONEncode(apiServer)
+		tlsBytes, err := json.Marshal(tlsProfile)
 		if err != nil {
-			return fmt.Errorf("failed to encode apiserver global config: %w", err)
+			return fmt.Errorf("failed to encode TLS security profile: %w", err)
 		}
-		globalConfigBytes.Write(apiServerBytes)
+		globalConfigBytes.Write(tlsBytes)
+		globalConfigBytes.WriteByte('\n')
 	}
 
 	return nil

--- a/hypershift-operator/controllers/nodepool/config_test.go
+++ b/hypershift-operator/controllers/nodepool/config_test.go
@@ -126,8 +126,8 @@ spec:
 	expectedGlobalConfigString := `{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"trustedCA":{"name":""}},"status":{}}
 {"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"additionalTrustedCA":{"name":""},"registrySources":{}},"status":{}}
 `
-	// For release versions >= 4.23.0, the apiserver config is additionally included.
-	expectedGlobalConfigStringWithAPIServer := expectedGlobalConfigString + `{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"servingCerts":{},"clientCA":{"name":""},"encryption":{},"audit":{}},"status":{}}
+	// For release versions >= 4.23.0, the TLS security profile is additionally included in the config hash.
+	expectedGlobalConfigStringWithAPIServer := expectedGlobalConfigString + `null
 `
 
 	hostedCluster := &hyperv1.HostedCluster{
@@ -296,7 +296,7 @@ spec:
 		},
 		{
 			name:                       "When osImageStream is set to non-default it should produce a different hash",
-			expectedHash:               "4ecbeb73",
+			expectedHash:               "3d08ada8",
 			expectedHashWithoutVersion: "3a158178",
 			expectedGlobalConfig:       expectedGlobalConfigStringWithAPIServer,
 			nodePool: &hyperv1.NodePool{
@@ -317,7 +317,7 @@ spec:
 		},
 		{
 			name:                       "When release version is 5.0.0 with no osImageStream it should normalize rhelStream to empty",
-			expectedHash:               "2d564196",
+			expectedHash:               "bc411add",
 			expectedHashWithoutVersion: "0db5756d",
 			expectedGlobalConfig:       expectedGlobalConfigStringWithAPIServer,
 			nodePool:                   &hyperv1.NodePool{},
@@ -334,7 +334,7 @@ spec:
 		},
 		{
 			name:                       "When osImageStream is rhel-10 on 5.0.0 it should normalize to empty and match unset hash",
-			expectedHash:               "2d564196",
+			expectedHash:               "bc411add",
 			expectedHashWithoutVersion: "0db5756d",
 			expectedGlobalConfig:       expectedGlobalConfigStringWithAPIServer,
 			nodePool: &hyperv1.NodePool{
@@ -355,7 +355,7 @@ spec:
 		},
 		{
 			name:                       "When runc ContainerRuntimeConfig on 5.0.0 with explicit rhel-9, it should normalize rhelStream to empty",
-			expectedHash:               "8dc0d4f5",
+			expectedHash:               "ff007b24",
 			expectedHashWithoutVersion: "6d5a7b66",
 			expectedGlobalConfig:       expectedGlobalConfigStringWithAPIServer,
 			nodePool: &hyperv1.NodePool{
@@ -385,7 +385,7 @@ spec:
 		},
 		{
 			name:                       "When runc ContainerRuntimeConfig on 5.0.0 with no osImageStream, it should match explicit rhel-9 hash",
-			expectedHash:               "8dc0d4f5",
+			expectedHash:               "ff007b24",
 			expectedHashWithoutVersion: "6d5a7b66",
 			expectedGlobalConfig:       expectedGlobalConfigStringWithAPIServer,
 			nodePool: &hyperv1.NodePool{
@@ -1948,9 +1948,14 @@ func TestGlobalConfigString(t *testing.T) {
 	expectedGlobalConfigStringWithValues := `{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"httpProxy":"proxy","noProxy":"noProxy","trustedCA":{"name":""}},"status":{"httpProxy":"proxy","noProxy":".cluster.local,.local,.svc,127.0.0.1,localhost,noProxy"}}
 {"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"externalRegistryHostnames":["external registry"],"additionalTrustedCA":{"name":""},"registrySources":{}},"status":{}}
 `
-	expectedGlobalConfigStringWithAPIServer := `{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"trustedCA":{"name":""}},"status":{}}
+	expectedGlobalConfigStringWithTLSProfile := `{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"trustedCA":{"name":""}},"status":{}}
 {"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"additionalTrustedCA":{"name":""},"registrySources":{}},"status":{}}
-{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"servingCerts":{},"clientCA":{"name":""},"encryption":{},"audit":{}},"status":{}}
+null
+`
+
+	expectedGlobalConfigStringWithTLSProfileSet := `{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"trustedCA":{"name":""}},"status":{}}
+{"metadata":{"name":"cluster","creationTimestamp":null},"spec":{"additionalTrustedCA":{"name":""},"registrySources":{}},"status":{}}
+{"type":"Custom","custom":{"ciphers":["TLS_AES_128_GCM_SHA256"],"minTLSVersion":"VersionTLS13"}}
 `
 
 	testCases := []struct {
@@ -2003,10 +2008,35 @@ func TestGlobalConfigString(t *testing.T) {
 			expectedOutput: expectedGlobalConfigStringWithValues,
 		},
 		{
-			name:           "When release image is >= 4.23 the apiserver is included in the global config string",
+			name:           "When release image is >= 4.23 with no TLS profile it should include null TLS profile in config string",
 			globalConfig:   &hyperv1.ClusterConfiguration{},
 			releaseImage:   &releaseinfo.ReleaseImage{ImageStream: &imageapi.ImageStream{ObjectMeta: metav1.ObjectMeta{Name: "4.23.0"}}},
-			expectedOutput: expectedGlobalConfigStringWithAPIServer,
+			expectedOutput: expectedGlobalConfigStringWithTLSProfile,
+		},
+		{
+			name: "When release image is >= 4.23 with TLS profile set it should include only TLS profile in config string",
+			globalConfig: &hyperv1.ClusterConfiguration{
+				APIServer: &configv1.APIServerSpec{
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+						Custom: &configv1.CustomTLSProfile{
+							TLSProfileSpec: configv1.TLSProfileSpec{
+								Ciphers:       []string{"TLS_AES_128_GCM_SHA256"},
+								MinTLSVersion: configv1.VersionTLS13,
+							},
+						},
+					},
+					Encryption: configv1.APIServerEncryption{Type: configv1.EncryptionTypeAESCBC},
+				},
+			},
+			releaseImage:   &releaseinfo.ReleaseImage{ImageStream: &imageapi.ImageStream{ObjectMeta: metav1.ObjectMeta{Name: "4.23.0"}}},
+			expectedOutput: expectedGlobalConfigStringWithTLSProfileSet,
+		},
+		{
+			name:           "When release image is a 4.23 CI pre-release it should still include TLS profile in config string",
+			globalConfig:   &hyperv1.ClusterConfiguration{},
+			releaseImage:   &releaseinfo.ReleaseImage{ImageStream: &imageapi.ImageStream{ObjectMeta: metav1.ObjectMeta{Name: "4.23.0-0.ci-2026-08-11-110857"}}},
+			expectedOutput: expectedGlobalConfigStringWithTLSProfile,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Only serialize `TLSSecurityProfile` (via `json.Marshal`) into the NodePool config hash for >= 4.23 clusters, instead of the full reconciled `APIServer` object (via `api.CompatibleJSONEncode`).
- Other APIServer fields (`ServingCerts`, `ClientCA`, `CORS`, `Encryption`, `Audit`) are control-plane-only and no longer trigger unnecessary NodePool rollouts.
- Adds a test case verifying that a non-TLS field (`Encryption`) alongside a TLS profile does not appear in the config string.

Fixes: https://issues.redhat.com/browse/OCPBUGS-105865

## Rollout impact
This changes the config hash for all existing NodePools on >= 4.23. A **one-time rollout** will occur when this operator version is deployed, because the hash input shrinks from the full APIServer blob to just the TLS profile. After that, non-TLS APIServer changes will no longer trigger rollouts.

## Test plan
- [x] `TestNewConfigGenerator` — all hash expectations updated, all pass
- [x] `TestGlobalConfigString` — expected strings updated, new test case for TLS profile set alongside Encryption
- [x] Full `nodepool` package test suite passes
- [ ] `e2e-aws-upgrade-hypershift-operator` — must pass to validate the one-time hash change rollout is safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node pool configuration tracking for release versions 4.23.0 and newer.
  * Changes to the API server TLS security profile are now detected reliably, triggering appropriate node pool updates.
  * Unrelated API server configuration changes, including encryption settings, no longer unnecessarily affect node pool rollout behavior.
* **Compatibility**
  * Preserved existing configuration-tracking behavior for release versions earlier than 4.23.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->