### PR TITLE
OCPBUGS-109196: fix(nodepool): validate KubeVirt additionalNetworks NAD namespace

### DIFF
--- a/docs/content/how-to/kubevirt/configuring-network.md
+++ b/docs/content/how-to/kubevirt/configuring-network.md
@@ -31,7 +31,30 @@ hcp create cluster kubevirt \
 
 In this example, the KubeVirt VMs will have interfaces attached to the networks
 for the NetworkAttachmentDefinitions network1 and network2 which reside in
-namespace my-namespace.
+namespace my-namespace (which must be the HCP namespace where virt-launcher
+pods run — see the important note below).
+
+!!! important "NAD Namespace Requirement"
+    The NetworkAttachmentDefinition must be created in the namespace where
+    virt-launcher pods run — the **hosted control plane (HCP) namespace** — not
+    the HostedCluster namespace. The HCP namespace follows the pattern
+    `<hc-namespace>-<hc-name>` (with dots in the cluster name replaced by
+    hyphens). For external infrastructure configurations, use the namespace
+    specified in `Credentials.InfraNamespace`.
+
+    With Multus namespace isolation enabled (the OpenShift default), pods can
+    only reference NADs in their own namespace or in the `default` namespace.
+    Placing the NAD in the HostedCluster namespace will result in Multus
+    rejecting the reference at pod sandbox creation time.
+
+    To determine the correct namespace:
+
+    ```shell
+    # For centralized infrastructure (dots in cluster name become hyphens):
+    HCP_NS="${HC_NAMESPACE}-$(echo ${HC_NAME} | tr '.' '-')"
+    # For external infrastructure:
+    HCP_NS=$(oc get hostedcluster <name> -n <ns> -o jsonpath='{.spec.platform.kubevirt.credentials.infraNamespace}')
+    ```
 
 ## Using Secondary Network as Default
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -25751,7 +25751,30 @@ hcp create cluster kubevirt \
 
 In this example, the KubeVirt VMs will have interfaces attached to the networks
 for the NetworkAttachmentDefinitions network1 and network2 which reside in
-namespace my-namespace.
+namespace my-namespace (which must be the HCP namespace where virt-launcher
+pods run — see the important note below).
+
+!!! important "NAD Namespace Requirement"
+    The NetworkAttachmentDefinition must be created in the namespace where
+    virt-launcher pods run — the **hosted control plane (HCP) namespace** — not
+    the HostedCluster namespace. The HCP namespace follows the pattern
+    `<hc-namespace>-<hc-name>` (with dots in the cluster name replaced by
+    hyphens). For external infrastructure configurations, use the namespace
+    specified in `Credentials.InfraNamespace`.
+
+    With Multus namespace isolation enabled (the OpenShift default), pods can
+    only reference NADs in their own namespace or in the `default` namespace.
+    Placing the NAD in the HostedCluster namespace will result in Multus
+    rejecting the reference at pod sandbox creation time.
+
+    To determine the correct namespace:
+
+    ```shell
+    # For centralized infrastructure (dots in cluster name become hyphens):
+    HCP_NS="${HC_NAMESPACE}-$(echo ${HC_NAME} | tr '.' '-')"
+    # For external infrastructure:
+    HCP_NS=$(oc get hostedcluster <name> -n <ns> -o jsonpath='{.spec.platform.kubevirt.credentials.infraNamespace}')
+    ```
 
 ## Using Secondary Network as Default
 

--- a/hypershift-operator/controllers/nodepool/conditions.go
+++ b/hypershift-operator/controllers/nodepool/conditions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/netip"
 	"strconv"
+	"strings"
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -1020,10 +1021,53 @@ func (r NodePoolReconciler) validPlatformConfigCondition(ctx context.Context, no
 			condition.Reason = hyperv1.AWSErrorReason
 			condition.Message = err.Error()
 		}
+	case hyperv1.KubevirtPlatform:
+		if err := r.validateKubevirtAdditionalNetworkNamespaces(nodePool, hc); err != nil {
+			condition.Status = corev1.ConditionFalse
+			condition.Reason = hyperv1.NodePoolValidationFailedReason
+			condition.Message = err.Error()
+		}
 	}
 
 	SetStatusCondition(&nodePool.Status.Conditions, *condition)
 	return nil, nil
+}
+
+// validateKubevirtAdditionalNetworkNamespaces checks that each additionalNetworks entry
+// references a NAD in the namespace where virt-launcher pods will run, or in "default".
+// With Multus namespace isolation enabled (OpenShift default), pods cannot reference NADs
+// in other namespaces.
+func (r *NodePoolReconciler) validateKubevirtAdditionalNetworkNamespaces(nodePool *hyperv1.NodePool, hc *hyperv1.HostedCluster) error {
+	kvPlatform := nodePool.Spec.Platform.Kubevirt
+	if kvPlatform == nil || len(kvPlatform.AdditionalNetworks) == 0 {
+		return nil
+	}
+
+	infraNS := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name)
+	if hc.Spec.Platform.Kubevirt != nil &&
+		hc.Spec.Platform.Kubevirt.Credentials != nil &&
+		len(hc.Spec.Platform.Kubevirt.Credentials.InfraNamespace) > 0 {
+		infraNS = hc.Spec.Platform.Kubevirt.Credentials.InfraNamespace
+	}
+
+	for _, network := range kvPlatform.AdditionalNetworks {
+		parts := strings.SplitN(network.Name, "/", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		nadNamespace := parts[0]
+		// "default" is always in Multus globalNamespaces on OCP. Other global namespaces
+		// (openshift-multus, openshift-sriov-network-operator) are also exempt from isolation
+		// but are operator-internal — user NADs should not be placed there.
+		if nadNamespace != infraNS && nadNamespace != "default" {
+			return fmt.Errorf(
+				"additionalNetwork %q references namespace %q, but virt-launcher pods run in namespace %q; "+
+					"with Multus namespace isolation (OpenShift default), this is likely to be rejected. "+
+					"Create the NetworkAttachmentDefinition in namespace %q or %q",
+				network.Name, nadNamespace, infraNS, infraNS, "default")
+		}
+	}
+	return nil
 }
 
 func (r *NodePoolReconciler) supportedVersionSkewCondition(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster) (*ctrl.Result, error) {

--- a/hypershift-operator/controllers/nodepool/conditions.go
+++ b/hypershift-operator/controllers/nodepool/conditions.go
@@ -1037,7 +1037,7 @@ func (r NodePoolReconciler) validPlatformConfigCondition(ctx context.Context, no
 // references a NAD in the namespace where virt-launcher pods will run, or in "default".
 // With Multus namespace isolation enabled (OpenShift default), pods cannot reference NADs
 // in other namespaces.
-func (r *NodePoolReconciler) validateKubevirtAdditionalNetworkNamespaces(nodePool *hyperv1.NodePool, hc *hyperv1.HostedCluster) error {
+func (r NodePoolReconciler) validateKubevirtAdditionalNetworkNamespaces(nodePool *hyperv1.NodePool, hc *hyperv1.HostedCluster) error {
 	kvPlatform := nodePool.Spec.Platform.Kubevirt
 	if kvPlatform == nil || len(kvPlatform.AdditionalNetworks) == 0 {
 		return nil
@@ -1052,13 +1052,13 @@ func (r *NodePoolReconciler) validateKubevirtAdditionalNetworkNamespaces(nodePoo
 
 	for _, network := range kvPlatform.AdditionalNetworks {
 		parts := strings.SplitN(network.Name, "/", 2)
+		// Bare names (no "/") are skipped because Multus resolves them in the pod's
+		// own namespace, which is already the virt-launcher namespace.
 		if len(parts) != 2 {
 			continue
 		}
 		nadNamespace := parts[0]
-		// "default" is always in Multus globalNamespaces on OCP. Other global namespaces
-		// (openshift-multus, openshift-sriov-network-operator) are also exempt from isolation
-		// but are operator-internal — user NADs should not be placed there.
+		// "default" is always in Multus globalNamespaces on OCP.
 		if nadNamespace != infraNS && nadNamespace != "default" {
 			return fmt.Errorf(
 				"additionalNetwork %q references namespace %q, but virt-launcher pods run in namespace %q; "+

--- a/hypershift-operator/controllers/nodepool/conditions_test.go
+++ b/hypershift-operator/controllers/nodepool/conditions_test.go
@@ -735,3 +735,283 @@ func setUpDummyMachineSet(nodePool *hyperv1.NodePool, hostedCluster *hyperv1.Hos
 	}
 	return machineSet
 }
+
+func TestValidateKubevirtAdditionalNetworkNamespaces(t *testing.T) {
+	tests := []struct {
+		name        string
+		nodePool    *hyperv1.NodePool
+		hc          *hyperv1.HostedCluster
+		expectError bool
+		errContains string
+	}{
+		{
+			name: "When NAD is in HCP namespace, it should pass validation",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtNodePoolPlatform{
+							AdditionalNetworks: []hyperv1.KubevirtNetwork{
+								{Name: "clusters-mycluster/mynad"},
+							},
+						},
+					},
+				},
+			},
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "clusters",
+					Name:      "mycluster",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "When NAD is in default namespace, it should pass validation",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtNodePoolPlatform{
+							AdditionalNetworks: []hyperv1.KubevirtNetwork{
+								{Name: "default/mynad"},
+							},
+						},
+					},
+				},
+			},
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "clusters",
+					Name:      "mycluster",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "When NAD is in HC namespace instead of HCP namespace, it should return namespace mismatch error",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtNodePoolPlatform{
+							AdditionalNetworks: []hyperv1.KubevirtNetwork{
+								{Name: "clusters/mynad"},
+							},
+						},
+					},
+				},
+			},
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "clusters",
+					Name:      "mycluster",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+					},
+				},
+			},
+			expectError: true,
+			errContains: "virt-launcher pods run in namespace",
+		},
+		{
+			name: "When NAD is in external infra namespace, it should pass validation",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtNodePoolPlatform{
+							AdditionalNetworks: []hyperv1.KubevirtNetwork{
+								{Name: "ext-infra/mynad"},
+							},
+						},
+					},
+				},
+			},
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "clusters",
+					Name:      "mycluster",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{
+							Credentials: &hyperv1.KubevirtPlatformCredentials{
+								InfraNamespace: "ext-infra",
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "When NAD is in HC namespace with external infra configured, it should return namespace mismatch error",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtNodePoolPlatform{
+							AdditionalNetworks: []hyperv1.KubevirtNetwork{
+								{Name: "clusters/mynad"},
+							},
+						},
+					},
+				},
+			},
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "clusters",
+					Name:      "mycluster",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{
+							Credentials: &hyperv1.KubevirtPlatformCredentials{
+								InfraNamespace: "ext-infra",
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errContains: "virt-launcher pods run in namespace",
+		},
+		{
+			name: "When HC name has dots, it should resolve HCP namespace with hyphens and pass",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtNodePoolPlatform{
+							AdditionalNetworks: []hyperv1.KubevirtNetwork{
+								{Name: "clusters-my-cluster/mynad"},
+							},
+						},
+					},
+				},
+			},
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "clusters",
+					Name:      "my.cluster",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "When no additional networks are configured, it should pass validation",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtNodePoolPlatform{
+							AdditionalNetworks: []hyperv1.KubevirtNetwork{},
+						},
+					},
+				},
+			},
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "clusters",
+					Name:      "mycluster",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "When NAD name has no namespace qualifier, it should pass validation",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtNodePoolPlatform{
+							AdditionalNetworks: []hyperv1.KubevirtNetwork{
+								{Name: "mynad-no-namespace"},
+							},
+						},
+					},
+				},
+			},
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "clusters",
+					Name:      "mycluster",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "When multiple NADs with first valid and second in wrong namespace, it should return error for the invalid entry",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtNodePoolPlatform{
+							AdditionalNetworks: []hyperv1.KubevirtNetwork{
+								{Name: "clusters-mycluster/valid-nad"},
+								{Name: "wrong-ns/bad-nad"},
+							},
+						},
+					},
+				},
+			},
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "clusters",
+					Name:      "mycluster",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+					},
+				},
+			},
+			expectError: true,
+			errContains: "wrong-ns/bad-nad",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			r := &NodePoolReconciler{}
+			err := r.validateKubevirtAdditionalNetworkNamespaces(tc.nodePool, tc.hc)
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred(), tc.name)
+				g.Expect(err.Error()).To(ContainSubstring(tc.errContains), tc.name)
+			} else {
+				g.Expect(err).ToNot(HaveOccurred(), tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds KubeVirt platform validation to `validPlatformConfigCondition` that checks `additionalNetworks` NAD namespace against the resolved virt-launcher pod namespace
- On mismatch, sets `ValidPlatformConfig=False` with an actionable message telling users where to create the NAD
- Documents the namespace requirement in the KubeVirt networking how-to guide

## Problem

`NodePool.spec.platform.kubevirt.additionalNetworks` accepts NAD references passed verbatim to Multus via `MultusNetwork.NetworkName`. Users naturally place NADs in the HostedCluster namespace, but virt-launcher pods run in the HCP namespace (`{hc-ns}-{hc-name}`). With Multus namespace isolation enabled (OCP default), the cross-namespace reference is rejected — but the only signal is an opaque pod sandbox error buried in virt-launcher events.

## Fix

Mirrors the existing AWS platform validation pattern:

```go
case hyperv1.KubevirtPlatform:
    if err := r.validateKubevirtAdditionalNetworkNamespaces(nodePool, hc); err != nil {
        condition.Status = corev1.ConditionFalse
        condition.Reason = hyperv1.NodePoolValidationFailedReason
        condition.Message = err.Error()
    }
```

The validation resolves the target namespace (HCP ns or `Credentials.InfraNamespace`) and checks each `additionalNetworks` entry's namespace portion.

## Why not CEL / admission-time validation

This check stays controller-time on purpose. The allowed NAD namespace is the virt-launcher namespace, which comes from the HostedCluster (`HostedControlPlaneNamespace` / `Credentials.InfraNamespace`). A NodePool CEL rule cannot see that cross-object data.

The issue's Expected Result asked for an immediate (admission) reject. This PR uses `ValidPlatformConfig=False` instead — asynchronous, informational, and aligned with the Proposed Fix and the existing AWS platform-validation pattern. There is no admission webhook in this change.

## Upgrade note

After this lands, KubeVirt NodePools whose `additionalNetworks` NAD is not in the virt-launcher namespace (HCP/infra) or `default` will report `ValidPlatformConfig=False`. Reconcile is not blocked and VMs are still created.

On OpenShift with default Multus isolation this matches real Multus rejection. If namespace isolation is disabled (or the management cluster is not OpenShift), the condition can be a false positive for monitoring.

## Test plan

- [x] 9 unit test cases covering: HCP namespace match, default namespace, external infra, HC namespace mismatch, dots in name, bare names, empty networks, multi-network mix
- [ ] CI: `ci/prow/unit`, `ci/prow/verify`, `ci/prow/lint`

## Verification output

```
$ git diff --stat origin/main
 docs/content/how-to/kubevirt/configuring-network.md | 25 +-
 hypershift-operator/controllers/nodepool/conditions.go | 45 ++++
 hypershift-operator/controllers/nodepool/conditions_test.go | 280 +++++++++++++++++++++
 3 files changed, 349 insertions(+), 1 deletion(-)
```

/jira OCPBUGS-109196

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for KubeVirt additional network namespaces.
  * Network definitions must now be located in the appropriate HCP infrastructure namespace or the `default` namespace.
  * Invalid namespace configurations are reported clearly and prevent the platform configuration from being marked valid.
  * Improved handling of valid and invalid network namespace combinations.

* **Documentation**
  * Clarified NetworkAttachmentDefinition placement, namespace naming, and commands for identifying the correct namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
