### PR TITLE
CNTRLPLANE-4115: fix(ci): report actionable cause when /rebase push hits workflow files

### DIFF
--- a/.github/workflows/reusable-claude-on-pr.yaml
+++ b/.github/workflows/reusable-claude-on-pr.yaml
@@ -161,15 +161,39 @@ jobs:
       - name: Push changes
         env:
           GH_TOKEN: ${{ github.token }}
-          PUSH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          PUSH_TOKEN: ${{ steps.app-token.outputs.token || secrets.REBASE_PUSH_TOKEN || github.token }}
           PR_REPO: ${{ steps.pr.outputs.repo }}
           PR_BRANCH: ${{ steps.pr.outputs.branch }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
           git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${PR_REPO}.git"
-          if ! git -c core.hooksPath=/dev/null push --force-with-lease origin "HEAD:${PR_BRANCH}" 2>&1; then
-            gh pr comment "$PR_NUMBER" --repo "$REPO" \
-              --body "⚠️ The operation succeeded locally but the push failed. If this is a fork PR, please enable **Allow edits from maintainers** and retry."
+          if git -c core.hooksPath=/dev/null push --force-with-lease origin "HEAD:${PR_BRANCH}" >/tmp/push.log 2>&1; then
+            cat /tmp/push.log
+            exit 0
+          fi
+          cat /tmp/push.log
+
+          # Neither GITHUB_TOKEN nor a token lacking workflow scope may push commits touching
+          # .github/workflows/, even when those commits come from upstream main rather than the
+          # PR itself. Syncing the fork's default branch makes them already-present, so the next
+          # push carries only PR commits. GitHub words this rejection differently per credential
+          # type ("workflows permission" for app tokens, "workflow scope" for PATs).
+          if grep -qiE 'refusing to allow .* to create or update workflow' /tmp/push.log; then
+            cat >/tmp/push-comment.md <<'EOF'
+          ⚠️ The operation succeeded locally, but the push was rejected by GitHub.
+
+          Your fork is missing workflow files that were added to `main`. Rebasing pulls those
+          commits into your branch, and the bot's token is not permitted to push files under
+          `.github/workflows/` into your fork.
+
+          **To unblock:** open your fork, switch to the `main` branch, click **Sync fork**,
+          then comment `/rebase` again.
+          EOF
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/push-comment.md
             exit 1
           fi
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "⚠️ The operation succeeded locally but the push failed. If this is a fork PR, please enable **Allow edits from maintainers** and retry."
+          exit 1


### PR DESCRIPTION
## Problem

`/rebase` is still broken. The revert in #9329 only undid the invalid `workflows: write` key from #9323 (which had made `rebase.yaml` unparseable for *every* PR). It never addressed the original failure.

There has been no successful `Rebase PR` run since **Aug 14**. Two runs since the revert both failed at **Push changes**:

- [run 32287597434](https://github.com/openshift/hypershift/actions/runs/32287597434) (Aug 19)
- [run 32322103135](https://github.com/openshift/hypershift/actions/runs/32322103135) (Aug 20, PR #8966, fork `vsolanki12/hypershift`)

```
! [remote rejected] HEAD -> vsolanki/cntrlplane-3532-tier2-optimistic-lock
(refusing to allow a GitHub App to create or update workflow
`.github/workflows/restructure-commits.yaml` without `workflows` permission)
```

The rebase itself succeeds cleanly — only the push is rejected.

## Root cause

`Push changes` uses `GITHUB_TOKEN` for every fork except `hypershift-community/hypershift`. GitHub never permits `GITHUB_TOKEN` to push commits that create or update files under `.github/workflows/`. There is no `workflows` scope in the `permissions:` block, which is why #9323 could not have worked.

This triggers whenever `main` gains a workflow file the contributor's fork does not have yet. The bot is not editing the file — rebasing simply drags those `main` commits underneath the branch, and the push then introduces them into the fork.

## Changes

**1. Report the real cause.** The comment previously blamed *"Allow edits from maintainers"*, which is not the cause and dead-ends the author. It now detects this specific rejection and points to the fix: sync the fork's default branch. Once the fork already contains those commits, a subsequent push carries only the PR's own commits and is accepted. Other push failures keep the existing message.

**2. Pre-wire an optional `REBASE_PUSH_TOKEN`.** A classic PAT with `repo` + `workflow` scopes is the only credential that can push workflow files into a contributor's fork — a GitHub App cannot be installed on personal forks, and fine-grained PATs cannot be scoped to another user's repo. The expression falls through to today's behaviour while the secret is unset, so this is inert until an admin configures it. `PUSH_TOKEN` stays scoped to this step, preserving the isolation from #9214.

## Validation

- Extracted the `run:` script and executed it under `bash -e` with stubbed `git`/`gh` for all three paths: push succeeds (exit 0), workflow rejection (new comment), other failure (original comment).
- `actionlint` reports 6 findings before and after — all pre-existing, none in the changed step.
- Pre-commit hooks pass, including yaml syntax and gitlint.

## Follow-up

Provisioning `REBASE_PUSH_TOKEN` requires an admin and is deliberately out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of automated push failures caused by workflow permission restrictions.
  * Added clearer guidance when fork synchronization cannot be completed.
  * Preserved retry guidance for other push failures.
  * Push results are now displayed more clearly, making successful updates and errors easier to understand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->