### PR TITLE
CNTRLPLANE-3950: fix flaky TestKMSRootVolumeEncryption race condition.

### DIFF
--- a/test/e2e/nodepool_kms_root_volume_test.go
+++ b/test/e2e/nodepool_kms_root_volume_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	aws "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -86,22 +87,26 @@ func (k *KMSRootVolumeTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes [
 	t.Logf("instanceID: %s", instanceID)
 
 	ec2client := ec2Client(k.clusterOpts.AWSPlatform.Credentials.AWSCredentialsFile, k.clusterOpts.AWSPlatform.Region)
-	output, err := ec2client.DescribeVolumes(k.ctx, &ec2.DescribeVolumesInput{
-		Filters: []ec2types.Filter{
-			{
-				Name:   aws.String("attachment.instance-id"),
-				Values: []string{instanceID},
+	var rootVolume ec2types.Volume
+	t.Log("Waiting for encrypted volume metadata to propagate...")
+	g.Eventually(func(g Gomega) {
+		output, err := ec2client.DescribeVolumes(k.ctx, &ec2.DescribeVolumesInput{
+			Filters: []ec2types.Filter{
+				{
+					Name:   aws.String("attachment.instance-id"),
+					Values: []string{instanceID},
+				},
+				{
+					Name:   aws.String("encrypted"),
+					Values: []string{"true"},
+				},
 			},
-			{
-				Name:   aws.String("encrypted"),
-				Values: []string{"true"},
-			},
-		},
-	})
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(output).NotTo(BeNil())
-	g.Expect(output.Volumes).NotTo(BeEmpty())
-	rootVolume := output.Volumes[0]
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).NotTo(BeNil())
+		g.Expect(output.Volumes).NotTo(BeEmpty())
+		rootVolume = output.Volumes[0]
+	}).WithContext(k.ctx).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 
 	if nodePool.Spec.Platform.AWS.RootVolume.EncryptionKey == "" {
 		resp, err := ec2client.GetEbsDefaultKmsKeyId(k.ctx, &ec2.GetEbsDefaultKmsKeyIdInput{})


### PR DESCRIPTION
The **TestKMSRootVolumeEncryption** e2e test fails intermittently because it makes a single-shot **DescribeVolumes** API 
  call with **attachment.instance-id** and **encrypted=true** filters and immediately asserts the result is not empty.

  ### Root cause
  The AWS **encrypted=true** filter metadata can lag behind the volume attachment metadata. We reproduced this on a live 
  cluster by creating a `KMS-encrypted` EBS volume, attaching it to a running instance, and polling **DescribeVolumes**
  immediately:

```
  poll 1 | 3s | total=2 encrypted=0  ← volume attached, but encrypted filter misses it
  poll 2 | 7s | total=2 encrypted=1  ← ~4 seconds later, metadata propagated
```
 ### Fix
  Wraped the \`DescribeVolumes\` call and its assertions in a Gomega \`Eventually\` retry loop with 1 minute timeout and 5 
  second polling interval. This follows the same pattern used by other e2e tests in the repo (\`nodepool_day2_tags_test.go\`,
  \`karpenter_test.go\`, etc.) for polling cloud provider resources.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes : [CNTRLPLANE-3950](https://redhat.atlassian.net/browse/CNTRLPLANE-3950)

 ## Test plan
 - [ ] e2e-aws CI job passes with TestKMSRootVolumeEncryption
  - [ ] No regression in other NodePool tests"

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when locating encrypted root volumes during environment setup by retrying volume discovery for up to one minute.
  * Added five-second polling between attempts to accommodate delayed volume availability.
  * Reduced setup failures caused by temporary delays in volume availability.
  * Improved consistency of environment initialization when storage resources take longer to become available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->