### PR TITLE
NO-JIRA: align GCP creds metric test case names with testcasename linter

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -575,43 +575,43 @@ func TestReportInvalidGcpCreds(t *testing.T) {
 		expected                           *dto.MetricFamily
 	}{
 		{
-			name:                               "When both GCP conditions are true, metric is reported with a value set to 0 (valid)",
+			name:                               "When both GCP conditions are true, it should report metric value 0 as valid",
 			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionTrue,
 			ValidGCPCredentialsCondStatus:      metav1.ConditionTrue,
 			expected:                           wrapExpectedValueAsMetric(0),
 		},
 		{
-			name:                               "When ValidGCPWorkloadIdentity status is false, metric is reported with a value set to 1 (invalid)",
+			name:                               "When ValidGCPWorkloadIdentity status is false, it should report metric value 1 as invalid",
 			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionFalse,
 			ValidGCPCredentialsCondStatus:      metav1.ConditionTrue,
 			expected:                           wrapExpectedValueAsMetric(1),
 		},
 		{
-			name:                               "When ValidGCPCredentials status is false, metric is reported with a value set to 1 (invalid)",
+			name:                               "When ValidGCPCredentials status is false, it should report metric value 1 as invalid",
 			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionTrue,
 			ValidGCPCredentialsCondStatus:      metav1.ConditionFalse,
 			expected:                           wrapExpectedValueAsMetric(1),
 		},
 		{
-			name:                               "When both GCP conditions are false, metric is reported with a value set to 1 (invalid)",
+			name:                               "When both GCP conditions are false, it should report metric value 1 as invalid",
 			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionFalse,
 			ValidGCPCredentialsCondStatus:      metav1.ConditionFalse,
 			expected:                           wrapExpectedValueAsMetric(1),
 		},
 		{
-			name:                               "When ValidGCPWorkloadIdentity status is unknown, metric is reported with a value set to 2 (unknown)",
+			name:                               "When ValidGCPWorkloadIdentity status is unknown, it should report metric value 2 as unknown",
 			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionUnknown,
 			ValidGCPCredentialsCondStatus:      metav1.ConditionTrue,
 			expected:                           wrapExpectedValueAsMetric(2),
 		},
 		{
-			name:                               "When ValidGCPCredentials status is unknown, metric is reported with a value set to 2 (unknown)",
+			name:                               "When ValidGCPCredentials status is unknown, it should report metric value 2 as unknown",
 			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionTrue,
 			ValidGCPCredentialsCondStatus:      metav1.ConditionUnknown,
 			expected:                           wrapExpectedValueAsMetric(2),
 		},
 		{
-			name:                               "When both GCP conditions are unknown, metric is reported with a value set to 2 (unknown)",
+			name:                               "When both GCP conditions are unknown, it should report metric value 2 as unknown",
 			ValidGCPWorkloadIdentityCondStatus: metav1.ConditionUnknown,
 			ValidGCPCredentialsCondStatus:      metav1.ConditionUnknown,
 			expected:                           wrapExpectedValueAsMetric(2),


### PR DESCRIPTION
## What this PR does / why we need it:

The `testcasename` hypershiftlinter rule requires test case names to match the
format `When <condition>, it should <expected behavior>`. The
`TestReportInvalidGcpCreds` subtests used a different phrasing
("...metric is reported with a value set to...") and therefore failed
`make lint`. This renames those seven subtests to follow the required format,
matching the neighboring `TestReportInvalidAwsCreds` cases that already comply.

Test-name-only change; no production code or test behavior is affected.

## Which issue(s) this PR fixes:

N/A — lint-only cleanup (NO-JIRA).

## Special notes for your reviewer:

The new names mirror the sibling `TestReportInvalidAwsCreds` cases
(`When <condition>, it should report metric value <N> as <valid|invalid|unknown>`),
which already pass the same linter. The pre-push hooks (`make verify-quick` and
the changed-package tests) passed.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the clarity and conciseness of GCP credential metrics test descriptions.
  * Test inputs and expected metric values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->