### PR TITLE
OCPBUGS-114265: Use managemet cluster kubeconfig for CAPI migration test

### DIFF
--- a/test/e2e/capi_storage_migration_test.go
+++ b/test/e2e/capi_storage_migration_test.go
@@ -23,7 +23,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclient "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -225,11 +224,8 @@ func getGaugeValue(mf map[string]*dto.MetricFamily, name string) *float64 {
 }
 
 func checkHOLogsForMigratorErrors(ctx context.Context, t *testing.T, g gomega.Gomega) {
-	cfg, err := rest.InClusterConfig()
-	if err != nil {
-		cfg, err = e2eutil.GetConfig()
-		g.Expect(err).ToNot(gomega.HaveOccurred(), "getting kubeconfig")
-	}
+	cfg, err := e2eutil.GetConfig()
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "getting kubeconfig")
 	kubeClient, err := kubeclient.NewForConfig(cfg)
 	g.Expect(err).ToNot(gomega.HaveOccurred(), "creating kube client")
 


### PR DESCRIPTION
## What this PR does / why we need it:
The CAPI storage version migration e2e test verifies the HO logs to check for migration errors, which has no sufficient permissions with the in-cluster config it was using.

By switching to the management cluster kubeconfig it should be able to properly stream the HO logs.

The issue was discovered rehearsing this new e2e test on CI:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/82464/rehearse-82464-periodic-ci-openshift-hypershift-main-e2e-aws-capi-storage-migration/2092575965325561856

```
Failed  === RUN   TestCAPIStorageVersionMigration/Main/When_checking_HO_logs,_it_should_have_no_CRD_migrator_errors
    capi_storage_migration_test.go:239: 
        listing HO pods
        Unexpected error:
            <*errors.StatusError | 0x13563a26d5e0>: 
            pods is forbidden: User "system:serviceaccount:ci-op-7sgykqs2:e2e-aws-capi-storage-migration" cannot list resource "pods" in API group "" in the namespace "hypershift"
            {
                ErrStatus: {
                    TypeMeta: {Kind: "", APIVersion: ""},
                    ListMeta: {
                        SelfLink: "",
                        ResourceVersion: "",
                        Continue: "",
                        RemainingItemCount: nil,
                        ShardInfo: nil,
                    },
                    Status: "Failure",
                    Message: "pods is forbidden: User \"system:serviceaccount:ci-op-7sgykqs2:e2e-aws-capi-storage-migration\" cannot list resource \"pods\" in API group \"\" in the namespace \"hypershift\"",
                    Reason: "Forbidden",
                    Details: {Name: "", Group: "", Kind: "pods", UID: "", Causes: nil, RetryAfterSeconds: 0},
                    Code: 403,
                },
            }
        occurred
```

## Which issue(s) this PR fixes:
Fixes [OCPBUGS-114265](https://redhat.atlassian.net/browse/OCPBUGS-114265)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end storage migration test configuration handling.
  * Removed an unused dependency from the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->