### PR TITLE
OCPBUGS-112450: remove shared global releaseversion state

### DIFF
--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -36,7 +36,7 @@ func TestAutoscaling(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 
 	clusterOpts.NodePoolReplicas = 1
 	var additionalNP *hyperv1.NodePool
@@ -169,7 +169,7 @@ func testAutoscalingBalancing(ctx context.Context, mgtClient crclient.Client, ho
 		defer cancel()
 
 		t.Log("Starting balancing scale-up test")
-		e2eutil.AtLeast(t, e2eutil.Version420)
+		e2eutil.AtLeast(t, releaseVersion, e2eutil.Version420)
 
 		// Get the newly created NodePool
 		defaultNodePool := getOnlyNodePool(t, ctx, mgtClient, hostedCluster.Namespace)
@@ -485,7 +485,7 @@ func pollCASLogsForPausedNodeGroup(t *testing.T, ctx context.Context, controlPla
 func testAutoscalerRespectsNodePoolPause(ctx context.Context, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, numNodes, max int32) func(t *testing.T) {
 	return func(t *testing.T) {
 		// spec.autoscaling.scaleDown requires CPO support added in 4.18 (CNTRLPLANE-952).
-		e2eutil.AtLeast(t, e2eutil.Version418)
+		e2eutil.AtLeast(t, releaseVersion, e2eutil.Version418)
 
 		g := NewWithT(t)
 		ctx, cancel := context.WithCancel(ctx)
@@ -707,7 +707,7 @@ func TestNodePoolAutoscalingScaleFromZero(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	clusterOpts.NodePoolReplicas = 1
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {

--- a/test/e2e/azure_oauth_lb_test.go
+++ b/test/e2e/azure_oauth_lb_test.go
@@ -36,7 +36,7 @@ func TestAzureOAuthLoadBalancer(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 	clusterOpts.AzurePlatform.OAuthPublishingStrategy = "LoadBalancer"
 

--- a/test/e2e/azure_private_link_test.go
+++ b/test/e2e/azure_private_link_test.go
@@ -59,7 +59,7 @@ func TestAzurePrivateTopology(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 
 	// Configure Azure private endpoint access

--- a/test/e2e/azure_scheduler_test.go
+++ b/test/e2e/azure_scheduler_test.go
@@ -33,7 +33,7 @@ func TestAzureScheduler(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 
 	if globalOpts.Platform != "Azure" {
 		t.Skip("Skipping test because it requires Azure")

--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -39,7 +39,7 @@ func TestHAEtcdChaos(t *testing.T) {
 	defer cancel()
 
 	// Create a cluster
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 	clusterOpts.NodePoolReplicas = 0
 
@@ -465,13 +465,13 @@ func testSingleMemberRecovery(parentCtx context.Context, client crclient.Client,
 // RequestServingNodeAdditionalSelector) to the HostedControlPlane even when the
 // pull secret is corrupted. This is a regression test for OCPBUGS-77268.
 func TestPullSecretUnavailable(t *testing.T) {
-	e2eutil.AtLeast(t, e2eutil.Version423)
+	e2eutil.AtLeast(t, releaseVersion, e2eutil.Version423)
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 	clusterOpts.NodePoolReplicas = 0
 

--- a/test/e2e/cilium_network_policy_test.go
+++ b/test/e2e/cilium_network_policy_test.go
@@ -30,7 +30,7 @@ func TestCiliumConnectivity(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 
 	if globalOpts.Platform != hyperv1.AzurePlatform {
 		t.Skip("Skipping test because it requires Azure platform")

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -15,7 +15,7 @@ import (
 func TestUpgradeControlPlane(t *testing.T) {
 	t.Parallel()
 
-	if globalOpts.Platform == hyperv1.AzurePlatform && e2eutil.IsLessThan(e2eutil.Version420) {
+	if globalOpts.Platform == hyperv1.AzurePlatform && e2eutil.IsLessThan(releaseVersion, e2eutil.Version420) {
 		t.Skip("TODO: Enable this test for Azure in 4.19. Skipping for now to let the 4.20 suite be covered.")
 	}
 
@@ -24,7 +24,7 @@ func TestUpgradeControlPlane(t *testing.T) {
 
 	t.Logf("Starting control plane upgrade test. FromImage: %s, toImage: %s", globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage)
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	clusterOpts.ReleaseImage = globalOpts.PreviousReleaseImage
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 
@@ -44,9 +44,10 @@ func TestUpgradeControlPlane(t *testing.T) {
 		}
 
 		// Set the semantic version to the latest release image for version gating tests
-		err := e2eutil.SetReleaseImageVersion(testContext, globalOpts.LatestReleaseImage, globalOpts.ConfigurableClusterOptions.PullSecretFile)
+		var err error
+		releaseVersion, err = e2eutil.GetReleaseImageVersion(testContext, globalOpts.LatestReleaseImage, globalOpts.ConfigurableClusterOptions.PullSecretFile)
 		if err != nil {
-			g.Expect(err).NotTo(HaveOccurred(), "failed to set latest release image version")
+			g.Expect(err).NotTo(HaveOccurred(), "failed to get latest release image version")
 		}
 
 		// Update the cluster image
@@ -64,12 +65,12 @@ func TestUpgradeControlPlane(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred(), "failed update hostedcluster image")
 
 		t.Run("Wait for control plane components to complete rollout", func(t *testing.T) {
-			e2eutil.AtLeast(t, e2eutil.Version420)
+			e2eutil.AtLeast(t, releaseVersion, e2eutil.Version420)
 			e2eutil.WaitForControlPlaneComponentRollout(t, ctx, mgtClient, hostedCluster, startingVersion)
 		})
 
 		t.Run("Wait for control plane version to complete rollout", func(t *testing.T) {
-			e2eutil.AtLeast(t, e2eutil.Version422)
+			e2eutil.AtLeast(t, releaseVersion, e2eutil.Version422)
 			e2eutil.WaitForControlPlaneRollout(t, ctx, mgtClient, hostedCluster)
 		})
 

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -40,7 +40,7 @@ func TestCreateCluster(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	zones := strings.Split(globalOpts.ConfigurableClusterOptions.Zone.String(), ",")
 	if len(zones) >= 3 {
 		// CreateCluster also tests multi-zone workers work properly if a sufficient number of zones are configured
@@ -49,7 +49,7 @@ func TestCreateCluster(t *testing.T) {
 		clusterOpts.InfrastructureAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 		clusterOpts.NodePoolReplicas = 1
 	}
-	if !e2eutil.IsLessThan(e2eutil.Version418) {
+	if !e2eutil.IsLessThan(releaseVersion, e2eutil.Version418) {
 		clusterOpts.FeatureSet = string(configv1.TechPreviewNoUpgrade)
 	}
 
@@ -103,7 +103,7 @@ func TestCreateCluster(t *testing.T) {
 		guestClients, err := integrationframework.NewClients(guestConfig)
 		g.Expect(err).NotTo(HaveOccurred(), "couldn't create guest clients")
 
-		integration.RunTestControlPlanePKIOperatorBreakGlassCredentials(t, testContext, hostedCluster, mgmtClients, guestClients)
+		integration.RunTestControlPlanePKIOperatorBreakGlassCredentials(t, testContext, releaseVersion, hostedCluster, mgmtClients, guestClients)
 		e2eutil.EnsureAPIUX(t, ctx, mgtClient, hostedCluster)
 		e2eutil.EnsureCustomLabels(t, ctx, mgtClient, hostedCluster)
 		e2eutil.EnsureCustomTolerations(t, ctx, mgtClient, hostedCluster)
@@ -123,7 +123,7 @@ func TestCreateCluster(t *testing.T) {
 			e2eutil.EnsureKubeAPIServerAllowedCIDRs(t, ctx, mgtClient, guestConfig, hostedCluster)
 		}
 
-		e2eutil.EnsureMetricsForwarderWorking(t, ctx, mgtClient, hostedCluster)
+		e2eutil.EnsureMetricsForwarderWorking(t, ctx, releaseVersion, mgtClient, hostedCluster)
 
 		// Verify CPO override image if TEST_CPO_OVERRIDE=1 is set
 		if os.Getenv("TEST_CPO_OVERRIDE") == "1" {
@@ -133,10 +133,10 @@ func TestCreateCluster(t *testing.T) {
 
 		if globalOpts.Platform == hyperv1.AzurePlatform || globalOpts.Platform == hyperv1.AWSPlatform {
 			// ensure Ingress Operator configuration is properly applied
-			e2eutil.EnsureIngressOperatorConfiguration(t, ctx, guestClient, hostedCluster)
+			e2eutil.EnsureIngressOperatorConfiguration(t, ctx, releaseVersion, guestClient, hostedCluster)
 		}
 
-		e2eutil.EnsureAWSCCMWithCustomizations(t, ctx, &e2eutil.AWSCCMTestConfig{
+		e2eutil.EnsureAWSCCMWithCustomizations(t, ctx, releaseVersion, &e2eutil.AWSCCMTestConfig{
 			MgtClient:     mgtClient,
 			GuestClient:   guestClient,
 			HostedCluster: hostedCluster,
@@ -157,7 +157,7 @@ func TestCreateClusterHABreakGlassCredentials(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 	clusterOpts.NodePoolReplicas = 0
 
@@ -203,7 +203,7 @@ func TestCreateClusterHABreakGlassCredentials(t *testing.T) {
 		guestClients, err := integrationframework.NewClients(guestConfig)
 		g.Expect(err).NotTo(HaveOccurred(), "couldn't create guest clients")
 
-		integration.RunTestControlPlanePKIOperatorBreakGlassCredentials(t, testContext, hostedCluster, mgmtClients, guestClients)
+		integration.RunTestControlPlanePKIOperatorBreakGlassCredentials(t, testContext, releaseVersion, hostedCluster, mgmtClients, guestClients)
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "ha-break-glass-creds", globalOpts.ServiceAccountSigningKey)
 }
 
@@ -214,7 +214,7 @@ func TestCreateClusterDefaultSecurityContextUID(t *testing.T) {
 	if globalOpts.Platform != hyperv1.AzurePlatform {
 		t.Skip("test only supported on platform Azure")
 	}
-	if e2eutil.IsLessThan(e2eutil.Version420) {
+	if e2eutil.IsLessThan(releaseVersion, e2eutil.Version420) {
 		t.Skip("test only supported on version 4.20 and higher")
 	}
 
@@ -291,7 +291,7 @@ func TestCreateClusterRequestServingIsolation(t *testing.T) {
 	nodePools := e2eutil.SetupReqServingClusterNodePools(ctx, t, globalOpts.ManagementParentKubeconfig, globalOpts.ManagementClusterNamespace, globalOpts.ManagementClusterName)
 	defer e2eutil.TearDownNodePools(ctx, t, globalOpts.ManagementParentKubeconfig, nodePools)
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	zones := strings.Split(globalOpts.ConfigurableClusterOptions.Zone.String(), ",")
 	if len(zones) >= 3 {
 		// CreateCluster also tests multi-zone workers work properly if a sufficient number of zones are configured
@@ -330,7 +330,7 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 		err                            error
 	)
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 
 	// Configure KMS settings for Azure platform (this test specifically tests KMS functionality)
 	if globalOpts.Platform == hyperv1.AzurePlatform {
@@ -357,7 +357,7 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 				hyperv1.InsightsCapability,
 				hyperv1.NodeTuningCapability,
 			}
-			if e2eutil.IsGreaterThanOrEqualTo(e2eutil.Version420) {
+			if e2eutil.IsGreaterThanOrEqualTo(releaseVersion, e2eutil.Version420) {
 				disabledCaps = append(disabledCaps, hyperv1.ConsoleCapability, hyperv1.IngressCapability)
 			}
 
@@ -433,13 +433,13 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 		e2eutil.EnsureConsoleCapabilityDisabled(ctx, t, g, clients)
 
 		// ensure NodeTuning component is disabled
-		e2eutil.EnsureNodeTuningCapabilityDisabled(ctx, t, clients, mgtClient, hostedCluster)
+		e2eutil.EnsureNodeTuningCapabilityDisabled(ctx, t, releaseVersion, clients, mgtClient, hostedCluster)
 
 		// ensure ingress component is disabled
-		e2eutil.EnsureIngressCapabilityDisabled(ctx, t, clients, mgtClient, hostedCluster)
+		e2eutil.EnsureIngressCapabilityDisabled(ctx, t, releaseVersion, clients, mgtClient, hostedCluster)
 
 		// ensure CNO operator configuration changes are properly handled
-		e2eutil.EnsureCNOOperatorConfiguration(t, ctx, mgtClient, guestClient, hostedCluster)
+		e2eutil.EnsureCNOOperatorConfiguration(t, ctx, releaseVersion, mgtClient, guestClient, hostedCluster)
 	}).WithAssetReader(content.ReadFile).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "custom-config", globalOpts.ServiceAccountSigningKey)
 }
 
@@ -452,7 +452,7 @@ func TestCreateClusterProxy(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	clusterOpts.AWSPlatform.EnableProxy = true
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 
@@ -480,8 +480,8 @@ func testCreateClusterPrivate(t *testing.T, enableExternalDNS bool) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
-	if e2eutil.IsLessThan(e2eutil.Version415) {
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
+	if e2eutil.IsLessThan(releaseVersion, e2eutil.Version415) {
 		cleanupAnnotationIndex := slices.Index(clusterOpts.Annotations, fmt.Sprintf("%s=true", hyperv1.CleanupCloudResourcesAnnotation))
 		if cleanupAnnotationIndex != -1 {
 			clusterOpts.Annotations = slices.Delete(clusterOpts.Annotations, cleanupAnnotationIndex, cleanupAnnotationIndex+1)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/go-logr/logr"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	controlplaneoperatoroverrides "github.com/openshift/hypershift/hypershift-operator/controlplaneoperator-overrides"
@@ -37,6 +38,10 @@ var (
 	// testContext should be used as the parent context for any test code, and will
 	// be cancelled if a SIGINT or SIGTERM is received. It's set up in TestMain.
 	testContext context.Context
+
+	// releaseVersion is the y-stream version of the release image under test,
+	// resolved once at suite startup and passed to version-gated helpers.
+	releaseVersion semver.Version
 
 	log = crzap.New(crzap.UseDevMode(true), crzap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
@@ -249,9 +254,10 @@ func main(m *testing.M) int {
 	if releaseImage == "" {
 		releaseImage = globalOpts.LatestReleaseImage
 	}
-	err := util.SetReleaseImageVersion(testContext, releaseImage, globalOpts.ConfigurableClusterOptions.PullSecretFile)
+	var err error
+	releaseVersion, err = util.GetReleaseImageVersion(testContext, releaseImage, globalOpts.ConfigurableClusterOptions.PullSecretFile)
 	if err != nil {
-		log.Error(err, "failed to set release image version")
+		log.Error(err, "failed to get release image version")
 		return -1
 	}
 

--- a/test/e2e/external_oidc_test.go
+++ b/test/e2e/external_oidc_test.go
@@ -77,7 +77,7 @@ func createTestUserWithGroup(ctx context.Context, kc *e2eutil.KeycloakAdminClien
 }
 
 func TestExternalOIDC(t *testing.T) {
-	e2eutil.AtLeast(t, e2eutil.Version419)
+	e2eutil.AtLeast(t, releaseVersion, e2eutil.Version419)
 
 	if globalOpts.ExternalOIDCProvider == "" {
 		t.Skipf("skip external OIDC test if e2e.external-oidc-provider is not provided")
@@ -88,7 +88,7 @@ func TestExternalOIDC(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	clusterOpts.NodePoolReplicas = 1
 	clusterOpts.FeatureSet = string(configv1.Default)
 
@@ -261,7 +261,7 @@ func TestExternalOIDC(t *testing.T) {
 		// patching the auth config has no effect and the legacy prefix-based mapping persists,
 		// causing these subtests to timeout waiting for a config reload that never happens.
 		if featuregates.Gate().Enabled(featuregates.ExternalOIDCWithUpstreamParity) {
-			e2eutil.AtLeast(t, e2eutil.Version423)
+			e2eutil.AtLeast(t, releaseVersion, e2eutil.Version423)
 			upstreamParityOpts := clusterOpts
 			upstreamParityOpts.FeatureSet = string(configv1.TechPreviewNoUpgrade)
 			upstreamParityOpts.ExtOIDCConfig.CustomizeAuthSpec = func(spec *configv1.AuthenticationSpec) {

--- a/test/e2e/karpenter_control_plane_upgrade_test.go
+++ b/test/e2e/karpenter_control_plane_upgrade_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestKarpenterUpgradeControlPlane(t *testing.T) {
-	e2eutil.ShouldRunKarpenterTests(t)
+	e2eutil.ShouldRunKarpenterTests(t, releaseVersion)
 	if globalOpts.Platform != hyperv1.AWSPlatform {
 		t.Skip("test only supported on platform AWS")
 	}
@@ -29,7 +29,7 @@ func TestKarpenterUpgradeControlPlane(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	clusterOpts.AWSPlatform.AutoNode = true
 	clusterOpts.AWSPlatform.PublicOnly = false
 	clusterOpts.AWSPlatform.EndpointAccess = string(hyperv1.PublicAndPrivate)

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -60,7 +60,7 @@ var kubeletCheckerPodTemplate = func() *corev1.Pod {
 }()
 
 func TestKarpenter(t *testing.T) {
-	e2eutil.ShouldRunKarpenterTests(t)
+	e2eutil.ShouldRunKarpenterTests(t, releaseVersion)
 	if globalOpts.Platform != hyperv1.AWSPlatform {
 		t.Skip("test only supported on platform AWS")
 	}
@@ -69,7 +69,7 @@ func TestKarpenter(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	clusterOpts.AWSPlatform.AutoNode = true
 	clusterOpts.AWSPlatform.PublicOnly = false
 	clusterOpts.AWSPlatform.EndpointAccess = string(hyperv1.PublicAndPrivate)

--- a/test/e2e/nodepool_additionalTrustBundlePropagation_test.go
+++ b/test/e2e/nodepool_additionalTrustBundlePropagation_test.go
@@ -63,7 +63,7 @@ func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv
 	)
 
 	t.Run("AdditionalTrustBundlePropagationTest", func(t *testing.T) {
-		e2eutil.AtLeast(t, e2eutil.Version418)
+		e2eutil.AtLeast(t, releaseVersion, e2eutil.Version418)
 
 		additionalTrustBundle := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -209,7 +209,7 @@ func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv
 
 		// Ensure the user-ca-bundle configmap is deleted from the guest cluster
 		// Only applicable for >= 4.22
-		if e2eutil.IsGreaterThanOrEqualTo(e2eutil.Version422) {
+		if e2eutil.IsGreaterThanOrEqualTo(releaseVersion, e2eutil.Version422) {
 			userCAConfigMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "user-ca-bundle",

--- a/test/e2e/nodepool_imagetype_test.go
+++ b/test/e2e/nodepool_imagetype_test.go
@@ -45,7 +45,7 @@ func (it *NodePoolImageTypeTest) Setup(t *testing.T) {
 	if globalOpts.Platform != hyperv1.AWSPlatform {
 		t.Skip("test is only supported for AWS platform")
 	}
-	if e2eutil.IsLessThan(e2eutil.Version419) {
+	if e2eutil.IsLessThan(releaseVersion, e2eutil.Version419) {
 		t.Skip("test only supported from version 4.19")
 	}
 	t.Log("Starting test NodePoolImageTypeTest")

--- a/test/e2e/nodepool_kv_advanced_multinet_test.go
+++ b/test/e2e/nodepool_kv_advanced_multinet_test.go
@@ -51,7 +51,7 @@ func (k KubeVirtAdvancedMultinetTest) Setup(t *testing.T) {
 	if globalOpts.Platform != hyperv1.KubevirtPlatform {
 		t.Skip("test only supported on KubeVirt platform")
 	}
-	if e2eutil.IsLessThan(e2eutil.Version415) {
+	if e2eutil.IsLessThan(releaseVersion, e2eutil.Version415) {
 		t.Skip("test only supported from version 4.15")
 	}
 

--- a/test/e2e/nodepool_mirrorconfigs_test.go
+++ b/test/e2e/nodepool_mirrorconfigs_test.go
@@ -59,7 +59,7 @@ func NewMirrorConfigsTest(ctx context.Context, mgmtClient crclient.Client, hoste
 func (mc *MirrorConfigsTest) Setup(t *testing.T) {
 	t.Log("Starting test MirrorConfigsTest")
 
-	if e2eutil.IsLessThan(e2eutil.Version418) {
+	if e2eutil.IsLessThan(releaseVersion, e2eutil.Version418) {
 		t.Skip("test only applicable for 4.18+")
 	}
 }

--- a/test/e2e/nodepool_nto_performanceprofile_test.go
+++ b/test/e2e/nodepool_nto_performanceprofile_test.go
@@ -153,7 +153,7 @@ func (mc *NTOPerformanceProfileTest) Run(t *testing.T, nodePool hyperv1.NodePool
 	)
 	// The remainder of the assertions only work in 4.17+
 	// https://github.com/openshift/hypershift/pull/4020
-	if e2eutil.IsLessThan(e2eutil.Version417) {
+	if e2eutil.IsLessThan(releaseVersion, e2eutil.Version417) {
 		return
 	}
 	e2eutil.EventuallyObjects(t, ctx, "performance profile status ConfigMap to exist",

--- a/test/e2e/nodepool_osp_advanced_test.go
+++ b/test/e2e/nodepool_osp_advanced_test.go
@@ -57,7 +57,7 @@ func (o OpenStackAdvancedTest) Setup(t *testing.T) {
 	}
 
 	// The features that are being tested here is only available in 4.18+
-	if e2eutil.IsLessThan(e2eutil.Version418) {
+	if e2eutil.IsLessThan(releaseVersion, e2eutil.Version418) {
 		t.Skip("test only applicable for 4.18+")
 	}
 }

--- a/test/e2e/nodepool_spot_termination_handler_test.go
+++ b/test/e2e/nodepool_spot_termination_handler_test.go
@@ -83,7 +83,7 @@ func (s *SpotTerminationHandlerTest) Setup(t *testing.T) {
 	if globalOpts.Platform != hyperv1.AWSPlatform {
 		t.Skip("test only supported on platform AWS")
 	}
-	if e2eutil.IsLessThan(e2eutil.Version422) {
+	if e2eutil.IsLessThan(releaseVersion, e2eutil.Version422) {
 		t.Skip("test only supported on version 4.22 and above")
 	}
 }

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -211,7 +211,7 @@ func executeNodePoolTests(t *testing.T, nodePoolTestCasesPerHostedCluster []Host
 				nodePoolTestCases.setup(t)
 			}
 			t.Parallel()
-			clusterOpts := globalOpts.DefaultClusterOptions(t)
+			clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 			// We set replicas to 0 in order to allow the inner tests to
 			// create their own NodePools with the proper replicas
 			clusterOpts.NodePoolReplicas = 0
@@ -367,7 +367,7 @@ func executeNodePoolTest(t *testing.T, ctx context.Context, mgmtClient crclient.
 	// machine-level details before machines are fully ready.
 	// The CAPI condition aggregation logic was introduced in 4.23; older operators don't produce
 	// the expected "machines are not healthy" message format during provisioning.
-	if e2eutil.IsGreaterThanOrEqualTo(e2eutil.Version423) && nodePool.Spec.Replicas != nil && *nodePool.Spec.Replicas > 0 {
+	if e2eutil.IsGreaterThanOrEqualTo(releaseVersion, e2eutil.Version423) && nodePool.Spec.Replicas != nil && *nodePool.Spec.Replicas > 0 {
 		validateCAPIConditionBubblingDuringProvisioning(t, ctx, mgmtClient, nodePool)
 	}
 
@@ -381,7 +381,7 @@ func executeNodePoolTest(t *testing.T, ctx context.Context, mgmtClient crclient.
 	// ValidationFailed(ConfigMap "pp-test" not found)
 	// This root cause of this failure is unknown but doesn't seem worth the time to figure out since
 	// the NTO performance profile code was heavily refactored in 4.17.
-	if e2eutil.IsLessThan(e2eutil.Version417) {
+	if e2eutil.IsLessThan(releaseVersion, e2eutil.Version417) {
 		// Wait for the rollout to be complete
 		e2eutil.WaitForImageRollout(t, ctx, mgmtClient, hostedCluster)
 	}
@@ -417,7 +417,7 @@ func validateNodePoolConditions(t *testing.T, ctx context.Context, client crclie
 		// When all machines are ready and healthy, the aggregation pipeline should produce
 		// Reason=AsExpected and Message="All is well".
 		// The CAPI condition aggregation logic was introduced in 4.23.
-		if expectedSupportedVersionSkew && e2eutil.IsGreaterThanOrEqualTo(e2eutil.Version423) {
+		if expectedSupportedVersionSkew && e2eutil.IsGreaterThanOrEqualTo(releaseVersion, e2eutil.Version423) {
 			switch conditionType {
 			case hyperv1.NodePoolAllMachinesReadyConditionType, hyperv1.NodePoolAllNodesHealthyConditionType:
 				condition.Reason = hyperv1.AsExpectedReason

--- a/test/e2e/olm_test.go
+++ b/test/e2e/olm_test.go
@@ -41,7 +41,7 @@ func TestOLM(t *testing.T) {
 	defer cancel()
 
 	// Create a cluster
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 		// Get guest client
 		t.Logf("Waiting for guest client to become available")

--- a/test/e2e/upgrade_hypershift_operator_test.go
+++ b/test/e2e/upgrade_hypershift_operator_test.go
@@ -51,7 +51,7 @@ func TestUpgradeHyperShiftOperator(t *testing.T) {
 
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 
 	t.Log("Starting HyperShift Operator upgrade test")
 	g := gomega.NewWithT(t)

--- a/test/e2e/util/aws_ccm.go
+++ b/test/e2e/util/aws_ccm.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 
@@ -36,10 +37,10 @@ type AWSCCMTestConfig struct {
 
 // EnsureAWSCCMWithCustomizations implements tests that exercise AWS CCM controller for critical features.
 // This test is only supported on platform AWS, as well runs only when the feature gate AWSServiceLBNetworkSecurityGroup is enabled.
-func EnsureAWSCCMWithCustomizations(t *testing.T, ctx context.Context, cfg *AWSCCMTestConfig) {
+func EnsureAWSCCMWithCustomizations(t *testing.T, ctx context.Context, releaseVersion semver.Version, cfg *AWSCCMTestConfig) {
 	t.Run("EnsureAWSCCMWithManagedSG", func(t *testing.T) {
 		t.Parallel()
-		AtLeast(t, Version423)
+		AtLeast(t, releaseVersion, Version423)
 		if cfg.Platform != hyperv1.AWSPlatform {
 			t.Skip("test only supported on platform AWS")
 		}

--- a/test/e2e/util/azure.go
+++ b/test/e2e/util/azure.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
@@ -100,9 +101,9 @@ func ValidateAzureWorkloadIdentityWebhookMutation(t testing.TB, ctx context.Cont
 	}).WithContext(ctx).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 }
 
-func EnsureAzureWorkloadIdentityWebhookMutation(t *testing.T, ctx context.Context, guestClient crclient.Client) {
+func EnsureAzureWorkloadIdentityWebhookMutation(t *testing.T, ctx context.Context, releaseVersion semver.Version, guestClient crclient.Client) {
 	t.Run("EnsureAzureWorkloadIdentityWebhookMutation", func(t *testing.T) {
-		AtLeast(t, Version420)
+		AtLeast(t, releaseVersion, Version420)
 		ValidateAzureWorkloadIdentityWebhookMutation(t, ctx, guestClient)
 	})
 }

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/cmd/cluster/aws"
 	"github.com/openshift/hypershift/cmd/cluster/azure"
@@ -234,7 +235,7 @@ func renderCreate(ctx context.Context, opts *core.RawCreateOptions, platformOpts
 
 // destroyCluster calls the correct cluster destroy CLI function based on the
 // cluster platform and the options used to create the cluster.
-func destroyCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedCluster, createOpts *PlatformAgnosticOptions, outputDir string) error {
+func destroyCluster(ctx context.Context, t *testing.T, releaseVersion semver.Version, hc *hyperv1.HostedCluster, createOpts *PlatformAgnosticOptions, outputDir string) error {
 	destroyLogFile := filepath.Join(outputDir, "destroy.log")
 	destroyLog, err := os.Create(destroyLogFile)
 	if err != nil {
@@ -262,7 +263,7 @@ func destroyCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedCluster
 			Credentials:      createOpts.AWSPlatform.Credentials,
 			PreserveIAM:      false,
 			Region:           createOpts.AWSPlatform.Region,
-			PostDeleteAction: validateAWSGuestResourcesDeletedFunc(ctx, t, hc.Spec.InfraID, createOpts.AWSPlatform.Credentials.AWSCredentialsFile, createOpts.AWSPlatform.Region),
+			PostDeleteAction: validateAWSGuestResourcesDeletedFunc(ctx, t, releaseVersion, hc.Spec.InfraID, createOpts.AWSPlatform.Credentials.AWSCredentialsFile, createOpts.AWSPlatform.Region),
 		}
 		return aws.DestroyCluster(ctx, opts)
 	case hyperv1.NonePlatform, hyperv1.KubevirtPlatform:
@@ -297,8 +298,8 @@ func destroyCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedCluster
 }
 
 // validateAWSGuestResourcesDeletedFunc waits for 15min or until the guest cluster resources are gone.
-func validateAWSGuestResourcesDeletedFunc(ctx context.Context, t *testing.T, infraID, awsCreds, awsRegion string) func() {
-	if IsLessThan(Version415) {
+func validateAWSGuestResourcesDeletedFunc(ctx context.Context, t *testing.T, releaseVersion semver.Version, infraID, awsCreds, awsRegion string) func() {
+	if IsLessThan(releaseVersion, Version415) {
 		return func() {
 			t.Log("SKIPPED: skipping AWS cleanup validation for OCP <= 4.14")
 		}

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -85,9 +86,10 @@ type UpgradeContext struct {
 
 type hypershiftTest struct {
 	*testing.T
-	ctx         context.Context
-	client      crclient.Client
-	assetReader assets.AssetReader
+	ctx            context.Context
+	client         crclient.Client
+	assetReader    assets.AssetReader
+	releaseVersion semver.Version
 
 	test hypershiftTestFunc
 
@@ -107,6 +109,11 @@ func NewHypershiftTest(t *testing.T, ctx context.Context, test hypershiftTestFun
 		client: client,
 		test:   test,
 	}
+}
+
+func (h *hypershiftTest) WithReleaseVersion(v semver.Version) *hypershiftTest {
+	h.releaseVersion = v
+	return h
 }
 
 func (h *hypershiftTest) WithAssetReader(reader assets.AssetReader) *hypershiftTest {
@@ -177,7 +184,7 @@ func (h *hypershiftTest) Execute(opts *PlatformAgnosticOptions, platform hyperv1
 	if h.Failed() {
 		numNodes := opts.ExpectedNodeCount()
 		h.Logf("Summarizing unexpected conditions for HostedCluster %s ", hostedCluster.Name)
-		ValidateHostedClusterConditions(h.T, h.ctx, h.client, hostedCluster, numNodes > 0, 2*time.Second, h.upgradeContext)
+		ValidateHostedClusterConditions(h.T, h.ctx, h.releaseVersion, h.client, hostedCluster, numNodes > 0, 2*time.Second, h.upgradeContext)
 	}
 }
 
@@ -189,9 +196,9 @@ func (h *hypershiftTest) before(hostedCluster *hyperv1.HostedCluster, opts *Plat
 			// IsPrivateHC includes PublicAndPrivate, which has a reachable API server
 			// and should use ValidatePublicCluster.
 			if !netutil.IsPublicHC(hostedCluster) {
-				ValidatePrivateCluster(t, h.ctx, h.client, hostedCluster, opts, h.upgradeContext)
+				ValidatePrivateCluster(t, h.ctx, h.releaseVersion, h.client, hostedCluster, opts, h.upgradeContext)
 			} else {
-				ValidatePublicCluster(t, h.ctx, h.client, hostedCluster, opts, h.upgradeContext)
+				ValidatePublicCluster(t, h.ctx, h.releaseVersion, h.client, hostedCluster, opts, h.upgradeContext)
 			}
 
 			// The following validation is here since TestHAEtcdChaos runs as NonePlatform and it's broken.
@@ -217,7 +224,7 @@ func (h *hypershiftTest) before(hostedCluster *hyperv1.HostedCluster, opts *Plat
 				// wait hosted cluster ready
 				WaitForNReadyNodes(t, context.Background(), guestClient, opts.NodePoolReplicas, platform)
 				WaitForImageRollout(t, context.Background(), h.client, hostedCluster)
-				ValidateHostedClusterConditions(t, context.Background(), h.client, hostedCluster, true, 10*time.Minute, h.upgradeContext)
+				ValidateHostedClusterConditions(t, context.Background(), h.releaseVersion, h.client, hostedCluster, true, 10*time.Minute, h.upgradeContext)
 			}
 
 		}
@@ -234,10 +241,10 @@ func (h *hypershiftTest) after(hostedCluster *hyperv1.HostedCluster, platform hy
 		hcpNs := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 
 		EnsurePayloadArchSetCorrectly(t, context.Background(), h.client, hostedCluster)
-		EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t, context.Background(), h.client, hcpNs)
-		EnsureReadOnlyRootFilesystem(t, context.Background(), h.client, hcpNs)
+		EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t, context.Background(), h.releaseVersion, h.client, hcpNs)
+		EnsureReadOnlyRootFilesystem(t, context.Background(), h.releaseVersion, h.client, hcpNs)
 		EnsureAllContainersHavePullPolicyIfNotPresent(t, context.Background(), h.client, hostedCluster)
-		EnsureAllContainersHaveTerminationMessagePolicyFallbackToLogsOnError(t, context.Background(), h.client, hostedCluster)
+		EnsureAllContainersHaveTerminationMessagePolicyFallbackToLogsOnError(t, context.Background(), h.releaseVersion, h.client, hostedCluster)
 		EnsureHCPContainersHaveResourceRequests(t, context.Background(), h.client, hostedCluster)
 		EnsureNoPodsWithTooHighPriority(t, context.Background(), h.client, hostedCluster)
 		EnsureNoRapidDeploymentRollouts(t, context.Background(), h.client, hostedCluster)
@@ -245,19 +252,19 @@ func (h *hypershiftTest) after(hostedCluster *hyperv1.HostedCluster, platform hy
 		EnsureAllRoutesUseHCPRouter(t, context.Background(), h.client, hostedCluster)
 		EnsureNetworkPolicies(t, context.Background(), h.client, hostedCluster)
 		if capabilities.IsNodeTuningCapabilityEnabled(hostedCluster.Spec.Capabilities) {
-			EnsureNodeTuningOperatorMetricsEndpoint(t, context.Background(), h.client, hostedCluster)
+			EnsureNodeTuningOperatorMetricsEndpoint(t, context.Background(), h.releaseVersion, h.client, hostedCluster)
 		}
 
 		if platform == hyperv1.AWSPlatform {
 			EnsureHCPPodsAffinitiesAndTolerations(t, context.Background(), h.client, hostedCluster)
 		}
-		EnsureSATokenNotMountedUnlessNecessary(t, context.Background(), h.client, hostedCluster)
+		EnsureSATokenNotMountedUnlessNecessary(t, context.Background(), h.releaseVersion, h.client, hostedCluster)
 		// HCCO installs the admission policies, however, NonePlatform clusters can be ready before
 		// the HCCO is fully up and reconciling, resulting in a potential race and flaky test assertions.
 		if platform != hyperv1.NonePlatform {
-			EnsureAdmissionPolicies(t, context.Background(), h.client, hostedCluster)
+			EnsureAdmissionPolicies(t, context.Background(), h.releaseVersion, h.client, hostedCluster)
 		}
-		if platform == hyperv1.AzurePlatform && azureutil.IsAroHCP() && !IsLessThan(Version420) {
+		if platform == hyperv1.AzurePlatform && azureutil.IsAroHCP() && !IsLessThan(h.releaseVersion, Version420) {
 			EnsureSecurityContextUID(t, context.Background(), h.client, hostedCluster)
 		}
 		metricsToValidate := []string{hcmetrics.SilenceAlertsMetricName, // common metrics
@@ -316,7 +323,7 @@ func (h *hypershiftTest) after(hostedCluster *hyperv1.HostedCluster, platform hy
 					}
 				}
 			}
-			ValidateHostedClusterConditions(t, t.Context(), h.client, hostedCluster, hasWorkerNodes, 10*time.Minute, h.upgradeContext)
+			ValidateHostedClusterConditions(t, t.Context(), h.releaseVersion, h.client, hostedCluster, hasWorkerNodes, 10*time.Minute, h.upgradeContext)
 		}
 	})
 }
@@ -331,7 +338,7 @@ func (h *hypershiftTest) teardown(hostedCluster *hyperv1.HostedCluster, opts *Pl
 	// t.Run() is not supported in cleanup phase
 	if cleanupPhase {
 		h.hasBeenTornedDown = true
-		teardownHostedCluster(h.T, context.Background(), hostedCluster, h.client, opts, artifactDir)
+		teardownHostedCluster(h.T, context.Background(), h.releaseVersion, hostedCluster, h.client, opts, artifactDir)
 		return
 	}
 
@@ -339,7 +346,7 @@ func (h *hypershiftTest) teardown(hostedCluster *hyperv1.HostedCluster, opts *Pl
 		// Set the flag inside the subtest callback to ensure it's only set
 		// when the subtest actually runs (not filtered out by -test.run)
 		h.hasBeenTornedDown = true
-		teardownHostedCluster(t, h.ctx, hostedCluster, h.client, opts, artifactDir)
+		teardownHostedCluster(t, h.ctx, h.releaseVersion, hostedCluster, h.client, opts, artifactDir)
 	})
 }
 
@@ -532,7 +539,7 @@ func (h *hypershiftTest) createHostedCluster(opts *PlatformAgnosticOptions, plat
 }
 
 // NOTE: Do not use t.Run() here as this function can be called in the Cleanup context and will fail immediately
-func teardownHostedCluster(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluster, client crclient.Client, opts *PlatformAgnosticOptions, artifactDir string) {
+func teardownHostedCluster(t *testing.T, ctx context.Context, releaseVersion semver.Version, hc *hyperv1.HostedCluster, client crclient.Client, opts *PlatformAgnosticOptions, artifactDir string) {
 	// TODO (Mulham): dumpCluster() uses testName to construct dumpDir, since we removed sub tests from this function
 	// we should pass dumpDir to the dumpCluster() as <artifactDir>/<testName>_<suffix>
 	dumpCluster := newClusterDumper(hc, opts, artifactDir)
@@ -564,7 +571,7 @@ func teardownHostedCluster(t *testing.T, ctx context.Context, hc *hyperv1.Hosted
 	}
 	var previousError string
 	err := wait.PollUntilContextCancel(ctx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-		err := destroyCluster(ctx, t, hc, opts, artifactDir)
+		err := destroyCluster(ctx, t, releaseVersion, hc, opts, artifactDir)
 		if err != nil {
 			if strings.Contains(err.Error(), "required inputs are missing") {
 				return false, err

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -209,7 +209,7 @@ type ConfigurableClusterOptions struct {
 	GCPBootImage                     string
 }
 
-func (o *Options) DefaultClusterOptions(t *testing.T) PlatformAgnosticOptions {
+func (o *Options) DefaultClusterOptions(t *testing.T, releaseVersion semver.Version) PlatformAgnosticOptions {
 	createOption := PlatformAgnosticOptions{
 		RawCreateOptions: core.RawCreateOptions{
 			ReleaseImage:                     o.LatestReleaseImage,
@@ -231,7 +231,7 @@ func (o *Options) DefaultClusterOptions(t *testing.T) PlatformAgnosticOptions {
 			DisableClusterCapabilities:       o.ConfigurableClusterOptions.DisableClusterCapabilities,
 		},
 		NonePlatform:        o.DefaultNoneOptions(),
-		AWSPlatform:         o.DefaultAWSOptions(),
+		AWSPlatform:         o.DefaultAWSOptions(releaseVersion),
 		KubevirtPlatform:    o.DefaultKubeVirtOptions(),
 		AzurePlatform:       o.DefaultAzureOptions(),
 		PowerVSPlatform:     o.DefaultPowerVSOptions(),
@@ -302,7 +302,7 @@ func (p *Options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions
 
 var nextAWSZoneIndex = 0
 
-func (o *Options) DefaultAWSOptions() hypershiftaws.RawCreateOptions {
+func (o *Options) DefaultAWSOptions(releaseVersion semver.Version) hypershiftaws.RawCreateOptions {
 	opts := hypershiftaws.RawCreateOptions{
 		RootVolumeSize: 64,
 		RootVolumeType: "gp3",
@@ -318,13 +318,13 @@ func (o *Options) DefaultAWSOptions() hypershiftaws.RawCreateOptions {
 		SharedRole:             true,
 	}
 
-	if IsLessThan(semver.MustParse("4.16.0")) {
+	if IsLessThan(releaseVersion, semver.MustParse("4.16.0")) {
 		opts.PublicOnly = false
 	}
 
 	// HCCO requires this fix https://github.com/openshift/hypershift/pull/7383
 	// in order for shared roles to work properly.
-	if IsLessThan(semver.MustParse("4.20.0")) {
+	if IsLessThan(releaseVersion, semver.MustParse("4.20.0")) {
 		opts.SharedRole = false
 	}
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -351,7 +352,11 @@ func WaitForGuestRestConfig(t *testing.T, ctx context.Context, client crclient.C
 	return guestConfig
 }
 
-func WaitForGuestClient(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) crclient.Client {
+func WaitForGuestClient(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, releaseVersion ...semver.Version) crclient.Client {
+	var rv semver.Version
+	if len(releaseVersion) > 0 {
+		rv = releaseVersion[0]
+	}
 	g := NewWithT(t)
 	guestKubeConfigSecretData := WaitForGuestKubeConfig(t, ctx, client, hostedCluster)
 
@@ -373,7 +378,7 @@ func WaitForGuestClient(t testing.TB, ctx context.Context, client crclient.Clien
 	if err != nil {
 		t.Fatalf("failed to create kube client for guest cluster: %v", err)
 	}
-	if IsLessThan(Version415) {
+	if IsLessThan(rv, Version415) {
 		// SelfSubjectReview API is only available in 4.15+
 		// Use the old method to check if the API server is up
 		err = wait.PollUntilContextTimeout(ctx, 35*time.Second, connectTimeout, true, func(ctx context.Context) (done bool, err error) {
@@ -1018,9 +1023,9 @@ func EnsureAllContainersHavePullPolicyIfNotPresent(t *testing.T, ctx context.Con
 	})
 }
 
-func EnsureAllContainersHaveTerminationMessagePolicyFallbackToLogsOnError(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func EnsureAllContainersHaveTerminationMessagePolicyFallbackToLogsOnError(t *testing.T, ctx context.Context, releaseVersion semver.Version, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureAllContainersHaveTerminationMessagePolicyFallbackToLogsOnError", func(t *testing.T) {
-		AtLeast(t, Version419)
+		AtLeast(t, releaseVersion, Version419)
 		var podList corev1.PodList
 		if err := client.List(ctx, &podList, &crclient.ListOptions{Namespace: manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)}); err != nil {
 			t.Fatalf("failed to list pods in cluster: %v", err)
@@ -1065,9 +1070,9 @@ func EnsureAllContainersHaveTerminationMessagePolicyFallbackToLogsOnError(t *tes
 
 // NOTE: This function assumes that it is not called in the middle of a version rollout
 // i.e. It expects that the first entry in ClusterVersion history is Completed
-func EnsureFeatureGateStatus(t *testing.T, ctx context.Context, guestClient crclient.Client) {
+func EnsureFeatureGateStatus(t *testing.T, ctx context.Context, releaseVersion semver.Version, guestClient crclient.Client) {
 	t.Run("EnsureFeatureGateStatus", func(t *testing.T) {
-		AtLeast(t, Version419)
+		AtLeast(t, releaseVersion, Version419)
 
 		// Use EventuallyObject to handle transient DNS/network errors when talking to the guest cluster API.
 		var currentVersion string
@@ -1163,9 +1168,9 @@ func EnsureMachineDeploymentGeneration(t *testing.T, ctx context.Context, hostCl
 	})
 }
 
-func EnsurePSANotPrivileged(t *testing.T, ctx context.Context, guestClient crclient.Client) {
+func EnsurePSANotPrivileged(t *testing.T, ctx context.Context, releaseVersion semver.Version, guestClient crclient.Client) {
 	t.Run("EnsurePSANotPrivileged", func(t *testing.T) {
-		AtLeast(t, Version421)
+		AtLeast(t, releaseVersion, Version421)
 
 		// Check if OpenShiftPodSecurityAdmission feature gate is enabled
 		featureGate := &configv1.FeatureGate{}
@@ -1307,8 +1312,8 @@ func EnsureNetworkPolicies(t *testing.T, ctx context.Context, c crclient.Client,
 
 // EnsureNodesRuntime ensures that all nodes in the NodePool have the expected runtime handlers.
 // This is only supported on 4.18+ when the default runtime is changed to crun.
-func EnsureNodesRuntime(t *testing.T, nodes []corev1.Node) {
-	AtLeast(t, Version418)
+func EnsureNodesRuntime(t *testing.T, releaseVersion semver.Version, nodes []corev1.Node) {
+	AtLeast(t, releaseVersion, Version418)
 	g := NewWithT(t)
 
 	validHandlers := map[string]bool{
@@ -1439,7 +1444,7 @@ func EnsureHCPContainersHaveResourceRequests(t *testing.T, ctx context.Context, 
 	})
 }
 
-func EnsureAPIUX(t *testing.T, ctx context.Context, hostClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func EnsureAPIUX(t *testing.T, ctx context.Context, releaseVersion semver.Version, hostClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureHostedClusterImmutability", func(t *testing.T) {
 		g := NewWithT(t)
 
@@ -1467,7 +1472,7 @@ func EnsureAPIUX(t *testing.T, ctx context.Context, hostClient crclient.Client, 
 	})
 
 	t.Run("EnsureHostedClusterCapabilitiesImmutability", func(t *testing.T) {
-		AtLeast(t, Version419)
+		AtLeast(t, releaseVersion, Version419)
 		g := NewWithT(t)
 
 		err := UpdateObject(t, ctx, hostClient, hostedCluster, func(obj *hyperv1.HostedCluster) {
@@ -1492,9 +1497,9 @@ func EnsureSecretEncryptedUsingKMSV1(t *testing.T, ctx context.Context, hostedCl
 	})
 }
 
-func EnsureSecretEncryptedUsingKMSV2(t *testing.T, ctx context.Context, hostedCluster *hyperv1.HostedCluster, guestClient crclient.Client) {
+func EnsureSecretEncryptedUsingKMSV2(t *testing.T, ctx context.Context, releaseVersion semver.Version, hostedCluster *hyperv1.HostedCluster, guestClient crclient.Client) {
 	t.Run("EnsureSecretEncryptedUsingKMSV2", func(t *testing.T) {
-		AtLeast(t, Version417)
+		AtLeast(t, releaseVersion, Version417)
 		ensureSecretEncryptedUsingKMS(t, ctx, hostedCluster, guestClient, "k8s:enc:kms:v2")
 	})
 }
@@ -1647,8 +1652,8 @@ func GetMetricsFromPod(ctx context.Context, c crclient.Client, componentName, co
 	return parser.TextToMetricFamilies(strings.NewReader(cmdOutput))
 }
 
-func EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t *testing.T, ctx context.Context, hostClient crclient.Client, hcpNs string) {
-	AtLeast(t, Version420)
+func EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t *testing.T, ctx context.Context, releaseVersion semver.Version, hostClient crclient.Client, hcpNs string) {
+	AtLeast(t, releaseVersion, Version420)
 
 	t.Run("EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations", func(t *testing.T) {
 		g := NewWithT(t)
@@ -1765,8 +1770,8 @@ func findAuditedContainers(pod *corev1.Pod, auditedContainersSelector map[labelS
 	return nil
 }
 
-func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, hostClient crclient.Client, hcpNs string) {
-	AtLeast(t, Version420)
+func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, releaseVersion semver.Version, hostClient crclient.Client, hcpNs string) {
+	AtLeast(t, releaseVersion, Version420)
 
 	// By default, we enable readOnlyRootFilesystem in every container.
 	// This testchecks to make sure that every container has this field enabled, unless manually specified in auditedAppContainersNoRORFS
@@ -1946,9 +1951,9 @@ func EnsureGuestWebhooksValidated(t *testing.T, ctx context.Context, guestClient
 	})
 }
 
-func skipGlobalPullSecretPreconditions(t *testing.T, entryHostedCluster *hyperv1.HostedCluster, additionalPullSecretFile string) {
+func skipGlobalPullSecretPreconditions(t *testing.T, releaseVersion semver.Version, entryHostedCluster *hyperv1.HostedCluster, additionalPullSecretFile string) {
 	t.Helper()
-	AtLeast(t, Version419)
+	AtLeast(t, releaseVersion, Version419)
 	// TODO (jparrill): Change check of release version `releaseVersion.GT(Version420)` to `releaseVersion.GE(Version420)`
 	// during the backport to 4.20 of this PR https://github.com/openshift/hypershift/pull/6736
 	if entryHostedCluster.Spec.Platform.Type != hyperv1.AzurePlatform && entryHostedCluster.Spec.Platform.Type != hyperv1.AWSPlatform {
@@ -1979,9 +1984,9 @@ func skipGlobalPullSecretPreconditions(t *testing.T, entryHostedCluster *hyperv1
 	}
 }
 
-func EnsureGlobalPullSecret(t *testing.T, ctx context.Context, mgmtClient crclient.Client, entryHostedCluster *hyperv1.HostedCluster, additionalPullSecretFile string) {
+func EnsureGlobalPullSecret(t *testing.T, ctx context.Context, releaseVersion semver.Version, mgmtClient crclient.Client, entryHostedCluster *hyperv1.HostedCluster, additionalPullSecretFile string) {
 	t.Run("EnsureGlobalPullSecret", func(t *testing.T) {
-		skipGlobalPullSecretPreconditions(t, entryHostedCluster, additionalPullSecretFile)
+		skipGlobalPullSecretPreconditions(t, releaseVersion, entryHostedCluster, additionalPullSecretFile)
 
 		additionalPullSecretReadOnlyE2EData, err := os.ReadFile(additionalPullSecretFile)
 		if err != nil {
@@ -2068,7 +2073,7 @@ func EnsureGlobalPullSecret(t *testing.T, ctx context.Context, mgmtClient crclie
 		})
 
 		t.Run("When management-cluster hostedCluster.Spec.PullSecret is updated in-place it should propagate to guest without rollout", func(t *testing.T) {
-			CPOAtLeast(t, Version422, entryHostedCluster)
+			CPOAtLeast(t, releaseVersion, Version422, entryHostedCluster)
 			g := NewWithT(t)
 			t.Logf("Reading management-cluster pull secret %s/%s", entryHostedCluster.Namespace, entryHostedCluster.Spec.PullSecret.Name)
 
@@ -2354,9 +2359,9 @@ func waitForDaemonSetReady(t *testing.T, ctx context.Context, client crclient.Cl
 	return nil
 }
 
-func EnsureKubeAPIDNSNameCustomCert(t *testing.T, ctx context.Context, mgmtClient crclient.Client, entryHostedCluster *hyperv1.HostedCluster, clusterOpts PlatformAgnosticOptions) {
+func EnsureKubeAPIDNSNameCustomCert(t *testing.T, ctx context.Context, releaseVersion semver.Version, mgmtClient crclient.Client, entryHostedCluster *hyperv1.HostedCluster, clusterOpts PlatformAgnosticOptions) {
 	t.Run("EnsureKubeAPIDNSNameCustomCert", func(t *testing.T) {
-		AtLeast(t, Version419)
+		AtLeast(t, releaseVersion, Version419)
 
 		if entryHostedCluster.Spec.Platform.Type == hyperv1.KubevirtPlatform {
 			t.Skip("Skipping EnsureKubeAPIDNSNameCustomCert test for kubevirt")
@@ -2732,13 +2737,13 @@ func setKubeAPIDNSNameAndCert(ctx context.Context, mgmtClient crclient.Client, h
 	})
 }
 
-func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crclient.Client, hc *hyperv1.HostedCluster) {
+func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, releaseVersion semver.Version, mgmtClient crclient.Client, hc *hyperv1.HostedCluster) {
 	if !netutil.IsPublicHC(hc) {
 		return // Admission policies are only validated in public clusters does not worth to test it in private ones.
 	}
 	guestClient := WaitForGuestClient(t, ctx, mgmtClient, hc)
 	t.Run("EnsureValidatingAdmissionPoliciesExists", func(t *testing.T) {
-		CPOAtLeast(t, Version418, hc)
+		CPOAtLeast(t, releaseVersion, Version418, hc)
 		g := NewWithT(t)
 		t.Log("Checking that all ValidatingAdmissionPolicies are present")
 		var validatingAdmissionPolicies k8sadmissionv1.ValidatingAdmissionPolicyList
@@ -2764,7 +2769,7 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 		}
 	})
 	t.Run("EnsureValidatingAdmissionPoliciesCheckDeniedRequests", func(t *testing.T) {
-		CPOAtLeast(t, Version418, hc)
+		CPOAtLeast(t, releaseVersion, Version418, hc)
 		g := NewWithT(t)
 		t.Log("Checking Denied KAS Requests for ValidatingAdmissionPolicies")
 		apiServer := &configv1.APIServer{
@@ -3036,7 +3041,7 @@ func deleteIngressRoute53Records(t *testing.T, ctx context.Context, hostedCluste
 	}
 }
 
-func ValidatePublicCluster(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *PlatformAgnosticOptions, upgradeContext *UpgradeContext) {
+func ValidatePublicCluster(t *testing.T, ctx context.Context, releaseVersion semver.Version, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *PlatformAgnosticOptions, upgradeContext *UpgradeContext) {
 	g := NewWithT(t)
 
 	// Sanity check the cluster by waiting for the nodes to report ready
@@ -3078,7 +3083,7 @@ func ValidatePublicCluster(t *testing.T, ctx context.Context, client crclient.Cl
 	if numNodes == 0 {
 		timeout = 20 * time.Minute
 	}
-	ValidateHostedClusterConditions(t, ctx, client, hostedCluster, numNodes > 0, timeout, upgradeContext)
+	ValidateHostedClusterConditions(t, ctx, releaseVersion, client, hostedCluster, numNodes > 0, timeout, upgradeContext)
 
 	EnsureNodeCountMatchesNodePoolReplicas(t, ctx, client, guestClient, hostedCluster.Spec.Platform.Type, hostedCluster.Namespace)
 	EnsureNoCrashingPods(t, ctx, client, hostedCluster)
@@ -3093,10 +3098,10 @@ func ValidatePublicCluster(t *testing.T, ctx context.Context, client crclient.Cl
 		g.Expect(hostedCluster.Spec.Configuration.Ingress.LoadBalancer.Platform.AWS.Type).To(Equal(configv1.NLB))
 	}
 	// Validate configuration status matches between HCP, HC, and guest cluster
-	ValidateConfigurationStatus(t, ctx, client, guestClient, hostedCluster)
+	ValidateConfigurationStatus(t, ctx, releaseVersion, client, guestClient, hostedCluster)
 }
 
-func ValidatePrivateCluster(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *PlatformAgnosticOptions, upgradeContext *UpgradeContext) {
+func ValidatePrivateCluster(t *testing.T, ctx context.Context, releaseVersion semver.Version, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *PlatformAgnosticOptions, upgradeContext *UpgradeContext) {
 	g := NewWithT(t)
 
 	// We can't wait for a guest client since we don't have connectivity to the API server
@@ -3129,7 +3134,7 @@ func ValidatePrivateCluster(t *testing.T, ctx context.Context, client crclient.C
 	if numNodes == 0 {
 		timeout = 20 * time.Minute
 	}
-	ValidateHostedClusterConditions(t, ctx, client, hostedCluster, numNodes > 0, timeout, upgradeContext)
+	ValidateHostedClusterConditions(t, ctx, releaseVersion, client, hostedCluster, numNodes > 0, timeout, upgradeContext)
 
 	EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 	EnsureOAPIMountsTrustBundle(t, context.Background(), client, hostedCluster)
@@ -3141,7 +3146,7 @@ func ValidatePrivateCluster(t *testing.T, ctx context.Context, client crclient.C
 
 // ValidateHostedClusterConditions checks that a HostedCluster's conditions and status fields
 // match expected values. Pass nil for uc when calling outside of an upgrade test context.
-func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, hasWorkerNodes bool, timeout time.Duration, upgradeContext *UpgradeContext) {
+func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, releaseVersion semver.Version, client crclient.Client, hostedCluster *hyperv1.HostedCluster, hasWorkerNodes bool, timeout time.Duration, upgradeContext *UpgradeContext) {
 	expectedConditions := conditions.ExpectedHCConditions(hostedCluster)
 	// OCPBUGS-59885: Ignore KubeVirtNodesLiveMigratable in e2e; CI envs may lack RWX-capable PVCs, causing false failures
 	delete(expectedConditions, hyperv1.KubeVirtNodesLiveMigratable)
@@ -3154,15 +3159,15 @@ func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 		expectedConditions[hyperv1.DataPlaneConnectionAvailable] = metav1.ConditionUnknown
 		expectedConditions[hyperv1.ControlPlaneConnectionAvailable] = metav1.ConditionUnknown
 	}
-	if IsLessThan(Version415) {
+	if IsLessThan(releaseVersion, Version415) {
 		// ValidKubeVirtInfraNetworkMTU condition is not present in versions < 4.15
 		delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkMTU)
 	}
-	if IsLessThan(Version421) {
+	if IsLessThan(releaseVersion, Version421) {
 		delete(expectedConditions, hyperv1.DataPlaneConnectionAvailable)
 	}
 
-	if IsLessThan(Version422) {
+	if IsLessThan(releaseVersion, Version422) {
 		delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
 		delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkPolicyRBAC)
 	}
@@ -3174,7 +3179,7 @@ func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 		delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
 	}
 
-	if IsLessThan(Version423) {
+	if IsLessThan(releaseVersion, Version423) {
 		delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
 	}
 
@@ -3193,7 +3198,7 @@ func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 		}))
 	}
 
-	if IsGreaterThanOrEqualTo(Version422) {
+	if IsGreaterThanOrEqualTo(releaseVersion, Version422) {
 		cpvFieldPath := "status.controlPlaneVersion"
 		cpvEnforce := controlPlaneVersionSteadyState(hasWorkerNodes)
 
@@ -3405,9 +3410,9 @@ func EnsureNoHCPPodsLandOnDefaultNode(t *testing.T, ctx context.Context, client 
 	}
 }
 
-func EnsureSATokenNotMountedUnlessNecessary(t *testing.T, ctx context.Context, c crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func EnsureSATokenNotMountedUnlessNecessary(t *testing.T, ctx context.Context, releaseVersion semver.Version, c crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureSATokenNotMountedUnlessNecessary", func(t *testing.T) {
-		AtLeast(t, Version416)
+		AtLeast(t, releaseVersion, Version416)
 		g := NewWithT(t)
 
 		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
@@ -3424,7 +3429,7 @@ func EnsureSATokenNotMountedUnlessNecessary(t *testing.T, ctx context.Context, c
 			"shared-resource-csi-driver-operator",
 		)
 
-		if IsLessThan(Version418) {
+		if IsLessThan(releaseVersion, Version418) {
 			expectedComponentsWithTokenMount = append(expectedComponentsWithTokenMount,
 				"csi-snapshot-webhook",
 			)
@@ -3505,9 +3510,9 @@ func EnsurePayloadArchSetCorrectly(t *testing.T, ctx context.Context, client crc
 	})
 }
 
-func EnsureCustomLabels(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func EnsureCustomLabels(t *testing.T, ctx context.Context, releaseVersion semver.Version, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureCustomLabels", func(t *testing.T) {
-		AtLeast(t, Version419)
+		AtLeast(t, releaseVersion, Version419)
 
 		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 		podList := &corev1.PodList{}
@@ -3534,9 +3539,9 @@ func EnsureCustomLabels(t *testing.T, ctx context.Context, client crclient.Clien
 	})
 }
 
-func EnsureCustomTolerations(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func EnsureCustomTolerations(t *testing.T, ctx context.Context, releaseVersion semver.Version, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureCustomTolerations", func(t *testing.T) {
-		AtLeast(t, Version419)
+		AtLeast(t, releaseVersion, Version419)
 
 		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 		podList := &corev1.PodList{}
@@ -3573,9 +3578,9 @@ func EnsureCustomTolerations(t *testing.T, ctx context.Context, client crclient.
 	})
 }
 
-func EnsureAppLabel(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func EnsureAppLabel(t *testing.T, ctx context.Context, releaseVersion semver.Version, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureAppLabel", func(t *testing.T) {
-		AtLeast(t, Version419)
+		AtLeast(t, releaseVersion, Version419)
 
 		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 		podList := &corev1.PodList{}
@@ -3605,9 +3610,9 @@ func EnsureAppLabel(t *testing.T, ctx context.Context, client crclient.Client, h
 	})
 }
 
-func EnsureDefaultSecurityGroupTags(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts PlatformAgnosticOptions) {
+func EnsureDefaultSecurityGroupTags(t *testing.T, ctx context.Context, releaseVersion semver.Version, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts PlatformAgnosticOptions) {
 	t.Run("EnsureDefaultSecurityGroupTags", func(t *testing.T) {
-		AtLeast(t, Version420)
+		AtLeast(t, releaseVersion, Version420)
 		if hostedCluster.Spec.Platform.Type != hyperv1.AWSPlatform {
 			t.Skip("This test is only applicable for AWS platform")
 		}
@@ -3821,9 +3826,9 @@ func generateTestCIDRs250() []string {
 }
 
 // EnsureImageRegistryCapabilityDisabled validates the expectations for when ImageRegistryCapability is Disabled
-func EnsureImageRegistryCapabilityDisabled(ctx context.Context, t *testing.T, g Gomega, clients *GuestClients) {
+func EnsureImageRegistryCapabilityDisabled(ctx context.Context, t *testing.T, releaseVersion semver.Version, g Gomega, clients *GuestClients) {
 	t.Run("EnsureImageRegistryCapabilityDisabled", func(t *testing.T) {
-		AtLeast(t, Version418)
+		AtLeast(t, releaseVersion, Version418)
 
 		_, err := clients.CfgClient.ConfigV1().ClusterOperators().Get(ctx, "image-registry", metav1.GetOptions{})
 		g.Expect(err).To(HaveOccurred())
@@ -3901,9 +3906,9 @@ func GenerateCustomCertificate(dnsNames []string, validity time.Duration) ([]byt
 }
 
 // EnsureOpenshiftSamplesCapabilityDisabled validates the expectations for when OpenShiftSamplesCapability is Disabled
-func EnsureOpenshiftSamplesCapabilityDisabled(ctx context.Context, t *testing.T, g Gomega, clients *GuestClients) {
+func EnsureOpenshiftSamplesCapabilityDisabled(ctx context.Context, t *testing.T, releaseVersion semver.Version, g Gomega, clients *GuestClients) {
 	t.Run("EnsureOpenshiftSamplesCapabilityDisabled", func(t *testing.T) {
-		AtLeast(t, Version420)
+		AtLeast(t, releaseVersion, Version420)
 
 		_, err := clients.CfgClient.ConfigV1().ClusterOperators().Get(ctx, "openshift-samples", metav1.GetOptions{})
 		g.Expect(err).To(HaveOccurred())
@@ -3917,9 +3922,9 @@ func EnsureOpenshiftSamplesCapabilityDisabled(ctx context.Context, t *testing.T,
 }
 
 // EnsureInsightsCapabilityDisabled validates the expectations for when InsightsCapability is Disabled
-func EnsureInsightsCapabilityDisabled(ctx context.Context, t *testing.T, g Gomega, clients *GuestClients) {
+func EnsureInsightsCapabilityDisabled(ctx context.Context, t *testing.T, releaseVersion semver.Version, g Gomega, clients *GuestClients) {
 	t.Run("EnsureInsightsCapabilityDisabled", func(t *testing.T) {
-		AtLeast(t, Version420)
+		AtLeast(t, releaseVersion, Version420)
 
 		_, err := clients.CfgClient.ConfigV1().ClusterOperators().Get(ctx, "insights", metav1.GetOptions{})
 		g.Expect(err).To(HaveOccurred())
@@ -3933,9 +3938,9 @@ func EnsureInsightsCapabilityDisabled(ctx context.Context, t *testing.T, g Gomeg
 }
 
 // EnsureConsoleCapabilityDisabled validates the expectations for when ConsoleCapability is Disabled
-func EnsureConsoleCapabilityDisabled(ctx context.Context, t *testing.T, g Gomega, clients *GuestClients) {
+func EnsureConsoleCapabilityDisabled(ctx context.Context, t *testing.T, releaseVersion semver.Version, g Gomega, clients *GuestClients) {
 	t.Run("EnsureConsoleCapabilityDisabled", func(t *testing.T) {
-		AtLeast(t, Version420)
+		AtLeast(t, releaseVersion, Version420)
 
 		_, err := clients.CfgClient.ConfigV1().ClusterOperators().Get(ctx, "console", metav1.GetOptions{})
 		g.Expect(err).To(HaveOccurred())
@@ -3949,9 +3954,9 @@ func EnsureConsoleCapabilityDisabled(ctx context.Context, t *testing.T, g Gomega
 }
 
 // EnsureNodeTuningCapabilityDisabled validates the expectations for when NodeTuningCapability is Disabled
-func EnsureNodeTuningCapabilityDisabled(ctx context.Context, t *testing.T, clients *GuestClients, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func EnsureNodeTuningCapabilityDisabled(ctx context.Context, t *testing.T, releaseVersion semver.Version, clients *GuestClients, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureNodeTuningCapabilityDisabled", func(t *testing.T) {
-		AtLeast(t, Version420)
+		AtLeast(t, releaseVersion, Version420)
 		g := NewWithT(t)
 		// Check guest cluster - node-tuning cluster operator should not exist
 		_, err := clients.CfgClient.ConfigV1().ClusterOperators().Get(ctx, "node-tuning", metav1.GetOptions{})
@@ -4032,9 +4037,9 @@ func EnsureNodeTuningCapabilityDisabled(ctx context.Context, t *testing.T, clien
 }
 
 // EnsureIngressCapabilityDisabled validates the expectations for when IngressCapability is Disabled
-func EnsureIngressCapabilityDisabled(ctx context.Context, t *testing.T, clients *GuestClients, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func EnsureIngressCapabilityDisabled(ctx context.Context, t *testing.T, releaseVersion semver.Version, clients *GuestClients, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureIngressCapabilityDisabled", func(t *testing.T) {
-		AtLeast(t, Version420)
+		AtLeast(t, releaseVersion, Version420)
 		g := NewWithT(t)
 
 		// Check guest cluster - ingress cluster operator should not exist
@@ -4296,9 +4301,9 @@ func EnsureSecurityContextUID(t *testing.T, ctx context.Context, client crclient
 
 // EnsureCNOOperatorConfiguration tests that changes to the CNO operator configuration on the HostedCluster are
 // properly reflected in the hosted cluster's API and that the CNO doesn't report any errors via HCP conditions.
-func EnsureCNOOperatorConfiguration(t *testing.T, ctx context.Context, mgmtClient crclient.Client, guestClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func EnsureCNOOperatorConfiguration(t *testing.T, ctx context.Context, releaseVersion semver.Version, mgmtClient crclient.Client, guestClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureCNOOperatorConfiguration", func(t *testing.T) {
-		AtLeast(t, Version420)
+		AtLeast(t, releaseVersion, Version420)
 		g := NewWithT(t)
 		// Skip test if network type is not OVNKubernetes
 		if hostedCluster.Spec.Networking.NetworkType != hyperv1.OVNKubernetes {
@@ -4354,7 +4359,7 @@ func EnsureCNOOperatorConfiguration(t *testing.T, ctx context.Context, mgmtClien
 			},
 			WithTimeout(10*time.Minute),
 		)
-		ValidateHostedClusterConditions(t, ctx, mgmtClient, hostedCluster, true, 5*time.Minute, nil)
+		ValidateHostedClusterConditions(t, ctx, releaseVersion, mgmtClient, hostedCluster, true, 5*time.Minute, nil)
 		// Check that the Network.operator.openshift.io resource in the guest cluster reflects our changes
 		EventuallyObject(t, ctx, "Network.operator.openshift.io/cluster in guest cluster to reflect the custom subnet changes",
 			func(ctx context.Context) (*operatorv1.Network, error) {
@@ -4413,10 +4418,10 @@ func EnsureCNOOperatorConfiguration(t *testing.T, ctx context.Context, mgmtClien
 
 // ValidateConfigurationStatus validates that the HCP and HC configuration status
 // matches the Authentication resource status from the hosted cluster
-func ValidateConfigurationStatus(t *testing.T, ctx context.Context, mgmtClient crclient.Client, guestClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func ValidateConfigurationStatus(t *testing.T, ctx context.Context, releaseVersion semver.Version, mgmtClient crclient.Client, guestClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("ValidateConfigurationStatus", func(t *testing.T) {
 		// Configuration status was added in 4.21
-		AtLeast(t, Version421)
+		AtLeast(t, releaseVersion, Version421)
 		g := NewWithT(t)
 
 		// Wait for both HCP and HC configuration status to be populated and validate consistency
@@ -4619,10 +4624,10 @@ func ApplyYAMLBytes(ctx context.Context, c crclient.Client, yamlContent []byte, 
 // EnsureNodeTuningOperatorMetricsEndpoint verifies that the node-tuning-operator
 // service and servicemonitor are properly configured and that the metrics endpoint
 // is accessible and returns valid metrics data. This validates the fix for OCPBUGS-72596.
-func EnsureNodeTuningOperatorMetricsEndpoint(t *testing.T, ctx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func EnsureNodeTuningOperatorMetricsEndpoint(t *testing.T, ctx context.Context, releaseVersion semver.Version, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureNodeTuningOperatorMetricsEndpoint", func(t *testing.T) {
 		// This test is only relevant for 4.22 and later until the fix for OCPBUGS-72596 is backported to 4.21.
-		AtLeast(t, Version422)
+		AtLeast(t, releaseVersion, Version422)
 		g := NewWithT(t)
 
 		// Check if cluster has workers - if not, skip validation

--- a/test/e2e/util/util_ingress_operator_configuration.go
+++ b/test/e2e/util/util_ingress_operator_configuration.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -63,9 +64,9 @@ func ValidateIngressOperatorConfiguration(t testing.TB, ctx context.Context, gue
 
 // EnsureIngressOperatorConfiguration tests that the Ingress Operator configuration on the HostedCluster
 // is properly reflected in the hosted cluster's IngressController and that the Ingress Operator doesn't report any errors via HCP conditions.
-func EnsureIngressOperatorConfiguration(t *testing.T, ctx context.Context, guestClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func EnsureIngressOperatorConfiguration(t *testing.T, ctx context.Context, releaseVersion semver.Version, guestClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureIngressOperatorConfiguration", func(t *testing.T) {
-		AtLeast(t, Version421)
+		AtLeast(t, releaseVersion, Version421)
 		ValidateIngressOperatorConfiguration(t, ctx, guestClient, hostedCluster)
 	})
 }

--- a/test/e2e/util/util_metrics_proxy.go
+++ b/test/e2e/util/util_metrics_proxy.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -41,9 +42,9 @@ const (
 // The data path tested is:
 //
 //	guest Prometheus → PodMonitor → metrics-forwarder (HAProxy TCP passthrough) → Route → metrics-proxy → kube-apiserver
-func EnsureMetricsForwarderWorking(t *testing.T, ctx context.Context, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func EnsureMetricsForwarderWorking(t *testing.T, ctx context.Context, releaseVersion semver.Version, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureMetricsForwarderWorking", func(t *testing.T) {
-		AtLeast(t, Version422)
+		AtLeast(t, releaseVersion, Version422)
 		g := NewWithT(t)
 		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -26,58 +26,38 @@ var (
 	Version416 = semver.MustParse("4.16.0")
 	Version415 = semver.MustParse("4.15.0")
 	Version414 = semver.MustParse("4.14.0")
-
-	releaseVersion semver.Version
 )
 
-func init() {
-	// Ensure that the version constants are valid semver versions
-	// This is a compile-time check to ensure that the versions are valid
-	// semver versions.
-	_ = Version51
-	_ = Version50
-	_ = Version423
-	_ = Version422
-	_ = Version421
-	_ = Version420
-	_ = Version419
-	_ = Version418
-	_ = Version417
-	_ = Version416
-	_ = Version415
-	_ = Version414
-}
-
-func SetReleaseImageVersion(ctx context.Context, latestReleaseImage string, pullSecretFile string) error {
+func GetReleaseImageVersion(ctx context.Context, releaseImage string, pullSecretFile string) (semver.Version, error) {
 	data, err := os.ReadFile(pullSecretFile)
 	if err != nil {
-		return fmt.Errorf("error reading file: %w", err)
+		return semver.Version{}, fmt.Errorf("error reading file: %w", err)
 	}
 	releaseInfoProvider := releaseinfo.RegistryClientProvider{}
-	releaseImage, err := releaseInfoProvider.Lookup(ctx, latestReleaseImage, data)
+	releaseImageInfo, err := releaseInfoProvider.Lookup(ctx, releaseImage, data)
 	if err != nil {
-		return fmt.Errorf("error looking up latest release image: %w", err)
+		return semver.Version{}, fmt.Errorf("error looking up latest release image: %w", err)
 	}
-	releaseVersion, err = semver.Parse(releaseImage.Version())
+	version, err := semver.Parse(releaseImageInfo.Version())
 	if err != nil {
-		return fmt.Errorf("error parsing version: %w", err)
+		return semver.Version{}, fmt.Errorf("error parsing version: %w", err)
 	}
-	releaseVersion.Patch = 0
-	releaseVersion.Pre = nil
-	releaseVersion.Build = nil
-	return nil
+	version.Patch = 0
+	version.Pre = nil
+	version.Build = nil
+	return version, nil
 }
 
-func AtLeast(t *testing.T, version semver.Version) {
+func AtLeast(t *testing.T, releaseVersion semver.Version, version semver.Version) {
 	if releaseVersion.LT(version) {
 		t.Skipf("Only tested in %s and later", version)
 	}
 }
 
-func CPOAtLeast(t *testing.T, version semver.Version, hc *hyperv1.HostedCluster) {
+func CPOAtLeast(t *testing.T, releaseVersion semver.Version, version semver.Version, hc *hyperv1.HostedCluster) {
 	if hc.Status.Version == nil || hc.Status.Version.Desired.Version == "" {
 		t.Logf("Desired version is not set on the HostedCluster using latestReleaseImage: %s", releaseVersion)
-		AtLeast(t, version)
+		AtLeast(t, releaseVersion, version)
 	}
 	cpoVersion := semver.MustParse(hc.Status.Version.Desired.Version)
 	if cpoVersion.LT(version) {
@@ -85,11 +65,11 @@ func CPOAtLeast(t *testing.T, version semver.Version, hc *hyperv1.HostedCluster)
 	}
 }
 
-func IsLessThan(version semver.Version) bool {
+func IsLessThan(releaseVersion semver.Version, version semver.Version) bool {
 	return releaseVersion.LT(version)
 }
 
-func IsGreaterThanOrEqualTo(version semver.Version) bool {
+func IsGreaterThanOrEqualTo(releaseVersion semver.Version, version semver.Version) bool {
 	return releaseVersion.GE(version)
 }
 
@@ -97,10 +77,10 @@ func IsGreaterThanOrEqualTo(version semver.Version) bool {
 // The v1 API exists on 4.23+, but when the operator is built from main and
 // tested against a 4.22 hosted cluster, set RUN_KARPENTER_TESTS=true to
 // lower the gate to 4.22.
-func ShouldRunKarpenterTests(t *testing.T) {
+func ShouldRunKarpenterTests(t *testing.T, releaseVersion semver.Version) {
 	if os.Getenv("RUN_KARPENTER_TESTS") == "true" {
-		AtLeast(t, Version422)
+		AtLeast(t, releaseVersion, Version422)
 	} else {
-		AtLeast(t, Version423)
+		AtLeast(t, releaseVersion, Version423)
 	}
 }

--- a/test/e2e/v2/internal/workload_registry.go
+++ b/test/e2e/v2/internal/workload_registry.go
@@ -521,8 +521,8 @@ func ShouldSkipWorkloadForPlatform(workload WorkloadSpec, hostedCluster *hyperv1
 
 // ShouldSkipWorkloadForVersion determines whether the workload should be skipped
 // based on the cluster version exceeding the workload's MaxVersion.
-func ShouldSkipWorkloadForVersion(workload WorkloadSpec) bool {
-	if workload.MaxVersion != nil && e2eutil.IsGreaterThanOrEqualTo(*workload.MaxVersion) {
+func ShouldSkipWorkloadForVersion(workload WorkloadSpec, releaseVersion semver.Version) bool {
+	if workload.MaxVersion != nil && e2eutil.IsGreaterThanOrEqualTo(releaseVersion, *workload.MaxVersion) {
 		return true
 	}
 	return false
@@ -536,11 +536,15 @@ func validateControlPlaneWorkloadsByType(testCtx *TestContext, workloadTypes []s
 	if err != nil {
 		return fmt.Errorf("failed to get HostedCluster: %w", err)
 	}
+	releaseVersion, err := testCtx.GetHostedClusterVersion()
+	if err != nil {
+		return fmt.Errorf("failed to get hosted cluster version: %w", err)
+	}
 	for _, workload := range workloads {
 		if ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 			continue
 		}
-		if ShouldSkipWorkloadForVersion(workload) {
+		if ShouldSkipWorkloadForVersion(workload, releaseVersion) {
 			continue
 		}
 		if !slices.Contains(workloadTypes, workload.Type) {

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -82,7 +82,9 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 
@@ -139,7 +141,9 @@ func SafeToEvictAnnotationsTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 
@@ -238,7 +242,9 @@ func ReadOnlyRootFilesystemTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 
@@ -315,7 +321,9 @@ func ReadOnlyRootFilesystemTmpDirMountTest(getTestCtx internal.TestContextGetter
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 
@@ -361,7 +369,9 @@ func ContainerImagePullPolicyTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 
@@ -415,7 +425,9 @@ func ContainerTerminationMessagePolicyTest(getTestCtx internal.TestContextGetter
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 
@@ -461,7 +473,9 @@ func ContainerResourceRequestsTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 
@@ -502,7 +516,9 @@ func PodPriorityTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 
@@ -582,7 +598,9 @@ func ServiceAccountTokenMountingTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 
@@ -627,7 +645,9 @@ func PodAffinitiesAndTolerationsTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 
@@ -831,7 +851,9 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 
@@ -939,7 +961,9 @@ func NoCrashingPodsTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 
@@ -1019,7 +1043,9 @@ func CustomLabelsTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 					if slices.Contains(exemptions, workload.Name) {
@@ -1062,7 +1088,9 @@ func CustomTolerationsTest(getTestCtx internal.TestContextGetter) {
 					if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 						Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 					}
-					if internal.ShouldSkipWorkloadForVersion(workload) {
+					clusterVersion, vErr := testCtx.GetHostedClusterVersion()
+					Expect(vErr).NotTo(HaveOccurred())
+					if internal.ShouldSkipWorkloadForVersion(workload, clusterVersion) {
 						Skip(fmt.Sprintf("workload %s is not expected on this cluster version", workload.Name))
 					}
 					if slices.Contains(exemptions, workload.Name) {

--- a/test/integration/control_plane_pki_operator.go
+++ b/test/integration/control_plane_pki_operator.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	certificatesv1alpha1 "github.com/openshift/hypershift/api/certificates/v1alpha1"
 	certificatesv1alpha1applyconfigurations "github.com/openshift/hypershift/client/applyconfiguration/certificates/v1alpha1"
 	cpomanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -37,7 +38,7 @@ import (
 	"github.com/openshift/hypershift/test/integration/framework"
 )
 
-func RunTestControlPlanePKIOperatorBreakGlassCredentials(t *testing.T, ctx context.Context, hostedCluster *hypershiftv1beta1.HostedCluster, mgmt, guest *framework.Clients) {
+func RunTestControlPlanePKIOperatorBreakGlassCredentials(t *testing.T, ctx context.Context, releaseVersion semver.Version, hostedCluster *hypershiftv1beta1.HostedCluster, mgmt, guest *framework.Clients) {
 	t.Run("break-glass-credentials", func(t *testing.T) {
 		if hostedCluster.Spec.Platform.Type == hypershiftv1beta1.KubevirtPlatform {
 			t.Skip("skipping break-glass credentials test on KubeVirt platform")
@@ -49,7 +50,7 @@ func RunTestControlPlanePKIOperatorBreakGlassCredentials(t *testing.T, ctx conte
 			t.Skip("skipping break-glass credentials test on GCP platform - GKE Warden blocks system: CSRs")
 		}
 		// control-plane-pki-operator is only available in 4.15 and later
-		e2eutil.AtLeast(t, e2eutil.Version415)
+		e2eutil.AtLeast(t, releaseVersion, e2eutil.Version415)
 		hostedControlPlaneNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 
 		for _, testCase := range []struct {

--- a/test/integration/control_plane_pki_operator_test.go
+++ b/test/integration/control_plane_pki_operator_test.go
@@ -5,11 +5,12 @@ package integration
 import (
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/openshift/hypershift/test/integration/framework"
 )
 
 func TestControlPlanePKIOperatorBreakGlassCredentials(t *testing.T) {
 	framework.RunHostedClusterTest(testContext, log, globalOpts, t, func(t *testing.T, testCtx *framework.TestContext) {
-		RunTestControlPlanePKIOperatorBreakGlassCredentials(t, testContext, testCtx.HostedCluster, testCtx.MgmtCluster, testCtx.GuestCluster)
+		RunTestControlPlanePKIOperatorBreakGlassCredentials(t, testContext, semver.Version{}, testCtx.HostedCluster, testCtx.MgmtCluster, testCtx.GuestCluster)
 	})
 }

--- a/test/reqserving-e2e/cp_autoscaling_test.go
+++ b/test/reqserving-e2e/cp_autoscaling_test.go
@@ -51,7 +51,7 @@ func TestControlPlaneAutoscalingIncreasesSize(t *testing.T) {
 	}
 
 	// Prepare cluster options based on the request-serving template, plus autoscaling annotation
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 	clusterOpts.RawCreateOptions.RedactBaseDomain = true
 	clusterOpts.Annotations = append(clusterOpts.Annotations,

--- a/test/reqserving-e2e/create_reqserving_cluster_test.go
+++ b/test/reqserving-e2e/create_reqserving_cluster_test.go
@@ -20,7 +20,7 @@ func TestCreateRequestServingIsolationCluster(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts := globalOpts.DefaultClusterOptions(t, releaseVersion)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 	clusterOpts.RawCreateOptions.RedactBaseDomain = true
 	clusterOpts.Annotations = append(clusterOpts.Annotations, "hypershift.openshift.io/topology=dedicated-request-serving-components")

--- a/test/reqserving-e2e/reqserving_e2e_test.go
+++ b/test/reqserving-e2e/reqserving_e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/blang/semver"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/util/reqserving"
@@ -32,6 +33,8 @@ var (
 	}))
 
 	reqServingDryRun bool
+
+	releaseVersion semver.Version
 )
 
 // TestMain deals with global options and setting up a signal-bound context
@@ -106,9 +109,10 @@ func main(m *testing.M) int {
 	// Set the semantic version of the release image
 	releaseImage := globalOpts.LatestReleaseImage
 	if releaseImage != "" {
-		err := e2eutil.SetReleaseImageVersion(testContext, releaseImage, globalOpts.ConfigurableClusterOptions.PullSecretFile)
+		var err error
+		releaseVersion, err = e2eutil.GetReleaseImageVersion(testContext, releaseImage, globalOpts.ConfigurableClusterOptions.PullSecretFile)
 		if err != nil {
-			log.Error(err, "failed to set release image version")
+			log.Error(err, "failed to get release image version")
 			return 1
 		}
 	}


### PR DESCRIPTION
WIP

Before this commit, v2 code was able to (and inadvertantly did) use the shared global resourceVersion state from the test/e2e/util package, which is never set in the v2 test code, causing callers to use a default-value structs. That package variable is coupled to the lifecycle of v1 test scaffolding.

Instead of relying on shared state and indirect test lifecycle paths to initialize it, this commit removes resourceVersion entirely and updates callers to use stateless alternative functions to avoid any lifecycle surprises when reusing the code across frameworks.

Potential alternative to https://github.com/openshift/hypershift/pull/9357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-version detection and validation across end-to-end and integration test scenarios.
  * Ensured version-specific checks and feature availability are evaluated against the selected release.
  * Updated cluster setup and cleanup validation to apply the correct release-specific behavior.
  * Added appropriate version gating for newer autoscaling, identity, networking, metrics, and workload capabilities.
* **Tests**
  * Improved reliability of version-dependent test execution across supported release versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->