### PR TITLE
OCPBUGS-98066: restore HostedCluster infraID from HostedControlPlane

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2772,7 +2772,12 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 	hcp.Spec.Networking = hcluster.Spec.Networking
 
 	hcp.Spec.ClusterID = hcluster.Spec.ClusterID
-	hcp.Spec.InfraID = hcluster.Spec.InfraID
+	// infraID is immutable once set on the HostedControlPlane. Copying a
+	// regenerated HostedCluster value here is what previously caused CAPI to
+	// provision a second cluster identity.
+	if hcp.Spec.InfraID == "" {
+		hcp.Spec.InfraID = hcluster.Spec.InfraID
+	}
 	hcp.Spec.DNS = hcluster.Spec.DNS
 	hcp.Spec.Services = hcluster.Spec.Services
 	hcp.Spec.ControllerAvailabilityPolicy = hcluster.Spec.ControllerAvailabilityPolicy
@@ -5240,15 +5245,28 @@ func (r *HostedClusterReconciler) defaultIngressDomain(ctx context.Context) (str
 }
 
 func (r *HostedClusterReconciler) defaultClusterIDsIfNeeded(ctx context.Context, hcluster *hyperv1.HostedCluster) error {
-	// Default the ClusterID if unset
+	log := ctrl.LoggerFrom(ctx)
 	needsUpdate := false
+	// Default the ClusterID if unset
 	if hcluster.Spec.ClusterID == "" {
 		hcluster.Spec.ClusterID = uuid.NewString()
 		needsUpdate = true
 	}
 
-	// Default the infraID if unset
-	if hcluster.Spec.InfraID == "" {
+	// Once a HostedControlPlane exists, its infraID is the source of truth.
+	// Generating a new HostedCluster value after the field was cleared (or
+	// rewritten) is what previously caused CAPI to provision a second identity.
+	existingInfraID, err := r.infraIDFromHostedControlPlane(ctx, hcluster)
+	if err != nil {
+		return err
+	}
+	if existingInfraID != "" {
+		if hcluster.Spec.InfraID != existingInfraID {
+			log.Info("Restoring infraID from HostedControlPlane", "infraID", existingInfraID)
+			hcluster.Spec.InfraID = existingInfraID
+			needsUpdate = true
+		}
+	} else if hcluster.Spec.InfraID == "" {
 		hcluster.Spec.InfraID = infraid.New(hcluster.Name)
 		needsUpdate = true
 	}
@@ -5259,6 +5277,23 @@ func (r *HostedClusterReconciler) defaultClusterIDsIfNeeded(ctx context.Context,
 		}
 	}
 	return nil
+}
+
+// infraIDFromHostedControlPlane returns the infraID already stored on the
+// HostedControlPlane, if it exists. An empty string is returned when the HCP
+// has not been created yet.
+func (r *HostedClusterReconciler) infraIDFromHostedControlPlane(ctx context.Context, hcluster *hyperv1.HostedCluster) (string, error) {
+	hcp := controlplaneoperator.HostedControlPlane(
+		manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name),
+		hcluster.Name,
+	)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(hcp), hcp); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get HostedControlPlane: %w", err)
+	}
+	return hcp.Spec.InfraID, nil
 }
 
 func validateClusterID(hc *hyperv1.HostedCluster) error {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -3316,32 +3316,61 @@ func TestDefaultClusterIDsIfNeeded(t *testing.T) {
 			},
 		}
 	}
+	testHCP := func(infraID string) *hyperv1.HostedControlPlane {
+		hcp := controlplaneoperator.HostedControlPlane(
+			hcpmanifests.HostedControlPlaneNamespace("fake-namespace", "fake-cluster"),
+			"fake-cluster",
+		)
+		hcp.Spec.InfraID = infraID
+		return hcp
+	}
 	tests := []struct {
-		name string
-		hc   *hyperv1.HostedCluster
+		name           string
+		hc             *hyperv1.HostedCluster
+		hcp            *hyperv1.HostedControlPlane
+		wantInfraID    string
+		expectRestored bool
 	}{
 		{
-			name: "When both IDs are missing it should generate both",
+			name: "When both IDs are missing, it should generate both",
 			hc:   testHC("", ""),
 		},
 		{
-			name: "When cluster ID is missing it should generate cluster ID",
+			name: "When cluster ID is missing, it should generate cluster ID",
 			hc:   testHC("fake-infra", ""),
 		},
 		{
-			name: "When infra ID is missing it should generate infra ID",
+			name: "When infra ID is missing, it should generate infra ID",
 			hc:   testHC("", "fake-uuid"),
 		},
 		{
-			name: "When both IDs are already set it should not generate any",
+			name: "When both IDs are already set, it should not generate any",
 			hc:   testHC("fake-infra", "fake-uuid"),
+		},
+		{
+			name:           "When infraID is cleared and HCP has the original, it should restore infraID",
+			hc:             testHC("", "fake-uuid"),
+			hcp:            testHCP("original-infra"),
+			wantInfraID:    "original-infra",
+			expectRestored: true,
+		},
+		{
+			name:           "When HostedCluster infraID differs from HCP, it should restore infraID from HCP",
+			hc:             testHC("new-infra", "fake-uuid"),
+			hcp:            testHCP("original-infra"),
+			wantInfraID:    "original-infra",
+			expectRestored: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			objects := []crclient.Object{test.hc}
+			if test.hcp != nil {
+				objects = append(objects, test.hcp)
+			}
 			r := &HostedClusterReconciler{
 				CertRotationScale: 24 * time.Hour,
-				Client:            fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(test.hc).Build(),
+				Client:            fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).Build(),
 			}
 			g := NewGomegaWithT(t)
 			previousInfraID := test.hc.Spec.InfraID
@@ -3353,12 +3382,64 @@ func TestDefaultClusterIDsIfNeeded(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resultHC.Spec.ClusterID).NotTo(BeEmpty())
 			g.Expect(resultHC.Spec.InfraID).NotTo(BeEmpty())
+			if test.expectRestored {
+				g.Expect(resultHC.Spec.InfraID).To(Equal(test.wantInfraID))
+				return
+			}
 			if len(previousClusterID) > 0 {
 				g.Expect(resultHC.Spec.ClusterID).To(BeIdenticalTo(previousClusterID))
 			}
 			if len(previousInfraID) > 0 {
 				g.Expect(resultHC.Spec.InfraID).To(BeIdenticalTo(previousInfraID))
 			}
+		})
+	}
+}
+
+func TestReconcileHostedControlPlaneIDImmutability(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		hcInfraID      string
+		hcClusterID    string
+		hcpInfraID     string
+		hcpClusterID   string
+		wantHCPInfraID string
+	}{
+		{
+			name:           "When HCP infraID is empty, it should copy infraID from the HostedCluster",
+			hcInfraID:      "hc-infra",
+			hcClusterID:    "hc-cluster",
+			wantHCPInfraID: "hc-infra",
+		},
+		{
+			name:           "When HCP already has infraID, it should not overwrite it with the HostedCluster value",
+			hcInfraID:      "new-infra",
+			hcClusterID:    "new-cluster",
+			hcpInfraID:     "original-infra",
+			hcpClusterID:   "original-cluster",
+			wantHCPInfraID: "original-infra",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			hc := &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					InfraID:   test.hcInfraID,
+					ClusterID: test.hcClusterID,
+				},
+			}
+			hcp := &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					InfraID:   test.hcpInfraID,
+					ClusterID: test.hcpClusterID,
+				},
+			}
+			err := reconcileHostedControlPlane(hcp, hc, false, false, func() (map[string]string, error) { return nil, nil })
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(hcp.Spec.InfraID).To(Equal(test.wantHCPInfraID))
+			g.Expect(hcp.Spec.ClusterID).To(Equal(test.hcClusterID))
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Changing or clearing HostedCluster `spec.infraID` caused the controller to mint a new cluster identity. CAPI then provisioned against that new identity.

CEL already rejects `infraID` removal (OCPBUGS-98065). This PR makes the HostedControlPlane the source of truth for `infraID` once it exists:

- If the HostedControlPlane already has an `infraID`, copy it onto the HostedCluster (empty or conflicting values)
- Do not overwrite HostedControlPlane `infraID` once it is set
- Generate a new `infraID` only on first create (no HostedControlPlane yet)

NodePool pause/delete still pauses and deletes all NodePool-owned CAPI resources, not only canonical names, so leftover MachineSets from rollouts cannot keep creating Machines after the NodePool is paused or deleted.

This PR does not add a HyperShift machine-count circuit breaker. Unbounded Machine creation in CAPI belongs in CAPI.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/OCPBUGS-98066

## Special notes for your reviewer:

Admission-time CEL immutability for `infraID` already landed in https://github.com/openshift/hypershift/pull/9102 (OCPBUGS-98065). This is the controller-side restore if that check is bypassed.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved HostedControlPlane infrastructure IDs during reconciliation instead of replacing existing values.
  * Improved synchronization of SSH keys and Karpenter configuration between cluster resources.
  * Added validation for Managed HSM support across applicable platform versions.
* **Reliability**
  * NodePool deletion now safely pauses and removes all associated compute resources, including rollout-created resources.
  * Prevented resources belonging to other NodePools from being modified or deleted.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->