### PR TITLE
OCPBUGS-111985,OCPBUGS-111986: bump haproxy to 3.0.5-6.el10_2.2 to fix CVE-2026-55203 and CVE-2026-55204

### DIFF
--- a/shared-ingress/Containerfile
+++ b/shared-ingress/Containerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi10/ubi:10.0-1753787353
 
-RUN dnf install -y haproxy-3.0.5-4.el10_1.1 socat-1.7.4.4-8.el10 \
+RUN dnf install -y haproxy-3.0.5-6.el10_2.2 socat-1.7.4.4-8.el10 \
   && dnf clean all
 
 ENTRYPOINT [ "/usr/sbin/haproxy" ]
@@ -10,7 +10,7 @@ LABEL name="multicluster-engine/hypershift-shared-ingress"
 LABEL description="HyperShift's HAProxy 3 based Shared Ingress container"
 LABEL summary="HyperShift Shared Ingress"
 LABEL url="https://quay.io/repository/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress"
-LABEL version="3.0.5-4.el10_1.1"
+LABEL version="3.0.5-6.el10_2.2"
 LABEL com.redhat.component="multicluster-engine-hypershift-shared-ingress"
 LABEL io.openshift.tags="data,images"
 LABEL io.k8s.display-name="multicluster-engine-hypershift-shared-ingress"

--- a/shared-ingress/rpms.lock.yaml
+++ b/shared-ingress/rpms.lock.yaml
@@ -4,13 +4,13 @@ lockfileVendor: redhat
 arches:
 - arch: aarch64
   packages:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/h/haproxy-3.0.5-4.el10_1.1.aarch64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/h/haproxy-3.0.5-6.el10_2.2.aarch64.rpm
     repoid: ubi-10-appstream-rpms
-    size: 2737587
-    checksum: sha256:d134409b5c20f96ee49c3a09638c40079711db12bec86e5d11dca8032e2c880e
+    size: 2745310
+    checksum: sha256:b9030f012edac0262fbac4f092f067c82514ef59824dd6f9a76624aa607aaf25
     name: haproxy
-    evr: 3.0.5-4.el10_1.1
-    sourcerpm: haproxy-3.0.5-4.el10_1.1.src.rpm
+    evr: 3.0.5-6.el10_2.2
+    sourcerpm: haproxy-3.0.5-6.el10_2.2.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/s/socat-1.7.4.4-8.el10.aarch64.rpm
     repoid: ubi-10-appstream-rpms
     size: 309604
@@ -22,13 +22,13 @@ arches:
   module_metadata: []
 - arch: x86_64
   packages:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/h/haproxy-3.0.5-4.el10_1.1.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/h/haproxy-3.0.5-6.el10_2.2.x86_64.rpm
     repoid: ubi-10-appstream-rpms
-    size: 2744446
-    checksum: sha256:ab597cc91bbd2be22853054d104ba161a4f93336b9d3369000aa830fd8c1aec8
+    size: 2751346
+    checksum: sha256:c0f8ea02a50e64e925c6d1dee057be2af75a9e2731afde8907f19d0ae6fbecfa
     name: haproxy
-    evr: 3.0.5-4.el10_1.1
-    sourcerpm: haproxy-3.0.5-4.el10_1.1.src.rpm
+    evr: 3.0.5-6.el10_2.2
+    sourcerpm: haproxy-3.0.5-6.el10_2.2.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/s/socat-1.7.4.4-8.el10.x86_64.rpm
     repoid: ubi-10-appstream-rpms
     size: 312918


### PR DESCRIPTION
## What this PR does / why we need it:

Bumps the pinned HAProxy RPM used by the shared-ingress image from `haproxy-3.0.5-4.el10_1.1` to `haproxy-3.0.5-6.el10_2.2` to pick up the fix for CVE-2026-55203 and CVE-2026-55204.

Changes:
- `shared-ingress/Containerfile`: update the `dnf install` version pin and the `LABEL version` metadata.
- `shared-ingress/rpms.lock.yaml`: regenerated via `rpm-lockfile-prototype` so the new HAProxy build (URL, checksum, evr, sourcerpm) is locked for both `aarch64` and `x86_64`. `socat` is unchanged.

## Which issue(s) this PR fixes:
Fixes OCPBUGS-111985

## Special notes for your reviewer:

- `socat` was intentionally left at `1.7.4.4-8.el10`; only HAProxy needed to move for the CVE.
- The `rpms.lock.yaml` checksums were regenerated by the tooling, not hand-edited.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the shared ingress container to HAProxy version 3.0.5-6.el10_2.2.
  * Refreshed the bundled HAProxy packages for both ARM64 and x86_64 platforms.
  * Updated the container version label to match the installed HAProxy release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->