### PR TITLE
CNTRLPLANE-4026: fix(ci): Enable Dependabot to track and automate GHA runner image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,3 +100,24 @@ updates:
     labels:
       - "area/ci-tooling"
       - "ok-to-test"
+  # GitHub Actions runner container image (Dockerfile.github-actions-runner).
+  # The docker ecosystem scans every Dockerfile/Containerfile in this directory,
+  # so `allow` restricts updates to the runner image only. All sibling images
+  # (ubi9, go-toolset, openshift/release, etc.) are product/CI images managed
+  # via the OpenShift release process and must not be bumped here.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "01:00"
+      timezone: "Etc/UTC"
+    commit-message:
+      prefix: "ci(deps)"
+    labels:
+      - "area/ci-tooling"
+      - "ok-to-test"
+    # Wildcard matches regardless of whether Dependabot includes the registry
+    # host (ghcr.io/) in the internal dependency name.
+    allow:
+      - dependency-name: "*actions-runner*"

--- a/Dockerfile.github-actions-runner
+++ b/Dockerfile.github-actions-runner
@@ -1,4 +1,4 @@
-FROM ghcr.io/actions/actions-runner@sha256:0cfdcc701ce933c6d243c6b0b2da767366dc9f2e99961d4c3754b0b78084cdda
+FROM ghcr.io/actions/actions-runner:2.336.0@sha256:0cfdcc701ce933c6d243c6b0b2da767366dc9f2e99961d4c3754b0b78084cdda
 
 USER root
 


### PR DESCRIPTION
### What this PR does / why we need it:

- Enables Dependabot to automatically track and update the GitHub Actions runner base image
  (`ghcr.io/actions/actions-runner`) to prevent future deprecation incidents.

 ### Context
  
 - On 2026-08-10, GitHub deprecated runner v2.334.0 with minimal notice. All self-hosted runners stopped accepting jobs, blocking CI for 8+ hours until manually fixed in #9275 
- This PR configures weekly Dependabot scans so version updates are proposed automatically rather than discovered via CI outage.

 ### Changes

  1. **Dockerfile.github-actions-runner**: Added `:2.336.0` tag to the existing digest
     - No digest change → no rebuild needed → no pod rollout for this PR
     - Dependabot requires `tag@sha256` format (digest-only is not trackable)
     - Confirmed through https://github.com/dependabot/dependabot-core/issues/4419

  2. **.github/dependabot.yml**: Added `docker` ecosystem entry
     - Scans weekly (Friday 01:00 UTC) to align with monthly runner releases
     - `allow: "*actions-runner*"` restricts updates to runner image only
     - All other root Dockerfiles use RHEL/OCP images managed via release process
     - Extends existing Dependabot setup (Mintmaker was disabled in 9b6bacdd)
### Which issue(s) this PR fixes:
Fixes [CNTRLPLANE-4026](https://redhat.atlassian.net/browse/CNTRLPLANE-4026)

### Special notes for your reviewer:
- The weekly frequency for Dependabot seems reasonable at this moment, as the [runner-dep-management](https://github.com/actions/runner/blob/main/docs/dependency-management.md) says the runner release is monthly basis.                                                    
- Also, when future Dependabot PRs merge and Konflux rebuilds the image, IIUC, the runner pods won't restart
  automatically. We may need to document the manual Helm upgrade command or add a post-merge workflow to comment the reminder.
    
## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated weekly updates for the GitHub Actions runner image.
  * Restricted automated updates to the runner dependency and applied standard CI labels.
  * Updated the GitHub Actions runner image to version 2.336.0 while retaining its integrity pin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->