### PR TITLE
CNTRLPLANE-3880: Add E2E test for etcd snapshot restore to prevent split brain regression

### DIFF
--- a/test/e2e/v2/backuprestore/etcd_snapshot.go
+++ b/test/e2e/v2/backuprestore/etcd_snapshot.go
@@ -5,12 +5,16 @@ package backuprestore
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	cpomanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 
 	corev1 "k8s.io/api/core/v1"
@@ -18,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -174,6 +179,83 @@ func validateEtcdInitResult(logger logr.Logger, result *etcdInitLogResult) error
 
 	return nil
 }
+
+// etcdMemberListResponse represents the JSON output of etcdctl member list -w json.
+type etcdMemberListResponse struct {
+	Header  etcdResponseHeader `json:"header"`
+	Members []etcdMember       `json:"members"`
+}
+
+// etcdResponseHeader contains the cluster-level metadata from an etcd response.
+type etcdResponseHeader struct {
+	ClusterID uint64 `json:"cluster_id"`
+}
+
+// etcdMember represents a single member in an etcd cluster.
+type etcdMember struct {
+	ID         uint64   `json:"ID"`
+	Name       string   `json:"name"`
+	PeerURLs   []string `json:"peerURLs"`
+	ClientURLs []string `json:"clientURLs"`
+}
+
+// parseEtcdMemberList parses the JSON output of etcdctl member list -w json.
+func parseEtcdMemberList(jsonOutput string) (*etcdMemberListResponse, error) {
+	var response etcdMemberListResponse
+	if err := json.Unmarshal([]byte(jsonOutput), &response); err != nil {
+		return nil, fmt.Errorf("failed to parse etcdctl member list output: %w", err)
+	}
+	return &response, nil
+}
+
+// VerifyEtcdClusterHealth verifies that all etcd members form a single cluster
+// after a snapshot restore. This detects split-brain scenarios where each member
+// starts as an independent 1-member cluster due to missing --name/--initial-cluster/
+// --initial-cluster-token flags during snapshot restore.
+func VerifyEtcdClusterHealth(ctx context.Context, logger logr.Logger, mgmtClient crclient.Client, cpNamespace string) error {
+	etcdSts := cpomanifests.EtcdStatefulSet(cpNamespace)
+	if err := mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(etcdSts), etcdSts); err != nil {
+		return fmt.Errorf("failed to get etcd StatefulSet: %w", err)
+	}
+	expectedReplicas := ptr.Deref(etcdSts.Spec.Replicas, 1)
+
+	ep := fmt.Sprintf("https://etcd-client.%s.svc:2379", cpNamespace)
+	command := []string{
+		"/bin/sh", "-c",
+		fmt.Sprintf("/usr/bin/etcdctl --cacert=/etc/etcd/tls/etcd-ca/ca.crt --cert=/etc/etcd/tls/server/server.crt --key=/etc/etcd/tls/server/server.key --endpoints=%s member list -w json 2>/dev/null", ep),
+	}
+
+	stdout, err := e2eutil.RunCommandInPod(ctx, mgmtClient, "etcd", cpNamespace, command, "etcd", 5*time.Minute)
+	if err != nil {
+		return fmt.Errorf("failed to run etcdctl member list: %w", err)
+	}
+
+	result, err := parseEtcdMemberList(stdout)
+	if err != nil {
+		return err
+	}
+
+	if int32(len(result.Members)) != expectedReplicas {
+		return fmt.Errorf("expected %d etcd members but found %d; this may indicate a split-brain cluster where each member started as an independent 1-member cluster",
+			expectedReplicas, len(result.Members))
+	}
+
+	for _, member := range result.Members {
+		if member.Name == "" {
+			return fmt.Errorf("etcd member %d has no name, indicating it has not fully started", member.ID)
+		}
+		if len(member.PeerURLs) == 0 {
+			return fmt.Errorf("etcd member %s has no peer URLs", member.Name)
+		}
+	}
+
+	logger.Info("etcd cluster health verified: all members form a single cluster",
+		"memberCount", len(result.Members),
+		"clusterID", result.Header.ClusterID)
+
+	return nil
+}
+
 
 // etcdInitLogResult holds the results of parsing etcd-init container logs.
 type etcdInitLogResult struct {

--- a/test/e2e/v2/backuprestore/etcd_snapshot_test.go
+++ b/test/e2e/v2/backuprestore/etcd_snapshot_test.go
@@ -3,6 +3,7 @@
 package backuprestore
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -35,8 +36,8 @@ func TestParseEtcdInitLogs(t *testing.T) {
 			lineCount:        9,
 		},
 		{
-			name: "When data directory is not empty it should detect restore was skipped",
-			logs: `/var/lib/data not empty, not restoring snapshot`,
+			name:             "When data directory is not empty it should detect restore was skipped",
+			logs:             `/var/lib/data not empty, not restoring snapshot`,
 			restoreStarted:   false,
 			restoreCompleted: false,
 			restoreSkipped:   true,
@@ -83,12 +84,91 @@ func TestParseEtcdInitLogs(t *testing.T) {
 	}
 }
 
+func TestParseEtcdMemberList(t *testing.T) {
+	tests := []struct {
+		name            string
+		jsonOutput      string
+		expectedMembers int
+		expectedErr     bool
+	}{
+		{
+			name: "When etcd member list returns a healthy 3-member cluster it should parse all members",
+			jsonOutput: `{"header":{"cluster_id":12345678901234567},"members":[` +
+				`{"ID":1,"name":"etcd-0","peerURLs":["https://etcd-0.etcd-discovery.ns.svc:2380"],"clientURLs":["https://etcd-0.etcd-discovery.ns.svc:2379"]},` +
+				`{"ID":2,"name":"etcd-1","peerURLs":["https://etcd-1.etcd-discovery.ns.svc:2380"],"clientURLs":["https://etcd-1.etcd-discovery.ns.svc:2379"]},` +
+				`{"ID":3,"name":"etcd-2","peerURLs":["https://etcd-2.etcd-discovery.ns.svc:2380"],"clientURLs":["https://etcd-2.etcd-discovery.ns.svc:2379"]}]}`,
+			expectedMembers: 3,
+			expectedErr:     false,
+		},
+		{
+			name: "When etcd member list returns a single member it should parse one member (possible split brain)",
+			jsonOutput: `{"header":{"cluster_id":99999},"members":[` +
+				`{"ID":1,"name":"etcd-0","peerURLs":["https://etcd-0.etcd-discovery.ns.svc:2380"],"clientURLs":["https://etcd-0.etcd-discovery.ns.svc:2379"]}]}`,
+			expectedMembers: 1,
+			expectedErr:     false,
+		},
+		{
+			name:            "When etcd member list returns empty JSON object it should parse zero members",
+			jsonOutput:      `{"header":{"cluster_id":0},"members":[]}`,
+			expectedMembers: 0,
+			expectedErr:     false,
+		},
+		{
+			name:            "When etcd member list returns invalid JSON it should return an error",
+			jsonOutput:      `not json`,
+			expectedMembers: 0,
+			expectedErr:     true,
+		},
+		{
+			name: "When etcd member list returns a member without a name it should parse it with empty name",
+			jsonOutput: `{"header":{"cluster_id":12345},"members":[` +
+				`{"ID":1,"name":"","peerURLs":["https://etcd-0.etcd-discovery.ns.svc:2380"],"clientURLs":[]}]}`,
+			expectedMembers: 1,
+			expectedErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result, err := parseEtcdMemberList(tt.jsonOutput)
+			if tt.expectedErr {
+				g.Expect(err).To(HaveOccurred(), "expected parsing error")
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(result.Members).To(HaveLen(tt.expectedMembers), "member count mismatch")
+		})
+	}
+}
+
+func TestParseEtcdMemberListFields(t *testing.T) {
+	g := NewWithT(t)
+	jsonOutput := `{"header":{"cluster_id":12345678901234567},"members":[` +
+		`{"ID":1,"name":"etcd-0","peerURLs":["https://etcd-0.etcd-discovery.ns.svc:2380"],"clientURLs":["https://etcd-0.etcd-discovery.ns.svc:2379"]},` +
+		`{"ID":2,"name":"etcd-1","peerURLs":["https://etcd-1.etcd-discovery.ns.svc:2380"],"clientURLs":["https://etcd-1.etcd-discovery.ns.svc:2379"]},` +
+		`{"ID":3,"name":"etcd-2","peerURLs":["https://etcd-2.etcd-discovery.ns.svc:2380"],"clientURLs":["https://etcd-2.etcd-discovery.ns.svc:2379"]}]}`
+
+	result, err := parseEtcdMemberList(jsonOutput)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Header.ClusterID).To(Equal(uint64(12345678901234567)), "cluster ID mismatch")
+	g.Expect(result.Members).To(HaveLen(3))
+
+	for i, expectedName := range []string{"etcd-0", "etcd-1", "etcd-2"} {
+		g.Expect(result.Members[i].Name).To(Equal(expectedName), "member %d name mismatch", i)
+		expectedPeerURL := fmt.Sprintf("https://%s.etcd-discovery.ns.svc:2380", expectedName)
+		expectedClientURL := fmt.Sprintf("https://%s.etcd-discovery.ns.svc:2379", expectedName)
+		g.Expect(result.Members[i].PeerURLs).To(Equal([]string{expectedPeerURL}), "member %d peer URL mismatch", i)
+		g.Expect(result.Members[i].ClientURLs).To(Equal([]string{expectedClientURL}), "member %d client URL mismatch", i)
+	}
+}
+
 func TestMatchesHCPEtcdBackupName(t *testing.T) {
 	tests := []struct {
-		name               string
-		hcpEtcdBackupName  string
-		oadpBackupName     string
-		expectedMatch      bool
+		name              string
+		hcpEtcdBackupName string
+		oadpBackupName    string
+		expectedMatch     bool
 	}{
 		{
 			name:              "When HCPEtcdBackup name matches the oadp pattern it should return true",

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -641,5 +641,12 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 			}).WithPolling(backuprestore.PollInterval).WithTimeout(backuprestore.RestoreTimeout).Should(Succeed())
 			GinkgoWriter.Printf("RestoreSnapshotURL is set on HostedCluster\n")
 		})
+
+		It("should have all etcd members in a single cluster after restore", Label(internal.InformingLabel), func() {
+			By("Verifying all etcd members form a single cluster (no split brain)")
+			err := backuprestore.VerifyEtcdClusterHealth(testCtx.Context, GinkgoLogr.WithName("etcd-cluster-health"), testCtx.MgmtClient, testCtx.ControlPlaneNamespace)
+			Expect(err).NotTo(HaveOccurred(), "all etcd members should form a single cluster after restore")
+		})
+
 	})
 })


### PR DESCRIPTION
## What this PR does / why we need it:

Adds an E2E test that verifies etcd cluster membership coherence after a snapshot restore, guarding against the split-brain regression from OCPBUGS-99534.

After restore, the test execs `etcdctl member list` into an etcd pod and verifies the member count matches the expected StatefulSet replicas. In a split-brain scenario (where each member starts as an independent 1-member cluster due to missing `--name`/`--initial-cluster`/`--initial-cluster-token` flags), member list would show only 1 member instead of the expected 3.

**Why existing conditions are not sufficient**: `EtcdAvailable=True` is determined by `sts.Status.ReadyReplicas >= quorum` in `etcdStatefulSetCondition` — it only checks StatefulSet readiness. In a split-brain, each pod is individually Ready (it is a functioning 1-member cluster), so `EtcdAvailable` stays True despite the cluster being broken.

### Changes:
- `test/e2e/v2/backuprestore/etcd_snapshot.go`: Add `VerifyEtcdClusterHealth` helper with `parseEtcdMemberList` JSON parser
- `test/e2e/v2/backuprestore/etcd_snapshot_test.go`: Add unit tests for parsing logic and field mapping verification
- `test/e2e/v2/tests/backup_restore_test.go`: Add E2E spec in the etcd snapshot restore post-restore phase

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3880](https://redhat.atlassian.net/browse/CNTRLPLANE-3880)

## Special notes for your reviewer:

This guards against regression of the fixes in [#9048](https://github.com/openshift/hypershift/pull/9048) (OCPBUGS-99534). The test runs as part of the existing `BackupRestoreEtcdSnapshot` ordered test suite with build tags `e2ev2,backuprestore`.

The CrashLoopBackOff check was removed per reviewer feedback — that scenario is already covered by `EtcdAvailable` condition checks in the existing post-restore validation.

A follow-up to surface cluster membership as an operator condition (e.g. `EtcdClusterCoherent`) could replace the `etcdctl` exec approach long-term.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

---

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added post-restore validation to confirm the etcd cluster has the expected members, consistent peer connections, and a single-cluster configuration.
  * Improved detection of unhealthy restores, including split-brain cluster conditions.

* **Tests**
  * Expanded coverage for parsing etcd member data, including cluster IDs, member names, URLs, invalid responses, and empty-member scenarios.
  * Added end-to-end validation of etcd health after restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->