### PR TITLE
NO-JIRA: fix(managed-azure): continue resource group cleanup when HC destroy fails

### DIFF
--- a/contrib/managed-azure/delete_hosted_cluster.sh
+++ b/contrib/managed-azure/delete_hosted_cluster.sh
@@ -29,17 +29,16 @@ CUSTOMER_VNET_RG_NAME="${PREFIX}-customer-vnet-rg"
 CUSTOMER_NSG_RG_NAME="${PREFIX}-customer-nsg-rg"
 CLUSTER_NAME="${PREFIX}-hc"
 
-# Delete the hosted cluster using hypershift destroy command
+# Delete the hosted cluster using hypershift destroy command.
+# If the HostedCluster object doesn't exist (e.g. creation failed before it was applied),
+# hypershift destroy will fail. We log the error but continue so Azure resource groups are
+# still cleaned up below.
 ${HYPERSHIFT_BINARY_PATH}/hypershift destroy cluster azure \
     --name "$CLUSTER_NAME" \
     --azure-creds "$AZURE_CREDS" \
     --resource-group-name "$MANAGED_RG_NAME" \
-    --dns-zone-rg-name "$PERSISTENT_RG_NAME"
-
-if [ $? -ne 0 ]; then
-    echo "Error: Failed to destroy hosted cluster $CLUSTER_NAME"
-    exit 1
-fi
+    --dns-zone-rg-name "$PERSISTENT_RG_NAME" || \
+    echo "Warning: hypershift destroy failed (cluster may not exist in management cluster), continuing with Azure resource group cleanup"
 
 # Clean up the customer resource groups that were created for this cluster
 


### PR DESCRIPTION
## Problem

- This `delete_hosted_cluster.sh` exits immediately if `hypershift destroy cluster azure`
fails. When a HostedCluster was never fully created (e.g. creation failed before
the HC object was applied to the management cluster), the destroy command logs
"infrastructure ID is required" and exits 1. This leaves the Azure managed,
customer VNET, and customer NSG resource groups undeleted with no automatic
cleanup path.

```
/hypershift destroy cluster azure --name rkshirsa-management-hc --azure-creds ./azure/osServicePrincipal.json --resource-group-name rkshirsa-management-managed-rg --dns-zone-rg-name os4-common
{"level":"info","ts":"2026-08-25T23:10:49+05:30","msg":"Hosted cluster not found, destroying infrastructure from user input","namespace":"clusters","name":"rkshirsa-management-hc","infraID":""}
{"level":"error","ts":"2026-08-25T23:10:49+05:30","msg":"Failed to destroy cluster","error":"required inputs are missing: infrastructure ID is required","stacktrace":"github.com/openshift/hypershift/cmd/cluster/azure.NewDestroyCommand.func1\n\t/Users/rkshirsa/claude-hcp/hypershift/cmd/cluster/azure/destroy.go:63\ngithub.com/spf13/cobra.(*Command).execute\n\t/Users/rkshirsa/claude-hcp/hypershift/vendor/github.com/spf13/cobra/command.go:1019\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/Users/rkshirsa/claude-hcp/hypershift/vendor/github.com/spf13/cobra/command.go:1148\ngithub.com/spf13/cobra.(*Command).Execute\n\t/Users/rkshirsa/claude-hcp/hypershift/vendor/github.com/spf13/cobra/command.go:1071\ngithub.com/spf13/cobra.(*Command).ExecuteContext\n\t/Users/rkshirsa/claude-hcp/hypershift/vendor/github.com/spf13/cobra/command.go:1064\nmain.main\n\t/Users/rkshirsa/claude-hcp/hypershift/main.go:81\nruntime.main\n\t/opt/homebrew/Cellar/go/1.26.3/libexec/src/runtime/proc.go:290"}
+ '[' 1 -ne 0 ']'
+ echo 'Error: Failed to destroy hosted cluster rkshirsa-management-hc'
Error: Failed to destroy hosted cluster rkshirsa-management-hc
+ exit 1
+ '[' 1 -ne 0 ']'
+ echo 'Error: Failed to delete hosted cluster. Stopping deletion process.
Error: Failed to delete hosted cluster. Stopping deletion process.
```

## Fix
- Make the `hypershift destroy` invocation non-fatal. On failure, a warning is
printed and the script continues to the `az group delete` cleanup steps that
follow, which handle the actual Azure resource group teardown regardless of
whether the HC object existed.

## Test plan

- [x] Run `delete_hosted_cluster.sh` when no HostedCluster object exists in the
  management cluster — verify warning is printed and resource groups are deleted.
- [x] Run `delete_hosted_cluster.sh` against a fully created cluster; verify
  normal destroy path still works end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure hosted cluster cleanup now continues deleting associated resource groups even if the cluster destruction command fails.
  * Displays a warning instead of stopping cleanup immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->