### PR TITLE
OCPBUGS-113991: Scope forced NodePool cleanup to the target cluster

### DIFF
--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -296,6 +296,31 @@ func stripFinalizersFromList(ctx context.Context, c client.Client, list client.O
 	return errs
 }
 
+func stripNodePoolFinalizers(ctx context.Context, c client.Client, namespace, clusterName string, log logr.Logger) []error {
+	nodePools := &hyperv1.NodePoolList{}
+	if err := c.List(ctx, nodePools, client.InNamespace(namespace)); err != nil {
+		if !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+			return []error{fmt.Errorf("failed to list %T: %w", nodePools, err)}
+		}
+		return nil
+	}
+
+	var errs []error
+	var count int
+	for i := range nodePools.Items {
+		nodePool := &nodePools.Items[i]
+		if nodePool.Spec.ClusterName != clusterName {
+			continue
+		}
+		count++
+		if err := stripFinalizers(ctx, c, nodePool, log); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	log.Info("Processed resources", "type", fmt.Sprintf("%T", nodePools), "namespace", namespace, "count", count)
+	return errs
+}
+
 // forceRemoveAllFinalizers strips finalizers from all child resources in the
 // control plane namespace and NodePools in the HC namespace, then from the
 // HostedCluster itself (preserving the destroy finalizer for the normal
@@ -329,7 +354,7 @@ func forceRemoveAllFinalizers(ctx context.Context, hostedCluster *hyperv1.Hosted
 	}
 
 	// NodePools live in the HC namespace, not the CP namespace
-	errs = append(errs, stripFinalizersFromList(ctx, c, &hyperv1.NodePoolList{}, o.Namespace, o.Log)...)
+	errs = append(errs, stripNodePoolFinalizers(ctx, c, o.Namespace, o.Name, o.Log)...)
 
 	// Strip all HostedCluster finalizers except the destroy finalizer, which
 	// is removed by the normal removeFinalizer path after platform cleanup.

--- a/cmd/cluster/core/destroy_test.go
+++ b/cmd/cluster/core/destroy_test.go
@@ -103,6 +103,20 @@ func TestForceRemoveAllFinalizers(t *testing.T) {
 				Namespace:  "clusters",
 				Finalizers: []string{"hypershift.openshift.io/finalizer"},
 			},
+			Spec: hyperv1.NodePoolSpec{
+				ClusterName: "test-cluster",
+			},
+		}
+
+		unrelatedNodePool := &hyperv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "other-cluster-np1",
+				Namespace:  "clusters",
+				Finalizers: []string{"hypershift.openshift.io/finalizer"},
+			},
+			Spec: hyperv1.NodePoolSpec{
+				ClusterName: "other-cluster",
+			},
 		}
 
 		hcp := &hyperv1.HostedControlPlane{
@@ -153,7 +167,7 @@ func TestForceRemoveAllFinalizers(t *testing.T) {
 
 		c := fake.NewClientBuilder().
 			WithScheme(hyperapi.Scheme).
-			WithObjects(hc, nodePool, hcp, azureMachine, capiCluster, capiMachine, deployment, ns).
+			WithObjects(hc, nodePool, unrelatedNodePool, hcp, azureMachine, capiCluster, capiMachine, deployment, ns).
 			Build()
 
 		opts := &DestroyOptions{
@@ -177,6 +191,12 @@ func TestForceRemoveAllFinalizers(t *testing.T) {
 		err = c.Get(ctx, types.NamespacedName{Namespace: "clusters", Name: "test-cluster-np1"}, updatedNP)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(updatedNP.Finalizers).To(BeEmpty())
+
+		// Verify unrelated NodePool finalizers are preserved
+		unrelatedNP := &hyperv1.NodePool{}
+		err = c.Get(ctx, types.NamespacedName{Namespace: "clusters", Name: "other-cluster-np1"}, unrelatedNP)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(unrelatedNP.Finalizers).To(Equal([]string{"hypershift.openshift.io/finalizer"}))
 
 		// Verify HCP finalizers are gone
 		updatedHCP := &hyperv1.HostedControlPlane{}
@@ -327,6 +347,52 @@ func TestStripFinalizersFromList(t *testing.T) {
 
 		errs := stripFinalizersFromList(ctx, c, &capzv1.AzureMachineList{}, "test-ns", log.Log)
 		g.Expect(errs).To(BeEmpty())
+	})
+}
+
+func TestStripNodePoolFinalizers(t *testing.T) {
+	t.Run("When NodePools belong to different HostedClusters, it should only strip finalizers from matching NodePools", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctx := context.Background()
+
+		nodePool := &hyperv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-cluster-np1",
+				Namespace:  "clusters",
+				Finalizers: []string{"hypershift.openshift.io/finalizer"},
+			},
+			Spec: hyperv1.NodePoolSpec{
+				ClusterName: "test-cluster",
+			},
+		}
+		unrelatedNodePool := &hyperv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "other-cluster-np1",
+				Namespace:  "clusters",
+				Finalizers: []string{"hypershift.openshift.io/finalizer"},
+			},
+			Spec: hyperv1.NodePoolSpec{
+				ClusterName: "other-cluster",
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(hyperapi.Scheme).
+			WithObjects(nodePool, unrelatedNodePool).
+			Build()
+
+		errs := stripNodePoolFinalizers(ctx, c, "clusters", "test-cluster", log.Log)
+		g.Expect(errs).To(BeEmpty())
+
+		updatedNodePool := &hyperv1.NodePool{}
+		err := c.Get(ctx, client.ObjectKeyFromObject(nodePool), updatedNodePool)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updatedNodePool.Finalizers).To(BeEmpty())
+
+		updatedUnrelatedNodePool := &hyperv1.NodePool{}
+		err = c.Get(ctx, client.ObjectKeyFromObject(unrelatedNodePool), updatedUnrelatedNodePool)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updatedUnrelatedNodePool.Finalizers).To(Equal([]string{"hypershift.openshift.io/finalizer"}))
 	})
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

Limits `hypershift destroy cluster --force` finalizer removal to NodePools whose `spec.clusterName` matches the HostedCluster being destroyed.

Previously, force cleanup listed every NodePool in the shared HostedCluster namespace and stripped finalizers from all of them. This was observed in the Azure deprovisioner rehearsal, which processed 186 NodePools and modified NodePools belonging to unrelated HostedClusters.

## Which issue(s) this PR fixes:

Fixes [OCPBUGS-113991](https://redhat.atlassian.net/browse/OCPBUGS-113991).

## Special notes for your reviewer:

The regression test includes a NodePool owned by another HostedCluster and verifies that its finalizer remains intact.

Validation:
- `GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor go test -race ./cmd/cluster/core/... ./cmd/cluster/azure/...`
- `make run-gitlint`

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin