### PR TITLE
OCPBUGS-112450: introduce e2e v2 linting rules and enforcement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ lint-fix: generate $(HYPERSHIFTLINTER_PLUGIN)
 
 .PHONY: hypershift-lint-all
 hypershift-lint-all: $(GOLANGCI_LINT) $(HYPERSHIFTLINTER_PLUGIN)
-	$(GOLANGCI_LINT) run --config ./.golangci.yml --modules-download-mode=readonly -v --enable-only hypershiftlinter --build-tags e2ev2
+	$(GOLANGCI_LINT) run --config ./.golangci.yml --modules-download-mode=readonly -v --enable-only hypershiftlinter --build-tags e2ev2,backuprestore
 
 .PHONY: test-linter
 test-linter:

--- a/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/e2eutilallowlist.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/e2eutilallowlist.go
@@ -1,0 +1,165 @@
+package e2eutilallowlist
+
+import (
+	"fmt"
+	"go/ast"
+	"strings"
+
+	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/pathutil"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "e2eutilallowlist",
+	Doc:  "restricts test/e2e/v2 files to a allowlist of approved symbols from test/e2e/util",
+	Run:  run,
+}
+
+// allowlist maps package path to set of allowed symbol names.
+var allowlist = map[string]map[string]bool{
+	"github.com/openshift/hypershift/test/e2e/util": {
+		// Condition/predicate helpers
+		"Condition":                    true,
+		"ConditionPredicate":           true,
+		"Conditions":                   true,
+		"EventuallyNotFound":           true,
+		"EventuallyObject":             true,
+		"EventuallyObjects":            true,
+		"Matches":                      true,
+		"MatchesLeaderElectionFailure": true,
+		"OSImageStreamPredicate":       true,
+		"Predicate":                    true,
+		"Reason":                       true,
+		"Status":                       true,
+		"String":                       true,
+		"Type":                         true,
+		"WithClientOptions":            true,
+		"WithInterval":                 true,
+		"WithTimeout":                  true,
+
+		// Client helpers
+		"GetClient":    true,
+		"GetConfig":    true,
+		"UpdateObject": true,
+
+		// Wait/rollout helpers
+		"WaitForControlPlaneComponentRollout":             true,
+		"WaitForControlPlaneRollout":                      true,
+		"WaitForDataPlaneRollout":                         true,
+		"WaitForGuestKubeConfig":                          true,
+		"WaitForNReadyNodesWithOptions":                   true,
+		"WaitForNodePoolConfigUpdateCompleteWithPlatform": true,
+		"WaitForReadyNodesByNodePool":                     true,
+
+		// Cloud provider helpers
+		"GetDefaultSecurityGroup": true,
+		"PutRolePolicy":           true,
+
+		// Utility helpers
+		"ExtractVersionFromReleaseImage": true,
+		"GenerateName":                   true,
+		"HasFieldInCRDSchema":            true,
+		"RunCommandInPod":                true,
+		"SimpleNameGenerator":            true,
+
+		// Validation helpers
+		"ValidateAzureWorkloadIdentityWebhookMutation":     true,
+		"ValidateIngressOperatorConfiguration":             true,
+		"ValidateKubeAPIServerAllowedCIDRs":                true,
+		"ValidateOAuthWithIdentityProviderViaLoadBalancer": true,
+
+		// OIDC helpers
+		"CliClientID":              true,
+		"ConsoleClientID":          true,
+		"ConsoleClientSecretName":  true,
+		"ConsoleClientSecretValue": true,
+		"ExtOIDCConfig":            true,
+		"ExternalOIDCProvider":     true,
+		"GetAuthenticationConfig":  true,
+		"GroupPrefix":              true,
+		"IssuerCAConfigmapName":    true,
+		"IssuerURL":                true,
+		"OIDCProviderName":         true,
+		"ProviderKeycloak":         true,
+		"TestUsers":                true,
+		"UserPrefix":               true,
+	},
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	for _, file := range pass.Files {
+		filename := pass.Fset.File(file.Pos()).Name()
+		if !pathutil.IsV2E2ETest(filename) {
+			continue
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			ident, ok := n.(*ast.Ident)
+			if !ok {
+				return true
+			}
+
+			// Skip blank identifiers
+			if ident.Name == "_" {
+				return true
+			}
+
+			// Look up the resolved object for this identifier
+			obj := pass.TypesInfo.Uses[ident]
+			if obj == nil {
+				return true
+			}
+
+			// Skip non-package-level objects
+			if obj.Pkg() == nil {
+				return true
+			}
+
+			pkgPath := obj.Pkg().Path()
+			const utilPkgPath = "github.com/openshift/hypershift/test/e2e/util"
+			if pkgPath != utilPkgPath && !strings.HasPrefix(pkgPath, utilPkgPath+"/") {
+				return true
+			}
+
+			// Check if this symbol is in the allowlist
+			if isAllowed(pkgPath, obj.Name()) {
+				return true
+			}
+
+			// Report diagnostic
+			pass.Report(analysis.Diagnostic{
+				Pos: ident.Pos(),
+				End: ident.End(),
+				Message: fmt.Sprintf(
+					"reference to %s.%s is not allowed from test/e2e/v2; add it to the e2eutilallowlist allowlist or refactor to remove the dependency",
+					pkgPath,
+					obj.Name(),
+				),
+			})
+			return true
+		})
+	}
+	return nil, nil
+}
+
+// isAllowed checks whether a symbol is in the allowlist for its package.
+func isAllowed(pkgPath string, symbolName string) bool {
+	allowed, ok := allowlist[pkgPath]
+	if !ok {
+		return false
+	}
+
+	// Explicit match
+	if allowed[symbolName] {
+		return true
+	}
+
+	// Allow Version* prefix for future version constants
+	if pkgPath == "github.com/openshift/hypershift/test/e2e/util" &&
+		strings.HasPrefix(symbolName, "Version") {
+		return true
+	}
+
+	return false
+}

--- a/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/e2eutilallowlist_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/e2eutilallowlist_test.go
@@ -1,0 +1,75 @@
+package e2eutilallowlist
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{
+			name:    "When symbols are in the allowlist, it should produce no diagnostics",
+			pattern: "test/e2e/v2/good",
+		},
+		{
+			name:    "When symbols are not in the allowlist, it should produce diagnostics including for aliased imports",
+			pattern: "test/e2e/v2/bad",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			analysistest.Run(t, testdata, Analyzer, tt.pattern)
+		})
+	}
+}
+
+func TestIsAllowed(t *testing.T) {
+	const utilPkg = "github.com/openshift/hypershift/test/e2e/util"
+
+	tests := []struct {
+		name       string
+		pkgPath    string
+		symbolName string
+		want       bool
+	}{
+		{
+			name:       "When symbol is explicitly allowlisted, it should be allowed",
+			pkgPath:    utilPkg,
+			symbolName: "GetConfig",
+			want:       true,
+		},
+		{
+			name:       "When symbol has Version prefix, it should be allowed via wildcard",
+			pkgPath:    utilPkg,
+			symbolName: "VersionFuture",
+			want:       true,
+		},
+		{
+			name:       "When symbol is not in the allowlist, it should not be allowed",
+			pkgPath:    utilPkg,
+			symbolName: "IsLessThan",
+			want:       false,
+		},
+		{
+			name:       "When package is unknown, it should not be allowed",
+			pkgPath:    "github.com/other/pkg",
+			symbolName: "GetConfig",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAllowed(tt.pkgPath, tt.symbolName); got != tt.want {
+				t.Errorf("isAllowed(%q, %q) = %v, want %v", tt.pkgPath, tt.symbolName, got, tt.want)
+			}
+		})
+	}
+}

--- a/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/testdata/src/github.com/openshift/hypershift/test/e2e/util/util.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/testdata/src/github.com/openshift/hypershift/test/e2e/util/util.go
@@ -1,0 +1,32 @@
+package util
+
+var (
+	Version414 = "4.14"
+	Version51  = "5.1"
+)
+
+type Predicate[T any] func(T) (bool, string, error)
+
+func GetConfig() (any, error) {
+	return nil, nil
+}
+
+func IsLessThan(a, b string) bool {
+	return a < b
+}
+
+func AtLeast(a, b string) bool {
+	return a >= b
+}
+
+func IsGreaterThanOrEqualTo(a, b string) bool {
+	return a >= b
+}
+
+func SetReleaseImageVersion() error {
+	return nil
+}
+
+func ShouldRunKarpenterTests() bool {
+	return true
+}

--- a/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/testdata/src/test/e2e/v2/bad/bad_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/testdata/src/test/e2e/v2/bad/bad_test.go
@@ -1,0 +1,23 @@
+package bad
+
+import (
+	"testing"
+
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	v "github.com/openshift/hypershift/test/e2e/util"
+)
+
+func TestDisallowedSymbols(t *testing.T) {
+	_ = e2eutil.IsLessThan("4.14", "4.23") // want `reference to github.com/openshift/hypershift/test/e2e/util.IsLessThan is not allowed from test/e2e/v2; add it to the e2eutilallowlist allowlist or refactor to remove the dependency`
+
+	_ = e2eutil.AtLeast("4.23", "4.14") // want `reference to github.com/openshift/hypershift/test/e2e/util.AtLeast is not allowed from test/e2e/v2; add it to the e2eutilallowlist allowlist or refactor to remove the dependency`
+
+	_ = e2eutil.IsGreaterThanOrEqualTo("4.23", "4.14") // want `reference to github.com/openshift/hypershift/test/e2e/util.IsGreaterThanOrEqualTo is not allowed from test/e2e/v2; add it to the e2eutilallowlist allowlist or refactor to remove the dependency`
+
+	_ = e2eutil.SetReleaseImageVersion() // want `reference to github.com/openshift/hypershift/test/e2e/util.SetReleaseImageVersion is not allowed from test/e2e/v2; add it to the e2eutilallowlist allowlist or refactor to remove the dependency`
+
+	_ = e2eutil.ShouldRunKarpenterTests() // want `reference to github.com/openshift/hypershift/test/e2e/util.ShouldRunKarpenterTests is not allowed from test/e2e/v2; add it to the e2eutilallowlist allowlist or refactor to remove the dependency`
+
+	// Aliased import: proves the analyzer resolves through aliases
+	_ = v.IsLessThan("4.14", "4.23") // want `reference to github.com/openshift/hypershift/test/e2e/util.IsLessThan is not allowed from test/e2e/v2; add it to the e2eutilallowlist allowlist or refactor to remove the dependency`
+}

--- a/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/testdata/src/test/e2e/v2/good/good_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/testdata/src/test/e2e/v2/good/good_test.go
@@ -1,0 +1,18 @@
+package good
+
+import (
+	"testing"
+
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+)
+
+func TestAllowedSymbols(t *testing.T) {
+	_, _ = e2eutil.GetConfig()
+
+	v414 := e2eutil.Version414
+	v51 := e2eutil.Version51
+	_ = v414
+	_ = v51
+
+	_ = e2eutil.Predicate[string](nil)
+}

--- a/hack/tools/hypershiftlinter/analyzers/ipv6url/ipv6url.go
+++ b/hack/tools/hypershiftlinter/analyzers/ipv6url/ipv6url.go
@@ -5,6 +5,7 @@ import (
 	"go/token"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/pathutil"
 
@@ -17,7 +18,12 @@ var Analyzer = &analysis.Analyzer{
 	Run:  run,
 }
 
-var hostPortPattern = regexp.MustCompile(`%s:%[dvs]`)
+var (
+	// %s:%d and %s:%v are almost always host:port (ports are numeric).
+	hostPortNumeric = regexp.MustCompile(`%s:%[dv]`)
+	// %s:%s is only host:port when there is URL context (scheme prefix).
+	hostPortStringWithScheme = regexp.MustCompile(`://%s:%s`)
+)
 
 func run(pass *analysis.Pass) (any, error) {
 	for _, file := range pass.Files {
@@ -56,7 +62,16 @@ func run(pass *analysis.Pass) (any, error) {
 				return true
 			}
 
-			match := hostPortPattern.FindString(formatStr)
+			// Strip escaped percent signs so %%s:%d (literal %s, not a format verb) is not matched.
+			stripped := strings.ReplaceAll(formatStr, "%%", "")
+
+			match := hostPortNumeric.FindString(stripped)
+			if match == "" {
+				match = hostPortStringWithScheme.FindString(stripped)
+				if match != "" {
+					match = "%s:%s"
+				}
+			}
 			if match != "" {
 				pass.Report(analysis.Diagnostic{
 					Pos:     call.Pos(),

--- a/hack/tools/hypershiftlinter/analyzers/ipv6url/testdata/src/test/e2e/v2/good/good.go
+++ b/hack/tools/hypershiftlinter/analyzers/ipv6url/testdata/src/test/e2e/v2/good/good.go
@@ -42,3 +42,16 @@ func TestErrorfNoHostPort() {
 	err := fmt.Errorf("failed to connect: %s", "timeout")
 	_ = err
 }
+
+// Valid: %s:%s without URL scheme is not host:port (e.g. user:password)
+func TestUserPasswordNotHostPort() {
+	creds := fmt.Sprintf("%s:%s", "admin", "secret")
+	_ = creds
+}
+
+// Valid: %%s is an escaped percent producing literal %s, not a format verb
+func TestEscapedPercentNotHostPort() {
+	port := 8080
+	url := fmt.Sprintf("https://%%s:%d", port)
+	_ = url
+}

--- a/hack/tools/hypershiftlinter/plugin.go
+++ b/hack/tools/hypershiftlinter/plugin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/contextbackground"
+	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/guestcluster"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/ipv6url"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/sippyannotation"
@@ -65,6 +66,7 @@ func allAnalyzers() []*analysis.Analyzer {
 		contextbackground.Analyzer,
 		vacuouspass.Analyzer,
 		ipv6url.Analyzer,
+		e2eutilallowlist.Analyzer,
 	}
 }
 

--- a/test/e2e/v2/backuprestore/cli_test.go
+++ b/test/e2e/v2/backuprestore/cli_test.go
@@ -3,7 +3,6 @@
 package backuprestore
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -535,7 +534,7 @@ func TestRunFixDrOidcIamValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// RunFixDrOidcIam will fail at validation before reaching CLI lookup
-			err := RunFixDrOidcIam(context.Background(), logr.Discard(), "/tmp/artifacts", tt.opts)
+			err := RunFixDrOidcIam(t.Context(), logr.Discard(), "/tmp/artifacts", tt.opts)
 			if err == nil {
 				t.Fatalf("expected error containing %q, got nil", tt.expectedErr)
 			}

--- a/test/e2e/v2/internal/test_context.go
+++ b/test/e2e/v2/internal/test_context.go
@@ -180,6 +180,18 @@ func (tc *TestContext) SkipIfPlatform(platforms ...hyperv1.PlatformType) {
 	}
 }
 
+// SkipIfWorkloadUnsupportedForVersion skips the test if the workload is incompatible
+// with the hosted cluster according to ShouldSkipWorkloadForVersion. Fails the test
+// if the HostedCluster cannot be fetched.
+func (tc *TestContext) SkipIfWorkloadUnsupportedForVersion(workload WorkloadSpec) {
+	GinkgoHelper()
+	version, err := tc.GetHostedClusterVersion()
+	Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster version for %s/%s", tc.ClusterNamespace, tc.ClusterName)
+	if ShouldSkipWorkloadForVersion(workload, version) {
+		Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
+	}
+}
+
 var testCtx *TestContext
 
 func GetTestContext() *TestContext {

--- a/test/e2e/v2/internal/workload_registry.go
+++ b/test/e2e/v2/internal/workload_registry.go
@@ -16,7 +16,6 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/podspec"
-	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -519,13 +518,10 @@ func ShouldSkipWorkloadForPlatform(workload WorkloadSpec, hostedCluster *hyperv1
 	return false
 }
 
-// ShouldSkipWorkloadForVersion determines whether the workload should be skipped
-// based on the cluster version exceeding the workload's MaxVersion.
-func ShouldSkipWorkloadForVersion(workload WorkloadSpec) bool {
-	if workload.MaxVersion != nil && e2eutil.IsGreaterThanOrEqualTo(*workload.MaxVersion) {
-		return true
-	}
-	return false
+// ShouldSkipWorkloadForVersion determines whether the workload should be skipped.
+// Returns true if the cluster version is at or above the workload's MaxVersion.
+func ShouldSkipWorkloadForVersion(workload WorkloadSpec, hcVersion semver.Version) bool {
+	return workload.MaxVersion != nil && hcVersion.GE(*workload.MaxVersion)
 }
 
 // validateControlPlaneWorkloadsByType validates control plane workloads of specified types.
@@ -536,11 +532,15 @@ func validateControlPlaneWorkloadsByType(testCtx *TestContext, workloadTypes []s
 	if err != nil {
 		return fmt.Errorf("failed to get HostedCluster: %w", err)
 	}
+	version, err := testCtx.GetHostedClusterVersion()
+	if err != nil {
+		return fmt.Errorf("failed to get HostedCluster version: %w", err)
+	}
 	for _, workload := range workloads {
 		if ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 			continue
 		}
-		if ShouldSkipWorkloadForVersion(workload) {
+		if ShouldSkipWorkloadForVersion(workload, version) {
 			continue
 		}
 		if !slices.Contains(workloadTypes, workload.Type) {

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -82,9 +82,7 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 
 					deployment := &appsv1.Deployment{}
 					err = testCtx.MgmtClient.Get(testCtx.Context, crclient.ObjectKey{
@@ -139,9 +137,7 @@ func SafeToEvictAnnotationsTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 
 					// Skip if workload is in exemption list
 					if slices.Contains(exemptions, workload.Name) {
@@ -238,9 +234,7 @@ func ReadOnlyRootFilesystemTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 
 					// Skip if workload is in exemption list
 					if slices.Contains(exemptions, workload.Name) {
@@ -315,9 +309,7 @@ func ReadOnlyRootFilesystemTmpDirMountTest(getTestCtx internal.TestContextGetter
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 
 					// Skip if workload is in exemption list
 					if slices.Contains(exemptions, workload.Name) {
@@ -361,9 +353,7 @@ func ContainerImagePullPolicyTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 
 					pods := getWorkloadPods(testCtx, workload)
 					if len(pods) == 0 {
@@ -415,9 +405,7 @@ func ContainerTerminationMessagePolicyTest(getTestCtx internal.TestContextGetter
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 
 					// Skip if workload is in exemption list
 					if slices.Contains(exemptions, workload.Name) {
@@ -461,9 +449,7 @@ func ContainerResourceRequestsTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 
 					pods := getWorkloadPods(testCtx, workload)
 					if len(pods) == 0 {
@@ -502,9 +488,7 @@ func PodPriorityTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 
 					pods := getWorkloadPods(testCtx, workload)
 					if len(pods) == 0 {
@@ -582,9 +566,7 @@ func ServiceAccountTokenMountingTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 
 					if slices.Contains(exemptions, workload.Name) {
 						Skip(fmt.Sprintf("workload %s is exempt from service account token mounting check", workload.Name))
@@ -627,9 +609,7 @@ func PodAffinitiesAndTolerationsTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 
 					// SRO is being removed in 4.18
 					if workload.Name == "shared-resource-csi-driver-operator" {
@@ -831,9 +811,7 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 
 					// Skip if workload is in exemption list
 					if slices.Contains(exemptions, workload.Name) {
@@ -939,9 +917,7 @@ func NoCrashingPodsTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 
 					pods := getWorkloadPods(testCtx, workload)
 					if len(pods) == 0 {
@@ -1019,9 +995,7 @@ func CustomLabelsTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 					if slices.Contains(exemptions, workload.Name) {
 						Skip(fmt.Sprintf("workload %s is exempt from custom labels check", workload.Name))
 					}
@@ -1062,9 +1036,7 @@ func CustomTolerationsTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
-						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
-					}
+					testCtx.SkipIfWorkloadUnsupportedForVersion(workload)
 					if slices.Contains(exemptions, workload.Name) {
 						Skip(fmt.Sprintf("workload %s is exempt from custom tolerations check", workload.Name))
 					}

--- a/test/e2e/v2/tests/hosted_cluster_azure_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_azure_test.go
@@ -236,14 +236,12 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			Expect(controlPlaneNamespace).NotTo(BeEmpty(), "control plane namespace must be set")
 
 			DeferCleanup(func() {
-				// Use context.Background() because DeferCleanup runs after the test completes,
-				// when testCtx.Context may already be canceled.
 				freshHC, err := testCtx.GetHostedCluster()
 				if err != nil {
 					GinkgoTB().Logf("WARNING: failed to fetch HostedCluster for cleanup: %v", err)
 					return
 				}
-				restoreErr := e2eutil.UpdateObject(GinkgoTB(), context.Background(), testCtx.MgmtClient, freshHC, func(obj *hyperv1.HostedCluster) {
+				restoreErr := e2eutil.UpdateObject(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, freshHC, func(obj *hyperv1.HostedCluster) {
 					obj.Spec.Platform.Azure.Topology = hyperv1.AzureTopologyPrivate
 				})
 				if restoreErr != nil {

--- a/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tests
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -117,7 +116,7 @@ func KMSFunctionalValidationTest(getTestCtx internal.TestContextGetter) {
 				"failed to create test secret in hosted cluster")
 
 			DeferCleanup(func() {
-				if err := hostedClusterClient.Delete(context.Background(), testSecret); err != nil && !apierrors.IsNotFound(err) {
+				if err := hostedClusterClient.Delete(ctx, testSecret); err != nil && !apierrors.IsNotFound(err) {
 					GinkgoWriter.Printf("WARNING: failed to cleanup test secret: %v\n", err)
 				}
 			})


### PR DESCRIPTION
The e2e v2 test packages are reusing v1 utility code from the `test/e2e/util` package. Not all v1 e2e test utility code is safe to use in v2 framework code. For example, any function which refers to `util.releaseVersion` (e.g. `AtLeast`) will silently have broken / unexpected behavior if called from a v2 test. Because the v1 packages are all exported for use by v2 tests, this becomes an ongoing source of subtle mistakes that require constant manual review to catch.

This commit draws a hard line between v1 and v2 testing code by expanding the new hypershift linter to include the v2 e2e packages during linting and add a new `e2eutilallowlist` analyzer which defines an allowlist of `test/e2e/util` package symbols which are considered safe to use by v2 testing code.

This helps us by:

1. Automatically preventing known incompatible functions from ever being used again
2. Inducing an intentional audit of any new coupling between v2 and v1 utility code going forward
3. Providing a comprehensive map of v1 code which should be incrementally migrated to v2 packages
4. Enabling us to easily deny any symbols later discovered to be incompatible (which is still possible)

This commit fixes existing violations and also fixes a small false-positive bug in the `ipv6url` analyzer so that all e2e code passes linting.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added lint checks to prevent unauthorized end-to-end utility usage.
  * Added automatic skipping for workloads unsupported by the hosted cluster version.

* **Bug Fixes**
  * Improved IPv6 URL detection to reduce false-positive warnings.
  * Improved end-to-end test cleanup and context handling.

* **Tests**
  * Expanded lint coverage for allowed and disallowed utility references.
  * Linting now covers both end-to-end and backup/restore test suites.
  * Improved workload version validation and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->