### PR TITLE
OCPBUGS-112451: fix(azure): check VMRunning condition for CAPZ VM deletion failures

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -372,7 +372,7 @@ const deletionFailedThreshold = 10 * time.Minute
 
 // DeleteOrphanedMachines removes the finalizer from AzureMachines that are stuck in deletion
 // due to credential failures. This is detected by checking each AzureMachine's Status.Conditions
-// for a Ready=False condition with Reason=DeletionFailed. Orphaning the machine allows management
+// for a VMRunning=False condition with Reason=DeletionFailed. Orphaning the machine allows management
 // cluster cleanup to proceed without requiring valid cloud credentials.
 func (Azure) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hyperv1.HostedCluster, controlPlaneNamespace string) error {
 	// This orphaning behavior is intended for managed-identity cleanup flow.
@@ -416,12 +416,12 @@ func (Azure) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hy
 	return utilerrors.NewAggregate(errs)
 }
 
-// hasDeletionFailedCondition returns true if the AzureMachine has a Ready condition with
+// hasDeletionFailedCondition returns true if the AzureMachine has a VMRunning condition with
 // Status=False and Reason=DeletionFailed, indicating the cloud provider could not delete
 // the underlying VM (e.g., due to invalid or expired credentials).
 func hasDeletionFailedCondition(azureMachine *capiazure.AzureMachine) bool {
 	for _, condition := range azureMachine.Status.Conditions {
-		if condition.Type == capiv1.ReadyCondition &&
+		if condition.Type == capiazure.VMRunningCondition &&
 			condition.Status == corev1.ConditionFalse &&
 			condition.Reason == capiazure.DeletionFailedReason {
 			return true

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
@@ -555,7 +555,7 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 
 	deletionFailedConditions := capiv1.Conditions{
 		{
-			Type:   capiv1.ReadyCondition,
+			Type:   capiazure.VMRunningCondition,
 			Status: corev1.ConditionFalse,
 			Reason: capiazure.DeletionFailedReason,
 		},
@@ -654,7 +654,7 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					Status: capiazure.AzureMachineStatus{
 						Conditions: capiv1.Conditions{
 							{
-								Type:   capiv1.ReadyCondition,
+								Type:   capiazure.VMRunningCondition,
 								Status: corev1.ConditionTrue,
 							},
 						},


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

Fix Azure orphaned-machine detection to check `VMRunning=False` with `Reason=DeletionFailed` instead of the CAPI `Ready` condition. CAPZ reports VM delete failures on `VMRunningCondition` during VM deletion ([CAPZ virtualmachines.go](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/69ec3a40a818ccbc32b8ce88c84609404d8cb7a2/azure/services/virtualmachines/virtualmachines.go#L160)). `Ready` is a summary of other conditions and is not the right signal here.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/OCPBUGS-112451

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of failed Azure machine deletions by using the provider-specific virtual machine running status.
  - Updated health checks to more accurately reflect Azure machine state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->