### PR TITLE
CNTRLPLANE-4041: fix(build): bump missed second-stage base image in Dockerfile.e2e to 5.1

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -9,7 +9,7 @@ RUN make e2e hypershift e2ev2-create-guests e2ev2-run-tests e2ev2-destroy-guests
 
 # Reuse the same image as builder because we need go command in ci-test-e2e.sh
 # Multi-stage build lets us drop the source code and build cache from the final image
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.26-openshift-4.23
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.26-openshift-5.1
 
 WORKDIR /hypershift
 


### PR DESCRIPTION
## Summary
- The base image bump in 282bb8c0e5 updated the builder stage of `Dockerfile.e2e` to `5.1` but missed the second (runtime) stage, which still referenced the stale `4.23` image.
- This broke Azure CLI installation during the e2e image build with a DNS resolution failure for `packages.microsoft.com`.
- Bumps the runtime stage base image to `5.1` to match the builder stage.

## Test plan
- [ ] e2e image builds successfully with Azure CLI installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the end-to-end testing environment to use the latest supported container image release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->