### PR TITLE
NO-JIRA: Add ci cluster release nightly image push

### DIFF
--- a/.tekton/hypershift-operator-release-nightly.yaml
+++ b/.tekton/hypershift-operator-release-nightly.yaml
@@ -5,7 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/openshift/hypershift?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/on-target-branch: "[release-*]"
+    pipelinesascode.tekton.dev/on-target-branch: "[release-5.1]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"

--- a/.tekton/hypershift-operator-release-nightly.yaml
+++ b/.tekton/hypershift-operator-release-nightly.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
+    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/nightly-release-build.yaml"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: hypershift-operator
@@ -24,8 +24,12 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    # The image tag should end up like 5.0.0-0-nightly-20260812-123456 depending on the target branch and push event timestamp
-    value: 'quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-operator/hypershift-operator-{{ target_branch }}-nightly-unverified:{{ cel:pac.target_branch.replace("release-", "") + "0.0-nightly-" + body.created_at.replace("T", "-").replace(":", "").replace("Z", "")}}}'
+    value: 'quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-operator/hypershift-operator-{{ target_branch }}-nightly-unverified'
+  - name: destination-image-tag
+    # The image tag should end up like 5.0.0-0.nightly-2026-08-12-123456 depending on the target branch and push event timestamp
+    value: '{{ cel:pac.target_branch.replace("release-", "") + ".0-0.nightly-" + body.created_at.replace("T", "-").replace(":", "").replace("Z", "")}}'
+  - name: destination-imagestream
+    value: 'hypershift/hypershift-operator-{{ target_branch }}-nightly'
   - name: build-platforms
     value:
     - linux/x86_64
@@ -36,11 +40,14 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    name: hypershift-common-operator-build
+    name: hypershift-nightly-release-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-hypershift-operator-main
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
+  - name: cluster-credentials
+    secret:
+      secretName: hypershift-ci-cluster-credentials
 status: {}

--- a/.tekton/hypershift-operator-release-nightly.yaml
+++ b/.tekton/hypershift-operator-release-nightly.yaml
@@ -1,0 +1,46 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/hypershift?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/on-target-branch: "[release-*]"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
+  creationTimestamp:
+  labels:
+    appstudio.openshift.io/application: hypershift-operator
+    appstudio.openshift.io/component: 'hypershift-operator-{{target_branch}}-nightly'
+    pipelines.appstudio.openshift.io/type: build
+  name: hypershift-operator-release-nightly-on-push
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    # The image tag should end up like 5.0.0-0-nightly-20260812-123456 depending on the target branch and push event timestamp
+    value: 'quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-operator/hypershift-operator-{{ target_branch }}-nightly-unverified:{{ cel:pac.target_branch.replace("release-", "") + "0.0-nightly-" + body.created_at.replace("T", "-").replace(":", "").replace("Z", "")}}}'
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+  - name: dockerfile
+    value: Containerfile.operator
+  - name: path-context
+    value: .
+  pipelineRef:
+    name: hypershift-common-operator-build
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-hypershift-operator-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/hypershift-operator-release-nightly.yaml
+++ b/.tekton/hypershift-operator-release-nightly.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: 'quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-operator/hypershift-operator-{{ target_branch }}-nightly-unverified'
+    value: 'quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-operator/hypershift-operator-nightly-unverified'
   - name: destination-image-tag
     # The image tag should end up like 5.0.0-0.nightly-2026-08-12-123456 depending on the target branch and push event timestamp
     value: '{{ cel:pac.target_branch.replace("release-", "") + ".0-0.nightly-" + body.created_at.replace("T", "-").replace(":", "").replace("Z", "")}}'

--- a/.tekton/pipelines/nightly-release-build.yaml
+++ b/.tekton/pipelines/nightly-release-build.yaml
@@ -4,9 +4,10 @@ metadata:
   name: hypershift-nightly-release-build
 spec:
   description: |
-    Nightly release pipeline. Runs the shared hypershift-common-operator-build
-    pipeline to build and push the multi-arch operator image, then tags the
-    resulting image into an OpenShift imagestream on the CI cluster.
+    Nightly release pipeline. Builds and pushes the multi-arch operator image
+    (tasks inlined from the hypershift-common-operator-build pipeline, since
+    Konflux does not support Pipelines-in-Pipelines), then tags the resulting
+    image into an OpenShift imagestream on the CI cluster.
   params:
   - description: Source Repository URL
     name: git-url
@@ -68,52 +69,446 @@ spec:
   results:
   - description: ""
     name: IMAGE_URL
-    value: $(tasks.build.results.IMAGE_URL)
+    value: $(tasks.build-image-index.results.IMAGE_URL)
   - description: ""
     name: IMAGE_DIGEST
-    value: $(tasks.build.results.IMAGE_DIGEST)
+    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+  - description: ""
+    name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - description: ""
+    name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
   tasks:
-  - name: build
+  - name: init
+    taskRef:
+      params:
+      - name: name
+        value: init
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.3@sha256:4dbbfedc4edb21884fa2ad84521408d2fad090d4d34eb6c555992f8444eba40d
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: clone-repository
     params:
-    - name: git-url
+    - name: url
       value: $(params.git-url)
     - name: revision
       value: $(params.revision)
-    - name: output-image
-      value: $(params.output-image):$(params.destination-image-tag)
-    - name: path-context
-      value: $(params.path-context)
-    - name: dockerfile
-      value: $(params.dockerfile)
-    - name: prefetch-input
+    - name: ociStorage
+      value: $(params.output-image):$(params.destination-image-tag).git
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - init
+    taskRef:
+      params:
+      - name: name
+        value: git-clone-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.5@sha256:437e4a29b0674420af96e497b6492d0408e59b97f98a35b84d2d32016503c2a0
+      - name: kind
+        value: task
+      resolver: bundles
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
       value: $(params.prefetch-input)
-    - name: image-expires-after
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    - name: ociStorage
+      value: $(params.output-image):$(params.destination-image-tag).prefetch
+    - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
     - name: dev-package-managers
       value: $(params.dev-package-managers)
-    - name: build-platforms
-      value:
-      - $(params.build-platforms[*])
-    - name: hermetic
-      value: $(params.hermetic)
-    - name: additional-tags
-      value:
-      - $(params.additional-tags[*])
-    pipelineRef:
-      name: hypershift-common-operator-build
+    - name: enable-package-registry-proxy
+      value: "true"
+    runAfter:
+    - clone-repository
+    taskRef:
+      params:
+      - name: name
+        value: prefetch-dependencies-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.9.0@sha256:4486aaa69770d6b27c59c8df7d82e450d95dab2302aef9b8a345f2ac0fabbab0
+      - name: kind
+        value: task
+      resolver: bundles
     workspaces:
-    - name: git-auth
+    - name: git-basic-auth
       workspace: git-auth
     - name: netrc
       workspace: netrc
+  - matrix:
+      params:
+      - name: PLATFORM
+        value: $(params.build-platforms[*])
+    name: build-images
+    params:
+    - name: IMAGE
+      value: $(params.output-image):$(params.destination-image-tag)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: IMAGE_APPEND_PLATFORM
+      value: "true"
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      params:
+      - name: name
+        value: buildah-remote-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.11.2@sha256:24dc105ebea83e1014a6df33f14681c3ddcef67ffe0a9bb52edcad2e01865625
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: build-image-index
+    params:
+    - name: IMAGE
+      value: $(params.output-image):$(params.destination-image-tag)
+    - name: ALWAYS_BUILD_INDEX
+      value: "true"
+    - name: IMAGES
+      value:
+      - $(tasks.build-images.results.IMAGE_REF[*])
+    runAfter:
+    - build-images
+    taskRef:
+      params:
+      - name: name
+        value: build-image-index
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:714a86d454203804fe14e422b4ba8d775d9ec19e5b7922cedd55ef93a3bc9166
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: deprecated-base-image-check
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: deprecated-image-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:0ccc688a77e9b7b0b8973c132a1e840844137e77f887be4a0bec8893b0776872
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: "false"
+      operator: in
+      values:
+      - "false"
+  - name: clair-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: clair-scan
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:f5b4415db9ac1fba3e11d993a617e0b275d1f0ed2fc669b12c400ed848c39174
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: "false"
+      operator: in
+      values:
+      - "false"
+  - matrix:
+      params:
+      - name: platform
+        value: $(params.build-platforms[*])
+    name: ecosystem-cert-preflight-checks
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: ecosystem-cert-preflight-checks
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:e438f3104d706f73812994953d3d0a9c62ac8e4a372d86337ff26bbca9902709
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: "false"
+      operator: in
+      values:
+      - "false"
+  - name: sast-snyk-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: sast-snyk-check-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:b78e9c05c5126613eddee53f2f3534a9b86bfca17d903599f2fa465b7938e241
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: "false"
+      operator: in
+      values:
+      - "false"
+  - matrix:
+      params:
+      - name: image-arch
+        value: $(params.build-platforms[*])
+    name: clamav-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: clamav-scan
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3.1@sha256:53a02326bfb930ca5ef6bfa7a33acca833d57752f34f3cb79255fe2e25e7d217
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: "false"
+      operator: in
+      values:
+      - "false"
+  - name: sast-coverity-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE
+      value: $(params.output-image):$(params.destination-image-tag)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - coverity-availability-check
+    taskRef:
+      params:
+      - name: name
+        value: sast-coverity-check-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:e92d00ed858233d0096627861192d3e4fc013cf1559c0d0b0ea0657d3377ce75
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: "false"
+      operator: in
+      values:
+      - "false"
+    - input: $(tasks.coverity-availability-check.results.STATUS)
+      operator: in
+      values:
+      - success
+  - name: coverity-availability-check
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: coverity-availability-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:8b501440a960aec446db2ebc6625a49d0317a9fc7bf0f7bd9b18cb63052db7de
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: "false"
+      operator: in
+      values:
+      - "false"
+  - name: sast-shell-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: sast-shell-check-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:beb05ae2fad733783b3b17e05871e0eaf527a07c904cf3fb2cb551025007eec1
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: "false"
+      operator: in
+      values:
+      - "false"
+  - name: sast-unicode-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: sast-unicode-check-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:d09f717cb84f0699a531773bc498745deef2c006a81918aa73b3be6d2f4778bd
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: "false"
+      operator: in
+      values:
+      - "false"
+  - name: apply-tags
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: ADDITIONAL_TAGS
+      value: $(params.additional-tags[*])
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: apply-tags
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:f89a59d4d043fd3c545a9cb5e89b53396f1e04017c6f68da1e50626715c2d423
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: push-dockerfile
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: push-dockerfile-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3.1@sha256:ee041e2bdf5638faaca60baa171c3e13927097a0e69ed2172ccf1de5e5ee711a
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: rpms-signature-scan
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: rpms-signature-scan
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:f53e60d7d4fd49546dbbc7298f4fbc8c2f2deea1d2ecac2a53822683480f8e2e
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: "false"
+      operator: in
+      values:
+      - "false"
+  # Tags the built image (referenced by digest) into an OpenShift imagestream on
+  # the CI cluster. The release controller then mirrors it to the production
+  # repository if it passes verification.
   - name: tag-image
     params:
     - name: source-image
-      value: $(tasks.build.results.IMAGE_DIGEST)
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: image-stream-tag
       value: $(params.destination-imagestream):$(params.destination-image-tag)
     runAfter:
-    - build
+    - build-image-index
     taskSpec:
       params:
       - name: source-image

--- a/.tekton/pipelines/nightly-release-build.yaml
+++ b/.tekton/pipelines/nightly-release-build.yaml
@@ -1,0 +1,144 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: hypershift-nightly-release-build
+spec:
+  description: |
+    Nightly release pipeline. Runs the shared hypershift-common-operator-build
+    pipeline to build and push the multi-arch operator image, then tags the
+    resulting image into an OpenShift imagestream on the CI cluster.
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image without the tag. The tag is destination-image-tag.
+      The image here will be treated as a temporary image. Once the image is tagged into the image stream,
+      the release controller will mirror the image to the appropriate production repository if the image
+      passes the verification process.
+    name: output-image
+    type: string
+  - description: Destination image tag for the resulting image to be pushed to.
+      This is just the tag, not the full image URL. Should be in the form X.Y.Z-0.nightly-YYYY-MM-DD-HHMMSS.
+    name: destination-image-tag
+    type: string
+  - description: Destination imagestream to push the image to. Should be in the form <namespace>/<imagestream>.
+    name: destination-imagestream
+    type: string
+  - default: .
+    description: Path to the source code of an application's component from where
+      to build image.
+    name: path-context
+    type: string
+  - default: Dockerfile
+    description: Path to the Dockerfile inside the context specified by parameter
+      path-context
+    name: dockerfile
+    type: string
+  - default: ""
+    description: Build dependencies to be prefetched by Cachi2
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like
+      1h, 2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+    type: string
+  - default: "false"
+    description: Enable development package managers in Cachi2 for prefetch-dependencies
+    name: dev-package-managers
+    type: string
+  - default:
+    - linux/x86_64
+    description: List of platforms to build the container images on. The available
+      set of values is determined by the configuration of the multi-platform-controller.
+    name: build-platforms
+    type: array
+  - default: "true"
+    description: Execute the build with network isolation
+    name: hermetic
+    type: string
+  - default: []
+    description: Additional tags to apply to the built image.
+    name: additional-tags
+    type: array
+  results:
+  - description: ""
+    name: IMAGE_URL
+    value: $(tasks.build.results.IMAGE_URL)
+  - description: ""
+    name: IMAGE_DIGEST
+    value: $(tasks.build.results.IMAGE_DIGEST)
+  tasks:
+  - name: build
+    params:
+    - name: git-url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    - name: output-image
+      value: $(params.output-image):$(params.destination-image-tag)
+    - name: path-context
+      value: $(params.path-context)
+    - name: dockerfile
+      value: $(params.dockerfile)
+    - name: prefetch-input
+      value: $(params.prefetch-input)
+    - name: image-expires-after
+      value: $(params.image-expires-after)
+    - name: dev-package-managers
+      value: $(params.dev-package-managers)
+    - name: build-platforms
+      value:
+      - $(params.build-platforms[*])
+    - name: hermetic
+      value: $(params.hermetic)
+    - name: additional-tags
+      value:
+      - $(params.additional-tags[*])
+    pipelineRef:
+      name: hypershift-common-operator-build
+    workspaces:
+    - name: git-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - name: tag-image
+    params:
+    - name: source-image
+      value: $(tasks.build.results.IMAGE_DIGEST)
+    - name: image-stream-tag
+      value: $(params.destination-imagestream):$(params.destination-image-tag)
+    runAfter:
+    - build
+    taskSpec:
+      params:
+      - name: source-image
+        type: string
+      - name: image-stream-tag
+        type: string
+      workspaces:
+      - name: cluster-credentials
+      steps:
+      - name: tag
+        image: registry.redhat.io/openshift4/ose-cli:latest
+        env:
+        - name: KUBECONFIG
+          value: $(workspaces.cluster-credentials.path)/kubeconfig
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          echo "Tagging $(params.source-image) into imagestream tag $(params.image-stream-tag)"
+          oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference "$(params.source-image)" "$(params.image-stream-tag)"
+    workspaces:
+    - name: cluster-credentials
+      workspace: cluster-credentials
+  workspaces:
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true
+  - name: cluster-credentials


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a new pipeline as code PipelineRun that is intended to push builds for release branches on pushes. These will push into the CI cluster which will create and maintain an imagestream. This will be the trigger for the release controller to start the nightly test and eventual promotion to quay.io.

The intention of this pipeline is to have it paramaterised for all release branches, I'm not certain if that makes sense, but the second commit pins it to just the 5.1 branch temporarily to test.

During regular development, release branches are fast forwarded from main every 2 hours. This means a new image tag will be pushed every 2 hours assuming there is a change to the main branch. On older branches this will happen any time a backport merges.

Need to explore mechanisms to "rate limit" these pushes either on this side, or on the release controller side (it has some ability for this but I haven't explored yet)

I am unsure how I would test this, or whether the pipeline is going to have permissions to push to the app.ci cluster, will try and work that out today

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated nightly builds for the Hypershift operator from the `release-5.1` branch.
  * Added multi-platform container image builds with timestamped tags.
  * Added image publishing, provenance tracking, security checks, and OpenShift imagestream tagging.
  * Added support for configurable build settings, dependency prefetching, and optional credential configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->