### PR TITLE
OCPBUGS-113580: Bound NodePool metrics cache reads

### DIFF
--- a/hypershift-operator/controllers/nodepool/metrics/metrics.go
+++ b/hypershift-operator/controllers/nodepool/metrics/metrics.go
@@ -140,6 +140,8 @@ type nodePoolsMetricsCollector struct {
 	clock     clock.Clock
 	mu        sync.Mutex
 
+	cacheReadTimeout time.Duration
+
 	ec2InstanceTypeToVCpusCount map[string]int32
 	// awsInstanceTypeUnknown caches instance types that are not recognized
 	// by the EC2 API, so subsequent calls skip the API
@@ -156,6 +158,7 @@ func createNodePoolsMetricsCollector(client client.Client, ec2Client ec2.Describ
 		Client:                      client,
 		ec2Client:                   ec2Client,
 		clock:                       clock,
+		cacheReadTimeout:            5 * time.Second,
 		ec2InstanceTypeToVCpusCount: make(map[string]int32),
 		awsInstanceTypeUnknown:      sets.New[string](),
 		transitionDurationMetric: prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -335,12 +338,12 @@ func (c *nodePoolsMetricsCollector) retrieveVCpusDetailsPerNode(ctx context.Cont
 func (c *nodePoolsMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	ctx := context.Background()
 	currentCollectTime := c.clock.Now()
 
-	hclusterPathToData := c.collectHostedClusterData(ctx)
-	machineSetPathToReplicasCount := c.collectMachineSetReplicas(ctx)
-	machineDeploymentPathToReplicasCount := c.collectMachineDeploymentReplicas(ctx)
+	cacheCtx, cancelCacheReads := context.WithTimeout(context.Background(), c.cacheReadTimeout)
+	hclusterPathToData := c.collectHostedClusterData(cacheCtx)
+	machineSetPathToReplicasCount := c.collectMachineSetReplicas(cacheCtx)
+	machineDeploymentPathToReplicasCount := c.collectMachineDeploymentReplicas(cacheCtx)
 
 	platformToNodePoolsCount := make(map[hyperv1.PlatformType]int)
 	for k := range knownPlatforms {
@@ -359,9 +362,10 @@ func (c *nodePoolsMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	npList := &hyperv1.NodePoolList{}
-	if err := c.List(ctx, npList); err != nil {
+	if err := c.List(cacheCtx, npList); err != nil {
 		ctrllog.Log.Error(err, "failed to list node pools while collecting metrics")
 	}
+	cancelCacheReads()
 
 	for k := range npList.Items {
 		nodePool := &npList.Items[k]
@@ -375,7 +379,7 @@ func (c *nodePoolsMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		if hcData := hclusterPathToData[nodePool.Namespace+"/"+nodePool.Spec.ClusterName]; hcData != nil {
 			hclusterId = hcData.id
 			hcData.nodePoolsCount += 1
-			c.aggregateVCpus(ctx, nodePool, hcData)
+			c.aggregateVCpus(context.Background(), nodePool, hcData)
 		}
 
 		c.observeTransitionDurations(nodePool, currentCollectTime)

--- a/hypershift-operator/controllers/nodepool/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/nodepool/metrics/metrics_test.go
@@ -22,7 +22,9 @@ import (
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -431,6 +433,46 @@ func TestCollectConcurrency(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestCollect(t *testing.T) {
+	t.Run("When a cache read is blocked, it should stop collecting after the cache read timeout", func(t *testing.T) {
+		g := NewWithT(t)
+		var deadlineSeen bool
+		var listErr error
+
+		blockedClient := fake.NewClientBuilder().
+			WithScheme(api.Scheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(ctx context.Context, _ crclient.WithWatch, _ crclient.ObjectList, _ ...crclient.ListOption) error {
+					_, deadlineSeen = ctx.Deadline()
+					<-ctx.Done()
+					listErr = ctx.Err()
+					return listErr
+				},
+			}).
+			Build()
+
+		collector := createNodePoolsMetricsCollector(blockedClient, nil, clock.RealClock{}).(*nodePoolsMetricsCollector)
+		collector.cacheReadTimeout = 10 * time.Millisecond
+
+		ch := make(chan prometheus.Metric)
+		done := make(chan struct{})
+		go func() {
+			for range ch {
+			}
+			close(done)
+		}()
+
+		start := time.Now()
+		collector.Collect(ch)
+		close(ch)
+		<-done
+
+		g.Expect(deadlineSeen).To(BeTrue())
+		g.Expect(listErr).To(MatchError(context.DeadlineExceeded))
+		g.Expect(time.Since(start)).To(BeNumerically("<", time.Second))
+	})
 }
 
 // drainVCpuValue reads all metrics from a closed channel and returns the


### PR DESCRIPTION
## What this PR does / why we need it:

Bounds the NodePool metrics collector cache-read phase with a shared five-second timeout. Controller-runtime cache reads block until their informers synchronize; using a background context allowed a `/metrics` scrape to hang indefinitely when CAPI conversion was unavailable.

This is defense-in-depth independent of #9387. That PR removes metrics from operator health probes and exposes webhook-aware readiness; this PR ensures an external Prometheus scrape cannot remain blocked forever on unsynchronized MachineSet or MachineDeployment informers.

The regression test intercepts a blocked cache `List`, verifies that collection supplies a deadline, and confirms the scrape returns after context cancellation.

Failure evidence: [Azure self-managed run 2091848958857973760](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/9052/pull-ci-openshift-hypershift-main-e2e-v2-azure-self-managed/2091848958857973760).

## Which issue(s) this PR fixes:

https://redhat.atlassian.net/browse/OCPBUGS-113580

## Special notes for your reviewer:

Related startup-readiness fix: #9387.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved node-pool metrics collection reliability by applying a five-second timeout to cache reads.
  - Prevented metrics collection from becoming indefinitely blocked when required data is unavailable or unresponsive.
  - Ensured vCPU metric aggregation can complete independently of cache-read timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
