### PR TITLE
OCPBUGS-109641: fix slice bounds out of range panic in getAvailableCandidates

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/inplaceupgrader.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/inplaceupgrader.go
@@ -577,6 +577,9 @@ func getAvailableCandidates(nodes []*corev1.Node, targetConfig string, capacity 
 	}
 
 	// TODO(jerzhang): do some ordering here
+	if capacity > len(candidateNodes) {
+		capacity = len(candidateNodes)
+	}
 	return candidateNodes[:capacity]
 }
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/inplaceupgrader_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/inplaceupgrader_test.go
@@ -532,6 +532,18 @@ func TestGetAvailableCandidates(t *testing.T) {
 			capacity:      0,
 			selectedNodes: nil,
 		},
+		{
+			name: "When capacity exceeds available candidates, it should return all eligible candidates without panicking",
+			inputNodes: []*corev1.Node{
+				awaitingNode1,
+				completedNode,
+			},
+			targetConfig: desiredConfigHash,
+			capacity:     3,
+			selectedNodes: []*corev1.Node{
+				awaitingNode1,
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a panic in the `InPlaceUpgrader` controller that occurs during NodePool in-place upgrades when `maxUnavailable` is set higher than the number of remaining eligible candidate nodes.

**Root Cause**: `getAvailableCandidates()` slices `candidateNodes[:capacity]` without checking that `capacity <= len(candidateNodes)`, causing a `runtime error: slice bounds out of range [:2] with capacity 1` panic.

**Fix**: Clamp `capacity` to `len(candidateNodes)` before slicing, so the function returns all available candidates when fewer exist than the requested capacity.

## Bug Details

- **Jira**: [OCPBUGS-109641](https://redhat.atlassian.net/browse/OCPBUGS-109641)
- **Affected versions**: All (main, release-4.20, release-4.22)
- **Symptom**: NodePool upgrade stalls indefinitely with repeated panic in HCCO logs
- **Trigger condition**: `maxUnavailable > 1` and number of eligible candidate nodes < `maxUnavailable` (e.g., when most nodes have already upgraded)

## Changes

- `inplaceupgrader.go`: Add bounds check before slicing `candidateNodes`
- `inplaceupgrader_test.go`: Add test case covering `capacity > len(candidateNodes)` scenario

## Test Plan

- [x] Unit test `TestGetAvailableCandidates/When_capacity_exceeds_available_candidates,_it_should_return_all_eligible_candidates_without_panicking` passes
- [x] All existing `TestGetAvailableCandidates` test cases continue to pass
- [x] Validated on live OCP 4.22.7 cluster with KubeVirt HCP:
  - Reproduced the panic with a NodePool (1 replica, `maxUnavailable=2`, InPlace strategy)
  - Deployed fixed HCCO image - panic resolved, controller reconciles normally


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved in-place upgrade handling when the requested capacity exceeds the available candidate nodes.
  - Prevented upgrade operations from failing due to invalid candidate selection.
  - In-place upgrades now select all eligible candidate nodes when fewer nodes are available than requested, while continuing to exclude nodes whose upgrades are already complete.
  - Improved reliability by preventing errors during candidate selection when capacity exceeds the number of available nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->