### PR TITLE
CNTRLPLANE-4004: test(envtest): add CEL validation tests for AWS resource tag types

### DIFF
--- a/cmd/install/assets/crds/hypershift-operator/tests/awsendpointservices.hypershift.openshift.io/stable.awsendpointservices.aws.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/awsendpointservices.hypershift.openshift.io/stable.awsendpointservices.aws.testsuite.yaml
@@ -13,3 +13,25 @@ tests:
         resourceTags:
           - key: env
             value: prod
+
+  - name: when resourceTag key contains invalid characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: AWSEndpointService
+      spec:
+        networkLoadBalancerName: my-nlb
+        resourceTags:
+          - key: "invalid!key"
+            value: prod
+    expectedError: "key must only contain letters, digits, and the characters _ . : / = + - @"
+
+  - name: when resourceTag value contains invalid characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: AWSEndpointService
+      spec:
+        networkLoadBalancerName: my-nlb
+        resourceTags:
+          - key: env
+            value: "invalid#value"
+    expectedError: "value must only contain letters, digits, and the characters _ . : / = + - @"

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.aws.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.aws.testsuite.yaml
@@ -1,0 +1,255 @@
+apiVersion: apiextensions.k8s.io/v1
+name: "HostedCluster AWS resource tag validation"
+crdName: hostedclusters.hypershift.openshift.io
+version: v1beta1
+tests:
+  onCreate:
+  # --- AWS resourceTags validation ---
+  - name: when resourceTags have valid key and value with overridePolicy Allow it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            rolesRef:
+              controlPlaneOperatorARN: arn:aws:iam::123456789012:role/cpo
+              imageRegistryARN: arn:aws:iam::123456789012:role/image
+              ingressARN: arn:aws:iam::123456789012:role/ingress
+              kubeCloudControllerARN: arn:aws:iam::123456789012:role/kcc
+              networkARN: arn:aws:iam::123456789012:role/network
+              nodePoolManagementARN: arn:aws:iam::123456789012:role/npm
+              storageARN: arn:aws:iam::123456789012:role/storage
+            resourceTags:
+              - key: env
+                value: prod
+                overridePolicy: Allow
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  - name: when resourceTags have valid key and value with overridePolicy Deny it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            rolesRef:
+              controlPlaneOperatorARN: arn:aws:iam::123456789012:role/cpo
+              imageRegistryARN: arn:aws:iam::123456789012:role/image
+              ingressARN: arn:aws:iam::123456789012:role/ingress
+              kubeCloudControllerARN: arn:aws:iam::123456789012:role/kcc
+              networkARN: arn:aws:iam::123456789012:role/network
+              nodePoolManagementARN: arn:aws:iam::123456789012:role/npm
+              storageARN: arn:aws:iam::123456789012:role/storage
+            resourceTags:
+              - key: env
+                value: prod
+                overridePolicy: Deny
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  - name: when resourceTags have valid key and value without overridePolicy it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            rolesRef:
+              controlPlaneOperatorARN: arn:aws:iam::123456789012:role/cpo
+              imageRegistryARN: arn:aws:iam::123456789012:role/image
+              ingressARN: arn:aws:iam::123456789012:role/ingress
+              kubeCloudControllerARN: arn:aws:iam::123456789012:role/kcc
+              networkARN: arn:aws:iam::123456789012:role/network
+              nodePoolManagementARN: arn:aws:iam::123456789012:role/npm
+              storageARN: arn:aws:iam::123456789012:role/storage
+            resourceTags:
+              - key: env
+                value: prod
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  - name: when resourceTag key contains invalid characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            rolesRef:
+              controlPlaneOperatorARN: arn:aws:iam::123456789012:role/cpo
+              imageRegistryARN: arn:aws:iam::123456789012:role/image
+              ingressARN: arn:aws:iam::123456789012:role/ingress
+              kubeCloudControllerARN: arn:aws:iam::123456789012:role/kcc
+              networkARN: arn:aws:iam::123456789012:role/network
+              nodePoolManagementARN: arn:aws:iam::123456789012:role/npm
+              storageARN: arn:aws:iam::123456789012:role/storage
+            resourceTags:
+              - key: "invalid!key"
+                value: prod
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "key must only contain letters, digits, and the characters _ . : / = + - @"
+
+  - name: when resourceTag value contains invalid characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            rolesRef:
+              controlPlaneOperatorARN: arn:aws:iam::123456789012:role/cpo
+              imageRegistryARN: arn:aws:iam::123456789012:role/image
+              ingressARN: arn:aws:iam::123456789012:role/ingress
+              kubeCloudControllerARN: arn:aws:iam::123456789012:role/kcc
+              networkARN: arn:aws:iam::123456789012:role/network
+              nodePoolManagementARN: arn:aws:iam::123456789012:role/npm
+              storageARN: arn:aws:iam::123456789012:role/storage
+            resourceTags:
+              - key: env
+                value: "invalid#value"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "value must only contain letters, digits, and the characters _ . : / = + - @"

--- a/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.aws.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.aws.testsuite.yaml
@@ -666,3 +666,87 @@ tests:
               id: "subnet-any"
             imageType: Linux
           type: AWS
+
+  # --- AWS resourceTags validation ---
+  - name: when resourceTags have valid key and value it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6i.large
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+            resourceTags:
+              - key: env
+                value: prod
+          type: AWS
+
+  - name: when resourceTag key contains invalid characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6i.large
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+            resourceTags:
+              - key: "invalid!key"
+                value: prod
+          type: AWS
+    expectedError: "key must only contain letters, digits, and the characters _ . : / = + - @"
+
+  - name: when resourceTag value contains invalid characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6i.large
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+            resourceTags:
+              - key: env
+                value: "invalid#value"
+          type: AWS
+    expectedError: "value must only contain letters, digits, and the characters _ . : / = + - @"


### PR DESCRIPTION
## What this PR does / why we need it:

Adds CEL validation envtests for the AWS resource tag XValidation regex rules introduced in #9152. These tests run against Kubernetes 1.30–1.35 via the envtest framework to ensure the tag key/value regex constraints are enforced at the CRD level across supported versions.

**10 new tests across 3 CRDs:**

| CRD | Positive | Negative | Total |
|-----|----------|----------|-------|
| HostedCluster | 3 (overridePolicy Allow, Deny, unset) | 2 (invalid key, invalid value) | 5 |
| NodePool | 1 (valid tags) | 2 (invalid key, invalid value) | 3 |
| AWSEndpointService | 0 (1 already existed) | 2 (invalid key, invalid value) | 2 |

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-4004](https://redhat.atlassian.net/browse/CNTRLPLANE-4004)

## Special notes for your reviewer:

Follow-up to #9152 which split `AWSResourceTag` into per-API types (`AWSClusterResourceTag`, `AWSNodePoolResourceTag`, `AWSEndpointServiceResourceTag`) and added per-tag `overridePolicy`. That PR added the XValidation rules but did not include envtest coverage — this PR fills that gap.

Negative tests use `!` (key) and `#` (value) as invalid characters to trigger the regex rejection: `"key must only contain letters, digits, and the characters _ . : / = + - @"`.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.