### PR TITLE
NO-JIRA: fix(ci): update restructure-commits workflow path after skills migration

### DIFF
--- a/.github/workflows/restructure-commits.yaml
+++ b/.github/workflows/restructure-commits.yaml
@@ -21,7 +21,7 @@ jobs:
     with:
       command-name: restructure-commits
       status-message: "Restructuring commits"
-      trusted-commands: "commands/restructure-commits.md skills/git-commit-format/SKILL.md"
+      trusted-commands: "skills/restructure-commits/SKILL.md skills/git-commit-format/SKILL.md"
       claude-prompt: >-
         Follow the "Restructure Commits by Component" instructions from the system prompt.
         You are running in CI. Do NOT push — the workflow handles pushing.


### PR DESCRIPTION
The commands→skills migration (#9062, 526b5e5) moved
`.claude/commands/restructure-commits.md` to
`.claude/skills/restructure-commits/SKILL.md` but did not update
the `trusted-commands` reference in the GitHub Actions workflow.

This fixes the `restructure-commits` workflow failing with:
```
fatal: path '.claude/commands/restructure-commits.md' exists on disk, but not in 'main'
```

See: https://github.com/openshift/hypershift/actions/runs/32180936738/job/95853531032#step:8:15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated commit restructuring workflow to use the current trusted command guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->