### PR TITLE
CNTRLPLANE-4006: fix(e2e) disable client-side rate limiting and increase NodePool config timeout

### DIFF
--- a/test/e2e/nodepool_additionalTrustBundlePropagation_test.go
+++ b/test/e2e/nodepool_additionalTrustBundlePropagation_test.go
@@ -55,7 +55,7 @@ func (k *AdditionalTrustBundlePropagationTest) BuildNodePoolManifest(defaultNode
 
 func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes []corev1.Node) {
 	const (
-		nodePoolConfigUpdateStartTimeout    = 5 * time.Minute
+		nodePoolConfigUpdateStartTimeout    = 10 * time.Minute
 		nodePoolConfigUpdateFinishTimeout   = 20 * time.Minute
 		defaultPollInterval                 = 15 * time.Second
 		cpoDeploymentUpdateTimeout          = 10 * time.Minute

--- a/test/e2e/util/client.go
+++ b/test/e2e/util/client.go
@@ -17,10 +17,12 @@ func GetConfig() (*rest.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Increased QPS and Burst to handle multiple parallel tests and polling operations
-	// Previous values (QPS=100, Burst=100) were insufficient for concurrent NodePool polling
-	cfg.QPS = 200
-	cfg.Burst = 300
+	// Disable client-side rate limiting (QPS=-1) for e2e tests. The API server's
+	// Priority and Fairness provides server-side flow control. Client-side rate
+	// limiting produced misleading "client rate limiter Wait returned an error"
+	// messages when test contexts expired.
+	cfg.QPS = -1
+	cfg.Burst = -1
 	cfg.Timeout = 5 * time.Minute
 	return cfg, nil
 }

--- a/test/e2e/v2/internal/test_context.go
+++ b/test/e2e/v2/internal/test_context.go
@@ -109,8 +109,9 @@ func (tc *TestContext) GetHostedClusterRESTConfig(hc *hyperv1.HostedCluster) (*r
 	if err != nil {
 		return nil, fmt.Errorf("failed to create REST config from kubeconfig: %w", err)
 	}
-	restConfig.QPS = 200
-	restConfig.Burst = 300
+	// Disable client-side rate limiting for e2e tests. See test/e2e/util/client.go.
+	restConfig.QPS = -1
+	restConfig.Burst = -1
 
 	return restConfig, nil
 }

--- a/test/e2e/v2/tests/nodepool_lifecycle_test.go
+++ b/test/e2e/v2/tests/nodepool_lifecycle_test.go
@@ -812,7 +812,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 
 		const (
 			defaultPollInterval                 = 15 * time.Second
-			nodePoolConfigUpdateStartTimeout    = 5 * time.Minute
+			nodePoolConfigUpdateStartTimeout    = 10 * time.Minute
 			nodePoolConfigUpdateFinishTimeout   = 20 * time.Minute
 			cpoDeploymentUpdateTimeout          = 10 * time.Minute
 			guestUserCABundlePropagationTimeout = 5 * time.Minute


### PR DESCRIPTION
 E2e tests fail with misleading error message: **client rate limiter Wait returned an error: context deadline exceeded**

  This occurred in two CI runs :
  - `TestAdditionalTrustBundlePropagation` (e2e-aks-override) - [build 2085017479670665216](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/o
  penshift_hypershift/9211/pull-ci-openshift-hypershift-main-e2e-aks-override/2085017479670665216)
  - `TestKarpenterUpgradeControlPlane` (e2e-aws) - [build 2085026687682088960](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hype
  rshift/9211/pull-ci-openshift-hypershift-main-e2e-aws/2085026687682088960)

 

  ### Root Causes

  **Failure 1: TestAdditionalTrustBundlePropagation**
  - 5-minute timeout too short for NodePool config propagation under CI load
  - NodePool reached expected state 2 minutes **after** timeout expired
  - Rate limiter's `Wait()` just noticed the already-expired context

  **Failure 2: TestKarpenterUpgradeControlPlane**
  - Parent context canceled after ~47 minutes (infrastructure timeout)
  - `mgtClient.Get()` called with already-canceled context
  - Same pattern: rate limiter surfaced the cancellation

  ### Error Path Analysis

  The misleading error occurs because `client-go`'s rate limiter `Wait()` checks `ctx.Done()` as its **first operation**:


  // vendor/k8s.io/client-go/rest/request.go
  func (r *Request) request() {
      r.tryThrottle(ctx)  // ← Called BEFORE HTTP request
        → rateLimiter.Wait(ctx)
          → checks ctx.Done() FIRST
          → returns ctx.Err() if expired
        → wraps: "client rate limiter Wait returned an error: %w"
  }

  The rate limiter didn't block anything—it just noticed the context was already dead.

  **Solution**

  **1. Disable Client-Side Rate Limiting**

  Set cfg.QPS = -1, which is documented behavior (https://github.com/kubernetes/client-go/blob/master/rest/config.go#L120) in k8s.io/client-go:

  // Setting this to a negative value will disable client-side ratelimiting

  **Why:** 
  - Tests never approach QPS=200 (0.3-1 req/s actual rate)
  - API server's Priority & Fairness (APF) provides server-side flow control
  - Eliminates misleading error wrapper
  - Future errors will be honest: context deadline exceeded instead of client rate limiter Wait returned an error: context deadline exceeded

  **Files changed:**
  - test/e2e/util/client.go: QPS 200→-1, remove Burst=300
  - test/e2e/v2/internal/test_context.go: same for v2 framework

  **2. Increase NodePool Config Update Timeout**

  Change nodePoolConfigUpdateStartTimeout from 5 to 10 minutes.

  **Why:** 
  - Config propagation legitimately takes 5-10 minutes under CI load with 20 parallel tests
  - 10 minutes matches existing cpoDeploymentUpdateTimeout pattern
  - Failure logs prove operation succeeded but needed more time
  - Timeout is a maximum—tests exit immediately when condition is met

  **Files changed:**
  - test/e2e/nodepool_additionalTrustBundlePropagation_test.go
  - test/e2e/v2/tests/nodepool_lifecycle_test.go
  
  **Testing**

  No functional behavior changes:
  - Tests still poll at same intervals (3s, 10s, 15s)
  - Fast completions remain fast (30s operation still takes 30s regardless of 10min timeout)
  - Server-side APF still provides rate limiting protection 
  - Per-test request rate unchanged



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased NodePool configuration update test timeouts to better accommodate trust-bundle propagation and lifecycle operations.
  * Updated test clients to avoid unnecessary client-side request throttling, improving reliability during end-to-end test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->