### PR TITLE
CNTRLPLANE-4053: Add workflow to refresh PR area labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,142 @@
+# Path-based configuration for actions/labeler.
+#
+# This file drives the "Refresh PR Area Labels" workflow
+# (.github/workflows/refresh-area-labels.yml), which keeps `area/*` labels on
+# pull requests in sync with the files a PR actually changes. Labels listed
+# here are added when a matching file changes, and removed when it no longer
+# does (see `sync-labels: true` in the workflow).
+#
+# This is complementary to the `/area <name>` comment command described in
+# .github/labels.yaml, which is handled by Prow rather than GitHub Actions.
+#
+# Config schema: https://github.com/actions/labeler#pull-request-labeler
+
+area/api:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'api/**'
+
+area/cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cmd/**'
+          - 'product-cli/**'
+
+area/documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '**/*.md'
+
+area/testing:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'test/**'
+
+area/hypershift-operator:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'hypershift-operator/**'
+
+area/control-plane-operator:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'control-plane-operator/**'
+
+area/control-plane-pki-operator:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'control-plane-pki-operator/**'
+
+area/karpenter-operator:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'karpenter-operator/**'
+          - 'api/karpenter/**'
+          - 'support/karpenter/**'
+
+area/ci-tooling:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+          - 'hack/**'
+          - 'hypershift-ci-python/**'
+
+area/ai:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.claude/**'
+          - '.cursor/**'
+          - '**/AGENTS.md'
+
+area/dependency:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/vendor/**'
+          - '**/go.mod'
+          - '**/go.sum'
+
+area/platform/aws:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cmd/**/aws/**'
+          - 'hypershift-operator/**/aws/**'
+          - 'control-plane-operator/**/aws/**'
+          - 'control-plane-operator/controllers/awsprivatelink/**'
+          - 'control-plane-operator/controllers/**/awsnodeterminationhandler/**'
+          - 'support/awsutil/**'
+          - 'support/awsapi/**'
+
+area/platform/azure:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cmd/**/azure/**'
+          - 'hypershift-operator/**/azure/**'
+          - 'control-plane-operator/**/azure/**'
+          - 'control-plane-operator/controllers/azureprivatelinkservice/**'
+          - 'support/azureutil/**'
+
+area/platform/gcp:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cmd/**/gcp/**'
+          - 'hypershift-operator/**/gcp/**'
+          - 'control-plane-operator/**/gcp/**'
+          - 'control-plane-operator/controllers/gcpprivateserviceconnect/**'
+          - 'support/gcpapi/**'
+          - 'support/gcputil/**'
+
+area/platform/ibmcloud:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'hypershift-operator/**/ibmcloud/**'
+          - 'api/ibmcapi/**'
+
+area/platform/openstack:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cmd/**/openstack/**'
+          - 'hypershift-operator/**/openstack/**'
+          - 'control-plane-operator/**/openstack/**'
+          - 'support/openstackutil/**'
+
+area/platform/kubevirt:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cmd/**/kubevirt/**'
+          - 'hypershift-operator/**/kubevirt/**'
+          - 'control-plane-operator/**/kubevirt/**'
+          - 'kubevirtexternalinfra/**'
+
+area/platform/powervs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cmd/**/powervs/**'
+          - 'hypershift-operator/**/powervs/**'
+          - 'control-plane-operator/**/powervs/**'
+
+area/platform/none:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cmd/cluster/none/**'
+          - 'hypershift-operator/**/platform/none/**'

--- a/.github/workflows/refresh-area-labels.yaml
+++ b/.github/workflows/refresh-area-labels.yaml
@@ -1,0 +1,21 @@
+name: Refresh PR Area Labels
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: refresh-area-labels-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
+        with:
+          sync-labels: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Useful Prow commands:
 - `lgtm` - From a reviewer via `/lgtm`
 - `jira/valid-reference` - PR title contains a valid Jira ticket reference (or NO-JIRA if no associated issue)
     **Note:** NO-JIRA should be used sparingly. Please have a Jira issue associated with your PR whenever possible.
-- `area/*` - Area label (e.g., `area/documentation`, `area/control-plane`)
+- `area/*` - Area label (e.g., `area/documentation`, `area/control-plane`). These are kept in sync automatically based on the files a PR changes (see `.github/labeler.yml` and the "Refresh PR Area Labels" workflow); they can also be set manually via the `/area <name>` comment command in `.github/labels.yaml`.
 - `verified` - QA verification passed (for more information refer to the [documentation](https://docs.ci.openshift.org/docs/architecture/jira/#the-verified-label))
 
 **Conditionally required:**


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a GitHub Actions workflow that keeps `area/*` labels on pull requests in
sync with the files a PR actually changes.

Previously, `area/*` labels could only be set manually (via the `/area
<name>` comment command described in `.github/labels.yaml`) and had no
mechanism to stay current as a PR's diff evolved — a label applied early in
review could become stale or misleading if later commits changed what parts
of the codebase were touched.

This adds:
- `.github/labeler.yml` — maps changed file paths to the project's existing
  `area/*` labels (operator/component directories, per-platform code for
  aws/azure/gcp/ibmcloud/openstack/kubevirt/powervs/none, api, cli, docs,
  tests, and dependency changes).
- `.github/workflows/refresh-area-labels.yaml` — runs `actions/labeler` (SHA
  pinned, per this repo's convention for third-party actions) on PR
  open/synchronize/reopen with `sync-labels: true`, so labels are both added
  when matching files change and removed when they no longer match.
- A short doc update in `CONTRIBUTING.md` noting that `area/*` labels are now
  reconciled automatically in addition to being settable manually.

The workflow uses `pull_request_target` (rather than `pull_request`) so PRs
from forks receive a token with permission to write labels; the action only
reads the PR's changed-file list and does not check out or execute any PR
code, so this does not introduce the security concerns normally associated
with `pull_request_target`.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-4053](https://redhat.atlassian.net/browse/CNTRLPLANE-4053)

## Special notes for your reviewer:

- `sync-labels: true` means any `area/*` label defined in `.github/labeler.yml`
  that no longer matches the current diff will be removed automatically, even
  if it was added manually via `/area`. This is intentional — it's the
  "refresh" behavior the ticket asks for — but worth calling out explicitly
  since it changes how `area/*` labels behave versus the current all-manual
  process.
- Path-to-label globs were derived by inspecting the actual directory layout
  of each platform's code (`cmd/`, `hypershift-operator/`,
  `control-plane-operator/`, `support/`) rather than guessing, to avoid
  matching `testdata/`, generated CRD manifests, or `vendor/`.
- `area/ROKS` and `area/licensing` were intentionally left out of
  `.github/labeler.yml` since they don't map cleanly to a set of file paths.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.

---
Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic area labels to pull requests based on the files changed.
  * Labels are refreshed when pull requests are opened, updated, or reopened.

* **Documentation**
  * Updated contribution guidance to explain automatic area labeling and manual label assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->