### PR TITLE
CNTRLPLANE-4174: add members to core-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -33,6 +33,13 @@ aliases:
     - clebs
     - Nirshal
     - ironcladlou
+    - georgelipceanu
+    - MehaBhalodiya
+    - dhgautam99
+    - vsolanki12
+    - PoornimaSingour
+    - vismishr
+    - rutvik23
   karpenter-approvers:
     - elmiko
     - enxebre


### PR DESCRIPTION
## What this PR does / why we need it:

Add georgelipceanu, MehaBhalodiya, dhgautam99, vsolanki12, PoornimaSingour, vismishr, and rutvik23 to the core-reviewers alias in OWNERS_ALIASES.

## Which issue(s) this PR fixes:

Fixes NO-JIRA

## Special notes for your reviewer:

Maintenance update to expand the core-reviewers roster.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the core reviewers alias to include seven additional reviewers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->