### PR TITLE
OCPBUGS-112277: Skip PodDisruptionBudgets for SingleReplica control planes

### DIFF
--- a/support/controlplane-component/common.go
+++ b/support/controlplane-component/common.go
@@ -11,22 +11,30 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// AdaptPodDisruptionBudget configures a PDB for HighlyAvailable control planes
+// (maxUnavailable=1) and skips the PDB entirely for SingleReplica.
+//
+// A SingleReplica PDB with minAvailable=1 can never permit a disruption
+// (disruptionsAllowed stays 0), so it blocks node drain indefinitely rather
+// than expressing a budget. ControllerAvailabilityPolicy is immutable, so
+// there is no later transition that would need the PDB added.
+// Existing SingleReplica PDBs are deleted by the predicate-false path.
 func AdaptPodDisruptionBudget() option {
-	return WithAdaptFunction(func(cpContext WorkloadContext, pdb *policyv1.PodDisruptionBudget) error {
-		var minAvailable *intstr.IntOrString
-		var maxUnavailable *intstr.IntOrString
-		switch cpContext.HCP.Spec.ControllerAvailabilityPolicy {
-		case hyperv1.SingleReplica:
-			minAvailable = ptr.To(intstr.FromInt32(1))
-		case hyperv1.HighlyAvailable:
-			maxUnavailable = ptr.To(intstr.FromInt32(1))
-		}
-
-		pdb.Spec.MinAvailable = minAvailable
-		pdb.Spec.MaxUnavailable = maxUnavailable
-		pdb.Spec.UnhealthyPodEvictionPolicy = ptr.To(policyv1.AlwaysAllow)
-		return nil
-	})
+	return func(ga *genericAdapter) {
+		WithPredicate(func(cpContext WorkloadContext) bool {
+			return cpContext.HCP.Spec.ControllerAvailabilityPolicy != hyperv1.SingleReplica
+		})(ga)
+		WithAdaptFunction(func(cpContext WorkloadContext, pdb *policyv1.PodDisruptionBudget) error {
+			// YAML assets ship minAvailable: 1; clear it so HA can use maxUnavailable.
+			pdb.Spec.MinAvailable = nil
+			pdb.Spec.MaxUnavailable = nil
+			if cpContext.HCP.Spec.ControllerAvailabilityPolicy == hyperv1.HighlyAvailable {
+				pdb.Spec.MaxUnavailable = ptr.To(intstr.FromInt32(1))
+			}
+			pdb.Spec.UnhealthyPodEvictionPolicy = ptr.To(policyv1.AlwaysAllow)
+			return nil
+		})(ga)
+	}
 }
 
 // SetHostedClusterAnnotation is a helper function to set the HostedCluster annotation on a resource.

--- a/support/controlplane-component/common_test.go
+++ b/support/controlplane-component/common_test.go
@@ -16,31 +16,44 @@ import (
 func TestAdaptPodDisruptionBudget(t *testing.T) {
 	t.Parallel()
 
+	yamlMinAvailable := ptr.To(intstr.FromInt32(1))
 	tests := []struct {
-		name               string
-		availabilityPolicy hyperv1.AvailabilityPolicy
-		wantPredicate      bool
-		wantMinAvailable   *intstr.IntOrString
-		wantMaxUnavailable *intstr.IntOrString
+		name                  string
+		availabilityPolicy    hyperv1.AvailabilityPolicy
+		initialMinAvailable   *intstr.IntOrString
+		initialMaxUnavailable *intstr.IntOrString
+		wantPredicate         bool
+		wantMinAvailable      *intstr.IntOrString
+		wantMaxUnavailable    *intstr.IntOrString
 	}{
 		{
-			name:               "When SingleReplica it should disable the PDB",
+			name:               "When SingleReplica, it should disable the PDB",
 			availabilityPolicy: hyperv1.SingleReplica,
 			wantPredicate:      false,
 		},
 		{
-			name:               "When HighlyAvailable it should set maxUnavailable to 1",
-			availabilityPolicy: hyperv1.HighlyAvailable,
-			wantPredicate:      true,
-			wantMinAvailable:   nil,
-			wantMaxUnavailable: ptr.To(intstr.FromInt32(1)),
+			name:                "When HighlyAvailable, it should set maxUnavailable to 1 and clear minAvailable",
+			availabilityPolicy:  hyperv1.HighlyAvailable,
+			initialMinAvailable: yamlMinAvailable,
+			wantPredicate:       true,
+			wantMinAvailable:    nil,
+			wantMaxUnavailable:  ptr.To(intstr.FromInt32(1)),
 		},
 		{
-			name:               "When availability policy is unset it should keep the PDB without minAvailable or maxUnavailable",
-			availabilityPolicy: "",
-			wantPredicate:      true,
-			wantMinAvailable:   nil,
-			wantMaxUnavailable: nil,
+			name:                "When availability policy is unset, it should clear minAvailable from the YAML default",
+			availabilityPolicy:  "",
+			initialMinAvailable: yamlMinAvailable,
+			wantPredicate:       true,
+			wantMinAvailable:    nil,
+			wantMaxUnavailable:  nil,
+		},
+		{
+			name:                  "When availability policy is unset and maxUnavailable is set, it should clear maxUnavailable",
+			availabilityPolicy:    "",
+			initialMaxUnavailable: ptr.To(intstr.FromInt32(1)),
+			wantPredicate:         true,
+			wantMinAvailable:      nil,
+			wantMaxUnavailable:    nil,
 		},
 	}
 
@@ -53,6 +66,10 @@ func TestAdaptPodDisruptionBudget(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pdb",
 					Namespace: "test-ns",
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable:   tt.initialMinAvailable,
+					MaxUnavailable: tt.initialMaxUnavailable,
 				},
 			}
 
@@ -68,8 +85,8 @@ func TestAdaptPodDisruptionBudget(t *testing.T) {
 				},
 			}
 
-			g.Expect(ga.predicate).ToNot(BeNil())
-			g.Expect(ga.predicate(cpContext)).To(Equal(tt.wantPredicate))
+			g.Expect(ga.predicate).ToNot(BeNil(), "AdaptPodDisruptionBudget must configure a predicate")
+			g.Expect(ga.predicate(cpContext)).To(Equal(tt.wantPredicate), "unexpected predicate result for availability policy %q", tt.availabilityPolicy)
 
 			if !tt.wantPredicate {
 				return
@@ -78,14 +95,14 @@ func TestAdaptPodDisruptionBudget(t *testing.T) {
 			err := ga.adapt(cpContext, pdb)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			g.Expect(pdb.Spec.MinAvailable).To(Equal(tt.wantMinAvailable))
-			g.Expect(pdb.Spec.MaxUnavailable).To(Equal(tt.wantMaxUnavailable))
+			g.Expect(pdb.Spec.MinAvailable).To(Equal(tt.wantMinAvailable), "minAvailable should be cleared or replaced for policy %q", tt.availabilityPolicy)
+			g.Expect(pdb.Spec.MaxUnavailable).To(Equal(tt.wantMaxUnavailable), "maxUnavailable mismatch for policy %q", tt.availabilityPolicy)
 			g.Expect(pdb.Spec.UnhealthyPodEvictionPolicy).ToNot(BeNil())
 			g.Expect(*pdb.Spec.UnhealthyPodEvictionPolicy).To(Equal(policyv1.AlwaysAllow))
 		})
 	}
 
-	t.Run("When PDB already has unhealthyPodEvictionPolicy set to IfHealthyBudget it should overwrite to AlwaysAllow", func(t *testing.T) {
+	t.Run("When PDB already has unhealthyPodEvictionPolicy set to IfHealthyBudget, it should overwrite to AlwaysAllow", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		pdb := &policyv1.PodDisruptionBudget{

--- a/support/controlplane-component/common_test.go
+++ b/support/controlplane-component/common_test.go
@@ -14,28 +14,39 @@ import (
 )
 
 func TestAdaptPodDisruptionBudget(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name               string
 		availabilityPolicy hyperv1.AvailabilityPolicy
+		wantPredicate      bool
 		wantMinAvailable   *intstr.IntOrString
 		wantMaxUnavailable *intstr.IntOrString
 	}{
 		{
-			name:               "When SingleReplica it should set minAvailable to 1",
+			name:               "When SingleReplica it should disable the PDB",
 			availabilityPolicy: hyperv1.SingleReplica,
-			wantMinAvailable:   ptr.To(intstr.FromInt32(1)),
-			wantMaxUnavailable: nil,
+			wantPredicate:      false,
 		},
 		{
 			name:               "When HighlyAvailable it should set maxUnavailable to 1",
 			availabilityPolicy: hyperv1.HighlyAvailable,
+			wantPredicate:      true,
 			wantMinAvailable:   nil,
 			wantMaxUnavailable: ptr.To(intstr.FromInt32(1)),
+		},
+		{
+			name:               "When availability policy is unset it should keep the PDB without minAvailable or maxUnavailable",
+			availabilityPolicy: "",
+			wantPredicate:      true,
+			wantMinAvailable:   nil,
+			wantMaxUnavailable: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewGomegaWithT(t)
 
 			pdb := &policyv1.PodDisruptionBudget{
@@ -55,6 +66,13 @@ func TestAdaptPodDisruptionBudget(t *testing.T) {
 						ControllerAvailabilityPolicy: tt.availabilityPolicy,
 					},
 				},
+			}
+
+			g.Expect(ga.predicate).ToNot(BeNil())
+			g.Expect(ga.predicate(cpContext)).To(Equal(tt.wantPredicate))
+
+			if !tt.wantPredicate {
+				return
 			}
 
 			err := ga.adapt(cpContext, pdb)


### PR DESCRIPTION
## Summary
- SingleReplica PDBs used `minAvailable: 1`, so `disruptionsAllowed` stayed 0 and management-cluster node drain could never evict control-plane pods (`TooManyRequests`).
- Skip creating those PDBs when `ControllerAvailabilityPolicy` is `SingleReplica`. Existing HCP-owned PDBs are deleted on reconcile. HighlyAvailable is unchanged (`maxUnavailable: 1`).
- `ControllerAvailabilityPolicy` is immutable, so there is no later HA transition that would need the PDB added.

## Test plan
- [x] Unit tests for `AdaptPodDisruptionBudget` (SingleReplica disables PDB; HA still sets `maxUnavailable: 1`)
- [ ] Deploy patched CPO to a SingleReplica HostedCluster and confirm control-plane PDBs (etcd, kube-apiserver, oauth, oapi, packageserver, router) are not created / are removed
- [ ] Dry-run eviction of `etcd-0` succeeds (`oc create --raw .../eviction` with `dryRun: [All]`)
- [ ] HighlyAvailable HostedCluster still has PDBs with `maxUnavailable: 1`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary Pod Disruption Budgets from being created for single-replica control planes.
  * Preserved highly available configurations with a maximum of one unavailable replica.
  * Ensured unspecified availability policies leave disruption budget limits unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->