### PR TITLE
no-jira: add karpenter-operator dev image override annotation

### DIFF
--- a/api/karpenter/v1/karpenter_types.go
+++ b/api/karpenter/v1/karpenter_types.go
@@ -13,6 +13,10 @@ const (
 	// a HostedControlPlane with AutoNode enabled.
 	KarpenterProviderAWSImage = "hypershift.openshift.io/karpenter-provider-aws-image"
 
+	// KarpenterOperatorImage overrides the standalone karpenter-operator image for
+	// a HostedControlPlane with AutoNode enabled.
+	KarpenterOperatorImage = "hypershift.openshift.io/karpenter-operator-image"
+
 	// TokenSecretNodePoolAnnotation is used to annotate the Karpenter token secret with its hyperv1.NodePool namespaced name.
 	TokenSecretNodePoolAnnotation = "hypershift.openshift.io/nodePool"
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
@@ -150,6 +151,9 @@ func adaptStandaloneDeployment(cpContext component.WorkloadContext, deployment *
 	)
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Image = cpContext.ReleaseImageProvider.GetImage("karpenter-operator")
+		if override, exists := hcp.Annotations[hyperkarpenterv1.KarpenterOperatorImage]; exists && override != "" {
+			c.Image = override
+		}
 		c.VolumeMounts = append(c.VolumeMounts,
 			corev1.VolumeMount{
 				Name:      "provider-creds",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
@@ -259,14 +260,15 @@ func TestAdaptDeployment(t *testing.T) {
 
 func TestAdaptStandaloneDeployment(t *testing.T) {
 	testCases := []struct {
-		name          string
-		platformType  hyperv1.PlatformType
-		awsRegion     string
-		azureLocation string
-		infraID       string
-		rhobsEnabled  bool
-		images        map[string]string
-		validateFunc  func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext)
+		name           string
+		platformType   hyperv1.PlatformType
+		awsRegion      string
+		azureLocation  string
+		infraID        string
+		rhobsEnabled   bool
+		hcpAnnotations map[string]string
+		images         map[string]string
+		validateFunc   func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext)
 	}{
 		{
 			name:         "When platform is AWS, it should configure AWS-specific env vars and karpenter image",
@@ -388,6 +390,78 @@ func TestAdaptStandaloneDeployment(t *testing.T) {
 				g.Expect(podspec.FindEnvVar(rhobsmonitoring.EnvironmentVariable, container.Env)).To(BeNil())
 			},
 		},
+		{
+			name:         "When HCP has KarpenterOperatorImage annotation, it should override the image",
+			platformType: hyperv1.AWSPlatform,
+			awsRegion:    "us-west-2",
+			infraID:      "test-infra-override",
+			hcpAnnotations: map[string]string{
+				hyperkarpenterv1.KarpenterOperatorImage: "quay.io/custom/karpenter-operator:test",
+			},
+			images: map[string]string{
+				"karpenter-operator":         "quay.io/openshift/karpenter-operator:latest",
+				"aws-karpenter-provider-aws": "quay.io/openshift/karpenter-aws:latest",
+			},
+			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
+				t.Helper()
+				deploymentObj, err := assets.LoadDeploymentManifest(ComponentName)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				err = adaptStandaloneDeployment(cpContext, deploymentObj)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				g.Expect(container).ToNot(BeNil())
+				g.Expect(container.Image).To(Equal("quay.io/custom/karpenter-operator:test"))
+			},
+		},
+		{
+			name:         "When HCP has no KarpenterOperatorImage annotation, it should use the default image",
+			platformType: hyperv1.AWSPlatform,
+			awsRegion:    "us-west-2",
+			infraID:      "test-infra-default",
+			images: map[string]string{
+				"karpenter-operator":         "quay.io/openshift/karpenter-operator:latest",
+				"aws-karpenter-provider-aws": "quay.io/openshift/karpenter-aws:latest",
+			},
+			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
+				t.Helper()
+				deploymentObj, err := assets.LoadDeploymentManifest(ComponentName)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				err = adaptStandaloneDeployment(cpContext, deploymentObj)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				g.Expect(container).ToNot(BeNil())
+				g.Expect(container.Image).To(Equal("quay.io/openshift/karpenter-operator:latest"))
+			},
+		},
+		{
+			name:         "When HCP has empty KarpenterOperatorImage annotation, it should use the default image",
+			platformType: hyperv1.AWSPlatform,
+			awsRegion:    "us-west-2",
+			infraID:      "test-infra-empty-override",
+			hcpAnnotations: map[string]string{
+				hyperkarpenterv1.KarpenterOperatorImage: "",
+			},
+			images: map[string]string{
+				"karpenter-operator":         "quay.io/openshift/karpenter-operator:latest",
+				"aws-karpenter-provider-aws": "quay.io/openshift/karpenter-aws:latest",
+			},
+			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
+				t.Helper()
+				deploymentObj, err := assets.LoadDeploymentManifest(ComponentName)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				err = adaptStandaloneDeployment(cpContext, deploymentObj)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				g.Expect(container).ToNot(BeNil())
+				g.Expect(container.Image).To(Equal("quay.io/openshift/karpenter-operator:latest"))
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -402,8 +476,9 @@ func TestAdaptStandaloneDeployment(t *testing.T) {
 
 			hcp := &hyperv1.HostedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-hcp",
-					Namespace: "test-namespace",
+					Name:        "test-hcp",
+					Namespace:   "test-namespace",
+					Annotations: tc.hcpAnnotations,
 				},
 				Spec: hyperv1.HostedControlPlaneSpec{
 					InfraID: tc.infraID,

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2624,6 +2624,7 @@ func reconcileHostedControlPlaneAnnotations(hcp *hyperv1.HostedControlPlane, hcl
 		hyperv1.AWSMachinePublicIPs,
 		hyperv1.AWSKarpenterDefaultInstanceProfile,
 		hyperkarpenterv1.KarpenterProviderAWSImage,
+		hyperkarpenterv1.KarpenterOperatorImage,
 		hyperv1.KubeAPIServerGoAwayChance,
 		hyperv1.KubeAPIServerServiceAccountTokenMaxExpiration,
 		hyperv1.HostedClusterRestoredFromBackupAnnotation,

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -19,6 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1"
 	"github.com/openshift/hypershift/api/util/ipnet"
 	"github.com/openshift/hypershift/cmd/util"
 	capimanagerv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager"
@@ -1182,6 +1183,19 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				k8sutil.HostedClusterAnnotation:                    hcKey,
 				hyperv1.AWSKarpenterDefaultInstanceProfile:         "test-instance-profile",
+				hyperv1.DisableClusterAutoscalerAnnotation:         "true",
+				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
+			},
+		},
+		{
+			name: "When HostedCluster has karpenter-operator-image annotation it should propagate to HCP",
+			hcAnnotations: map[string]string{
+				hyperkarpenterv1.KarpenterOperatorImage: "quay.io/custom/karpenter-operator:test",
+			},
+			hcpAnnotations: map[string]string{},
+			expectedAnnotations: map[string]string{
+				k8sutil.HostedClusterAnnotation:                    hcKey,
+				hyperkarpenterv1.KarpenterOperatorImage:            "quay.io/custom/karpenter-operator:test",
 				hyperv1.DisableClusterAutoscalerAnnotation:         "true",
 				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
 			},

--- a/vendor/github.com/openshift/hypershift/api/karpenter/v1/karpenter_types.go
+++ b/vendor/github.com/openshift/hypershift/api/karpenter/v1/karpenter_types.go
@@ -13,6 +13,10 @@ const (
 	// a HostedControlPlane with AutoNode enabled.
 	KarpenterProviderAWSImage = "hypershift.openshift.io/karpenter-provider-aws-image"
 
+	// KarpenterOperatorImage overrides the standalone karpenter-operator image for
+	// a HostedControlPlane with AutoNode enabled.
+	KarpenterOperatorImage = "hypershift.openshift.io/karpenter-operator-image"
+
 	// TokenSecretNodePoolAnnotation is used to annotate the Karpenter token secret with its hyperv1.NodePool namespaced name.
 	TokenSecretNodePoolAnnotation = "hypershift.openshift.io/nodePool"
 


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a new `HostedCluster` annotation `hypershift.openshift.io/karpenter-operator-image`.
Specifying this overrides the standalone karpenter-operator image for dev purposes.

Assisted-by: Cursor Grok 4.5 (via Cursor)

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Related to this effort to refactor karpenter-operator: https://redhat.atlassian.net/browse/AUTOSCALE-522

## Special notes for your reviewer:

Similar to: https://github.com/openshift/hypershift/pull/5999

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the standalone Karpenter Operator image for HostedControlPlanes with AutoNode enabled.
  * HostedCluster configuration now passes the Karpenter Operator image override through to the HostedControlPlane.

* **Bug Fixes**
  * Ensured the release-provided Karpenter Operator image remains the default when no override is specified.
  * Empty image overrides are ignored, preventing invalid deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->