### PR TITLE
CNTRLPLANE-3871: add [FeatureGate:OSStreams] tag for FG promotion tracking

### DIFF
--- a/test/e2e/v2/tests/nodepool_osimagestream_test.go
+++ b/test/e2e/v2/tests/nodepool_osimagestream_test.go
@@ -79,7 +79,7 @@ func osImageStreamBeforeEach(testCtx **internal.TestContext) {
 	}
 }
 
-var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolOSImageStream] NodePool OSImageStream Lifecycle", Label("lifecycle", "nodepool-osimagestream"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][FeatureGate:OSStreams][Feature:NodePoolOSImageStream] NodePool OSImageStream Lifecycle", Label("lifecycle", "nodepool-osimagestream"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {
@@ -90,7 +90,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolOSImageStrea
 })
 
 // TODO(jparrill): Remove "lifecycle" label after OSStreams FG graduates to Default (openshift/api#2950)
-var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolOSImageStream] NodePool OSImageStream Status", Label("lifecycle", "nodepool-osimagestream"), func() {
+var _ = Describe("[sig-hypershift][Jira:Hypershift][FeatureGate:OSStreams][Feature:NodePoolOSImageStream] NodePool OSImageStream Status", Label("lifecycle", "nodepool-osimagestream"), func() {
 	var testCtx *internal.TestContext
 
 	BeforeEach(func() {


### PR DESCRIPTION
## Summary
- Adds `[FeatureGate:OSStreams]` to both OSImageStream e2e test Describe blocks
- Required by `openshift/api` `verify-feature-promotion` CI check, which queries Sippy for tests matching substring `FeatureGate:<name>]`
- Without this tag, Sippy finds 0 tests and blocks the OSStreams FG promotion to Default (openshift/api#2950)

## Context
The `featuregate-test-analyzer` in openshift/api builds its search pattern as:
```go
testPattern := fmt.Sprintf("FeatureGate:%s]", featureGate)
```
Our tests used `[Feature:NodePoolOSImageStream]` which doesn't match. This PR fixes the mismatch.

Related PRs:
- openshift/api#2950 — OSStreams FG promotion to Default (blocked by this)
- openshift/hypershift#9099 — Main dual-stream RHEL 9/10 implementation
- openshift/release#82438 — Dedicated CI job for OSImageStream tests

## Test plan
- [x] `go build -tags e2ev2 ./test/e2e/v2/...` compiles
- [x] `go vet -tags e2ev2 ./test/e2e/v2/...` passes
- [ ] After merge + CI runs, Sippy indexes tests with `FeatureGate:OSStreams]` pattern
- [ ] `verify-feature-promotion` passes on openshift/api#2950

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test coverage for NodePool OS image stream lifecycle and status behavior.
  * Updated test scenarios to run with the relevant OS image stream feature enabled, helping verify consistent functionality in supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->