### PR TITLE
CNTRLPLANE-4038: feat(supportedversion): bump latest supported OCP version to 5.1

### DIFF
--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -31,7 +31,7 @@ const (
 // NOTE: The .0 (z release) should be ignored. It's only here to support
 // semver parsing.
 var (
-	LatestSupportedVersion      = semver.MustParse("5.0.0")
+	LatestSupportedVersion      = semver.MustParse("5.1.0")
 	MinSupportedVersion         = semver.MustParse("4.14.0")
 	IBMCloudMinSupportedVersion = semver.MustParse("4.14.0")
 	// prevLatestSupportedMajor holds the value of the latest version before we updated to a new major.
@@ -53,14 +53,18 @@ var ocpVersionToKubeVersion = map[string]semver.Version{
 	"4.21.0": semver.MustParse("1.34.0"),
 	"4.22.0": semver.MustParse("1.35.0"),
 	"4.23.0": semver.MustParse("1.36.0"),
+	"5.0.0":  semver.MustParse("1.36.0"),
+	"5.1.0":  semver.MustParse("1.37.0"),
 }
 
 func GetKubeVersionForSupportedVersion(supportedVersion semver.Version) (*semver.Version, error) {
-	normalized, err := normalizeToV4(supportedVersion)
-	if err != nil {
-		return nil, err
-	}
-	lookupKey := semver.Version{Major: normalized.Major, Minor: normalized.Minor}
+	// Unlike other version-aware functions in this package, we do NOT normalize
+	// to 4.x here. normalizeToV4 is used elsewhere for arithmetic and comparison
+	// (e.g. skew validation, release validation) where mapping 5.x to 4.(23+x)
+	// preserves ordering. Here we need a direct lookup: 5.0 and 4.23 are the
+	// same OCP release (dual versioning), but 5.1+ are distinct versions with
+	// no 4.x equivalent, so the map uses real version keys for both series.
+	lookupKey := semver.Version{Major: supportedVersion.Major, Minor: supportedVersion.Minor}
 	kubeVersion, ok := ocpVersionToKubeVersion[lookupKey.String()]
 	if !ok {
 		return nil, fmt.Errorf("unknown supported version %q", supportedVersion.String())

--- a/support/supportedversion/version_test.go
+++ b/support/supportedversion/version_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestSupportedVersions(t *testing.T) {
 	g := NewGomegaWithT(t)
-	g.Expect(Supported()).To(Equal([]string{"5.0", "4.23", "4.22", "4.21", "4.20", "4.19", "4.18", "4.17", "4.16", "4.15", "4.14"}))
+	g.Expect(Supported()).To(Equal([]string{"5.1", "5.0", "4.23", "4.22", "4.21", "4.20", "4.19", "4.18", "4.17", "4.16", "4.15", "4.14"}))
 }
 
 func TestString(t *testing.T) {
@@ -67,9 +67,14 @@ func TestGetKubeVersionForSupportedVersion(t *testing.T) {
 			expectedKubeVer: "1.34.0",
 		},
 		{
-			name:            "When OCP 5.0 is provided, it should normalize to 4.23 and return Kubernetes 1.36",
+			name:            "When OCP 5.0 is provided it should return Kubernetes 1.36 via direct lookup",
 			ocpVersion:      "5.0.0",
 			expectedKubeVer: "1.36.0",
+		},
+		{
+			name:            "When OCP 5.1 is provided it should return Kubernetes 1.37 via direct lookup",
+			ocpVersion:      "5.1.0",
+			expectedKubeVer: "1.37.0",
 		},
 		{
 			name:       "When an unmapped OCP version is provided it should return an error",
@@ -614,6 +619,13 @@ func TestPreviousMinorVersion(t *testing.T) {
 			n:             2,
 			expectedMajor: 4,
 			expectedMinor: 21,
+		},
+		{
+			name:          "When crossing the 5.x to 4.x bridge from 5.1, n-2 should be 4.22",
+			version:       semver.MustParse("5.1.0"),
+			n:             2,
+			expectedMajor: 4,
+			expectedMinor: 22,
 		},
 		{
 			name:          "When staying within 5.x, it should return the correct 5.x version",

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	// y-stream versions supported by e2e in main
+	Version51  = semver.MustParse("5.1.0")
 	Version50  = semver.MustParse("5.0.0")
 	Version423 = semver.MustParse("4.23.0")
 	Version422 = semver.MustParse("4.22.0")
@@ -34,6 +35,7 @@ func init() {
 	// Ensure that the version constants are valid semver versions
 	// This is a compile-time check to ensure that the versions are valid
 	// semver versions.
+	_ = Version51
 	_ = Version50
 	_ = Version423
 	_ = Version422


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps `LatestSupportedVersion` from 5.0 to 5.1 to unblock 5.1 nightly payload acceptance and the Azure AKS conformance periodic job (`e2e-azure-aks-ovn-conformance`) on the `release-5.1` branch.

The HyperShift operator's `supported-versions` ConfigMap only listed up to 5.0, causing all 5.1 nightly payload runs to fail because NodePool rejects the 5.1 payload as unsupported.

Changes:
- Bump `LatestSupportedVersion` to `5.1.0`
- Add OCP `4.24` (5.1 normalized) to Kubernetes `1.37` version mapping
- Add `Version51` e2e constant with compile-time check
- Update test expectations for the new supported versions list

**Which issue(s) this PR fixes**:
Fixes [CNTRLPLANE-4038](https://issues.redhat.com/browse/CNTRLPLANE-4038)

Previous version bump for reference: [CNTRLPLANE-1370](https://issues.redhat.com/browse/CNTRLPLANE-1370) / [PR #6739](https://github.com/openshift/hypershift/pull/6739)

Slack thread flagging the issue: [link](https://redhat-internal.slack.com/archives/C01CQA76KMX/p1786460640434099)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OpenShift 5.1.0.
  * Added Kubernetes 1.37 mapping for OpenShift 5.1 and retained Kubernetes 1.36 mapping for OpenShift 5.0.
  * Added compatibility with determining the previous supported OpenShift minor version.

* **Bug Fixes**
  * Updated version validation and compatibility lookups to correctly recognize distinct OpenShift 5.x releases.
  * Updated test coverage for OpenShift 5.1.0 and its Kubernetes version mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->