### PR TITLE
OCPBUGS-111601: Prevent conversion webhook startup deadlock

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -121,6 +121,7 @@ const (
 	externaDNSCredsSecretName     = "external-dns-credentials"
 
 	HypershiftOperatorName                = "operator"
+	HypershiftOperatorHealthProbePort     = 8081
 	ExternalDNSDeploymentName             = "external-dns"
 	HyperShiftInstallCLIVersionAnnotation = "hypershift.openshift.io/install-cli-version"
 )
@@ -677,8 +678,8 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Path:   "/metrics",
-										Port:   intstr.FromInt(9000),
+										Path:   "/healthz",
+										Port:   intstr.FromInt(HypershiftOperatorHealthProbePort),
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
@@ -691,8 +692,8 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Path:   "/metrics",
-										Port:   intstr.FromInt(9000),
+										Path:   "/readyz",
+										Port:   intstr.FromInt(HypershiftOperatorHealthProbePort),
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
@@ -711,6 +712,11 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 								{
 									Name:          "manager",
 									ContainerPort: 9443,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "health",
+									ContainerPort: HypershiftOperatorHealthProbePort,
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
@@ -593,8 +594,24 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 			deployment := test.inputBuildParameters.Build()
 			g.Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(BeEquivalentTo(test.expectedArgs))
 			g.Expect(deployment.Spec.Template.Spec.Volumes).To(BeEquivalentTo(test.expectedVolumes))
-			g.Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts).To(BeEquivalentTo(test.expectedVolumeMounts))
-			g.Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(ContainElements(test.expectedEnvVars))
+			container := deployment.Spec.Template.Spec.Containers[0]
+			g.Expect(container.VolumeMounts).To(BeEquivalentTo(test.expectedVolumeMounts))
+			g.Expect(container.Env).To(ContainElements(test.expectedEnvVars))
+			g.Expect(container.LivenessProbe.HTTPGet).To(Equal(&corev1.HTTPGetAction{
+				Path:   "/healthz",
+				Port:   intstr.FromInt(HypershiftOperatorHealthProbePort),
+				Scheme: corev1.URISchemeHTTP,
+			}))
+			g.Expect(container.ReadinessProbe.HTTPGet).To(Equal(&corev1.HTTPGetAction{
+				Path:   "/readyz",
+				Port:   intstr.FromInt(HypershiftOperatorHealthProbePort),
+				Scheme: corev1.URISchemeHTTP,
+			}))
+			g.Expect(container.Ports).To(ContainElement(corev1.ContainerPort{
+				Name:          "health",
+				ContainerPort: HypershiftOperatorHealthProbePort,
+				Protocol:      corev1.ProtocolTCP,
+			}))
 		})
 	}
 }

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -99,6 +99,7 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -279,6 +280,9 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	if err != nil {
 		return err
 	}
+	if err := setupHealthChecks(mgr, opts.CertDir != ""); err != nil {
+		return err
+	}
 
 	operatorImage, err := resolveOperatorImage(ctx, mgr, opts, log)
 	if err != nil {
@@ -452,11 +456,34 @@ func createManager(restConfig *rest.Config, webhookOptions webhook.Options, opts
 		LeaseDuration:                 &leaseDuration,
 		RenewDeadline:                 &renewDeadline,
 		RetryPeriod:                   &retryPeriod,
+		HealthProbeBindAddress:        fmt.Sprintf(":%d", assets.HypershiftOperatorHealthProbePort),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to start manager: %w", err)
 	}
 	return mgr, nil
+}
+
+type healthCheckManager interface {
+	AddHealthzCheck(string, healthz.Checker) error
+	AddReadyzCheck(string, healthz.Checker) error
+	GetWebhookServer() webhook.Server
+}
+
+func setupHealthChecks(mgr healthCheckManager, webhookEnabled bool) error {
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return fmt.Errorf("unable to set up health check: %w", err)
+	}
+	readyCheck := healthz.Ping
+	if webhookEnabled {
+		// Conversion webhooks must be reachable before caches can sync resources
+		// requested in a version different from their storage version.
+		readyCheck = mgr.GetWebhookServer().StartedChecker()
+	}
+	if err := mgr.AddReadyzCheck("readyz", readyCheck); err != nil {
+		return fmt.Errorf("unable to set up ready check: %w", err)
+	}
+	return nil
 }
 
 func resolveOperatorImage(ctx context.Context, mgr ctrl.Manager, opts *StartOptions, log logr.Logger) (string, error) {

--- a/hypershift-operator/main_test.go
+++ b/hypershift-operator/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+type fakeHealthCheckManager struct {
+	webhookServer webhook.Server
+	healthChecks  map[string]healthz.Checker
+	readyChecks   map[string]healthz.Checker
+}
+
+func (m *fakeHealthCheckManager) AddHealthzCheck(name string, check healthz.Checker) error {
+	m.healthChecks[name] = check
+	return nil
+}
+
+func (m *fakeHealthCheckManager) AddReadyzCheck(name string, check healthz.Checker) error {
+	m.readyChecks[name] = check
+	return nil
+}
+
+func (m *fakeHealthCheckManager) GetWebhookServer() webhook.Server {
+	return m.webhookServer
+}
+
+func TestSetupHealthChecks(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		webhookEnabled     bool
+		expectReadyToError bool
+	}{
+		{
+			name:               "webhook readiness waits for the webhook server",
+			webhookEnabled:     true,
+			expectReadyToError: true,
+		},
+		{
+			name:           "readiness succeeds when webhooks are disabled",
+			webhookEnabled: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			mgr := &fakeHealthCheckManager{
+				webhookServer: webhook.NewServer(webhook.Options{}),
+				healthChecks:  map[string]healthz.Checker{},
+				readyChecks:   map[string]healthz.Checker{},
+			}
+
+			g.Expect(setupHealthChecks(mgr, tc.webhookEnabled)).To(Succeed())
+			g.Expect(mgr.healthChecks).To(HaveKey("healthz"))
+			g.Expect(mgr.readyChecks).To(HaveKey("readyz"))
+
+			request := httptest.NewRequest("GET", "/", nil)
+			g.Expect(mgr.healthChecks["healthz"](request)).To(Succeed())
+			if tc.expectReadyToError {
+				g.Expect(mgr.readyChecks["readyz"](request)).To(MatchError("webhook server has not been started yet"))
+			} else {
+				g.Expect(mgr.readyChecks["readyz"](request)).To(Succeed())
+			}
+		})
+	}
+}

--- a/hypershift-operator/main_test.go
+++ b/hypershift-operator/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -58,7 +59,7 @@ func TestSetupHealthChecks(t *testing.T) {
 			g.Expect(mgr.healthChecks).To(HaveKey("healthz"))
 			g.Expect(mgr.readyChecks).To(HaveKey("readyz"))
 
-			request := httptest.NewRequest("GET", "/", nil)
+			request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 			g.Expect(mgr.healthChecks["healthz"](request)).To(Succeed())
 			if tc.expectReadyToError {
 				g.Expect(mgr.readyChecks["readyz"](request)).To(MatchError("webhook server has not been started yet"))

--- a/hypershift-operator/main_test.go
+++ b/hypershift-operator/main_test.go
@@ -37,12 +37,12 @@ func TestSetupHealthChecks(t *testing.T) {
 		expectReadyToError bool
 	}{
 		{
-			name:               "webhook readiness waits for the webhook server",
+			name:               "When webhooks are enabled it should wait for the webhook server",
 			webhookEnabled:     true,
 			expectReadyToError: true,
 		},
 		{
-			name:           "readiness succeeds when webhooks are disabled",
+			name:           "When webhooks are disabled it should report ready",
 			webhookEnabled: false,
 		},
 	} {


### PR DESCRIPTION
## What this PR does / why we need it:

Prevents the HyperShift operator from deadlocking during startup when CAPI resources are stored as v1beta2 but operator caches request v1beta1 resources.

### Failure evidence

- [Failed Azure self-managed run 2091848958857973760](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/9052/pull-ci-openshift-hypershift-main-e2e-v2-azure-self-managed/2091848958857973760)
- [Original operator container log](https://storage.googleapis.com/test-platform-results/pr-logs/pull/openshift_hypershift/9052/pull-ci-openshift-hypershift-main-e2e-v2-azure-self-managed/2091848958857973760/artifacts/e2e-v2-azure-self-managed/dump-management-cluster/artifacts/output/namespaces/hypershift/core/pods/logs/operator-69df4b4bbf-9gvlc-operator.log)
- [Original operator previous-container log](https://storage.googleapis.com/test-platform-results/pr-logs/pull/openshift_hypershift/9052/pull-ci-openshift-hypershift-main-e2e-v2-azure-self-managed/2091848958857973760/artifacts/e2e-v2-azure-self-managed/dump-management-cluster/artifacts/output/namespaces/hypershift/core/pods/logs/operator-69df4b4bbf-9gvlc-operator-previous.log)

The management HostedCluster was created but never received status and timed out waiting to become available. Every operator container repeatedly failed to synchronize the v1beta1 MachineSet and MachineDeployment informers:

```text
conversion webhook for cluster.x-k8s.io/v1beta2, Kind=MachineSet failed:
Post "https://operator.hypershift.svc:443/convert?timeout=30s":
no endpoints available for service "operator"
```

The operator's webhook server was listening locally on port 9443, but the Service excluded the pods because they were not Ready. The existing readiness and liveness probes scraped `/metrics`. The NodePool metrics collector synchronously lists v1beta1 MachineSets and MachineDeployments through the controller-runtime cache with a background context. Those requests block until the same informers synchronize, so `/metrics` cannot complete while conversion is unavailable.

This creates a loop:

1. Cache synchronization requires v1beta2-to-v1beta1 conversion.
2. Conversion requires a ready operator Service endpoint.
3. Readiness probes `/metrics`.
4. `/metrics` waits for cache synchronization.
5. Liveness eventually restarts the container and repeats the cycle.

The captured containers restarted after approximately five and a half minutes, matching the configured liveness timing. A [healthy post-migration periodic](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-5.1-periodics-e2e-v2-azure-self-managed/2091699786414559232) had ready operator endpoints and no conversion errors, demonstrating that normal v1beta1 reads work once the webhook is reachable. The failure is specifically the zero-ready-endpoint startup case, not conversion functionality in a healthy deployment.

### Fix

- Serve liveness and readiness from controller-runtime's dedicated health server instead of `/metrics`.
- Keep liveness independent of caches with `healthz.Ping`.
- When webhooks are enabled, report Ready only after the local TLS webhook listener is reachable using `WebhookServer.StartedChecker()`.
- Preserve simple ping readiness for local runs where webhooks are disabled.

This allows the pod to become a Service endpoint before cache synchronization, which lets conversion complete and the controllers start.

This is separate from #9384. That PR fixes the independently reproduced v2 upgrade-test rollout race; this PR fixes management-cluster creation failures where the operator cannot start.

## Which issue(s) this PR fixes:

Related to https://redhat.atlassian.net/browse/OCPBUGS-111601

## Special notes for your reviewer:

Local validation:

- `go test ./hypershift-operator ./cmd/install/assets`
- `make verify-quick`
- Push-hook changed-package tests

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated health and readiness endpoints for the HyperShift operator.
  * Added liveness checks at `/healthz` and readiness checks at `/readyz` on port 8081.
  * Readiness checks now account for webhook server availability when webhooks are enabled.
* **Bug Fixes**
  * Improved operator health monitoring by replacing metrics-based probes with dedicated health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->