### PR TITLE
CNTRLPLANE-3532: migrate HCCO/route status patches to statuspatching

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -88,6 +88,7 @@ import (
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/netutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/openshift/hypershift/support/statuspatching"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 	"github.com/openshift/hypershift/support/validations"
@@ -110,7 +111,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2320,20 +2320,20 @@ func (r *HostedControlPlaneReconciler) removeHCPIngressFromRoutes(ctx context.Co
 		// when the HCP router admits routes. We filter by this specific name to ensure
 		// we only remove ingress entries from the HCP router, not from other routers
 		// (e.g., the default ingress controller router).
-		originalRoute := route.DeepCopy()
-		filteredIngress := make([]routev1.RouteIngress, 0, len(route.Status.Ingress))
-		for _, ingress := range route.Status.Ingress {
-			if ingress.RouterName != "router" {
-				filteredIngress = append(filteredIngress, ingress)
-			}
-		}
-		if len(filteredIngress) != len(route.Status.Ingress) {
-			route.Status.Ingress = filteredIngress
-			if !equality.Semantic.DeepEqual(originalRoute.Status, route.Status) {
-				if err := r.Status().Patch(ctx, route, client.MergeFrom(originalRoute)); err != nil {
-					return fmt.Errorf("failed to clear route %s ingress: %w", route.Name, err)
+		// The filtering is recomputed inside the PatchStatus closure against whatever is
+		// freshly fetched on each retry, rather than a value captured beforehand, so a
+		// concurrent ingress write from the actual router controller isn't clobbered.
+		if err := statuspatching.PatchStatus(ctx, r.Client, route, func() error {
+			filteredIngress := make([]routev1.RouteIngress, 0, len(route.Status.Ingress))
+			for _, ingress := range route.Status.Ingress {
+				if ingress.RouterName != "router" {
+					filteredIngress = append(filteredIngress, ingress)
 				}
 			}
+			route.Status.Ingress = filteredIngress
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to clear route %s ingress: %w", route.Name, err)
 		}
 	}
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -2801,13 +2801,11 @@ func (r *reconciler) destroyCloudResources(ctx context.Context, hcp *hyperv1.Hos
 		Message: message,
 	}
 
-	originalHCP := hcp.DeepCopy()
-	meta.SetStatusCondition(&hcp.Status.Conditions, *resourcesDestroyedCond)
-
-	if !equality.Semantic.DeepEqual(hcp, originalHCP) {
-		if err := r.cpClient.Status().Patch(ctx, hcp, client.MergeFromWithOptions(originalHCP, client.MergeFromWithOptimisticLock{})); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to patch resources destroyed condition: %w", err)
-		}
+	// resourcesDestroyedCond is derived from a live guest-cluster check above, not a stale
+	// snapshot, so replaying it on PatchStatusCondition's retry is safe even if CPO's
+	// fallback timeout condition landed on the object in between.
+	if err := statuspatching.PatchStatusCondition(ctx, r.cpClient, hcp, &hcp.Status.Conditions, *resourcesDestroyedCond); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to patch resources destroyed condition: %w", err)
 	}
 
 	if remaining.Len() > 0 {


### PR DESCRIPTION
## What this PR does / why we need it:

Completes 2 of the remaining [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532) status-patching sites flagged during #8966's review:

- **HCCO `resources.go`**: `destroyCloudResources`'s `CloudResourcesDestroyed` condition patch — was raw `MergeFromWithOptimisticLock` (correct locking, no retry). Migrated to `statuspatching.PatchStatusCondition`.
- **CPO `hostedcontrolplane_controller.go`**: `removeHCPIngressFromRoutes`'s route-ingress status patch — was bare `client.MergeFrom` with **no optimistic lock at all**, the worst of the remaining sites. Migrated to `statuspatching.PatchStatus`, with the ingress-filtering logic moved inside the mutate closure so it recomputes against whatever is freshly fetched on retry instead of replaying a value captured beforehand.

Part of the broader [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532) migration. Independent of #8966 — different functions/files, no overlap, no ordering dependency.

## Which issue(s) this PR fixes:

Part of [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532) — does not close it, see remaining work below.

## Special notes for your reviewer:

- **Design note on the HCCO site** (deliberate choice, not an oversight): `resourcesDestroyedCond` is computed synchronously from a live guest-cluster check (`ensureCloudResourcesDestroyed`) right before the patch — traced the full call chain, it depends only on Spec + live checks, never on `hcp.Status`. So replaying it on `PatchStatusCondition`'s retry is safe even if CPO's fallback timeout condition landed on the object in between — HCCO is the authoritative writer for this condition when reachable, and this is intentionally a "last-live-write-wins" pattern, not a race.
- **Still not done for [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532)** (separate follow-up): static analysis linter + `make lint` integration; `AGENTS.md` guidance update; `support/statuspatching` JSON Patch (RFC 6902) variant + nullable-field test; `resources.go:1125` (`reconcileConfig`'s Infrastructure status update) — same "no retry-on-conflict" bug class, different resource/function, found during review of this PR but out of scope here.
- No new tests added — existing tests (`TestDestroyCloudResources*`, `TestRemoveHCPIngressFromRoutes`) already exercise both call sites end-to-end against a real fake client and pass unchanged; the shared helper's retry-on-conflict mechanics are covered separately in `support/statuspatching/statuspatching_test.go`.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating route ingress status during concurrent changes.
  * Prevented cleanup updates from overwriting newer routing information.
  * Made cloud resource cleanup status updates safer and more consistent during retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->