### PR TITLE
NO-JIRA: fix(install): increase WaitUntilAvailable timeout from 5m to 10m

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -724,7 +724,9 @@ func WaitUntilAvailable(ctx context.Context, opts Options) (*appsv1.Deployment, 
 	if err != nil {
 		return nil, err
 	}
-	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	// 10 minutes to accommodate GKE Autopilot clusters that need to scale
+	// up nodes before the operator pods can be scheduled.
+	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
 	deployment := getOperatorDeployment(opts)


### PR DESCRIPTION
## Problem

On GKE Autopilot clusters, the HyperShift operator deployment may take longer than 5 minutes to roll out because Autopilot needs to scale up nodes before pods can be scheduled. This causes `hypershift install --wait-until-available` to fail with:

```
failed to wait for operator deployment: client rate limiter Wait returned an error: context deadline exceeded
```

This is one of the root causes of the `e2e-v2-gke` CI flakiness:
https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-openshift-hypershift-main-e2e-v2-gke

## Fix

Increase the `WaitUntilAvailable` context timeout from 5 minutes to 10 minutes in `cmd/install/install.go`. This accommodates GKE Autopilot cold-start scheduling latency without affecting non-Autopilot environments (the wait returns as soon as the deployment is available).

## Related

- Companion PR to openshift/release: https://github.com/openshift/release/pull/83388 (increases CI step-registry timeouts and patches cert-manager with explicit resource requests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the installation wait time to up to 10 minutes, improving reliability for slower operator deployments and endpoint availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->