### PR TITLE
CNTRLPLANE-4043: ci(e2e): add CI workflow to verify e2e compilation on PRs

### DIFF
--- a/.github/workflows/e2e-compile-reusable.yaml
+++ b/.github/workflows/e2e-compile-reusable.yaml
@@ -1,0 +1,70 @@
+name: E2E Compile (Reusable)
+
+on:
+  workflow_call:
+  push:
+    branches:
+      - main
+      - release-4.22
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect Changes
+    runs-on: arc-runner-set
+    timeout-minutes: 5
+    outputs:
+      run_e2e: ${{ steps.changes.outputs.run_e2e }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check for non-contrib changes
+        id: changes
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_SHA: ${{ github.sha }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            FILES=$(git diff --name-only "origin/$BASE_REF...HEAD")
+          else
+            if [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            FILES=$(git diff --name-only "$EVENT_BEFORE..$EVENT_SHA")
+          fi
+          if echo "$FILES" | grep -qvE '^(contrib|\.github|docs)/'; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  e2e-compile:
+    name: E2E Compile
+    needs: changes
+    if: needs.changes.outputs.run_e2e == 'true'
+    runs-on: arc-runner-set
+    timeout-minutes: 30
+    env:
+      GOMODCACHE: /tmp/go-mod-cache
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        env:
+          HOME: /tmp
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Compile E2E tests
+        run: make e2e

--- a/.github/workflows/e2e-compile.yaml
+++ b/.github/workflows/e2e-compile.yaml
@@ -1,0 +1,14 @@
+name: E2E Compile
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release-4.22
+  workflow_dispatch: {}
+
+jobs:
+  e2e-compile:
+    uses: openshift/hypershift/.github/workflows/e2e-compile-reusable.yaml@main
+    permissions:
+      contents: read

--- a/Makefile
+++ b/Makefile
@@ -519,7 +519,7 @@ endif
 test-envtest-api-all: test-envtest-ocp test-envtest-kube ## Run all envtest API tests (ENVTEST_JOBS=0|N|MAX)
 
 .PHONY: e2e
-e2e: reqserving-e2e e2ev2 backuprestore-e2e
+e2e: reqserving-e2e e2ev2 e2ev2-create-guests e2ev2-run-tests e2ev2-destroy-guests e2ev2-dump-guests backuprestore-e2e
 	$(GO_E2E_RECIPE) -o bin/test-e2e ./test/e2e
 	$(GO_BUILD_RECIPE) -o bin/test-setup ./test/setup
 	cd $(TOOLS_DIR); GO111MODULE=on GOFLAGS=-mod=vendor GOWORK=off go build -tags=tools -o ../../bin/gotestsum gotest.tools/gotestsum


### PR DESCRIPTION
## What this PR does / why we need it:
PR verification jobs do not currently run `make e2e` as part of the verify/lint steps, which means PRs can merge with code that does not compile against the e2e test framework (e.g. openshift/hypershift#9283).

This PR:
1. Adds a GitHub Action workflow (`e2e-compile`) that runs `make e2e` on PRs targeting `main`.
2. Updates the `Makefile` `e2e` target so that `e2ev2-create-guests`, `e2ev2-run-tests`, `e2ev2-destroy-guests`, and `e2ev2-dump-guests` (the v2 cmd binaries) are dependencies of `make e2e`, ensuring all v2 test binaries are verified during compilation.

## Which issue(s) this PR fixes:
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-4043

## Special notes for your reviewer:
None.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end compilation coverage to include guest lifecycle scenarios, including creation, testing, destruction, and diagnostics.
  * Added automated E2E compilation checks for pull requests and selected branch updates.
  * Added support for manually triggering E2E compilation checks.
  * Improved validation efficiency by skipping checks for changes unrelated to end-to-end functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->