### PR TITLE
WIP:AUTOSCALE-875: Add HYPERSHIFT_AUTONODE_ONLY to allow running only Karpenter tests

### DIFF
--- a/test/e2e/v2/lifecycle/aws.go
+++ b/test/e2e/v2/lifecycle/aws.go
@@ -18,6 +18,7 @@ type AWSPlatformConfig struct {
 	zones          []string
 	additionalTags []string
 	sharedDir      string
+	autonodeOnly   bool
 }
 
 type AWSPlatformOptions struct {
@@ -38,9 +39,10 @@ func NewAWSPlatformConfig(opts AWSPlatformOptions, sharedDir string) *AWSPlatfor
 		sharedDir:      sharedDir,
 		additionalTags: tags,
 		zones:          zones,
+		autonodeOnly:   os.Getenv("HYPERSHIFT_AUTONODE_ONLY") == "true",
 	}
 
-	log.Printf("AWS platform config: region=%s, zones=%v, additionalTags=%v", cfg.region, cfg.zones, cfg.additionalTags)
+	log.Printf("AWS platform config: region=%s, zones=%v, additionalTags=%v, autonodeOnly=%v", cfg.region, cfg.zones, cfg.additionalTags, cfg.autonodeOnly)
 	return cfg
 }
 
@@ -56,6 +58,19 @@ func (a *AWSPlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Cluster
 	if envArgs := os.Getenv("EXTRA_ARGS"); envArgs != "" {
 		extraArgs = strings.Fields(envArgs)
 	}
+
+	karpenterSpec := ClusterSpec{
+		Variant: "karpenter",
+		ExtraArgs: append(extraArgs, []string{
+			"--auto-node",
+			"--endpoint-access=PublicAndPrivate",
+		}...),
+	}
+
+	if a.autonodeOnly {
+		return []ClusterSpec{karpenterSpec}
+	}
+
 	return []ClusterSpec{
 		{
 			Variant: "public",
@@ -73,15 +88,7 @@ func (a *AWSPlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Cluster
 		// ability to make any such lifecycle assertions. This could mean that either
 		// the assertion itself needs to change to decouple it from lifecycle somehow,
 		// or there's a gap in the v2 framework for this sort of use case...
-		{
-			Variant: "karpenter",
-			ExtraArgs: append(extraArgs, []string{
-				// Enables Karpenter-based node provisioning (AutoNode)
-				"--auto-node",
-				// Required for karpenter to reach the hosted cluster API server from the mgmt cluster
-				"--endpoint-access=PublicAndPrivate",
-			}...),
-		},
+		karpenterSpec,
 	}
 }
 
@@ -120,6 +127,19 @@ func (a *AWSPlatformConfig) PostVersionRollout(ctx context.Context, cl crclient.
 }
 
 func (a *AWSPlatformConfig) TestMatrix(releaseImage string) TestMatrix {
+	karpenterGroup := TestGroup{
+		Name:        "karpenter",
+		Variant:     "karpenter",
+		LabelFilter: "karpenter",
+		JUnitFile:   "junit_karpenter.xml",
+	}
+
+	if a.autonodeOnly {
+		return TestMatrix{
+			Parallel: []TestGroup{karpenterGroup},
+		}
+	}
+
 	return TestMatrix{
 		Parallel: []TestGroup{
 			{
@@ -128,12 +148,7 @@ func (a *AWSPlatformConfig) TestMatrix(releaseImage string) TestMatrix {
 				LabelFilter: "!lifecycle || hosted-cluster-aws",
 				JUnitFile:   "junit_public.xml",
 			},
-			{
-				Name:        "karpenter",
-				Variant:     "karpenter",
-				LabelFilter: "karpenter",
-				JUnitFile:   "junit_karpenter.xml",
-			},
+			karpenterGroup,
 		},
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Enables the ability to run all Karpenter-related tests (and nothing more) for the new `e2e-aws-autonode-standalone-ko` test being added by https://github.com/openshift/release/pull/84052.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes [AUTOSCALE-875](https://redhat.atlassian.net/browse/AUTOSCALE-875)

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running AWS lifecycle configurations in autonode-only mode.
  * Autonode-only mode limits cluster test coverage to the Karpenter variant.
  * Standard mode continues to support both public and Karpenter variants.
  * Configuration logs now indicate whether autonode-only mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->