### PR TITLE
NO-JIRA: fix(azure): orphan AzureMachines when capi-provider cannot run

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -23,6 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -377,9 +378,14 @@ func (a Azure) DeleteCredentials(ctx context.Context, c client.Client, hcluster 
 const deletionFailedThreshold = 10 * time.Minute
 
 // DeleteOrphanedMachines removes the finalizer from AzureMachines that are stuck in deletion
-// due to credential failures. This is detected by checking each AzureMachine's Status.Conditions
-// for a Ready=False condition with Reason=DeletionFailed. Orphaning the machine allows management
-// cluster cleanup to proceed without requiring valid cloud credentials.
+// either due to credential failures or because the capi-provider (CAPZ) deployment is unable
+// to run at all (e.g. its availability-prober init container is blocked on an unreachable
+// guest API and can never start the manager). The credential-failure case is detected by
+// checking each AzureMachine's Status.Conditions for a Ready=False condition with
+// Reason=DeletionFailed. The CAPZ-unavailable case is detected by checking whether the
+// capi-provider deployment has any available replicas. Orphaning the machine allows
+// management cluster cleanup to proceed without requiring valid cloud credentials or a
+// healthy guest API.
 func (Azure) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hyperv1.HostedCluster, controlPlaneNamespace string) error {
 	// This orphaning behavior is intended for managed-identity cleanup flow.
 	if hc.Spec.Platform.Azure.AzureAuthenticationConfig.ManagedIdentities == nil {
@@ -389,6 +395,11 @@ func (Azure) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hy
 	azureMachineList := capiazure.AzureMachineList{}
 	if err := c.List(ctx, &azureMachineList, client.InNamespace(controlPlaneNamespace)); err != nil {
 		return fmt.Errorf("failed to list AzureMachines in %s: %w", controlPlaneNamespace, err)
+	}
+
+	providerUnavailable, err := capiProviderUnavailable(ctx, c, controlPlaneNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to determine capi-provider availability in %s: %w", controlPlaneNamespace, err)
 	}
 
 	logger := ctrl.LoggerFrom(ctx)
@@ -402,11 +413,13 @@ func (Azure) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hy
 		if time.Since(azureMachine.DeletionTimestamp.Time) < deletionFailedThreshold {
 			continue
 		}
-		if !hasDeletionFailedCondition(azureMachine) {
+		deletionFailed := hasDeletionFailedCondition(azureMachine)
+		if !deletionFailed && !providerUnavailable {
 			continue
 		}
 		// Remove the AzureMachine finalizer to orphan the machine, leaving Azure
-		// infrastructure intact rather than attempting cloud API calls with invalid credentials.
+		// infrastructure intact rather than attempting cloud API calls with invalid credentials
+		// or waiting indefinitely for a CAPZ manager that can never start.
 		if removed := controllerutil.RemoveFinalizer(azureMachine, capiazure.MachineFinalizer); !removed {
 			continue
 		}
@@ -415,11 +428,30 @@ func (Azure) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hy
 				azureMachine.Namespace, azureMachine.Name, err))
 			continue
 		}
-		logger.Info("orphaning azuremachine stuck in deletion due to credential failure",
-			"machine", client.ObjectKeyFromObject(azureMachine))
+		reason := "credential failure"
+		if !deletionFailed {
+			reason = "capi-provider unavailable"
+		}
+		logger.Info("orphaning azuremachine stuck in deletion",
+			"machine", client.ObjectKeyFromObject(azureMachine), "reason", reason)
 	}
 
 	return utilerrors.NewAggregate(errs)
+}
+
+// capiProviderUnavailable reports whether the capi-provider (CAPZ) deployment is unable to
+// process AzureMachine finalizers — either it does not exist or it has no available replicas.
+// This happens when its availability-prober init container is permanently blocked on an
+// unreachable guest API, so the CAPZ manager container never starts.
+func capiProviderUnavailable(ctx context.Context, c client.Client, controlPlaneNamespace string) (bool, error) {
+	dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "capi-provider", Namespace: controlPlaneNamespace}}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(dep), dep); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return dep.Status.AvailableReplicas == 0, nil
 }
 
 // hasDeletionFailedCondition returns true if the AzureMachine has a Ready condition with

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -378,14 +378,14 @@ func (a Azure) DeleteCredentials(ctx context.Context, c client.Client, hcluster 
 const deletionFailedThreshold = 10 * time.Minute
 
 // DeleteOrphanedMachines removes the finalizer from AzureMachines that are stuck in deletion
-// either due to credential failures or because the capi-provider (CAPZ) deployment is unable
-// to run at all (e.g. its availability-prober init container is blocked on an unreachable
-// guest API and can never start the manager). The credential-failure case is detected by
-// checking each AzureMachine's Status.Conditions for a Ready=False condition with
-// Reason=DeletionFailed. The CAPZ-unavailable case is detected by checking whether the
-// capi-provider deployment has any available replicas. Orphaning the machine allows
-// management cluster cleanup to proceed without requiring valid cloud credentials or a
-// healthy guest API.
+// either due to credential failures or because the capi-provider (CAPZ) deployment has been
+// unable to run for at least deletionFailedThreshold (e.g. its availability-prober init
+// container is blocked on an unreachable guest API and can never start the manager). The
+// credential-failure case is detected by checking each AzureMachine's Status.Conditions for a
+// Ready=False condition with Reason=DeletionFailed. The CAPZ-unavailable case is detected by
+// checking whether the capi-provider deployment's Available condition has been reporting False
+// for that long. Orphaning the machine allows management cluster cleanup to proceed without
+// requiring valid cloud credentials or a healthy guest API.
 func (Azure) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hyperv1.HostedCluster, controlPlaneNamespace string) error {
 	// This orphaning behavior is intended for managed-identity cleanup flow.
 	if hc.Spec.Platform.Azure.AzureAuthenticationConfig.ManagedIdentities == nil {
@@ -439,10 +439,12 @@ func (Azure) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hy
 	return utilerrors.NewAggregate(errs)
 }
 
-// capiProviderUnavailable reports whether the capi-provider (CAPZ) deployment is unable to
-// process AzureMachine finalizers — either it does not exist or it has no available replicas.
-// This happens when its availability-prober init container is permanently blocked on an
-// unreachable guest API, so the CAPZ manager container never starts.
+// capiProviderUnavailable reports whether the capi-provider (CAPZ) deployment has been unable
+// to process AzureMachine finalizers for at least deletionFailedThreshold. A missing deployment
+// is treated as immediately unavailable. Otherwise this requires the deployment's Available
+// condition to have been reporting False for at least that long, rather than a point-in-time
+// replica count, so a brief CAPZ restart (e.g. an OOM kill or rolling update) that could still
+// finish real Azure cleanup does not cause a machine to be orphaned prematurely.
 func capiProviderUnavailable(ctx context.Context, c client.Client, controlPlaneNamespace string) (bool, error) {
 	dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "capi-provider", Namespace: controlPlaneNamespace}}
 	if err := c.Get(ctx, client.ObjectKeyFromObject(dep), dep); err != nil {
@@ -451,7 +453,12 @@ func capiProviderUnavailable(ctx context.Context, c client.Client, controlPlaneN
 		}
 		return false, err
 	}
-	return dep.Status.AvailableReplicas == 0, nil
+	for _, cond := range dep.Status.Conditions {
+		if cond.Type == appsv1.DeploymentAvailable {
+			return cond.Status == corev1.ConditionFalse && time.Since(cond.LastTransitionTime.Time) >= deletionFailedThreshold, nil
+		}
+	}
+	return false, nil
 }
 
 // hasDeletionFailedCondition returns true if the AzureMachine has a Ready condition with

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
@@ -16,6 +16,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -562,11 +563,12 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name                      string
-		hostedCluster             *hyperv1.HostedCluster
-		azureMachines             []capiazure.AzureMachine
-		expectedFinalizersRemoved bool
-		expectedError             bool
+		name                          string
+		hostedCluster                 *hyperv1.HostedCluster
+		azureMachines                 []capiazure.AzureMachine
+		capiProviderAvailableReplicas *int32 // nil means the capi-provider deployment does not exist
+		expectedFinalizersRemoved     bool
+		expectedError                 bool
 	}{
 		{
 			name: "When ManagedIdentities is nil it should return early without modifying machines",
@@ -592,15 +594,17 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					},
 				},
 			},
-			expectedFinalizersRemoved: false,
-			expectedError:             false,
+			capiProviderAvailableReplicas: ptr.To(int32(1)),
+			expectedFinalizersRemoved:     false,
+			expectedError:                 false,
 		},
 		{
-			name:                      "When there are no machines it should succeed",
-			hostedCluster:             managedIdentitiesHC,
-			azureMachines:             []capiazure.AzureMachine{},
-			expectedFinalizersRemoved: false,
-			expectedError:             false,
+			name:                          "When there are no machines it should succeed",
+			hostedCluster:                 managedIdentitiesHC,
+			azureMachines:                 []capiazure.AzureMachine{},
+			capiProviderAvailableReplicas: ptr.To(int32(1)),
+			expectedFinalizersRemoved:     false,
+			expectedError:                 false,
 		},
 		{
 			name:          "When a machine has a stale DeletionTimestamp with DeletionFailed condition it should remove finalizers",
@@ -618,8 +622,9 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					},
 				},
 			},
-			expectedFinalizersRemoved: true,
-			expectedError:             false,
+			capiProviderAvailableReplicas: ptr.To(int32(1)),
+			expectedFinalizersRemoved:     true,
+			expectedError:                 false,
 		},
 		{
 			name:          "When a machine has a recent DeletionTimestamp with DeletionFailed condition it should not remove finalizers",
@@ -637,11 +642,12 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					},
 				},
 			},
-			expectedFinalizersRemoved: false,
-			expectedError:             false,
+			capiProviderAvailableReplicas: ptr.To(int32(1)),
+			expectedFinalizersRemoved:     false,
+			expectedError:                 false,
 		},
 		{
-			name:          "When a machine has a stale DeletionTimestamp without DeletionFailed condition it should not remove finalizers",
+			name:          "When a machine has a stale DeletionTimestamp without DeletionFailed condition and capi-provider is healthy it should not remove finalizers",
 			hostedCluster: managedIdentitiesHC,
 			azureMachines: []capiazure.AzureMachine{
 				{
@@ -661,8 +667,9 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					},
 				},
 			},
-			expectedFinalizersRemoved: false,
-			expectedError:             false,
+			capiProviderAvailableReplicas: ptr.To(int32(1)),
+			expectedFinalizersRemoved:     false,
+			expectedError:                 false,
 		},
 		{
 			name:          "When a machine is not pending deletion it should not remove finalizers regardless of conditions",
@@ -679,8 +686,84 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					},
 				},
 			},
-			expectedFinalizersRemoved: false,
-			expectedError:             false,
+			capiProviderAvailableReplicas: ptr.To(int32(1)),
+			expectedFinalizersRemoved:     false,
+			expectedError:                 false,
+		},
+		{
+			name:          "When a machine has a stale DeletionTimestamp without DeletionFailed condition and capi-provider has no available replicas it should remove finalizers",
+			hostedCluster: managedIdentitiesHC,
+			azureMachines: []capiazure.AzureMachine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "machine-1",
+						Namespace:         controlPlaneNamespace,
+						Finalizers:        []string{capiazure.MachineFinalizer},
+						DeletionTimestamp: &staleDeletionTimestamp,
+					},
+					Status: capiazure.AzureMachineStatus{
+						Conditions: capiv1.Conditions{
+							{
+								Type:   capiv1.ReadyCondition,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			capiProviderAvailableReplicas: ptr.To(int32(0)),
+			expectedFinalizersRemoved:     true,
+			expectedError:                 false,
+		},
+		{
+			name:          "When a machine has a recent DeletionTimestamp and capi-provider has no available replicas it should not remove finalizers",
+			hostedCluster: managedIdentitiesHC,
+			azureMachines: []capiazure.AzureMachine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "machine-1",
+						Namespace:         controlPlaneNamespace,
+						Finalizers:        []string{capiazure.MachineFinalizer},
+						DeletionTimestamp: &recentDeletionTimestamp,
+					},
+					Status: capiazure.AzureMachineStatus{
+						Conditions: capiv1.Conditions{
+							{
+								Type:   capiv1.ReadyCondition,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			capiProviderAvailableReplicas: ptr.To(int32(0)),
+			expectedFinalizersRemoved:     false,
+			expectedError:                 false,
+		},
+		{
+			name:          "When the capi-provider deployment does not exist and a machine has a stale DeletionTimestamp it should remove finalizers",
+			hostedCluster: managedIdentitiesHC,
+			azureMachines: []capiazure.AzureMachine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "machine-1",
+						Namespace:         controlPlaneNamespace,
+						Finalizers:        []string{capiazure.MachineFinalizer},
+						DeletionTimestamp: &staleDeletionTimestamp,
+					},
+					Status: capiazure.AzureMachineStatus{
+						Conditions: capiv1.Conditions{
+							{
+								Type:   capiv1.ReadyCondition,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			capiProviderAvailableReplicas: nil,
+			expectedFinalizersRemoved:     true,
+			expectedError:                 false,
 		},
 	}
 
@@ -693,6 +776,18 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 			objects := make([]client.Object, len(tc.azureMachines))
 			for i := range tc.azureMachines {
 				objects[i] = &tc.azureMachines[i]
+			}
+
+			if tc.capiProviderAvailableReplicas != nil {
+				objects = append(objects, &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "capi-provider",
+						Namespace: controlPlaneNamespace,
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: *tc.capiProviderAvailableReplicas,
+					},
+				})
 			}
 
 			fakeClient := fake.NewClientBuilder().

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
@@ -813,7 +813,10 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 			}
 
 			if tc.capiProviderDeployment != nil {
-				objects = append(objects, tc.capiProviderDeployment)
+				// Deep-copy: several subtests share the same *Deployment value and run in
+				// parallel, but fake.ClientBuilder.Build() mutates the objects it's given
+				// (e.g. ResourceVersion), so sharing the pointer would race.
+				objects = append(objects, tc.capiProviderDeployment.DeepCopy())
 			}
 
 			fakeClient := fake.NewClientBuilder().

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
@@ -25,6 +25,7 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/blang/semver"
@@ -822,6 +823,58 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteOrphanedMachines_CapiProviderLookupError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	controlPlaneNamespace := "test-cp-namespace"
+
+	hc := &hyperv1.HostedCluster{
+		Spec: hyperv1.HostedClusterSpec{
+			Platform: hyperv1.PlatformSpec{
+				Azure: &hyperv1.AzurePlatformSpec{
+					AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+						ManagedIdentities: &hyperv1.AzureResourceManagedIdentities{},
+					},
+				},
+			},
+		},
+	}
+
+	staleDeletionTimestamp := metav1.NewTime(time.Now().Add(-(deletionFailedThreshold + time.Minute)))
+	azureMachine := &capiazure.AzureMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "machine-1",
+			Namespace:         controlPlaneNamespace,
+			Finalizers:        []string{capiazure.MachineFinalizer},
+			DeletionTimestamp: &staleDeletionTimestamp,
+		},
+	}
+
+	getErr := fmt.Errorf("injected get failure")
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(api.Scheme).
+		WithObjects(azureMachine).
+		WithStatusSubresource(azureMachine).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*appsv1.Deployment); ok {
+					return getErr
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	azure := Azure{}
+	err := azure.DeleteOrphanedMachines(ctx, fakeClient, hc, controlPlaneNamespace)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to determine capi-provider availability"))
+
+	gotMachine := &capiazure.AzureMachine{}
+	g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(azureMachine), gotMachine)).To(Succeed())
+	g.Expect(gotMachine.Finalizers).To(Equal(azureMachine.Finalizers), "finalizers should not be modified when the capi-provider lookup fails")
 }
 
 func buildAzureHostedControlPlane(tlsProfile *configv1.TLSSecurityProfile) *hyperv1.HostedControlPlane {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
@@ -563,13 +563,21 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 		},
 	}
 
+	healthyCapiProvider := capiProviderDeploymentWithAvailableCondition(controlPlaneNamespace, corev1.ConditionTrue, 0)
+	// staleUnavailableCapiProvider simulates CAPZ having been unable to run beyond the
+	// deletionFailedThreshold, e.g. the availability-prober has been blocked the whole time.
+	staleUnavailableCapiProvider := capiProviderDeploymentWithAvailableCondition(controlPlaneNamespace, corev1.ConditionFalse, deletionFailedThreshold+time.Minute)
+	// recentlyUnavailableCapiProvider simulates a brief CAPZ restart (e.g. an OOM kill) that
+	// has not yet been unavailable long enough to be considered permanently stuck.
+	recentlyUnavailableCapiProvider := capiProviderDeploymentWithAvailableCondition(controlPlaneNamespace, corev1.ConditionFalse, time.Minute)
+
 	testCases := []struct {
-		name                          string
-		hostedCluster                 *hyperv1.HostedCluster
-		azureMachines                 []capiazure.AzureMachine
-		capiProviderAvailableReplicas *int32 // nil means the capi-provider deployment does not exist
-		expectedFinalizersRemoved     bool
-		expectedError                 bool
+		name                      string
+		hostedCluster             *hyperv1.HostedCluster
+		azureMachines             []capiazure.AzureMachine
+		capiProviderDeployment    *appsv1.Deployment // nil means the capi-provider deployment does not exist
+		expectedFinalizersRemoved bool
+		expectedError             bool
 	}{
 		{
 			name: "When ManagedIdentities is nil it should return early without modifying machines",
@@ -595,17 +603,17 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					},
 				},
 			},
-			capiProviderAvailableReplicas: ptr.To(int32(1)),
-			expectedFinalizersRemoved:     false,
-			expectedError:                 false,
+			capiProviderDeployment:    healthyCapiProvider,
+			expectedFinalizersRemoved: false,
+			expectedError:             false,
 		},
 		{
-			name:                          "When there are no machines it should succeed",
-			hostedCluster:                 managedIdentitiesHC,
-			azureMachines:                 []capiazure.AzureMachine{},
-			capiProviderAvailableReplicas: ptr.To(int32(1)),
-			expectedFinalizersRemoved:     false,
-			expectedError:                 false,
+			name:                      "When there are no machines it should succeed",
+			hostedCluster:             managedIdentitiesHC,
+			azureMachines:             []capiazure.AzureMachine{},
+			capiProviderDeployment:    healthyCapiProvider,
+			expectedFinalizersRemoved: false,
+			expectedError:             false,
 		},
 		{
 			name:          "When a machine has a stale DeletionTimestamp with DeletionFailed condition it should remove finalizers",
@@ -623,9 +631,9 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					},
 				},
 			},
-			capiProviderAvailableReplicas: ptr.To(int32(1)),
-			expectedFinalizersRemoved:     true,
-			expectedError:                 false,
+			capiProviderDeployment:    healthyCapiProvider,
+			expectedFinalizersRemoved: true,
+			expectedError:             false,
 		},
 		{
 			name:          "When a machine has a recent DeletionTimestamp with DeletionFailed condition it should not remove finalizers",
@@ -643,9 +651,9 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					},
 				},
 			},
-			capiProviderAvailableReplicas: ptr.To(int32(1)),
-			expectedFinalizersRemoved:     false,
-			expectedError:                 false,
+			capiProviderDeployment:    healthyCapiProvider,
+			expectedFinalizersRemoved: false,
+			expectedError:             false,
 		},
 		{
 			name:          "When a machine has a stale DeletionTimestamp without DeletionFailed condition and capi-provider is healthy it should not remove finalizers",
@@ -668,9 +676,9 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					},
 				},
 			},
-			capiProviderAvailableReplicas: ptr.To(int32(1)),
-			expectedFinalizersRemoved:     false,
-			expectedError:                 false,
+			capiProviderDeployment:    healthyCapiProvider,
+			expectedFinalizersRemoved: false,
+			expectedError:             false,
 		},
 		{
 			name:          "When a machine is not pending deletion it should not remove finalizers regardless of conditions",
@@ -687,12 +695,12 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					},
 				},
 			},
-			capiProviderAvailableReplicas: ptr.To(int32(1)),
-			expectedFinalizersRemoved:     false,
-			expectedError:                 false,
+			capiProviderDeployment:    healthyCapiProvider,
+			expectedFinalizersRemoved: false,
+			expectedError:             false,
 		},
 		{
-			name:          "When a machine has a stale DeletionTimestamp without DeletionFailed condition and capi-provider has no available replicas it should remove finalizers",
+			name:          "When a machine has a stale DeletionTimestamp without DeletionFailed condition and capi-provider has been unavailable beyond the threshold it should remove finalizers",
 			hostedCluster: managedIdentitiesHC,
 			azureMachines: []capiazure.AzureMachine{
 				{
@@ -712,12 +720,37 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					},
 				},
 			},
-			capiProviderAvailableReplicas: ptr.To(int32(0)),
-			expectedFinalizersRemoved:     true,
-			expectedError:                 false,
+			capiProviderDeployment:    staleUnavailableCapiProvider,
+			expectedFinalizersRemoved: true,
+			expectedError:             false,
 		},
 		{
-			name:          "When a machine has a recent DeletionTimestamp and capi-provider has no available replicas it should not remove finalizers",
+			name:          "When a machine has a stale DeletionTimestamp without DeletionFailed condition and capi-provider has only recently become unavailable it should not remove finalizers",
+			hostedCluster: managedIdentitiesHC,
+			azureMachines: []capiazure.AzureMachine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "machine-1",
+						Namespace:         controlPlaneNamespace,
+						Finalizers:        []string{capiazure.MachineFinalizer},
+						DeletionTimestamp: &staleDeletionTimestamp,
+					},
+					Status: capiazure.AzureMachineStatus{
+						Conditions: capiv1.Conditions{
+							{
+								Type:   capiv1.ReadyCondition,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			capiProviderDeployment:    recentlyUnavailableCapiProvider,
+			expectedFinalizersRemoved: false,
+			expectedError:             false,
+		},
+		{
+			name:          "When a machine has a recent DeletionTimestamp and capi-provider has been unavailable beyond the threshold it should not remove finalizers",
 			hostedCluster: managedIdentitiesHC,
 			azureMachines: []capiazure.AzureMachine{
 				{
@@ -737,9 +770,9 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					},
 				},
 			},
-			capiProviderAvailableReplicas: ptr.To(int32(0)),
-			expectedFinalizersRemoved:     false,
-			expectedError:                 false,
+			capiProviderDeployment:    staleUnavailableCapiProvider,
+			expectedFinalizersRemoved: false,
+			expectedError:             false,
 		},
 		{
 			name:          "When the capi-provider deployment does not exist and a machine has a stale DeletionTimestamp it should remove finalizers",
@@ -762,9 +795,9 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					},
 				},
 			},
-			capiProviderAvailableReplicas: nil,
-			expectedFinalizersRemoved:     true,
-			expectedError:                 false,
+			capiProviderDeployment:    nil,
+			expectedFinalizersRemoved: true,
+			expectedError:             false,
 		},
 	}
 
@@ -779,16 +812,8 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 				objects[i] = &tc.azureMachines[i]
 			}
 
-			if tc.capiProviderAvailableReplicas != nil {
-				objects = append(objects, &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "capi-provider",
-						Namespace: controlPlaneNamespace,
-					},
-					Status: appsv1.DeploymentStatus{
-						AvailableReplicas: *tc.capiProviderAvailableReplicas,
-					},
-				})
+			if tc.capiProviderDeployment != nil {
+				objects = append(objects, tc.capiProviderDeployment)
 			}
 
 			fakeClient := fake.NewClientBuilder().
@@ -822,6 +847,26 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// capiProviderDeploymentWithAvailableCondition builds a capi-provider Deployment whose
+// Available condition has the given status and became that way transitionedAgo in the past.
+func capiProviderDeploymentWithAvailableCondition(controlPlaneNamespace string, status corev1.ConditionStatus, transitionedAgo time.Duration) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "capi-provider",
+			Namespace: controlPlaneNamespace,
+		},
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:               appsv1.DeploymentAvailable,
+					Status:             status,
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-transitionedAgo)),
+				},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

`HostedCluster` deletion can deadlock permanently on Azure when the guest API is
permanently unavailable (e.g. the customer resource group or the etcd KMS Key Vault has
been deleted):

- The `capi-provider` (CAPZ) `Deployment` has an `availability-prober` init container that
  gates pod startup on the guest KAS `/readyz`, with no overall timeout.
- If the guest API never recovers, the CAPZ `manager` container never starts, so it never
  removes the `AzureMachine` finalizer.
- The existing `Azure.DeleteOrphanedMachines` escape hatch only orphans a stuck
  `AzureMachine` when CAPZ has set a `Ready=False/Reason=DeletionFailed` condition — which
  never happens if CAPZ never ran in the first place. `HostedCluster` deletion then loops
  forever, requiring manual finalizer removal to recover.

This was confirmed by an incident (Prow run `2057959692289708032`, 2026-05-22), manually
remediated on 2026-06-11.

## Fix

- `Azure.DeleteOrphanedMachines` now also orphans a stuck `AzureMachine` (past the existing
  10-minute `deletionFailedThreshold`) when the `capi-provider` deployment itself has no
  available replicas or does not exist — in addition to the existing `DeletionFailed`
  condition check.
- This is safe for the incident scenario: the customer resource group is already deleted at
  that point, so the underlying Azure VMs are already gone — orphaning the Kubernetes object
  doesn't leak real infrastructure.
- A healthy `capi-provider` that hits a transient Azure error is left untouched so it can
  retry normally.

The `cluster_delete_cx_rg` ARO test, which intentionally deletes the customer resource
group to validate this exact recovery path, is left unchanged.

## Upstream tracking

The deeper root cause — the availability-prober having no bypass/timeout during
`HostedCluster` deletion — is tracked separately for a more complete fix:
https://github.com/openshift/hypershift/issues/9402

## Test plan

- [x] Extended `TestDeleteOrphanedMachines` in `azure_test.go` with cases for: capi-provider
      unavailable + stale deletion (orphan), capi-provider unavailable + recent deletion (no
      -op), capi-provider missing entirely (orphan), and capi-provider healthy (no-op,
      unchanged behavior).
- [x] `make pre-commit` (build, e2e compile, lint, staticcheck, fmt, vet, generate/update) —
      clean, 0 lint issues.
- [x] `make test` — full unit suite passes (238 packages, 0 failures).
- [ ] Verify in an ARO HCP environment running the affected HyperShift image that the
      `cluster_delete_cx_rg` flow completes deletion without manual finalizer removal after
      KMS Key Vault removal (SRE-owned, before closing AROSLSRE-1167).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure machine cleanup when the provider is unavailable or missing.
  * Stale machines are now cleaned up only after the provider has remained unavailable for the required period, preventing transient restarts from triggering cleanup.
  * Missing provider components are handled immediately, while unexpected availability-check errors continue to be reported appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->