### PR TITLE
ROSAENG-65488: fix(certs): re-sign leaf when it no longer chains to the current CA

### DIFF
--- a/hypershift-operator/controllers/webhookcerts/webhookcerts_controller_test.go
+++ b/hypershift-operator/controllers/webhookcerts/webhookcerts_controller_test.go
@@ -386,6 +386,49 @@ func TestReconcile(t *testing.T) {
 		g.Expect(cl.Get(t.Context(), client.ObjectKey{Name: ServingCertSecretName, Namespace: "hypershift"}, updatedSecret)).To(Succeed())
 		g.Expect(updatedSecret.Data[corev1.TLSCertKey]).To(Equal(originalCert))
 	})
+
+	t.Run("When the serving cert was signed by a stale CA it should be re-signed against the current CA (ROSAENG-65488)", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Simulate the incident: the CA secret was regenerated at some point (staleCASecret
+		// represents the CA that originally signed the still-valid leaf), but the leaf itself
+		// (servingSecret) was never re-issued against the new CA. The current CA secret in the
+		// cluster is now currentCASecret, which is different from the one that signed the leaf.
+		staleCASecret, servingSecret, _, err := GenerateInitialWebhookCerts("hypershift", "operator")
+		g.Expect(err).ToNot(HaveOccurred())
+		originalCert := append([]byte(nil), servingSecret.Data[corev1.TLSCertKey]...)
+
+		currentCASecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: CASecretName, Namespace: "hypershift"},
+			Type:       corev1.SecretTypeOpaque,
+		}
+		g.Expect(certs.ReconcileSelfSignedCA(currentCASecret, "hypershift-webhook-ca", "openshift")).To(Succeed())
+		g.Expect(currentCASecret.Data[certs.CASignerCertMapKey]).ToNot(Equal(staleCASecret.Data[certs.CASignerCertMapKey]))
+
+		cl := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(currentCASecret, servingSecret).Build()
+		r := newReconciler(cl)
+
+		_, err = r.Reconcile(t.Context(), caRequest())
+		g.Expect(err).ToNot(HaveOccurred())
+
+		updatedSecret := &corev1.Secret{}
+		g.Expect(cl.Get(t.Context(), client.ObjectKey{Name: ServingCertSecretName, Namespace: "hypershift"}, updatedSecret)).To(Succeed())
+
+		// The leaf must be re-signed even though the original was still time-valid with correct SANs.
+		g.Expect(updatedSecret.Data[corev1.TLSCertKey]).ToNot(Equal(originalCert))
+
+		// The re-signed leaf must chain to the current CA.
+		updatedCASecret := &corev1.Secret{}
+		g.Expect(cl.Get(t.Context(), client.ObjectKey{Name: CASecretName, Namespace: "hypershift"}, updatedCASecret)).To(Succeed())
+		caPool := x509.NewCertPool()
+		g.Expect(caPool.AppendCertsFromPEM(updatedCASecret.Data[certs.CASignerCertMapKey])).To(BeTrue())
+		block, _ := pem.Decode(updatedSecret.Data[corev1.TLSCertKey])
+		g.Expect(block).ToNot(BeNil())
+		leaf, err := x509.ParseCertificate(block.Bytes)
+		g.Expect(err).ToNot(HaveOccurred())
+		_, err = leaf.Verify(x509.VerifyOptions{Roots: caPool})
+		g.Expect(err).ToNot(HaveOccurred())
+	})
 }
 
 func TestGenerateInitialWebhookCerts(t *testing.T) {

--- a/support/certs/tls.go
+++ b/support/certs/tls.go
@@ -291,9 +291,14 @@ func parsePemKeypair(key, certificate []byte) (*rsa.PrivateKey, *x509.Certificat
 }
 
 func ValidateKeyPair(pemKey, pemCertificate []byte, cfg *CertCfg, minimumRemainingValidity time.Duration) error {
+	_, err := validateKeyPair(pemKey, pemCertificate, cfg, minimumRemainingValidity)
+	return err
+}
+
+func validateKeyPair(pemKey, pemCertificate []byte, cfg *CertCfg, minimumRemainingValidity time.Duration) (*x509.Certificate, error) {
 	_, cert, err := parsePemKeypair(pemKey, pemCertificate)
 	if err != nil {
-		return fmt.Errorf("failed to parse keypair: %w", err)
+		return nil, fmt.Errorf("failed to parse keypair: %w", err)
 	}
 
 	var errs []error
@@ -343,7 +348,7 @@ func ValidateKeyPair(pemKey, pemCertificate []byte, cfg *CertCfg, minimumRemaini
 		errs = append(errs, fmt.Errorf("actual isCA %t does not match expected %t", cert.IsCA, cfg.IsCA))
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return cert, utilerrors.NewAggregate(errs)
 }
 
 // normalizedIPAddresses expands IPs to 16-byte form for comparison so 4-byte
@@ -361,8 +366,12 @@ func normalizedIPAddresses(ips []net.IP) []net.IP {
 	return normalizedIPs
 }
 
-// ReconcileSignedCert reconciles a certificate secret using the provided config. It will
-// rotate the cert if there are less than 30 days of validity left.
+// ReconcileSignedCert reconciles a certificate secret using the provided config. It
+// re-signs the leaf whenever ValidateKeyPair reports the existing certificate no longer
+// matches the desired config - a SAN (DNS or IP), subject, key-usage/EKU, or IsCA change,
+// or insufficient remaining validity (30 days by default, tunable via
+// CertificateRenewalEnvVar) - or when the existing leaf was not signed by the current CA
+// (e.g. the CA secret was regenerated since the leaf was last issued).
 func ReconcileSignedCert(
 	secret *corev1.Secret,
 	ca *corev1.Secret,
@@ -429,9 +438,10 @@ func ReconcileSignedCert(
 		minimumRemainingValidity = time.Duration(float64(certValidity) * renewalPercentage)
 	}
 
-	if err := ValidateKeyPair(secret.Data[keyKey], secret.Data[crtKey], cfg, minimumRemainingValidity); err == nil {
+	if validateSignedCert(secret.Data[keyKey], secret.Data[crtKey], cfg, minimumRemainingValidity, ca, opts) == nil {
 		return nil
 	}
+
 	certBytes, keyBytes, _, err := signCertificate(cfg, ca, opts)
 	if err != nil {
 		return fmt.Errorf("error signing cert(cn=%s,o=%v): %w", cn, org, err)
@@ -529,6 +539,24 @@ func annotateWithCA(secret, ca *corev1.Secret, opts *CAOpts) {
 		secret.Annotations = map[string]string{}
 	}
 	secret.Annotations[CAHashAnnotation] = computeCAHash(ca, opts)
+}
+
+func validateSignedCert(pemKey, pemCertificate []byte, cfg *CertCfg, minimumRemainingValidity time.Duration, ca *corev1.Secret, opts *CAOpts) error {
+	leaf, err := validateKeyPair(pemKey, pemCertificate, cfg, minimumRemainingValidity)
+	if err != nil {
+		return err
+	}
+	caCert, err := PemToCertificate(ca.Data[opts.CASignerCertMapKey])
+	if err != nil {
+		return fmt.Errorf("failed to parse CA certificate: %w", err)
+	}
+	if !bytes.Equal(leaf.RawIssuer, caCert.RawSubject) {
+		return errors.New("leaf certificate issuer does not match current CA subject")
+	}
+	if err := leaf.CheckSignatureFrom(caCert); err != nil {
+		return fmt.Errorf("leaf certificate was not signed by current CA: %w", err)
+	}
+	return nil
 }
 
 func decodeCA(ca *corev1.Secret, opts *CAOpts) (*x509.Certificate, *rsa.PrivateKey, error) {

--- a/support/certs/tls_internal_test.go
+++ b/support/certs/tls_internal_test.go
@@ -1,0 +1,146 @@
+package certs
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+)
+
+import corev1 "k8s.io/api/core/v1"
+
+func TestValidateSignedCert(t *testing.T) {
+	newCA := func(t *testing.T, commonName string) *corev1.Secret {
+		t.Helper()
+
+		ca := &corev1.Secret{}
+		if err := ReconcileSelfSignedCA(ca, commonName, "test"); err != nil {
+			t.Fatalf("reconciling CA: %v", err)
+		}
+		return ca
+	}
+
+	newLeaf := func(t *testing.T, ca *corev1.Secret) ([]byte, []byte) {
+		t.Helper()
+
+		caCert, caKey, err := decodeCA(ca, (&CAOpts{}).withDefaults())
+		if err != nil {
+			t.Fatalf("decoding CA: %v", err)
+		}
+		key, leaf, err := GenerateSignedCertificate(caKey, caCert, &CertCfg{
+			Subject:      pkix.Name{CommonName: "test.example.com"},
+			KeyUsages:    x509.KeyUsageDigitalSignature,
+			ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			Validity:     ValidityOneYear,
+			DNSNames:     []string{"test.example.com"},
+		})
+		if err != nil {
+			t.Fatalf("generating leaf certificate: %v", err)
+		}
+		return PrivateKeyToPem(key), CertToPem(leaf)
+	}
+
+	newCAWithSameKeyDifferentSubject := func(t *testing.T, ca *corev1.Secret) *corev1.Secret {
+		t.Helper()
+
+		_, caKey, err := decodeCA(ca, (&CAOpts{}).withDefaults())
+		if err != nil {
+			t.Fatalf("decoding CA: %v", err)
+		}
+		certTemplate := &x509.Certificate{
+			SerialNumber:          big.NewInt(2),
+			Subject:               pkix.Name{CommonName: "replacement-ca"},
+			NotBefore:             time.Now(),
+			NotAfter:              time.Now().Add(ValidityTenYears),
+			KeyUsage:              x509.KeyUsageCertSign,
+			IsCA:                  true,
+			BasicConstraintsValid: true,
+		}
+		certBytes, err := x509.CreateCertificate(rand.Reader, certTemplate, certTemplate, &caKey.PublicKey, caKey)
+		if err != nil {
+			t.Fatalf("generating replacement CA certificate: %v", err)
+		}
+		replacementCA, err := x509.ParseCertificate(certBytes)
+		if err != nil {
+			t.Fatalf("parsing replacement CA certificate: %v", err)
+		}
+		return &corev1.Secret{Data: map[string][]byte{
+			CASignerCertMapKey: CertToPem(replacementCA),
+		}}
+	}
+
+	currentCA := newCA(t, "current-ca")
+	otherCA := newCA(t, "current-ca")
+	validKey, validLeaf := newLeaf(t, currentCA)
+	otherKey, otherLeaf := newLeaf(t, otherCA)
+	replacementCA := newCAWithSameKeyDifferentSubject(t, currentCA)
+	cfg := &CertCfg{
+		Subject:      pkix.Name{CommonName: "test.example.com"},
+		KeyUsages:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		Validity:     ValidityOneYear,
+		DNSNames:     []string{"test.example.com"},
+	}
+
+	testCases := []struct {
+		name    string
+		keyPEM  []byte
+		leafPEM []byte
+		ca      *corev1.Secret
+		valid   bool
+	}{
+		{
+			name:  "When the leaf certificate is missing, it should return an error",
+			ca:    currentCA,
+			valid: false,
+		},
+		{
+			name:    "When the leaf certificate is malformed, it should return an error",
+			keyPEM:  validKey,
+			leafPEM: []byte("not a certificate"),
+			ca:      currentCA,
+			valid:   false,
+		},
+		{
+			name:    "When the current CA certificate is malformed, it should return an error",
+			keyPEM:  validKey,
+			leafPEM: validLeaf,
+			ca: &corev1.Secret{Data: map[string][]byte{
+				CASignerCertMapKey: []byte("not a certificate"),
+			}},
+			valid: false,
+		},
+		{
+			name:    "When the leaf certificate was signed by another CA with the same subject, it should return an error",
+			keyPEM:  otherKey,
+			leafPEM: otherLeaf,
+			ca:      currentCA,
+			valid:   false,
+		},
+		{
+			name:    "When the current CA reuses a key with a different subject, it should return an error",
+			keyPEM:  validKey,
+			leafPEM: validLeaf,
+			ca:      replacementCA,
+			valid:   false,
+		},
+		{
+			name:    "When the leaf certificate was signed by the current CA, it should not return an error",
+			keyPEM:  validKey,
+			leafPEM: validLeaf,
+			ca:      currentCA,
+			valid:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSignedCert(tc.keyPEM, tc.leafPEM, cfg, 0, tc.ca, (&CAOpts{}).withDefaults())
+			if (err == nil) != tc.valid {
+				t.Errorf("expected valid=%t, got error: %v", tc.valid, err)
+			}
+		})
+	}
+}

--- a/support/certs/tls_test.go
+++ b/support/certs/tls_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"net"
 	"reflect"
 	"strconv"
@@ -337,6 +338,142 @@ func TestReconcileSignedCertWithCustomCAKeys(t *testing.T) {
 		t.Errorf("unexpected keys in cert secret: %s", diff)
 
 	}
+}
+
+// TestReconcileSignedCertReSignsOnCAMismatch reproduces ROSAENG-65488: a leaf certificate
+// that is still time-valid and has correct SANs must be re-signed when the CA secret it
+// was issued from is no longer the CA secret currently in use (e.g. after CA regeneration),
+// otherwise the leaf is orphaned against a CA nothing trusts anymore.
+func TestReconcileSignedCertReSignsOnCAMismatch(t *testing.T) {
+	t.Parallel()
+
+	newCA := func(t *testing.T, cn string) *corev1.Secret {
+		t.Helper()
+		ca := &corev1.Secret{Type: corev1.SecretTypeOpaque}
+		if err := certs.ReconcileSelfSignedCA(ca, cn, "some-ou"); err != nil {
+			t.Fatalf("failed to reconcile CA %s: %v", cn, err)
+		}
+		return ca
+	}
+
+	reconcileLeaf := func(t *testing.T, secret, ca *corev1.Secret, o ...func(*certs.CAOpts)) {
+		t.Helper()
+		if err := certs.ReconcileSignedCert(
+			secret,
+			ca,
+			"some-cn",
+			[]string{"some-ou"},
+			[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			corev1.TLSCertKey,
+			corev1.TLSPrivateKeyKey,
+			"",
+			[]string{"some.svc"},
+			nil,
+			o...,
+		); err != nil {
+			t.Fatalf("failed to reconcile cert: %v", err)
+		}
+	}
+
+	verifiesAgainst := func(t *testing.T, leafSecret, ca *corev1.Secret, caCertKey string) bool {
+		t.Helper()
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(ca.Data[caCertKey]) {
+			t.Fatalf("failed to add CA cert to pool")
+		}
+		block, _ := pem.Decode(leafSecret.Data[corev1.TLSCertKey])
+		if block == nil {
+			t.Fatalf("failed to decode leaf cert PEM")
+		}
+		leaf, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			t.Fatalf("failed to parse leaf cert: %v", err)
+		}
+		_, err = leaf.Verify(x509.VerifyOptions{Roots: pool})
+		return err == nil
+	}
+
+	t.Run("When a leaf is signed by a stale CA but is still time-valid with correct SANs, it should be re-signed against the current CA", func(t *testing.T) {
+		caA := newCA(t, "ca-a")
+		caB := newCA(t, "ca-b")
+
+		leaf := &corev1.Secret{Type: corev1.SecretTypeTLS}
+		reconcileLeaf(t, leaf, caA)
+		if !verifiesAgainst(t, leaf, caA, certs.CASignerCertMapKey) {
+			t.Fatalf("leaf should verify against CA-A right after issuance")
+		}
+		originalCert := append([]byte(nil), leaf.Data[corev1.TLSCertKey]...)
+
+		// Simulate CA regeneration: reconcile the same leaf secret against a new CA.
+		// The leaf is still well within its validity window and SANs are unchanged,
+		// so the legacy behavior (skip re-sign) would leave it orphaned.
+		reconcileLeaf(t, leaf, caB)
+
+		if bytes.Equal(originalCert, leaf.Data[corev1.TLSCertKey]) {
+			t.Errorf("expected leaf to be re-signed after CA rotation, but cert bytes are unchanged")
+		}
+		if verifiesAgainst(t, leaf, caA, certs.CASignerCertMapKey) {
+			t.Errorf("leaf should no longer verify against the old CA-A")
+		}
+		if !verifiesAgainst(t, leaf, caB, certs.CASignerCertMapKey) {
+			t.Errorf("leaf should verify against the current CA-B after re-sign")
+		}
+		if !certs.HasCAHash(leaf, caB, &certs.CAOpts{}) {
+			t.Errorf("leaf's CA-hash annotation should reflect the current CA-B")
+		}
+	})
+
+	t.Run("When a leaf is signed by the current CA with validity remaining, it should remain unchanged", func(t *testing.T) {
+		ca := newCA(t, "ca-a")
+
+		leaf := &corev1.Secret{Type: corev1.SecretTypeTLS}
+		reconcileLeaf(t, leaf, ca)
+		originalCert := append([]byte(nil), leaf.Data[corev1.TLSCertKey]...)
+		originalKey := append([]byte(nil), leaf.Data[corev1.TLSPrivateKeyKey]...)
+
+		// Reconciling again against the same, unchanged CA should be a no-op.
+		reconcileLeaf(t, leaf, ca)
+
+		if !bytes.Equal(originalCert, leaf.Data[corev1.TLSCertKey]) {
+			t.Errorf("expected leaf cert to be unchanged when CA has not changed")
+		}
+		if !bytes.Equal(originalKey, leaf.Data[corev1.TLSPrivateKeyKey]) {
+			t.Errorf("expected leaf key to be unchanged when CA has not changed")
+		}
+	})
+
+	t.Run("When the CA cert is stored under the tls.crt key and the CA rotates, it should re-sign then no-op", func(t *testing.T) {
+		// endpoint_resolver, ignitionserver, and metrics_proxy override
+		// CASignerCertMapKey to tls.crt; exercise that path explicitly so a
+		// refactor that assumes the default ca.crt key can't silently break
+		// re-signing for those components.
+		withTLSKey := func(o *certs.CAOpts) { o.CASignerCertMapKey = corev1.TLSCertKey }
+
+		caA := newCA(t, "ca-a")
+		caB := newCA(t, "ca-b")
+
+		leaf := &corev1.Secret{Type: corev1.SecretTypeTLS}
+		reconcileLeaf(t, leaf, caA, withTLSKey)
+		if !verifiesAgainst(t, leaf, caA, corev1.TLSCertKey) {
+			t.Fatalf("leaf should verify against CA-A right after issuance")
+		}
+		originalCert := append([]byte(nil), leaf.Data[corev1.TLSCertKey]...)
+
+		reconcileLeaf(t, leaf, caB, withTLSKey)
+		if bytes.Equal(originalCert, leaf.Data[corev1.TLSCertKey]) {
+			t.Errorf("expected leaf to be re-signed after CA rotation, but cert bytes are unchanged")
+		}
+		if !verifiesAgainst(t, leaf, caB, corev1.TLSCertKey) {
+			t.Errorf("leaf should verify against the current CA-B after re-sign")
+		}
+
+		// Reconciling again against the unchanged CA-B should be a no-op.
+		stableCert := append([]byte(nil), leaf.Data[corev1.TLSCertKey]...)
+		reconcileLeaf(t, leaf, caB, withTLSKey)
+		if !bytes.Equal(stableCert, leaf.Data[corev1.TLSCertKey]) {
+			t.Errorf("expected leaf cert to be unchanged when CA has not changed")
+		}
+	})
 }
 
 func TestCertChainingAttributesPresent(t *testing.T) {


### PR DESCRIPTION
## What this PR does / why we need it:

`ReconcileSignedCert` only re-issued a leaf certificate when `ValidateKeyPair`
failed (less than 30 days of validity remaining, or a SAN change). It never
checked whether the existing leaf actually chains to the *current* CA
secret's key. When a CA secret is regenerated, an otherwise still-valid leaf
can be left orphaned indefinitely: it keeps serving a certificate that no
longer verifies against the CA bundle injected into its consumers.

This caused the HyperShift conversion webhook to break after a
`webhook-serving-ca` rotation. The operator's `manager-serving-cert` leaf
remained signed by the previous CA while the regenerated CA was injected
into the CRD `caBundle`, producing prolonged `tls: bad certificate` failures
on the CAPI conversion webhook and `FinalizingPartiallyFailed` HCP Velero
backups, until the leaf secret was deleted manually to force re-issuance.

This PR adds `certSignedByCA`, which cryptographically verifies
(`CheckSignatureFrom`) whether the existing leaf was signed by the current
CA certificate. `ReconcileSignedCert` now only takes its "still valid, skip"
early return when the leaf both passes `ValidateKeyPair` **and** was signed
by the current CA; otherwise it re-signs.

`ReconcileSignedCert` is the shared cert primitive used by the webhook
controller, CPO PKI, `metrics_proxy`, `ignitionserver`, and
`endpoint_resolver`, so this closes the CA-rotation gap for all of them
without per-caller changes.

The webhook controller already watches the CA secret and re-patches every
`caBundle` on each reconcile, so a CA change now flows end-to-end:
reconcile → re-sign leaf → re-patch `caBundle`s → cert hot-reload.

Regenerating an existing self-signed CA on expiry (`ReconcileSelfSignedCA`)
and alerting on TLS handshake failures are out of scope for this change.

## Which issue(s) this PR fixes:
Fixes [ROSAENG-65488](https://redhat.atlassian.net/browse/ROSAENG-65488)

## Special notes for your reviewer:
- Core fix lives in the shared `support/certs` primitive rather than only
  in the webhook controller, so it also protects CPO PKI, `metrics_proxy`,
  `ignitionserver`, and `endpoint_resolver` cert reconciliation.
- Verified `go test` passes for all affected packages, including the
  previously-existing CPO PKI test suite, unmodified.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Serving certificates are automatically re-issued when signed by an outdated or mismatched certificate authority.
  * Certificate rotation now correctly responds to changes in the active certificate authority, including updated certificate data.
  * Certificates remain unchanged when valid and signed by the current authority.
  * Missing, malformed, or invalid certificate data is handled more reliably during certificate reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->