### PR TITLE
CNTRLPLANE-4097: Add clebs to core-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,6 +20,7 @@ aliases:
     - cblecker
     - jparrill
     - devguyio
+    - clebs
   core-reviewers:
     - enxebre
     - csrwng


### PR DESCRIPTION
## What this PR does / why we need it:

Add clebs to core-approvers. We need it to have him help carry the load and responsibility of approvals.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-4097](https://redhat.atlassian.net/browse/CNTRLPLANE-4097)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal approval configuration to include an additional core approver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->