### PR TITLE
[release-4.22] OCPBUGS-112720: fix(cpo): handle service-ca generation errors in CSI serving cert reconciliation

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1637,7 +1637,7 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		NodeTuningOperatorService := manifests.ClusterNodeTuningOperatorMetricsService(hcp.Namespace)
 		err := removeServiceCAAnnotationAndSecret(ctx, r.Client, NodeTuningOperatorService, NodeTuningOperatorServingCert)
 		if err != nil {
-			r.Log.Error(err, "failed to remove service ca annotation and secret: %w")
+			r.Log.Error(err, "failed to remove service ca annotation and secret", "service", client.ObjectKeyFromObject(NodeTuningOperatorService))
 		}
 		if _, err = createOrUpdate(ctx, r, NodeTuningOperatorServingCert, func() error {
 			return pki.ReconcileNodeTuningOperatorServingCertSecret(NodeTuningOperatorServingCert, rootCASecret, p.OwnerRef)
@@ -1712,9 +1712,8 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		if hasServiceCAAnnotation := doesServiceHaveServiceCAAnnotation(multusAdmissionControllerService); !hasServiceCAAnnotation {
 			multusAdmissionControllerServingCertSecret := manifests.MultusAdmissionControllerServingCert(hcp.Namespace)
 
-			err = removeServiceCASecret(ctx, r.Client, multusAdmissionControllerServingCertSecret)
-			if err != nil {
-				return err
+			if err := removeServiceCAAnnotationAndSecret(ctx, r.Client, multusAdmissionControllerService, multusAdmissionControllerServingCertSecret); err != nil {
+				return fmt.Errorf("failed to remove service ca annotation and secret for %s: %w", client.ObjectKeyFromObject(multusAdmissionControllerService), err)
 			}
 
 			if _, err = createOrUpdate(ctx, r, multusAdmissionControllerServingCertSecret, func() error {
@@ -1738,9 +1737,8 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 	if hasServiceCAAnnotation := doesServiceHaveServiceCAAnnotation(networkNodeIdentityService); !hasServiceCAAnnotation {
 		networkNodeIdentityServingCertSecret := manifests.NetworkNodeIdentityControllerServingCert(hcp.Namespace)
 
-		err = removeServiceCASecret(ctx, r.Client, networkNodeIdentityServingCertSecret)
-		if err != nil {
-			return err
+		if err := removeServiceCAAnnotationAndSecret(ctx, r.Client, networkNodeIdentityService, networkNodeIdentityServingCertSecret); err != nil {
+			return fmt.Errorf("failed to remove service ca annotation and secret for %s: %w", client.ObjectKeyFromObject(networkNodeIdentityService), err)
 		}
 
 		if _, err = createOrUpdate(ctx, r, networkNodeIdentityServingCertSecret, func() error {
@@ -1763,9 +1761,8 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 	if hasServiceCAAnnotation := doesServiceHaveServiceCAAnnotation(ovnControlPlaneService); !hasServiceCAAnnotation {
 		ovnControlPlaneMetricsServingCertSecret := manifests.OVNControlPlaneMetricsServingCert(hcp.Namespace)
 
-		err = removeServiceCASecret(ctx, r.Client, ovnControlPlaneMetricsServingCertSecret)
-		if err != nil {
-			return err
+		if err := removeServiceCAAnnotationAndSecret(ctx, r.Client, ovnControlPlaneService, ovnControlPlaneMetricsServingCertSecret); err != nil {
+			return fmt.Errorf("failed to remove service ca annotation and secret for %s: %w", client.ObjectKeyFromObject(ovnControlPlaneService), err)
 		}
 
 		if _, err = createOrUpdate(ctx, r, ovnControlPlaneMetricsServingCertSecret, func() error {
@@ -1806,9 +1803,8 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		if hasServiceCAAnnotation := doesServiceHaveServiceCAAnnotation(awsEBSCsiDriverControllerMetricsService); !hasServiceCAAnnotation {
 			awsEBSCsiDriverControllerMetricsServingCert := manifests.AWSEBSCsiDriverControllerMetricsServingCert(hcp.Namespace)
 
-			err = removeServiceCASecret(ctx, r.Client, awsEBSCsiDriverControllerMetricsServingCert)
-			if err != nil {
-				return err
+			if err := removeServiceCAAnnotationAndSecret(ctx, r.Client, awsEBSCsiDriverControllerMetricsService, awsEBSCsiDriverControllerMetricsServingCert); err != nil {
+				return fmt.Errorf("failed to remove service ca annotation and secret for %s: %w", client.ObjectKeyFromObject(awsEBSCsiDriverControllerMetricsService), err)
 			}
 
 			if _, err = createOrUpdate(ctx, r, awsEBSCsiDriverControllerMetricsServingCert, func() error {
@@ -1830,7 +1826,7 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		AzureDiskCsiDriverOperatorService := manifests.AzureDiskCSIDriverOperatorMetricsService(hcp.Namespace)
 		err := removeServiceCAAnnotationAndSecret(ctx, r.Client, AzureDiskCsiDriverOperatorService, AzureDiskCsiDriverOperatorServingCert)
 		if err != nil {
-			r.Log.Error(err, "failed to remove service ca annotation and secret: %w")
+			r.Log.Error(err, "failed to remove service ca annotation and secret", "service", client.ObjectKeyFromObject(AzureDiskCsiDriverOperatorService))
 		}
 		if _, err = createOrUpdate(ctx, r, AzureDiskCsiDriverOperatorServingCert, func() error {
 			z := pki.ReconcileAzureDiskCsiDriverOperatorMetricsServingCertSecret(AzureDiskCsiDriverOperatorServingCert, rootCASecret, p.OwnerRef)
@@ -1849,9 +1845,8 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		if hasServiceCAAnnotation := doesServiceHaveServiceCAAnnotation(azureDiskCsiDriverControllerMetricsService); !hasServiceCAAnnotation {
 			azureDiskCsiDriverControllerMetricsServingCert := manifests.AzureDiskCsiDriverControllerMetricsServingCert(hcp.Namespace)
 
-			err = removeServiceCASecret(ctx, r.Client, azureDiskCsiDriverControllerMetricsServingCert)
-			if err != nil {
-				return err
+			if err := removeServiceCAAnnotationAndSecret(ctx, r.Client, azureDiskCsiDriverControllerMetricsService, azureDiskCsiDriverControllerMetricsServingCert); err != nil {
+				return fmt.Errorf("failed to remove service ca annotation and secret for %s: %w", client.ObjectKeyFromObject(azureDiskCsiDriverControllerMetricsService), err)
 			}
 
 			if _, err = createOrUpdate(ctx, r, azureDiskCsiDriverControllerMetricsServingCert, func() error {
@@ -1866,7 +1861,7 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		AzureFileCsiDriverOperatorService := manifests.AzureFileCSIDriverOperatorMetricsService(hcp.Namespace)
 		err = removeServiceCAAnnotationAndSecret(ctx, r.Client, AzureFileCsiDriverOperatorService, AzureFileCsiDriverOperatorServingCert)
 		if err != nil {
-			r.Log.Error(err, "failed to remove service ca annotation and secret: %w")
+			r.Log.Error(err, "failed to remove service ca annotation and secret", "service", client.ObjectKeyFromObject(AzureFileCsiDriverOperatorService))
 		}
 		if _, err = createOrUpdate(ctx, r, AzureFileCsiDriverOperatorServingCert, func() error {
 			z := pki.ReconcileAzureFileCsiDriverOperatorMetricsServingCertSecret(AzureFileCsiDriverOperatorServingCert, rootCASecret, p.OwnerRef)
@@ -1885,9 +1880,8 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		if hasServiceCAAnnotation := doesServiceHaveServiceCAAnnotation(azureFileCsiDriverControllerMetricsService); !hasServiceCAAnnotation {
 			azureFileCsiDriverControllerMetricsServingCert := manifests.AzureFileCsiDriverControllerMetricsServingCert(hcp.Namespace)
 
-			err = removeServiceCASecret(ctx, r.Client, azureFileCsiDriverControllerMetricsServingCert)
-			if err != nil {
-				return err
+			if err := removeServiceCAAnnotationAndSecret(ctx, r.Client, azureFileCsiDriverControllerMetricsService, azureFileCsiDriverControllerMetricsServingCert); err != nil {
+				return fmt.Errorf("failed to remove service ca annotation and secret for %s: %w", client.ObjectKeyFromObject(azureFileCsiDriverControllerMetricsService), err)
 			}
 
 			if _, err := createOrUpdate(ctx, r, azureFileCsiDriverControllerMetricsServingCert, func() error {
@@ -2236,52 +2230,75 @@ func (r *HostedControlPlaneReconciler) removeHCPIngressFromRoutes(ctx context.Co
 	return nil
 }
 
+const (
+	servingCertSecretNameAlpha  = "service.alpha.openshift.io/serving-cert-secret-name"
+	servingCertSecretNameBeta   = "service.beta.openshift.io/serving-cert-secret-name"
+	servingCertGenErrorAlpha    = "service.alpha.openshift.io/serving-cert-generation-error"
+	servingCertGenErrorNumAlpha = "service.alpha.openshift.io/serving-cert-generation-error-num"
+	servingCertGenErrorBeta     = "service.beta.openshift.io/serving-cert-generation-error"
+	servingCertGenErrorNumBeta  = "service.beta.openshift.io/serving-cert-generation-error-num"
+)
+
 // removeServiceCAAnnotationAndSecret will delete Secret 'secret' and
-// remove the annotation "service.beta.openshift.io/serving-cert-secret-name"
-// from Service 'service' if it contains this annotation.
-// This is used to remove Secrets generated by the service-ca in case
-// of upgrade, from a control-plane version using service-ca generated certs
-// to a version where the service uses HCP controller generated certs.
+// remove service-ca annotations from Service 'service'.
+// This cleans up both the cert-secret-name annotations and any
+// serving-cert-generation-error annotations left by service-ca,
+// preventing a dead state where no serving certificate is generated.
 func removeServiceCAAnnotationAndSecret(ctx context.Context, c client.Client, service *corev1.Service, secret *corev1.Secret) error {
 	if err := c.Get(ctx, client.ObjectKeyFromObject(service), service); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to get service: %w", err)
 		}
 	} else {
-		_, ok := service.Annotations["service.alpha.openshift.io/serving-cert-secret-name"]
-		if ok {
-			delete(service.Annotations, "service.alpha.openshift.io/serving-cert-secret-name")
-			err := c.Update(ctx, service)
-			if err != nil {
-				return fmt.Errorf("failed to update service: %w", err)
+		serviceCAAnnotations := []string{
+			servingCertSecretNameAlpha,
+			servingCertSecretNameBeta,
+			servingCertGenErrorAlpha,
+			servingCertGenErrorNumAlpha,
+			servingCertGenErrorBeta,
+			servingCertGenErrorNumBeta,
+		}
+		needsUpdate := false
+		for _, key := range serviceCAAnnotations {
+			if _, ok := service.Annotations[key]; ok {
+				delete(service.Annotations, key)
+				needsUpdate = true
 			}
 		}
-
-		_, ok = service.Annotations["service.beta.openshift.io/serving-cert-secret-name"]
-		if ok {
-			delete(service.Annotations, "service.beta.openshift.io/serving-cert-secret-name")
-			err := c.Update(ctx, service)
-			if err != nil {
+		if needsUpdate {
+			if err := c.Update(ctx, service); err != nil {
 				return fmt.Errorf("failed to update service: %w", err)
 			}
 		}
 	}
 
-	err := removeServiceCASecret(ctx, c, secret)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return removeServiceCASecret(ctx, c, secret)
 }
 
 func doesServiceHaveServiceCAAnnotation(service *corev1.Service) bool {
-	_, ok := service.Annotations["service.alpha.openshift.io/serving-cert-secret-name"]
+	// If service-ca has recorded a generation error, treat the annotation as
+	// absent so the CPO falls through to create its own cert. service-ca
+	// will not self-heal from this state, so without this check the service
+	// remains stuck with no serving certificate indefinitely.
+	if _, hasErr := service.Annotations[servingCertGenErrorAlpha]; hasErr {
+		return false
+	}
+	if _, hasErr := service.Annotations[servingCertGenErrorBeta]; hasErr {
+		return false
+	}
+	if _, hasErr := service.Annotations[servingCertGenErrorNumAlpha]; hasErr {
+		return false
+	}
+	if _, hasErr := service.Annotations[servingCertGenErrorNumBeta]; hasErr {
+		return false
+	}
+
+	_, ok := service.Annotations[servingCertSecretNameAlpha]
 	if ok {
 		return true
 	}
 
-	_, ok = service.Annotations["service.beta.openshift.io/serving-cert-secret-name"]
+	_, ok = service.Annotations[servingCertSecretNameBeta]
 	return ok
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/service_ca_annotation_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/service_ca_annotation_test.go
@@ -1,0 +1,269 @@
+package hostedcontrolplane
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDoesServiceHaveServiceCAAnnotation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "When service has no annotations, it should return false",
+			annotations: nil,
+			expected:    false,
+		},
+		{
+			name: "When beta cert annotation is present without error, it should return true",
+			annotations: map[string]string{
+				servingCertSecretNameBeta: "my-cert",
+			},
+			expected: true,
+		},
+		{
+			name: "When alpha cert annotation is present without error, it should return true",
+			annotations: map[string]string{
+				servingCertSecretNameAlpha: "my-cert",
+			},
+			expected: true,
+		},
+		{
+			name: "When beta cert annotation is present with beta generation error, it should return false",
+			annotations: map[string]string{
+				servingCertSecretNameBeta: "my-cert",
+				servingCertGenErrorBeta:   "secret does not have corresponding service UID",
+			},
+			expected: false,
+		},
+		{
+			name: "When alpha cert annotation is present with alpha generation error, it should return false",
+			annotations: map[string]string{
+				servingCertSecretNameAlpha: "my-cert",
+				servingCertGenErrorAlpha:   "secret does not have corresponding service UID",
+			},
+			expected: false,
+		},
+		{
+			name: "When beta cert annotation is present with alpha generation error, it should return false",
+			annotations: map[string]string{
+				servingCertSecretNameBeta: "my-cert",
+				servingCertGenErrorAlpha:  "UID mismatch",
+			},
+			expected: false,
+		},
+		{
+			name: "When only generation error annotation is present without cert annotation, it should return false",
+			annotations: map[string]string{
+				servingCertGenErrorBeta: "some error",
+			},
+			expected: false,
+		},
+		{
+			name: "When service has only unrelated annotations, it should return false",
+			annotations: map[string]string{
+				"app.kubernetes.io/name": "test",
+			},
+			expected: false,
+		},
+		{
+			name: "When beta cert annotation is present with generation error num only, it should return false",
+			annotations: map[string]string{
+				servingCertSecretNameBeta:   "my-cert",
+				servingCertGenErrorNumAlpha: "3",
+			},
+			expected: false,
+		},
+	}
+
+	svcBase := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-svc",
+			Namespace: "test-ns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			svc := svcBase.DeepCopy()
+			svc.Annotations = tt.annotations
+			got := doesServiceHaveServiceCAAnnotation(svc)
+			if got != tt.expected {
+				t.Errorf("doesServiceHaveServiceCAAnnotation() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRemoveServiceCAAnnotationAndSecret(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	tests := []struct {
+		name                     string
+		serviceAnnotations       map[string]string
+		secretExists             bool
+		secretAnnotations        map[string]string
+		wantRemovedAnnotations   []string
+		wantPreservedAnnotations map[string]string
+		wantSecretDeleted        bool
+	}{
+		{
+			name: "When all service-ca annotations are present, it should remove them in one batch",
+			serviceAnnotations: map[string]string{
+				servingCertSecretNameBeta:   "my-cert",
+				servingCertGenErrorBeta:     "UID mismatch",
+				servingCertGenErrorNumBeta:  "5",
+				servingCertSecretNameAlpha:  "my-cert",
+				servingCertGenErrorAlpha:    "UID mismatch",
+				servingCertGenErrorNumAlpha: "5",
+				"app.kubernetes.io/name":    "keep-me",
+			},
+			secretExists: true,
+			secretAnnotations: map[string]string{
+				"service.beta.openshift.io/originating-service-name": "test-svc",
+			},
+			wantRemovedAnnotations: []string{
+				servingCertSecretNameBeta,
+				servingCertGenErrorBeta,
+				servingCertGenErrorNumBeta,
+				servingCertSecretNameAlpha,
+				servingCertGenErrorAlpha,
+				servingCertGenErrorNumAlpha,
+			},
+			wantPreservedAnnotations: map[string]string{
+				"app.kubernetes.io/name": "keep-me",
+			},
+			wantSecretDeleted: true,
+		},
+		{
+			name: "When service has no service-ca annotations and no secret, it should leave annotations unchanged",
+			serviceAnnotations: map[string]string{
+				"app.kubernetes.io/name": "keep-me",
+			},
+			secretExists: false,
+			wantPreservedAnnotations: map[string]string{
+				"app.kubernetes.io/name": "keep-me",
+			},
+			wantSecretDeleted: false,
+		},
+		{
+			name: "When only error annotations are present, it should remove them",
+			serviceAnnotations: map[string]string{
+				servingCertGenErrorBeta:    "some error",
+				servingCertGenErrorNumBeta: "3",
+			},
+			secretExists: false,
+			wantRemovedAnnotations: []string{
+				servingCertGenErrorBeta,
+				servingCertGenErrorNumBeta,
+			},
+			wantSecretDeleted: false,
+		},
+		{
+			name: "When secret lacks originating-service annotation, it should not delete the secret",
+			serviceAnnotations: map[string]string{
+				servingCertSecretNameBeta: "my-cert",
+			},
+			secretExists: true,
+			secretAnnotations: map[string]string{
+				"some-other-annotation": "value",
+			},
+			wantRemovedAnnotations: []string{
+				servingCertSecretNameBeta,
+			},
+			wantSecretDeleted: false,
+		},
+	}
+
+	ctx := context.Background()
+	svcBase := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-svc",
+			Namespace: "test-ns",
+		},
+	}
+	secretBase := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cert",
+			Namespace: "test-ns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := svcBase.DeepCopy()
+			svc.Annotations = tt.serviceAnnotations
+
+			secretRef := secretBase.DeepCopy()
+
+			objs := []runtime.Object{svc}
+			if tt.secretExists {
+				secretObj := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-cert",
+						Namespace:   "test-ns",
+						Annotations: tt.secretAnnotations,
+					},
+				}
+				objs = append(objs, secretObj)
+			}
+
+			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+			err := removeServiceCAAnnotationAndSecret(ctx, c, svc, secretRef)
+			if err != nil {
+				t.Fatalf("removeServiceCAAnnotationAndSecret() error = %v", err)
+			}
+
+			// Re-fetch the service to verify annotations
+			updatedSvc := &corev1.Service{}
+			if err := c.Get(ctx, client.ObjectKeyFromObject(svc), updatedSvc); err != nil {
+				t.Fatalf("failed to get updated service: %v", err)
+			}
+
+			for _, key := range tt.wantRemovedAnnotations {
+				if _, ok := updatedSvc.Annotations[key]; ok {
+					t.Errorf("expected annotation %q to be removed from service, but it still exists", key)
+				}
+			}
+
+			for key, wantVal := range tt.wantPreservedAnnotations {
+				if gotVal, ok := updatedSvc.Annotations[key]; !ok {
+					t.Errorf("expected annotation %q to be preserved, but it was removed", key)
+				} else if gotVal != wantVal {
+					t.Errorf("annotation %q = %q, want %q", key, gotVal, wantVal)
+				}
+			}
+
+			// Check secret deletion
+			fetchedSecret := &corev1.Secret{}
+			err = c.Get(ctx, client.ObjectKey{Name: "test-cert", Namespace: "test-ns"}, fetchedSecret)
+			secretGone := apierrors.IsNotFound(err)
+			if tt.wantSecretDeleted && !secretGone {
+				t.Errorf("expected secret to be deleted, but it still exists")
+			}
+			if !tt.wantSecretDeleted && tt.secretExists && secretGone {
+				t.Errorf("expected secret to be preserved, but it was deleted")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Manual backport of https://github.com/openshift/hypershift/pull/8622 to `release-4.22` (OCPBUGS-86670).
- Automated `/cherry-pick release-4.22` failed: 4.22 still inlines PKI serving-cert reconciliation in `reconcilePKI`; main later split that into helpers (`reconcileAzurePlatformCerts`, etc.). 4.23 (#9346) and 5.0 (#9347) applied cleanly.
- Same behavior as #8622: `doesServiceHaveServiceCAAnnotation` treats `serving-cert-generation-error` as annotation-absent so the CPO creates its own cert; `removeServiceCAAnnotationAndSecret` clears error annotations in one batch.

## Test plan
- [x] `gofmt` clean
- [x] `go vet ./control-plane-operator/controllers/hostedcontrolplane/`
- [x] Helper unit tests:

```
go test ./control-plane-operator/controllers/hostedcontrolplane/ -count=1 -timeout 120s -run 'TestDoesServiceHaveServiceCAAnnotation|TestRemoveServiceCAAnnotationAndSecret'
ok  	github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane	1.374s
```

- [ ] CI e2e on this PR
- [ ] `/jira refresh` after open so the 4.22.z bug stays valid

/assign chdeshpa-hue

Made with [Cursor](https://cursor.com)