### PR TITLE
CNTRLPLANE-3532: add hcpstatuspatch linter and status-patching AGENTS.md guidance

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,21 @@ linters:
       hypershiftlinter:
         path: hack/tools/bin/hypershiftlinter.so
         description: "Enforces HyperShift test conventions from TESTING.md and test/e2e/v2/AGENTS.md"
+        settings:
+          analyzers:
+            # hcpstatuspatch is intentionally excluded here: enabling it now would fail
+            # on the last couple of HostedControlPlane status-patch call sites still being
+            # migrated to support/statuspatching in-flight PRs. Add it to this list once
+            # those land. See hack/tools/hypershiftlinter/README.md's staged rollout section.
+            enable:
+              - testcasename
+              - testfuncname
+              - sippyannotation
+              - guestcluster
+              - contextbackground
+              - vacuouspass
+              - ipv6url
+              - e2eutilallowlist
     gocyclo:
       min-complexity: 30
     govet:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Project documentation is published via MkDocs. The site structure and navigation
 | **API types and CRD machinery** | [api/AGENTS.md](api/AGENTS.md) |
 | **Control plane components (CPOv2)** | [support/controlplane-component/AGENTS.md](support/controlplane-component/AGENTS.md) and [support/controlplane-component/README.md](support/controlplane-component/README.md) |
 | **Control plane operator** | [control-plane-operator/AGENTS.md](control-plane-operator/AGENTS.md) |
+| **HostedControlPlane status patching** | [control-plane-operator/AGENTS.md](control-plane-operator/AGENTS.md#hostedcontrolplane-status-patching) — never `Status().Update()`/unguarded `MergeFrom()` on HCP; use `support/statuspatching` |
 | **E2E v2 test framework** | [test/e2e/v2/AGENTS.md](test/e2e/v2/AGENTS.md) |
 | **Envtest (CEL validation tests)** | [test/envtest/README.md](test/envtest/README.md) — YAML-driven, runs across k8s 1.30–1.36, supports feature gate filtering |
 | **CEL over webhooks** | [.claude/rules/webhook-validation.md](.claude/rules/webhook-validation.md) |

--- a/control-plane-operator/AGENTS.md
+++ b/control-plane-operator/AGENTS.md
@@ -25,6 +25,41 @@ HCCO is a **separate binary in the same image**, invoked as `control-plane-opera
 
 HCCO controllers are in `hostedclusterconfigoperator/controllers/`. They do **not** use the v2 component framework today — this is a migration opportunity.
 
+## HostedControlPlane Status Patching
+
+CPO, HCCO, and the hypershift-operator (karpenter) all write to the same
+`HostedControlPlane.Status` concurrently. Never patch HCP status with a raw
+`Status().Update()` or an unguarded `client.MergeFrom()` — both can silently
+overwrite a concurrent writer's changes (`Update()` replaces the whole status
+subresource; `MergeFrom()` without an optimistic lock lets a stale
+`resourceVersion` succeed silently instead of conflicting).
+
+Use `support/statuspatching` instead:
+
+- `statuspatching.PatchStatus(ctx, c, obj, mutate)` — general case. Re-fetches
+  the object, applies `mutate`, patches with `MergeFromWithOptimisticLock`, and
+  retries automatically on conflict.
+- `statuspatching.PatchStatusCondition(ctx, c, obj, conditions, condition)` —
+  single-condition updates. Uses `meta.SetStatusCondition`'s own change
+  detection to skip no-ops without a false positive from `LastTransitionTime`.
+
+**The mutate callback must recompute from the object it's given, not replay a
+value captured earlier.** `PatchStatus`/`PatchStatusCondition` re-fetch the
+object before calling `mutate`, so if `mutate` just re-applies a value computed
+before the call, a conflict-retry blindly overwrites whatever concurrent write
+the re-fetch picked up — defeating the point of the optimistic lock. If the
+desired value depends on `Spec` and needs an expensive computation done once
+outside the callback (e.g. an AWS API call), guard against the spec changing
+mid-flight by comparing a captured `Generation` inside the callback instead of
+patching unconditionally. A value is only safe to blindly replay on retry if
+it's derived from a live check with no other writer (e.g. a fresh guest-cluster
+probe done right before patching), not from an earlier `Status` snapshot.
+
+The `hcpstatuspatch` static analyzer (`hack/tools/hypershiftlinter`) flags
+direct `Status().Update()`/unguarded `MergeFrom()` on `HostedControlPlane` —
+see [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532) for
+migration status.
+
 ## Key Directories
 
 | Directory | Purpose |

--- a/control-plane-operator/AGENTS.md
+++ b/control-plane-operator/AGENTS.md
@@ -52,8 +52,9 @@ desired value depends on `Spec` and needs an expensive computation done once
 outside the callback (e.g. an AWS API call), guard against the spec changing
 mid-flight by comparing a captured `Generation` inside the callback instead of
 patching unconditionally. A value is only safe to blindly replay on retry if
-it's derived from a live check with no other writer (e.g. a fresh guest-cluster
-probe done right before patching), not from an earlier `Status` snapshot.
+it's derived from a fresh external probe performed immediately before the patch
+call, where no concurrent writer can invalidate the value between the probe and
+the patch, not from an earlier `Status` snapshot.
 
 The `hcpstatuspatch` static analyzer (`hack/tools/hypershiftlinter`) flags
 direct `Status().Update()`/unguarded `MergeFrom()` on `HostedControlPlane` —

--- a/hack/tools/hypershiftlinter/README.md
+++ b/hack/tools/hypershiftlinter/README.md
@@ -30,7 +30,7 @@ relying on reviewer memory. That matters for several reasons:
 
 ## Analyzers
 
-The plugin ships 7 analyzers, scoped so each rule only fires where it applies.
+The plugin ships 8 analyzers, scoped so each rule only fires where it applies.
 
 ### Unit test conventions (`TESTING.md`, unit tests only)
 
@@ -48,6 +48,12 @@ The plugin ships 7 analyzers, scoped so each rule only fires where it applies.
 | `vacuouspass`       | Flags vacuously-passing tests that iterate a collection without asserting it is non-empty.        |
 | `ipv6url`           | Detects `fmt.Sprintf` URL patterns that break with IPv6; use `net.JoinHostPort` instead.          |
 | `sippyannotation`   | Requires the correct Sippy/Jira `[Feature:X]` annotations on Ginkgo `Describe` blocks.            |
+
+### HostedControlPlane status patching (repo-wide, see [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532))
+
+| Analyzer          | Enforces                                                                                                    |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| `hcpstatuspatch`  | Bans `Status().Update()` and unguarded `MergeFrom()` status patches on `HostedControlPlane`; use `support/statuspatching` instead. **Not yet enabled in `.golangci.yml`** — see below. |
 
 ## How it's built and run
 
@@ -79,3 +85,9 @@ analyzers' own tests before enforcement is turned on. (A brand-new reusable
 workflow can't get a green pre-merge run on the PR that introduces it, because
 GitHub resolves `uses: ...@main` and the `pull_request` trigger from the base
 branch — so the foundational plumbing has to land on `main` first.)
+
+The same staging applies per-analyzer when a new rule would fail on violations
+still being fixed in other in-flight PRs: `hcpstatuspatch` lands with its own
+tests but is deliberately left out of `linters.settings.custom.hypershiftlinter.settings.analyzers.enable`
+in `.golangci.yml` until the last HostedControlPlane status-patch call sites it
+would flag are migrated to `support/statuspatching` elsewhere.

--- a/hack/tools/hypershiftlinter/README.md
+++ b/hack/tools/hypershiftlinter/README.md
@@ -30,7 +30,7 @@ relying on reviewer memory. That matters for several reasons:
 
 ## Analyzers
 
-The plugin ships 8 analyzers, scoped so each rule only fires where it applies.
+The plugin ships 9 analyzers, scoped so each rule only fires where it applies.
 
 ### Unit test conventions (`TESTING.md`, unit tests only)
 
@@ -48,6 +48,7 @@ The plugin ships 8 analyzers, scoped so each rule only fires where it applies.
 | `vacuouspass`       | Flags vacuously-passing tests that iterate a collection without asserting it is non-empty.        |
 | `ipv6url`           | Detects `fmt.Sprintf` URL patterns that break with IPv6; use `net.JoinHostPort` instead.          |
 | `sippyannotation`   | Requires the correct Sippy/Jira `[Feature:X]` annotations on Ginkgo `Describe` blocks.            |
+| `e2eutilallowlist`  | Restricts `test/e2e/v2` to an allowlist of approved symbols from `test/e2e/util`.                 |
 
 ### HostedControlPlane status patching (repo-wide, see [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532))
 
@@ -91,3 +92,9 @@ still being fixed in other in-flight PRs: `hcpstatuspatch` lands with its own
 tests but is deliberately left out of `linters.settings.custom.hypershiftlinter.settings.analyzers.enable`
 in `.golangci.yml` until the last HostedControlPlane status-patch call sites it
 would flag are migrated to `support/statuspatching` elsewhere.
+
+[CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532) also asks
+the linter to warn on `reflect.DeepEqual` for Kubernetes API objects (use
+`equality.Semantic.DeepEqual` instead). That check is intentionally a follow-up:
+it is a different rule from `hcpstatuspatch`, with a repo-wide blast radius, and
+is not registered here.

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch.go
@@ -16,7 +16,12 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
-const controllerRuntimeClientPkg = "sigs.k8s.io/controller-runtime/pkg/client"
+const (
+	controllerRuntimeClientPkg = "sigs.k8s.io/controller-runtime/pkg/client"
+	hostedControlPlanePkg      = "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hostedControlPlaneType     = "HostedControlPlane"
+	optimisticLockType         = "MergeFromWithOptimisticLock"
+)
 
 var Analyzer = &analysis.Analyzer{
 	Name: "hcpstatuspatch",
@@ -55,8 +60,8 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-// isHCPStatusUpdate matches `<expr>.Status().Update(ctx, obj, ...)` where obj's
-// type is named HostedControlPlane.
+// isHCPStatusUpdate matches `<expr>.Status().Update(ctx, obj, ...)` where obj is
+// a HyperShift HostedControlPlane.
 func isHCPStatusUpdate(pass *analysis.Pass, call *ast.CallExpr) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok || sel.Sel.Name != "Update" {
@@ -76,8 +81,8 @@ func isHCPStatusUpdate(pass *analysis.Pass, call *ast.CallExpr) bool {
 	return isHostedControlPlane(pass.TypesInfo.TypeOf(call.Args[1]))
 }
 
-// isHCPStatusPatch matches `<expr>.Status().Patch(ctx, obj, patch)` where obj's
-// type is named HostedControlPlane.
+// isHCPStatusPatch matches `<expr>.Status().Patch(ctx, obj, patch)` where obj is
+// a HyperShift HostedControlPlane.
 func isHCPStatusPatch(pass *analysis.Pass, call *ast.CallExpr) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok || sel.Sel.Name != "Patch" {
@@ -109,8 +114,8 @@ func reportUnguardedPatchConstructors(pass *analysis.Pass, statusPatch *ast.Call
 		}
 	}
 	for _, call := range mergeCallsForPatchExpr(pass, statusPatch.Args[2], enclosingFn) {
-		name, _ := mergePatchConstructorName(pass, call)
-		if name == "" {
+		name, isControllerRuntime := mergePatchConstructorName(pass, call)
+		if !isControllerRuntime {
 			continue
 		}
 		if len(call.Args) < 1 || !isHostedControlPlane(pass.TypesInfo.TypeOf(call.Args[0])) {
@@ -207,26 +212,38 @@ func assignDefinesIdent(stmt *ast.AssignStmt, ident string) bool {
 }
 
 func mergePatchConstructorName(pass *analysis.Pass, call *ast.CallExpr) (name string, isControllerRuntime bool) {
-	switch fn := call.Fun.(type) {
-	case *ast.SelectorExpr:
-		name = fn.Sel.Name
-		if sel, ok := pass.TypesInfo.Selections[fn]; ok {
-			if obj, ok := sel.Obj().(*types.Func); ok && obj.Pkg() != nil && obj.Pkg().Path() == controllerRuntimeClientPkg {
-				isControllerRuntime = name == "MergeFrom" || name == "MergeFromWithOptions"
-			}
-		}
-	case *ast.Ident:
-		name = fn.Name
-		if obj, ok := pass.TypesInfo.Uses[fn].(*types.Func); ok && obj.Pkg() != nil && obj.Pkg().Path() == controllerRuntimeClientPkg {
-			isControllerRuntime = name == "MergeFrom" || name == "MergeFromWithOptions"
-		}
-	default:
+	obj := funcObject(pass, call.Fun)
+	if obj == nil {
 		return "", false
 	}
+	name = obj.Name()
 	if name != "MergeFrom" && name != "MergeFromWithOptions" {
 		return "", false
 	}
-	return name, isControllerRuntime
+	if isFromPackage(obj, controllerRuntimeClientPkg) {
+		return name, true
+	}
+	return name, false
+}
+
+// funcObject resolves a call's function. Package-level functions such as
+// client.MergeFrom are recorded in TypesInfo.Uses on the selector Ident, not in
+// TypesInfo.Selections (which only records method selections on values).
+func funcObject(pass *analysis.Pass, fun ast.Expr) *types.Func {
+	switch fn := fun.(type) {
+	case *ast.Ident:
+		obj, _ := pass.TypesInfo.Uses[fn].(*types.Func)
+		return obj
+	case *ast.SelectorExpr:
+		if sel, ok := pass.TypesInfo.Selections[fn]; ok {
+			obj, _ := sel.Obj().(*types.Func)
+			return obj
+		}
+		obj, _ := pass.TypesInfo.Uses[fn.Sel].(*types.Func)
+		return obj
+	default:
+		return nil
+	}
 }
 
 func hasOptimisticLockOption(pass *analysis.Pass, call *ast.CallExpr) bool {
@@ -239,55 +256,39 @@ func hasOptimisticLockOption(pass *analysis.Pass, call *ast.CallExpr) bool {
 }
 
 func isOptimisticLockOption(pass *analysis.Pass, expr ast.Expr) bool {
-	switch e := expr.(type) {
-	case *ast.CompositeLit:
-		return isOptimisticLockType(pass, e.Type)
-	case *ast.CallExpr:
-		return callName(e) == "MergeFromWithOptimisticLock"
-	default:
+	named := namedType(pass.TypesInfo.TypeOf(expr))
+	if named == nil {
 		return false
 	}
+	obj := named.Obj()
+	return obj.Name() == optimisticLockType && isFromPackage(obj, controllerRuntimeClientPkg)
 }
 
-func isOptimisticLockType(pass *analysis.Pass, typ ast.Expr) bool {
-	if typ == nil {
-		return false
-	}
-	switch t := typ.(type) {
-	case *ast.Ident:
-		return t.Name == "MergeFromWithOptimisticLock"
-	case *ast.SelectorExpr:
-		return t.Sel.Name == "MergeFromWithOptimisticLock"
-	default:
-		return false
-	}
-}
-
-func callName(call *ast.CallExpr) string {
-	switch fn := call.Fun.(type) {
-	case *ast.Ident:
-		return fn.Name
-	case *ast.SelectorExpr:
-		return fn.Sel.Name
-	default:
-		return ""
-	}
-}
-
-// isHostedControlPlane reports whether t is (a pointer to) a named type called
-// HostedControlPlane. Matching on name only, not full package path, since it's
-// specific enough in practice and keeps the analyzer testable against local
-// fixture types instead of requiring the real hypershift API module.
-func isHostedControlPlane(t types.Type) bool {
+func namedType(t types.Type) *types.Named {
 	if t == nil {
-		return false
+		return nil
 	}
+	t = types.Unalias(t)
 	if ptr, ok := t.(*types.Pointer); ok {
-		t = ptr.Elem()
+		t = types.Unalias(ptr.Elem())
 	}
-	named, ok := t.(*types.Named)
-	if !ok {
+	named, _ := t.(*types.Named)
+	return named
+}
+
+func isFromPackage(obj types.Object, path string) bool {
+	return obj != nil && obj.Pkg() != nil && obj.Pkg().Path() == path
+}
+
+// isHostedControlPlane reports whether t is (a pointer to) HyperShift's
+// HostedControlPlane type. Matching requires both the type name and the
+// hypershift/v1beta1 package path so a local or third-party type of the same
+// name does not trigger the rule.
+func isHostedControlPlane(t types.Type) bool {
+	named := namedType(t)
+	if named == nil {
 		return false
 	}
-	return named.Obj().Name() == "HostedControlPlane"
+	obj := named.Obj()
+	return obj.Name() == hostedControlPlaneType && isFromPackage(obj, hostedControlPlanePkg)
 }

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch.go
@@ -1,0 +1,293 @@
+// Package hcpstatuspatch bans direct Status().Update() calls and unguarded
+// client.MergeFrom() status patches on HostedControlPlane. Multiple controllers
+// (CPO, HCCO, HO/karpenter) write to the same HostedControlPlane.Status
+// concurrently — Status().Update() replaces the whole status subresource and
+// silently overwrites concurrent changes, and MergeFrom() without an optimistic
+// lock lets a stale resourceVersion succeed silently. See
+// support/statuspatching for the safe pattern.
+package hcpstatuspatch
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const controllerRuntimeClientPkg = "sigs.k8s.io/controller-runtime/pkg/client"
+
+var Analyzer = &analysis.Analyzer{
+	Name: "hcpstatuspatch",
+	Doc:  "bans Status().Update() and unguarded MergeFrom() status patches on HostedControlPlane; use support/statuspatching instead",
+	Run:  run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	for _, file := range pass.Files {
+		filename := pass.Fset.File(file.Pos()).Name()
+		// Test files legitimately seed fixture status via a fake client's
+		// Status().Update() — there's no concurrent writer to race with in a
+		// synchronous unit test, so the rule doesn't apply there.
+		if strings.HasSuffix(filename, "_test.go") {
+			continue
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if isHCPStatusUpdate(pass, call) {
+				pass.Report(analysis.Diagnostic{
+					Pos:     call.Pos(),
+					End:     call.End(),
+					Message: "do not call Status().Update() on HostedControlPlane; use statuspatching.PatchStatus instead — Update() replaces the whole status subresource and silently overwrites concurrent writers",
+				})
+			}
+			if isHCPStatusPatch(pass, call) {
+				reportUnguardedPatchConstructors(pass, call)
+			}
+			return true
+		})
+	}
+	return nil, nil
+}
+
+// isHCPStatusUpdate matches `<expr>.Status().Update(ctx, obj, ...)` where obj's
+// type is named HostedControlPlane.
+func isHCPStatusUpdate(pass *analysis.Pass, call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Update" {
+		return false
+	}
+	statusCall, ok := sel.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	statusSel, ok := statusCall.Fun.(*ast.SelectorExpr)
+	if !ok || statusSel.Sel.Name != "Status" {
+		return false
+	}
+	if len(call.Args) < 2 {
+		return false
+	}
+	return isHostedControlPlane(pass.TypesInfo.TypeOf(call.Args[1]))
+}
+
+// isHCPStatusPatch matches `<expr>.Status().Patch(ctx, obj, patch)` where obj's
+// type is named HostedControlPlane.
+func isHCPStatusPatch(pass *analysis.Pass, call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Patch" {
+		return false
+	}
+	statusCall, ok := sel.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	statusSel, ok := statusCall.Fun.(*ast.SelectorExpr)
+	if !ok || statusSel.Sel.Name != "Status" {
+		return false
+	}
+	if len(call.Args) < 2 {
+		return false
+	}
+	return isHostedControlPlane(pass.TypesInfo.TypeOf(call.Args[1]))
+}
+
+func reportUnguardedPatchConstructors(pass *analysis.Pass, statusPatch *ast.CallExpr) {
+	if len(statusPatch.Args) < 3 {
+		return
+	}
+	var enclosingFn *ast.FuncDecl
+	for _, file := range pass.Files {
+		if file.Pos() <= statusPatch.Pos() && statusPatch.Pos() < file.End() {
+			enclosingFn = enclosingFuncDecl(file, statusPatch.Pos())
+			break
+		}
+	}
+	for _, call := range mergeCallsForPatchExpr(pass, statusPatch.Args[2], enclosingFn) {
+		name, _ := mergePatchConstructorName(pass, call)
+		if name == "" {
+			continue
+		}
+		if len(call.Args) < 1 || !isHostedControlPlane(pass.TypesInfo.TypeOf(call.Args[0])) {
+			continue
+		}
+		switch name {
+		case "MergeFrom":
+			pass.Report(analysis.Diagnostic{
+				Pos:     call.Pos(),
+				End:     call.End(),
+				Message: "do not use MergeFrom() on HostedControlPlane without an optimistic lock; use statuspatching.PatchStatus/PatchStatusCondition, or MergeFromWithOptions(..., MergeFromWithOptimisticLock{}) at minimum",
+			})
+		case "MergeFromWithOptions":
+			if !hasOptimisticLockOption(pass, call) {
+				pass.Report(analysis.Diagnostic{
+					Pos:     call.Pos(),
+					End:     call.End(),
+					Message: "do not use MergeFromWithOptions() on HostedControlPlane without MergeFromWithOptimisticLock{}; use statuspatching.PatchStatus/PatchStatusCondition instead",
+				})
+			}
+		}
+	}
+}
+
+func enclosingFuncDecl(file *ast.File, pos token.Pos) *ast.FuncDecl {
+	var found *ast.FuncDecl
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok {
+			return true
+		}
+		if fn.Pos() <= pos && pos < fn.End() {
+			found = fn
+		}
+		return true
+	})
+	return found
+}
+
+func mergeCallsForPatchExpr(pass *analysis.Pass, patchExpr ast.Expr, enclosingFn *ast.FuncDecl) []*ast.CallExpr {
+	switch expr := patchExpr.(type) {
+	case *ast.CallExpr:
+		return collectMergePatchConstructorCalls(pass, expr)
+	case *ast.Ident:
+		if enclosingFn == nil || enclosingFn.Body == nil {
+			return nil
+		}
+		return findMergeAssignments(pass, expr.Name, enclosingFn.Body)
+	default:
+		return nil
+	}
+}
+
+func collectMergePatchConstructorCalls(pass *analysis.Pass, expr ast.Expr) []*ast.CallExpr {
+	var calls []*ast.CallExpr
+	ast.Inspect(expr, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if name, _ := mergePatchConstructorName(pass, call); name != "" {
+			calls = append(calls, call)
+		}
+		return true
+	})
+	return calls
+}
+
+func findMergeAssignments(pass *analysis.Pass, ident string, body *ast.BlockStmt) []*ast.CallExpr {
+	var calls []*ast.CallExpr
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch stmt := n.(type) {
+		case *ast.AssignStmt:
+			if !assignDefinesIdent(stmt, ident) {
+				return true
+			}
+			for _, rhs := range stmt.Rhs {
+				calls = append(calls, collectMergePatchConstructorCalls(pass, rhs)...)
+			}
+		}
+		return true
+	})
+	return calls
+}
+
+func assignDefinesIdent(stmt *ast.AssignStmt, ident string) bool {
+	for _, lhs := range stmt.Lhs {
+		id, ok := lhs.(*ast.Ident)
+		if ok && id.Name == ident {
+			return true
+		}
+	}
+	return false
+}
+
+func mergePatchConstructorName(pass *analysis.Pass, call *ast.CallExpr) (name string, isControllerRuntime bool) {
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		name = fn.Sel.Name
+		if sel, ok := pass.TypesInfo.Selections[fn]; ok {
+			if obj, ok := sel.Obj().(*types.Func); ok && obj.Pkg() != nil && obj.Pkg().Path() == controllerRuntimeClientPkg {
+				isControllerRuntime = name == "MergeFrom" || name == "MergeFromWithOptions"
+			}
+		}
+	case *ast.Ident:
+		name = fn.Name
+		if obj, ok := pass.TypesInfo.Uses[fn].(*types.Func); ok && obj.Pkg() != nil && obj.Pkg().Path() == controllerRuntimeClientPkg {
+			isControllerRuntime = name == "MergeFrom" || name == "MergeFromWithOptions"
+		}
+	default:
+		return "", false
+	}
+	if name != "MergeFrom" && name != "MergeFromWithOptions" {
+		return "", false
+	}
+	return name, isControllerRuntime
+}
+
+func hasOptimisticLockOption(pass *analysis.Pass, call *ast.CallExpr) bool {
+	for _, arg := range call.Args[1:] {
+		if isOptimisticLockOption(pass, arg) {
+			return true
+		}
+	}
+	return false
+}
+
+func isOptimisticLockOption(pass *analysis.Pass, expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.CompositeLit:
+		return isOptimisticLockType(pass, e.Type)
+	case *ast.CallExpr:
+		return callName(e) == "MergeFromWithOptimisticLock"
+	default:
+		return false
+	}
+}
+
+func isOptimisticLockType(pass *analysis.Pass, typ ast.Expr) bool {
+	if typ == nil {
+		return false
+	}
+	switch t := typ.(type) {
+	case *ast.Ident:
+		return t.Name == "MergeFromWithOptimisticLock"
+	case *ast.SelectorExpr:
+		return t.Sel.Name == "MergeFromWithOptimisticLock"
+	default:
+		return false
+	}
+}
+
+func callName(call *ast.CallExpr) string {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name
+	case *ast.SelectorExpr:
+		return fn.Sel.Name
+	default:
+		return ""
+	}
+}
+
+// isHostedControlPlane reports whether t is (a pointer to) a named type called
+// HostedControlPlane. Matching on name only, not full package path, since it's
+// specific enough in practice and keeps the analyzer testable against local
+// fixture types instead of requiring the real hypershift API module.
+func isHostedControlPlane(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	return named.Obj().Name() == "HostedControlPlane"
+}

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch.go
@@ -113,7 +113,7 @@ func reportUnguardedPatchConstructors(pass *analysis.Pass, statusPatch *ast.Call
 			break
 		}
 	}
-	for _, call := range mergeCallsForPatchExpr(pass, statusPatch.Args[2], enclosingFn) {
+	for _, call := range mergeCallsForPatchExpr(pass, statusPatch.Args[2], enclosingFn, statusPatch.Pos()) {
 		name, isControllerRuntime := mergePatchConstructorName(pass, call)
 		if !isControllerRuntime {
 			continue
@@ -150,12 +150,13 @@ func enclosingFuncDecl(file *ast.File, pos token.Pos) *ast.FuncDecl {
 		if fn.Pos() <= pos && pos < fn.End() {
 			found = fn
 		}
+		// *ast.FuncDecl nodes are package-level and never nest; found is set at most once.
 		return true
 	})
 	return found
 }
 
-func mergeCallsForPatchExpr(pass *analysis.Pass, patchExpr ast.Expr, enclosingFn *ast.FuncDecl) []*ast.CallExpr {
+func mergeCallsForPatchExpr(pass *analysis.Pass, patchExpr ast.Expr, enclosingFn *ast.FuncDecl, patchPos token.Pos) []*ast.CallExpr {
 	switch expr := patchExpr.(type) {
 	case *ast.CallExpr:
 		return collectMergePatchConstructorCalls(pass, expr)
@@ -163,7 +164,7 @@ func mergeCallsForPatchExpr(pass *analysis.Pass, patchExpr ast.Expr, enclosingFn
 		if enclosingFn == nil || enclosingFn.Body == nil {
 			return nil
 		}
-		return findMergeAssignments(pass, expr.Name, enclosingFn.Body)
+		return findMergeAssignments(pass, expr, enclosingFn.Body, patchPos)
 	default:
 		return nil
 	}
@@ -184,31 +185,426 @@ func collectMergePatchConstructorCalls(pass *analysis.Pass, expr ast.Expr) []*as
 	return calls
 }
 
-func findMergeAssignments(pass *analysis.Pass, ident string, body *ast.BlockStmt) []*ast.CallExpr {
+func findMergeAssignments(pass *analysis.Pass, ident *ast.Ident, body *ast.BlockStmt, patchPos token.Pos) []*ast.CallExpr {
+	obj := pass.TypesInfo.ObjectOf(ident)
+	if obj == nil {
+		return nil
+	}
+	return collectMergePatchConstructorsForObject(pass, obj, body, patchPos, make(map[types.Object]bool))
+}
+
+// collectMergePatchConstructorsForObject resolves reaching definitions for obj,
+// recursively following identifier RHS aliases at their use positions. The
+// path-local visited set prevents cyclic aliases from recursing forever while
+// allowing separate control-flow definitions to be resolved independently.
+func collectMergePatchConstructorsForObject(pass *analysis.Pass, obj types.Object, body *ast.BlockStmt, usePos token.Pos, visited map[types.Object]bool) []*ast.CallExpr {
+	if visited[obj] {
+		return nil
+	}
+	visited[obj] = true
+	defer delete(visited, obj)
+
+	var rhsList []ast.Expr
+	collectReachingAssigns(pass, body.List, obj, usePos, &rhsList)
 	var calls []*ast.CallExpr
-	ast.Inspect(body, func(n ast.Node) bool {
-		switch stmt := n.(type) {
-		case *ast.AssignStmt:
-			if !assignDefinesIdent(stmt, ident) {
-				return true
-			}
-			for _, rhs := range stmt.Rhs {
-				calls = append(calls, collectMergePatchConstructorCalls(pass, rhs)...)
-			}
-		}
-		return true
-	})
+	for _, rhs := range rhsList {
+		calls = append(calls, collectMergePatchConstructorsForExpr(pass, rhs, body, rhs.Pos(), visited)...)
+	}
 	return calls
 }
 
-func assignDefinesIdent(stmt *ast.AssignStmt, ident string) bool {
-	for _, lhs := range stmt.Lhs {
+func collectMergePatchConstructorsForExpr(pass *analysis.Pass, expr ast.Expr, body *ast.BlockStmt, usePos token.Pos, visited map[types.Object]bool) []*ast.CallExpr {
+	switch expr := expr.(type) {
+	case *ast.Ident:
+		obj := pass.TypesInfo.ObjectOf(expr)
+		if obj == nil {
+			return nil
+		}
+		return collectMergePatchConstructorsForObject(pass, obj, body, usePos, visited)
+	case *ast.ParenExpr:
+		return collectMergePatchConstructorsForExpr(pass, expr.X, body, usePos, visited)
+	default:
+		return collectMergePatchConstructorCalls(pass, expr)
+	}
+}
+
+// collectReachingAssigns records the RHS expressions that can reach patchPos.
+// Unconditional blocks replace the reaching definitions from before the block;
+// conditional constructs conservatively retain both the pre-branch and
+// post-branch definitions. The object identity is preserved throughout so a
+// nested shadow cannot affect the outer patch variable.
+func collectReachingAssigns(pass *analysis.Pass, stmts []ast.Stmt, obj types.Object, patchPos token.Pos, out *[]ast.Expr) {
+	defs, found := reachingDefinitionsInList(pass, stmts, obj, patchPos, nil)
+	if found {
+		*out = appendUniqueExpressions(*out, defs...)
+	}
+}
+
+func rhsAssignedToObject(pass *analysis.Pass, stmt ast.Stmt, obj types.Object) ast.Expr {
+	switch stmt := stmt.(type) {
+	case *ast.AssignStmt:
+		return rhsForObject(pass, stmt, obj)
+	case *ast.DeclStmt:
+		gen, ok := stmt.Decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.VAR {
+			return nil
+		}
+		for _, spec := range gen.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range valueSpec.Names {
+				if pass.TypesInfo.ObjectOf(name) != obj {
+					continue
+				}
+				if len(valueSpec.Values) == 1 {
+					return valueSpec.Values[0]
+				}
+				if i < len(valueSpec.Values) {
+					return valueSpec.Values[i]
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func rhsForObject(pass *analysis.Pass, assign *ast.AssignStmt, obj types.Object) ast.Expr {
+	if len(assign.Rhs) == 0 {
+		return nil
+	}
+	for i, lhs := range assign.Lhs {
 		id, ok := lhs.(*ast.Ident)
-		if ok && id.Name == ident {
+		if !ok || pass.TypesInfo.ObjectOf(id) != obj {
+			continue
+		}
+		if len(assign.Rhs) == 1 {
+			return assign.Rhs[0]
+		}
+		if i < len(assign.Rhs) {
+			return assign.Rhs[i]
+		}
+	}
+	return nil
+}
+
+func reachingDefinitionsInList(pass *analysis.Pass, stmts []ast.Stmt, obj types.Object, patchPos token.Pos, defs []ast.Expr) ([]ast.Expr, bool) {
+	for _, stmt := range stmts {
+		if patchPos < stmt.Pos() {
+			break
+		}
+		if containsPosition(stmt, patchPos) {
+			return reachingDefinitionsInNode(pass, stmt, obj, patchPos, defs), true
+		}
+		defs = advanceDefinitionsForStmt(pass, stmt, obj, defs)
+	}
+	return defs, false
+}
+
+// reachingDefinitionsInNode follows the lexical control-flow container that
+// contains patchPos. Statements outside that container have already been
+// processed by reachingDefinitionsInList.
+func reachingDefinitionsInNode(pass *analysis.Pass, node ast.Node, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	switch node := node.(type) {
+	case *ast.BlockStmt:
+		return reachingDefinitionsInBlock(pass, node, obj, patchPos, defs)
+	case *ast.IfStmt:
+		return reachingDefinitionsInIf(pass, node, obj, patchPos, defs)
+	case *ast.ForStmt:
+		return reachingDefinitionsInFor(pass, node, obj, patchPos, defs)
+	case *ast.RangeStmt:
+		return reachingDefinitionsInRange(pass, node, obj, patchPos, defs)
+	case *ast.SwitchStmt:
+		return reachingDefinitionsInSwitch(pass, node, obj, patchPos, defs)
+	case *ast.TypeSwitchStmt:
+		return reachingDefinitionsInTypeSwitch(pass, node, obj, patchPos, defs)
+	case *ast.SelectStmt:
+		return reachingDefinitionsInSelect(pass, node, obj, patchPos, defs)
+	case *ast.FuncLit:
+		return reachingDefinitionsInFuncLit(pass, node, obj, patchPos, defs)
+	case *ast.CaseClause:
+		return reachingDefinitionsInCaseClause(pass, node, obj, patchPos, defs)
+	case *ast.CommClause:
+		return reachingDefinitionsInCommClause(pass, node, obj, patchPos, defs)
+	case *ast.LabeledStmt:
+		return reachingDefinitionsInLabeledStmt(pass, node, obj, patchPos, defs)
+	}
+
+	return reachingDefinitionsInNestedNode(pass, node, obj, patchPos, defs)
+}
+
+func reachingDefinitionsInBlock(pass *analysis.Pass, node *ast.BlockStmt, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	if reaching, found := reachingDefinitionsInList(pass, node.List, obj, patchPos, defs); found {
+		return reaching
+	}
+	return defs
+}
+
+func reachingDefinitionsInIf(pass *analysis.Pass, node *ast.IfStmt, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	initDefs := defs
+	if node.Init != nil {
+		if containsPosition(node.Init, patchPos) {
+			return reachingDefinitionsInNode(pass, node.Init, obj, patchPos, defs)
+		}
+		initDefs = advanceDefinitionsForStmt(pass, node.Init, obj, initDefs)
+	}
+	if node.Cond != nil && containsPosition(node.Cond, patchPos) {
+		return reachingDefinitionsInNode(pass, node.Cond, obj, patchPos, initDefs)
+	}
+	if containsPosition(node.Body, patchPos) {
+		return reachingDefinitionsInNode(pass, node.Body, obj, patchPos, initDefs)
+	}
+	if node.Else != nil && containsPosition(node.Else, patchPos) {
+		return reachingDefinitionsInNode(pass, node.Else, obj, patchPos, initDefs)
+	}
+	return initDefs
+}
+
+func reachingDefinitionsInFor(pass *analysis.Pass, node *ast.ForStmt, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	initDefs := defs
+	if node.Init != nil {
+		if containsPosition(node.Init, patchPos) {
+			return reachingDefinitionsInNode(pass, node.Init, obj, patchPos, defs)
+		}
+		initDefs = advanceDefinitionsForStmt(pass, node.Init, obj, initDefs)
+	}
+	if node.Cond != nil && containsPosition(node.Cond, patchPos) {
+		// The condition may be evaluated for the first iteration or after a
+		// previous body/post iteration, so retain both possible definitions.
+		iterDefs := advanceDefinitionsForStmt(pass, node.Body, obj, initDefs)
+		if node.Post != nil {
+			iterDefs = advanceDefinitionsForStmt(pass, node.Post, obj, iterDefs)
+		}
+		return appendUniqueExpressions(initDefs, iterDefs...)
+	}
+	if containsPosition(node.Body, patchPos) {
+		return reachingDefinitionsInNode(pass, node.Body, obj, patchPos, initDefs)
+	}
+	if node.Post != nil && containsPosition(node.Post, patchPos) {
+		bodyDefs := advanceDefinitionsForStmt(pass, node.Body, obj, initDefs)
+		return reachingDefinitionsInNode(pass, node.Post, obj, patchPos, bodyDefs)
+	}
+	return initDefs
+}
+
+func reachingDefinitionsInRange(pass *analysis.Pass, node *ast.RangeStmt, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	if containsPosition(node.X, patchPos) || containsPosition(node.Key, patchPos) || containsPosition(node.Value, patchPos) {
+		return defs
+	}
+	if containsPosition(node.Body, patchPos) {
+		return reachingDefinitionsInNode(pass, node.Body, obj, patchPos, defs)
+	}
+	return defs
+}
+
+func reachingDefinitionsInSwitch(pass *analysis.Pass, node *ast.SwitchStmt, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	initDefs := defs
+	if node.Init != nil {
+		if containsPosition(node.Init, patchPos) {
+			return reachingDefinitionsInNode(pass, node.Init, obj, patchPos, defs)
+		}
+		initDefs = advanceDefinitionsForStmt(pass, node.Init, obj, initDefs)
+	}
+	if node.Tag != nil && containsPosition(node.Tag, patchPos) {
+		return reachingDefinitionsInNode(pass, node.Tag, obj, patchPos, initDefs)
+	}
+	if containsPosition(node.Body, patchPos) {
+		return reachingDefinitionsInNode(pass, node.Body, obj, patchPos, initDefs)
+	}
+	return initDefs
+}
+
+func reachingDefinitionsInTypeSwitch(pass *analysis.Pass, node *ast.TypeSwitchStmt, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	initDefs := defs
+	if node.Init != nil {
+		if containsPosition(node.Init, patchPos) {
+			return reachingDefinitionsInNode(pass, node.Init, obj, patchPos, defs)
+		}
+		initDefs = advanceDefinitionsForStmt(pass, node.Init, obj, initDefs)
+	}
+	if node.Assign != nil && containsPosition(node.Assign, patchPos) {
+		return reachingDefinitionsInNode(pass, node.Assign, obj, patchPos, initDefs)
+	}
+	if containsPosition(node.Body, patchPos) {
+		return reachingDefinitionsInNode(pass, node.Body, obj, patchPos, initDefs)
+	}
+	return initDefs
+}
+
+func reachingDefinitionsInSelect(pass *analysis.Pass, node *ast.SelectStmt, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	if containsPosition(node.Body, patchPos) {
+		return reachingDefinitionsInNode(pass, node.Body, obj, patchPos, defs)
+	}
+	return defs
+}
+
+func reachingDefinitionsInFuncLit(pass *analysis.Pass, node *ast.FuncLit, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	if node.Body != nil && containsPosition(node.Body, patchPos) {
+		return reachingDefinitionsInBlock(pass, node.Body, obj, patchPos, defs)
+	}
+	return defs
+}
+
+func reachingDefinitionsInCaseClause(pass *analysis.Pass, node *ast.CaseClause, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	if containsPositionInStmts(node.Body, patchPos) {
+		return reachingDefinitionsInListResult(pass, node.Body, obj, patchPos, defs)
+	}
+	return defs
+}
+
+func reachingDefinitionsInCommClause(pass *analysis.Pass, node *ast.CommClause, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	if containsPositionInStmts(node.Body, patchPos) {
+		return reachingDefinitionsInListResult(pass, node.Body, obj, patchPos, defs)
+	}
+	return defs
+}
+
+func reachingDefinitionsInListResult(pass *analysis.Pass, stmts []ast.Stmt, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	if reaching, found := reachingDefinitionsInList(pass, stmts, obj, patchPos, defs); found {
+		return reaching
+	}
+	return defs
+}
+
+func reachingDefinitionsInLabeledStmt(pass *analysis.Pass, node *ast.LabeledStmt, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	if containsPosition(node.Stmt, patchPos) {
+		return reachingDefinitionsInNode(pass, node.Stmt, obj, patchPos, defs)
+	}
+	return defs
+}
+
+func reachingDefinitionsInNestedNode(pass *analysis.Pass, node ast.Node, obj types.Object, patchPos token.Pos, defs []ast.Expr) []ast.Expr {
+	// The target is often nested in a return or expression statement. Descend
+	// only through the child whose source range contains patchPos; the control
+	// flow cases above handle the nodes that can change reaching definitions.
+	var child ast.Node
+	ast.Inspect(node, func(candidate ast.Node) bool {
+		if candidate == nil || candidate == node {
+			return candidate == node
+		}
+		if containsPosition(candidate, patchPos) {
+			child = candidate
+		}
+		return false
+	})
+	if child != nil {
+		return reachingDefinitionsInNode(pass, child, obj, patchPos, defs)
+	}
+	return defs
+}
+
+func advanceDefinitionsForStmt(pass *analysis.Pass, stmt ast.Stmt, obj types.Object, defs []ast.Expr) []ast.Expr {
+	switch stmt := stmt.(type) {
+	case *ast.BlockStmt:
+		return advanceDefinitionsForList(pass, stmt.List, obj, defs)
+	case *ast.IfStmt:
+		initDefs := defs
+		if stmt.Init != nil {
+			initDefs = advanceDefinitionsForStmt(pass, stmt.Init, obj, initDefs)
+		}
+		paths := [][]ast.Expr{initDefs, advanceDefinitionsForStmt(pass, stmt.Body, obj, initDefs)}
+		if stmt.Else != nil {
+			paths = append(paths, advanceDefinitionsForStmt(pass, stmt.Else, obj, initDefs))
+		}
+		return unionDefinitions(paths...)
+	case *ast.ForStmt:
+		initDefs := defs
+		if stmt.Init != nil {
+			initDefs = advanceDefinitionsForStmt(pass, stmt.Init, obj, initDefs)
+		}
+		bodyDefs := advanceDefinitionsForStmt(pass, stmt.Body, obj, initDefs)
+		paths := [][]ast.Expr{initDefs, bodyDefs}
+		if stmt.Post != nil {
+			paths = append(paths, advanceDefinitionsForStmt(pass, stmt.Post, obj, bodyDefs))
+		}
+		return unionDefinitions(paths...)
+	case *ast.RangeStmt:
+		return unionDefinitions(defs, advanceDefinitionsForStmt(pass, stmt.Body, obj, defs))
+	case *ast.SwitchStmt:
+		initDefs := defs
+		if stmt.Init != nil {
+			initDefs = advanceDefinitionsForStmt(pass, stmt.Init, obj, initDefs)
+		}
+		return advanceDefinitionsForSwitchBody(pass, stmt.Body, obj, initDefs)
+	case *ast.TypeSwitchStmt:
+		initDefs := defs
+		if stmt.Init != nil {
+			initDefs = advanceDefinitionsForStmt(pass, stmt.Init, obj, initDefs)
+		}
+		return advanceDefinitionsForSwitchBody(pass, stmt.Body, obj, initDefs)
+	case *ast.SelectStmt:
+		return advanceDefinitionsForSwitchBody(pass, stmt.Body, obj, defs)
+	case *ast.CaseClause:
+		return advanceDefinitionsForList(pass, stmt.Body, obj, defs)
+	case *ast.CommClause:
+		return advanceDefinitionsForList(pass, stmt.Body, obj, defs)
+	case *ast.LabeledStmt:
+		return advanceDefinitionsForStmt(pass, stmt.Stmt, obj, defs)
+	default:
+		if rhs := rhsAssignedToObject(pass, stmt, obj); rhs != nil {
+			return []ast.Expr{rhs}
+		}
+		return defs
+	}
+}
+
+func advanceDefinitionsForList(pass *analysis.Pass, stmts []ast.Stmt, obj types.Object, defs []ast.Expr) []ast.Expr {
+	for _, stmt := range stmts {
+		defs = advanceDefinitionsForStmt(pass, stmt, obj, defs)
+	}
+	return defs
+}
+
+func advanceDefinitionsForSwitchBody(pass *analysis.Pass, body *ast.BlockStmt, obj types.Object, defs []ast.Expr) []ast.Expr {
+	if body == nil {
+		return defs
+	}
+	paths := [][]ast.Expr{defs}
+	for _, stmt := range body.List {
+		paths = append(paths, advanceDefinitionsForStmt(pass, stmt, obj, defs))
+	}
+	return unionDefinitions(paths...)
+}
+
+func containsPosition(node ast.Node, pos token.Pos) bool {
+	return node != nil && node.Pos() <= pos && pos < node.End()
+}
+
+func containsPositionInStmts(stmts []ast.Stmt, pos token.Pos) bool {
+	for _, stmt := range stmts {
+		if containsPosition(stmt, pos) {
 			return true
 		}
 	}
 	return false
+}
+
+func unionDefinitions(groups ...[]ast.Expr) []ast.Expr {
+	var result []ast.Expr
+	for _, group := range groups {
+		result = appendUniqueExpressions(result, group...)
+	}
+	return result
+}
+
+func appendUniqueExpressions(expressions []ast.Expr, additions ...ast.Expr) []ast.Expr {
+	for _, addition := range additions {
+		if addition == nil {
+			continue
+		}
+		duplicate := false
+		for _, expression := range expressions {
+			if expression.Pos() == addition.Pos() && expression.End() == addition.End() {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			expressions = append(expressions, addition)
+		}
+	}
+	return expressions
 }
 
 func mergePatchConstructorName(pass *analysis.Pass, call *ast.CallExpr) (name string, isControllerRuntime bool) {

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch_test.go
@@ -8,5 +8,24 @@ import (
 
 func TestAnalyzer(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, Analyzer, "a/good", "a/bad")
+
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{
+			name:    "When patches use statuspatching, optimistic lock, or non-HCP types, it should produce no diagnostics",
+			pattern: "a/good",
+		},
+		{
+			name:    "When HostedControlPlane status is updated or patched without an optimistic lock, it should produce diagnostics",
+			pattern: "a/bad",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			analysistest.Run(t, testdata, Analyzer, tt.pattern)
+		})
+	}
 }

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch_test.go
@@ -1,0 +1,12 @@
+package hcpstatuspatch
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, Analyzer, "a/good", "a/bad")
+}

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestAnalyzer(t *testing.T) {
+	t.Parallel()
+
 	testdata := analysistest.TestData()
 
 	tests := []struct {
@@ -21,11 +23,16 @@ func TestAnalyzer(t *testing.T) {
 			name:    "When HostedControlPlane status is updated or patched without an optimistic lock, it should produce diagnostics",
 			pattern: "a/bad",
 		},
+		{
+			name:    "When a patch is passed as a function parameter, it should produce no diagnostics",
+			pattern: "a/interprocedural",
+		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			analysistest.Run(t, testdata, Analyzer, tt.pattern)
+		t.Run(tt.name, func(subtest *testing.T) {
+			subtest.Parallel()
+			analysistest.Run(subtest, testdata, Analyzer, tt.pattern)
 		})
 	}
 }

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/bad/bad.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/bad/bad.go
@@ -1,0 +1,43 @@
+package bad
+
+type HostedControlPlane struct {
+	Status Status
+}
+
+type Status struct {
+	Ready bool
+}
+
+type StatusWriter interface {
+	Update(ctx any, obj *HostedControlPlane) error
+	Patch(ctx any, obj *HostedControlPlane, patch Patch) error
+}
+
+type Client interface {
+	Status() StatusWriter
+	Patch(ctx any, obj *HostedControlPlane, patch Patch) error
+}
+
+type Patch struct{}
+
+func MergeFrom(obj *HostedControlPlane) Patch { return Patch{} }
+
+func MergeFromWithOptions(obj *HostedControlPlane, opts ...any) Patch { return Patch{} }
+
+func directUpdate(c Client, hcp *HostedControlPlane) error {
+	return c.Status().Update(nil, hcp) // want `do not call Status\(\)\.Update\(\) on HostedControlPlane`
+}
+
+func unguardedMergeFromInline(c Client, hcp *HostedControlPlane) error {
+	return c.Status().Patch(nil, hcp, MergeFrom(hcp)) // want `do not use MergeFrom\(\) on HostedControlPlane without an optimistic lock`
+}
+
+func unguardedMergeFromVar(c Client, hcp *HostedControlPlane) error {
+	original := hcp
+	patch := MergeFrom(original) // want `do not use MergeFrom\(\) on HostedControlPlane without an optimistic lock`
+	return c.Status().Patch(nil, hcp, patch)
+}
+
+func unguardedMergeFromWithOptions(c Client, hcp *HostedControlPlane) error {
+	return c.Status().Patch(nil, hcp, MergeFromWithOptions(hcp)) // want `do not use MergeFromWithOptions\(\) on HostedControlPlane without MergeFromWithOptimisticLock`
+}

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/bad/bad.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/bad/bad.go
@@ -1,43 +1,31 @@
 package bad
 
-type HostedControlPlane struct {
-	Status Status
-}
+import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
-type Status struct {
-	Ready bool
-}
-
-type StatusWriter interface {
-	Update(ctx any, obj *HostedControlPlane) error
-	Patch(ctx any, obj *HostedControlPlane, patch Patch) error
-}
-
-type Client interface {
-	Status() StatusWriter
-	Patch(ctx any, obj *HostedControlPlane, patch Patch) error
-}
-
-type Patch struct{}
-
-func MergeFrom(obj *HostedControlPlane) Patch { return Patch{} }
-
-func MergeFromWithOptions(obj *HostedControlPlane, opts ...any) Patch { return Patch{} }
-
-func directUpdate(c Client, hcp *HostedControlPlane) error {
+func directUpdate(c client.Client, hcp *hyperv1.HostedControlPlane) error {
 	return c.Status().Update(nil, hcp) // want `do not call Status\(\)\.Update\(\) on HostedControlPlane`
 }
 
-func unguardedMergeFromInline(c Client, hcp *HostedControlPlane) error {
-	return c.Status().Patch(nil, hcp, MergeFrom(hcp)) // want `do not use MergeFrom\(\) on HostedControlPlane without an optimistic lock`
+func unguardedMergeFromInline(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	return c.Status().Patch(nil, hcp, client.MergeFrom(hcp)) // want `do not use MergeFrom\(\) on HostedControlPlane without an optimistic lock`
 }
 
-func unguardedMergeFromVar(c Client, hcp *HostedControlPlane) error {
+func unguardedMergeFromVar(c client.Client, hcp *hyperv1.HostedControlPlane) error {
 	original := hcp
-	patch := MergeFrom(original) // want `do not use MergeFrom\(\) on HostedControlPlane without an optimistic lock`
+	patch := client.MergeFrom(original) // want `do not use MergeFrom\(\) on HostedControlPlane without an optimistic lock`
 	return c.Status().Patch(nil, hcp, patch)
 }
 
-func unguardedMergeFromWithOptions(c Client, hcp *HostedControlPlane) error {
-	return c.Status().Patch(nil, hcp, MergeFromWithOptions(hcp)) // want `do not use MergeFromWithOptions\(\) on HostedControlPlane without MergeFromWithOptimisticLock`
+func unguardedMergeFromWithOptions(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	return c.Status().Patch(nil, hcp, client.MergeFromWithOptions(hcp)) // want `do not use MergeFromWithOptions\(\) on HostedControlPlane without MergeFromWithOptimisticLock`
+}
+
+// A same-name local type must not count as the controller-runtime optimistic lock.
+type MergeFromWithOptimisticLock struct{}
+
+func spoofedOptimisticLock(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	return c.Status().Patch(nil, hcp, client.MergeFromWithOptions(hcp, MergeFromWithOptimisticLock{})) // want `do not use MergeFromWithOptions\(\) on HostedControlPlane without MergeFromWithOptimisticLock`
 }

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/bad/bad.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/bad/bad.go
@@ -19,6 +19,13 @@ func unguardedMergeFromVar(c client.Client, hcp *hyperv1.HostedControlPlane) err
 	return c.Status().Patch(nil, hcp, patch)
 }
 
+func aliasedUnguardedMergeFrom(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	unsafe := client.MergeFrom(hcp) // want `do not use MergeFrom\(\) on HostedControlPlane without an optimistic lock`
+	alias := unsafe
+	patch := alias
+	return c.Status().Patch(nil, hcp, patch)
+}
+
 func unguardedMergeFromWithOptions(c client.Client, hcp *hyperv1.HostedControlPlane) error {
 	return c.Status().Patch(nil, hcp, client.MergeFromWithOptions(hcp)) // want `do not use MergeFromWithOptions\(\) on HostedControlPlane without MergeFromWithOptimisticLock`
 }
@@ -28,4 +35,39 @@ type MergeFromWithOptimisticLock struct{}
 
 func spoofedOptimisticLock(c client.Client, hcp *hyperv1.HostedControlPlane) error {
 	return c.Status().Patch(nil, hcp, client.MergeFromWithOptions(hcp, MergeFromWithOptimisticLock{})) // want `do not use MergeFromWithOptions\(\) on HostedControlPlane without MergeFromWithOptimisticLock`
+}
+
+func reassignedStillUnguarded(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	patch := client.MergeFromWithOptions(hcp, client.MergeFromWithOptimisticLock{})
+	patch = client.MergeFrom(hcp) // want `do not use MergeFrom\(\) on HostedControlPlane without an optimistic lock`
+	return c.Status().Patch(nil, hcp, patch)
+}
+
+func nestedUnguardedStatusPatch(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	return func() error {
+		patch := client.MergeFrom(hcp) // want `do not use MergeFrom\(\) on HostedControlPlane without an optimistic lock`
+		return c.Status().Patch(nil, hcp, patch)
+	}()
+}
+
+func nestedBlockStillUnguarded(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	patch := client.MergeFromWithOptions(hcp, client.MergeFromWithOptimisticLock{})
+	{
+		patch = client.MergeFrom(hcp) // want `do not use MergeFrom\(\) on HostedControlPlane without an optimistic lock`
+	}
+	return c.Status().Patch(nil, hcp, patch)
+}
+
+func multiValueAssignmentUnguarded(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	other, patch := client.MergeFromWithOptions(hcp, client.MergeFromWithOptimisticLock{}), client.MergeFrom(hcp) // want `do not use MergeFrom\(\) on HostedControlPlane without an optimistic lock`
+	_ = other
+	return c.Status().Patch(nil, hcp, patch)
+}
+
+func ifReassignmentStillReaches(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	patch := client.MergeFrom(hcp) // want `do not use MergeFrom\(\) on HostedControlPlane without an optimistic lock`
+	if hcp.Status.Ready {
+		patch = client.MergeFromWithOptions(hcp, client.MergeFromWithOptimisticLock{})
+	}
+	return c.Status().Patch(nil, hcp, patch)
 }

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/good.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/good.go
@@ -1,69 +1,72 @@
 package good
 
-type HostedControlPlane struct {
-	Status Status
-}
-
-type Status struct {
-	Ready bool
-}
+import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 type OtherObject struct {
-	Status Status
+	Status struct{ Ready bool }
 }
 
-type StatusWriter interface {
-	Update(ctx any, obj *HostedControlPlane) error
-	Patch(ctx any, obj *HostedControlPlane, patch Patch) error
+type otherStatusWriter interface {
+	Update(ctx any, obj *OtherObject, opts ...any) error
 }
 
-type OtherStatusWriter interface {
-	Update(ctx any, obj *OtherObject) error
+type otherClient interface {
+	Status() otherStatusWriter
 }
-
-type Client interface {
-	Status() StatusWriter
-	Patch(ctx any, obj *HostedControlPlane, patch Patch) error
-}
-
-type OtherClient interface {
-	Status() OtherStatusWriter
-}
-
-type Patch struct{}
-
-func MergeFrom(obj *HostedControlPlane) Patch { return Patch{} }
-
-func MergeFromWithOptions(obj *HostedControlPlane, opts ...any) Patch { return Patch{} }
-
-func MergeFromWithOptimisticLock() any { return nil }
 
 // PatchStatus stands in for statuspatching.PatchStatus.
-func PatchStatus(c Client, hcp *HostedControlPlane, mutate func() error) error {
+func PatchStatus(c client.Client, hcp *hyperv1.HostedControlPlane, mutate func() error) error {
 	if err := mutate(); err != nil {
 		return err
 	}
-	return c.Patch(nil, hcp, Patch{})
+	return c.Patch(nil, hcp, nil)
 }
 
-func viaHelper(c Client, hcp *HostedControlPlane) error {
+func viaHelper(c client.Client, hcp *hyperv1.HostedControlPlane) error {
 	return PatchStatus(c, hcp, func() error {
 		hcp.Status.Ready = true
 		return nil
 	})
 }
 
-func guardedMergeFrom(c Client, hcp *HostedControlPlane) error {
-	patch := MergeFromWithOptions(hcp, MergeFromWithOptimisticLock())
+func guardedMergeFrom(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	patch := client.MergeFromWithOptions(hcp, client.MergeFromWithOptimisticLock{})
 	return c.Status().Patch(nil, hcp, patch)
 }
 
 // Local MergeFrom used for a non-status object patch is unaffected.
-func localMergeFromForObjectPatch(c Client, hcp *HostedControlPlane) error {
-	return c.Patch(nil, hcp, MergeFrom(hcp))
+func objectPatchMergeFrom(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	return c.Patch(nil, hcp, client.MergeFrom(hcp))
 }
 
 // Status().Update() on a non-HostedControlPlane object is unaffected.
-func updateOtherObject(c OtherClient, obj *OtherObject) error {
+func updateOtherObject(c otherClient, obj *OtherObject) error {
 	return c.Status().Update(nil, obj)
+}
+
+// A local type named HostedControlPlane is not the HyperShift API type.
+type HostedControlPlane struct{}
+
+type localStatusWriter interface {
+	Update(ctx any, obj *HostedControlPlane, opts ...any) error
+	Patch(ctx any, obj *HostedControlPlane, patch any, opts ...any) error
+}
+
+type localClient interface {
+	Status() localStatusWriter
+}
+
+func updateLocalSameNameType(c localClient, hcp *HostedControlPlane) error {
+	return c.Status().Update(nil, hcp)
+}
+
+func MergeFrom(obj any) client.Patch { return nil }
+
+// A same-name local MergeFrom on a HyperShift HCP status patch is not the
+// controller-runtime constructor, so it must not fire.
+func localMergeFromOnHCPStatus(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	return c.Status().Patch(nil, hcp, MergeFrom(hcp))
 }

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/good.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/good.go
@@ -1,0 +1,69 @@
+package good
+
+type HostedControlPlane struct {
+	Status Status
+}
+
+type Status struct {
+	Ready bool
+}
+
+type OtherObject struct {
+	Status Status
+}
+
+type StatusWriter interface {
+	Update(ctx any, obj *HostedControlPlane) error
+	Patch(ctx any, obj *HostedControlPlane, patch Patch) error
+}
+
+type OtherStatusWriter interface {
+	Update(ctx any, obj *OtherObject) error
+}
+
+type Client interface {
+	Status() StatusWriter
+	Patch(ctx any, obj *HostedControlPlane, patch Patch) error
+}
+
+type OtherClient interface {
+	Status() OtherStatusWriter
+}
+
+type Patch struct{}
+
+func MergeFrom(obj *HostedControlPlane) Patch { return Patch{} }
+
+func MergeFromWithOptions(obj *HostedControlPlane, opts ...any) Patch { return Patch{} }
+
+func MergeFromWithOptimisticLock() any { return nil }
+
+// PatchStatus stands in for statuspatching.PatchStatus.
+func PatchStatus(c Client, hcp *HostedControlPlane, mutate func() error) error {
+	if err := mutate(); err != nil {
+		return err
+	}
+	return c.Patch(nil, hcp, Patch{})
+}
+
+func viaHelper(c Client, hcp *HostedControlPlane) error {
+	return PatchStatus(c, hcp, func() error {
+		hcp.Status.Ready = true
+		return nil
+	})
+}
+
+func guardedMergeFrom(c Client, hcp *HostedControlPlane) error {
+	patch := MergeFromWithOptions(hcp, MergeFromWithOptimisticLock())
+	return c.Status().Patch(nil, hcp, patch)
+}
+
+// Local MergeFrom used for a non-status object patch is unaffected.
+func localMergeFromForObjectPatch(c Client, hcp *HostedControlPlane) error {
+	return c.Patch(nil, hcp, MergeFrom(hcp))
+}
+
+// Status().Update() on a non-HostedControlPlane object is unaffected.
+func updateOtherObject(c OtherClient, obj *OtherObject) error {
+	return c.Status().Update(nil, obj)
+}

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/good.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/good.go
@@ -70,3 +70,55 @@ func MergeFrom(obj any) client.Patch { return nil }
 func localMergeFromOnHCPStatus(c client.Client, hcp *hyperv1.HostedControlPlane) error {
 	return c.Status().Patch(nil, hcp, MergeFrom(hcp))
 }
+
+func reassignedToOptimisticLock(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	patch := client.MergeFrom(hcp)
+	patch = client.MergeFromWithOptions(hcp, client.MergeFromWithOptimisticLock{})
+	return c.Status().Patch(nil, hcp, patch)
+}
+
+func nestedShadowDoesNotAffectOuter(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	patch := client.MergeFromWithOptions(hcp, client.MergeFromWithOptimisticLock{})
+	_ = func() client.Patch {
+		patch := client.MergeFrom(hcp)
+		return patch
+	}
+	return c.Status().Patch(nil, hcp, patch)
+}
+
+func nestedBlockReassignment(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	patch := client.MergeFrom(hcp)
+	{
+		patch = client.MergeFromWithOptions(hcp, client.MergeFromWithOptimisticLock{})
+	}
+	return c.Status().Patch(nil, hcp, patch)
+}
+
+func nestedBlockThenReassignment(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	patch := client.MergeFromWithOptions(hcp, client.MergeFromWithOptimisticLock{})
+	{
+		patch = client.MergeFrom(hcp)
+	}
+	patch = client.MergeFromWithOptions(hcp, client.MergeFromWithOptimisticLock{})
+	return c.Status().Patch(nil, hcp, patch)
+}
+
+func multiValueAssignmentGuarded(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	unguarded, patch := client.MergeFrom(hcp), client.MergeFromWithOptions(hcp, client.MergeFromWithOptimisticLock{})
+	_ = unguarded
+	return c.Status().Patch(nil, hcp, patch)
+}
+
+func aliasedGuardedMergeFrom(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	guarded := client.MergeFromWithOptions(hcp, client.MergeFromWithOptimisticLock{})
+	alias := guarded
+	patch := alias
+	return c.Status().Patch(nil, hcp, patch)
+}
+
+func cyclicAliases(c client.Client, hcp *hyperv1.HostedControlPlane) error {
+	var first, second client.Patch
+	first = second
+	second = first
+	return c.Status().Patch(nil, hcp, first)
+}

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/good_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/good_test.go
@@ -1,7 +1,12 @@
 package good
 
+import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
 // Seeding fixture status via Status().Update() in a unit test is fine — there's
 // no concurrent writer to race with in a synchronous test.
-func seedFixtureStatus(c Client, hcp *HostedControlPlane) error {
+func seedFixtureStatus(c client.Client, hcp *hyperv1.HostedControlPlane) error {
 	return c.Status().Update(nil, hcp)
 }

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/good_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/good_test.go
@@ -1,0 +1,7 @@
+package good
+
+// Seeding fixture status via Status().Update() in a unit test is fine — there's
+// no concurrent writer to race with in a synchronous test.
+func seedFixtureStatus(c Client, hcp *HostedControlPlane) error {
+	return c.Status().Update(nil, hcp)
+}

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/interprocedural/interprocedural.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/interprocedural/interprocedural.go
@@ -1,0 +1,15 @@
+package interprocedural
+
+import (
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func patchWithParameter(c client.Client, hcp *v1beta1.HostedControlPlane, patch client.Patch) error {
+	return c.Status().Patch(nil, hcp, patch)
+}
+
+func passPatchAsParameter(c client.Client, hcp *v1beta1.HostedControlPlane) error {
+	patch := client.MergeFrom(hcp)
+	return patchWithParameter(c, hcp, patch)
+}

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/github.com/openshift/hypershift/api/hypershift/v1beta1/hosted_controlplane.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/github.com/openshift/hypershift/api/hypershift/v1beta1/hosted_controlplane.go
@@ -1,0 +1,9 @@
+package v1beta1
+
+type HostedControlPlane struct {
+	Status Status
+}
+
+type Status struct {
+	Ready bool
+}

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/sigs.k8s.io/controller-runtime/pkg/client/client.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/sigs.k8s.io/controller-runtime/pkg/client/client.go
@@ -1,0 +1,20 @@
+package client
+
+type Object any
+type Patch any
+
+type StatusWriter interface {
+	Update(ctx any, obj Object, opts ...any) error
+	Patch(ctx any, obj Object, patch Patch, opts ...any) error
+}
+
+type Client interface {
+	Status() StatusWriter
+	Patch(ctx any, obj Object, patch Patch, opts ...any) error
+}
+
+func MergeFrom(obj Object) Patch { return nil }
+
+func MergeFromWithOptions(obj Object, opts ...any) Patch { return nil }
+
+type MergeFromWithOptimisticLock struct{}

--- a/hack/tools/hypershiftlinter/plugin.go
+++ b/hack/tools/hypershiftlinter/plugin.go
@@ -68,6 +68,9 @@ func allAnalyzers() []*analysis.Analyzer {
 		vacuouspass.Analyzer,
 		ipv6url.Analyzer,
 		e2eutilallowlist.Analyzer,
+		// CNTRLPLANE-3532 also asks to warn on reflect.DeepEqual for Kubernetes
+		// API objects (use equality.Semantic.DeepEqual). That is a separate
+		// analyzer from hcpstatuspatch and is a follow-up; see README.
 		hcpstatuspatch.Analyzer,
 	}
 }

--- a/hack/tools/hypershiftlinter/plugin.go
+++ b/hack/tools/hypershiftlinter/plugin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/contextbackground"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/guestcluster"
+	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/ipv6url"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/sippyannotation"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/testcasename"
@@ -67,6 +68,7 @@ func allAnalyzers() []*analysis.Analyzer {
 		vacuouspass.Analyzer,
 		ipv6url.Analyzer,
 		e2eutilallowlist.Analyzer,
+		hcpstatuspatch.Analyzer,
 	}
 }
 

--- a/hack/tools/hypershiftlinter/plugin.go
+++ b/hack/tools/hypershiftlinter/plugin.go
@@ -68,6 +68,7 @@ func allAnalyzers() []*analysis.Analyzer {
 		vacuouspass.Analyzer,
 		ipv6url.Analyzer,
 		e2eutilallowlist.Analyzer,
+		// TODO(CNTRLPLANE-3532): add the reflect.DeepEqual rule.
 		// CNTRLPLANE-3532 also asks to warn on reflect.DeepEqual for Kubernetes
 		// API objects (use equality.Semantic.DeepEqual). That is a separate
 		// analyzer from hcpstatuspatch and is a follow-up; see README.


### PR DESCRIPTION
## What this PR does / why we need it:

Completes items 5&6 of the [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532) status-patching migration plan:

- **`hcpstatuspatch` static analyzer** (`hack/tools/hypershiftlinter`): bans direct `Status().Update()` and unguarded `MergeFrom()` status patches on `HostedControlPlane` objects (matched by type name via `go/types`) — both patterns can silently overwrite a concurrent writer's changes since CPO/HCCO/HO all write to the same `HostedControlPlane.Status`. `_test.go` files are excluded (fixture-seeding via a fake client has no concurrent writer to race with).
- **`AGENTS.md` guidance**: new "HostedControlPlane Status Patching" section in `control-plane-operator/AGENTS.md` explaining the safe pattern (`support/statuspatching`'s `PatchStatus`/`PatchStatusCondition`) and the recompute-vs-replay pitfall found during [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532) review, plus a cross-reference in root `AGENTS.md`.

Part of the broader [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532) migration. Independent of #8966/#9385 — no code overlap — but the linter is staged inert on purpose, see below.

## Which issue(s) this PR fixes:

Part of [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532) — does not close it (JSON Patch/RFC 6902 variant + nullable-field test still outstanding).

## Special notes for your reviewer:

- **`hcpstatuspatch` is landed but NOT enabled** in `.golangci.yml` (added to an explicit `enable:` allowlist that deliberately excludes it), following this repo's own documented staged-rollout pattern for new hypershiftlinter analyzers. Enabling it now would fail CI on `control-plane-operator/hostedclusterconfigoperator/controllers/reencryption/reencryption.go:73` (`MergeFrom(originalHCP)` on HCP), which is already fixed in #8966 but not yet merged to `main`. Follow-up PR flips it on once #8966 (and any other in-flight HCP status-patch migrations) land — verified this is the *only* remaining violation by temporarily enabling it locally and running `make hypershift-lint-all` against the full tree.
- Verified no false positives from the type-name-only matching approach (repo-wide grep confirms `HostedControlPlane` is a unique type name, no collision).
- Verified test-file exclusion is correct: without it, the analyzer would (incorrectly) flag `hypershift-operator/controllers/hostedcluster/karpenter_test.go:502`, a legitimate fixture-seeding `Status().Update()` call in a synchronous unit test.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded linting coverage for test naming, annotations, guest clusters, context usage, vacuous passes, IPv6 URLs, and approved E2E utility usage.
  - Added detection for unsafe HostedControlPlane status updates; enforcement remains excluded during staged migration.

- **Documentation**
  - Added guidance for safe concurrent status updates, retries, generation checks, and required helpers.
  - Documented analyzer coverage, approved E2E utilities, and migration requirements.

- **Tests**
  - Added coverage for unsafe status update patterns, including interprocedural cases.
  - Improved test parallelization for analyzer validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->