### PR TITLE
CNTRLPLANE-4213: decouple konflux pr pipelines

### DIFF
--- a/.tekton/control-plane-operator-main-pull-request-from-main.yaml
+++ b/.tekton/control-plane-operator-main-pull-request-from-main.yaml
@@ -11,18 +11,17 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && ".tekton/***".pathChanged()
+      && !".tekton/***".pathChanged()
       && ( "control-plane-operator/***".pathChanged() ||
            "support/***".pathChanged() ||
            ".tekton/control-plane-operator*".pathChanged() ||
            "/Containerfile.control-plane-operator".pathChanged() )
-    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: control-plane-operator
     appstudio.openshift.io/component: control-plane-operator-main
     pipelines.appstudio.openshift.io/type: build
-  name: control-plane-operator-main-on-pull-request
+  name: control-plane-operator-main-on-pr-from-main
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -42,7 +41,14 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    name: hypershift-common-operator-build
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift/hypershift.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/pipelines/common-operator-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-control-plane-operator-main
   workspaces:

--- a/.tekton/control-plane-operator-main-pull-request-from-main.yaml
+++ b/.tekton/control-plane-operator-main-pull-request-from-main.yaml
@@ -11,11 +11,12 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && !".tekton/***".pathChanged()
       && ( "control-plane-operator/***".pathChanged() ||
            "support/***".pathChanged() ||
            ".tekton/control-plane-operator*".pathChanged() ||
-           "/Containerfile.control-plane-operator".pathChanged() )
+           "/Containerfile.control-plane".pathChanged() )
+      && !".tekton/pipelines/common-operator-build.yaml".pathChanged()
+      && !".tekton/control-plane-operator-main-pull-request.yaml".pathChanged()
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: control-plane-operator

--- a/.tekton/control-plane-operator-main-pull-request.yaml
+++ b/.tekton/control-plane-operator-main-pull-request.yaml
@@ -11,11 +11,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && ".tekton/***".pathChanged()
-      && ( "control-plane-operator/***".pathChanged() ||
-           "support/***".pathChanged() ||
-           ".tekton/control-plane-operator*".pathChanged() ||
-           "/Containerfile.control-plane-operator".pathChanged() )
+      && (".tekton/pipelines/common-operator-build.yaml".pathChanged()
+         || ".tekton/control-plane-operator-main-pull-request.yaml".pathChanged())
     pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
   creationTimestamp:
   labels:

--- a/.tekton/control-plane-operator-main-push.yaml
+++ b/.tekton/control-plane-operator-main-push.yaml
@@ -12,7 +12,7 @@ metadata:
       && ( "control-plane-operator/***".pathChanged() ||
            "support/***".pathChanged() ||
            ".tekton/control-plane-operator*".pathChanged() ||
-           "/Containerfile.control-plane-operator".pathChanged() )
+           "/Containerfile.control-plane".pathChanged() )
     pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
   creationTimestamp:
   labels:

--- a/.tekton/hypershift-gh-actions-runner-pull-request-from-main.yaml
+++ b/.tekton/hypershift-gh-actions-runner-pull-request-from-main.yaml
@@ -8,11 +8,15 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && !".tekton/***".pathChanged() && ("Dockerfile.github-actions-runner".pathChanged()
-      || "contrib/ci/gocacheprog".pathChanged()
-      || ".tekton/hypershift-gh-actions-runner-pull-request.yaml".pathChanged()
-      || ".tekton/hypershift-gh-actions-runner-pull-request-from-main.yaml".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "main"
+      && ("Dockerfile.github-actions-runner".pathChanged()
+         || "contrib/ci/gocacheprog".pathChanged()
+         || ".tekton/hypershift-gh-actions-runner-pull-request.yaml".pathChanged()
+         || ".tekton/hypershift-gh-actions-runner-pull-request-from-main.yaml".pathChanged())
+      && !".tekton/pipelines/common-operator-build.yaml".pathChanged()
+      && !".tekton/hypershift-gh-actions-runner-pull-request.yaml".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: hypershift-actions

--- a/.tekton/hypershift-gh-actions-runner-pull-request-from-main.yaml
+++ b/.tekton/hypershift-gh-actions-runner-pull-request-from-main.yaml
@@ -9,17 +9,16 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ".tekton/***".pathChanged() && ("Dockerfile.github-actions-runner".pathChanged()
+      == "main" && !".tekton/***".pathChanged() && ("Dockerfile.github-actions-runner".pathChanged()
       || "contrib/ci/gocacheprog".pathChanged()
       || ".tekton/hypershift-gh-actions-runner-pull-request.yaml".pathChanged()
       || ".tekton/hypershift-gh-actions-runner-pull-request-from-main.yaml".pathChanged())
-    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: hypershift-actions
     appstudio.openshift.io/component: hypershift-gh-actions-runner
     pipelines.appstudio.openshift.io/type: build
-  name: hypershift-gh-actions-runner-on-pull-request
+  name: hypershift-gh-actions-runner-on-pr-from-main
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -40,7 +39,14 @@ spec:
   - name: dockerfile
     value: Dockerfile.github-actions-runner
   pipelineRef:
-    name: hypershift-common-operator-build
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift/hypershift.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/pipelines/common-operator-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-hypershift-gh-actions-runner
   workspaces:

--- a/.tekton/hypershift-gh-actions-runner-pull-request.yaml
+++ b/.tekton/hypershift-gh-actions-runner-pull-request.yaml
@@ -8,11 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ".tekton/***".pathChanged() && ("Dockerfile.github-actions-runner".pathChanged()
-      || "contrib/ci/gocacheprog".pathChanged()
-      || ".tekton/hypershift-gh-actions-runner-pull-request.yaml".pathChanged()
-      || ".tekton/hypershift-gh-actions-runner-pull-request-from-main.yaml".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "main"
+      && (".tekton/pipelines/common-operator-build.yaml".pathChanged()
+         || ".tekton/hypershift-gh-actions-runner-pull-request.yaml".pathChanged())
     pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
   creationTimestamp: null
   labels:

--- a/.tekton/hypershift-gomaxprocs-webhook-pull-request-from-main.yaml
+++ b/.tekton/hypershift-gomaxprocs-webhook-pull-request-from-main.yaml
@@ -11,10 +11,11 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && !".tekton/***".pathChanged()
       && ( "contrib/gomaxprocs-webhook/***".pathChanged() ||
            ".tekton/hypershift-gomaxprocs-webhook*".pathChanged() ||
            ".tekton/pipelines/common-operator-build.yaml".pathChanged() )
+      && !".tekton/pipelines/common-operator-build.yaml".pathChanged()
+      && !".tekton/hypershift-gomaxprocs-webhook-pull-request.yaml".pathChanged()
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: hypershift-gomaxprocs-webhook

--- a/.tekton/hypershift-gomaxprocs-webhook-pull-request-from-main.yaml
+++ b/.tekton/hypershift-gomaxprocs-webhook-pull-request-from-main.yaml
@@ -12,8 +12,7 @@ metadata:
       event == "pull_request"
       && target_branch == "main"
       && ( "contrib/gomaxprocs-webhook/***".pathChanged() ||
-           ".tekton/hypershift-gomaxprocs-webhook*".pathChanged() ||
-           ".tekton/pipelines/common-operator-build.yaml".pathChanged() )
+           ".tekton/hypershift-gomaxprocs-webhook*".pathChanged() )
       && !".tekton/pipelines/common-operator-build.yaml".pathChanged()
       && !".tekton/hypershift-gomaxprocs-webhook-pull-request.yaml".pathChanged()
   creationTimestamp:

--- a/.tekton/hypershift-gomaxprocs-webhook-pull-request-from-main.yaml
+++ b/.tekton/hypershift-gomaxprocs-webhook-pull-request-from-main.yaml
@@ -11,18 +11,16 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && ".tekton/***".pathChanged()
-      && ( "control-plane-operator/***".pathChanged() ||
-           "support/***".pathChanged() ||
-           ".tekton/control-plane-operator*".pathChanged() ||
-           "/Containerfile.control-plane-operator".pathChanged() )
-    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
+      && !".tekton/***".pathChanged()
+      && ( "contrib/gomaxprocs-webhook/***".pathChanged() ||
+           ".tekton/hypershift-gomaxprocs-webhook*".pathChanged() ||
+           ".tekton/pipelines/common-operator-build.yaml".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: control-plane-operator
-    appstudio.openshift.io/component: control-plane-operator-main
+    appstudio.openshift.io/application: hypershift-gomaxprocs-webhook
+    appstudio.openshift.io/component: hypershift-gomaxprocs-webhook
     pipelines.appstudio.openshift.io/type: build
-  name: control-plane-operator-main-on-pull-request
+  name: hypershift-gomaxprocs-webhook-on-pr-from-main
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -31,20 +29,31 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-main:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-gomaxprocs-webhook:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
     value:
     - linux/x86_64
   - name: dockerfile
-    value: /Containerfile.control-plane
+    value: /Dockerfile
   - name: path-context
-    value: .
+    value: contrib/gomaxprocs-webhook
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "contrib/gomaxprocs-webhook"}]'
+  - name: dev-package-managers
+    value: "true"
   pipelineRef:
-    name: hypershift-common-operator-build
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift/hypershift.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/pipelines/common-operator-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-control-plane-operator-main
+    serviceAccountName: build-pipeline-hypershift-gomaxprocs-webhook
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/hypershift-gomaxprocs-webhook-pull-request.yaml
+++ b/.tekton/hypershift-gomaxprocs-webhook-pull-request.yaml
@@ -11,6 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
+      && ".tekton/***".pathChanged()
       && ( "contrib/gomaxprocs-webhook/***".pathChanged() ||
            ".tekton/hypershift-gomaxprocs-webhook*".pathChanged() ||
            ".tekton/pipelines/common-operator-build.yaml".pathChanged() )

--- a/.tekton/hypershift-gomaxprocs-webhook-pull-request.yaml
+++ b/.tekton/hypershift-gomaxprocs-webhook-pull-request.yaml
@@ -11,10 +11,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && ".tekton/***".pathChanged()
-      && ( "contrib/gomaxprocs-webhook/***".pathChanged() ||
-           ".tekton/hypershift-gomaxprocs-webhook*".pathChanged() ||
-           ".tekton/pipelines/common-operator-build.yaml".pathChanged() )
+      && (".tekton/pipelines/common-operator-build.yaml".pathChanged()
+         || ".tekton/hypershift-gomaxprocs-webhook-pull-request.yaml".pathChanged())
     pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
   creationTimestamp:
   labels:

--- a/.tekton/hypershift-operator-main-pull-request-from-main.yaml
+++ b/.tekton/hypershift-operator-main-pull-request-from-main.yaml
@@ -11,19 +11,18 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && ".tekton/***".pathChanged()
+      && !".tekton/***".pathChanged()
       && (files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib|hack|\\.tekton|\\.github|\\.claude|\\.chai-bot)/|\\.md$|^(?:Dockerfile|Containerfile)\\b|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|renovate\\.json)$'))
          || "Containerfile.operator".pathChanged()
          || ".tekton/pipelines/common-operator-build.yaml".pathChanged()
          || ".tekton/hypershift-operator-main-pull-request.yaml".pathChanged()
          || ".tekton/hypershift-operator-main-pull-request-from-main.yaml".pathChanged())
-    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: hypershift-operator
     appstudio.openshift.io/component: hypershift-operator-main
     pipelines.appstudio.openshift.io/type: build
-  name: hypershift-operator-main-on-pull-request
+  name: hypershift-operator-main-on-pr-from-main
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -43,7 +42,14 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    name: hypershift-common-operator-build
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift/hypershift.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/pipelines/common-operator-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-hypershift-operator-main
   workspaces:

--- a/.tekton/hypershift-operator-main-pull-request-from-main.yaml
+++ b/.tekton/hypershift-operator-main-pull-request-from-main.yaml
@@ -11,12 +11,13 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && !".tekton/***".pathChanged()
       && (files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib|hack|\\.tekton|\\.github|\\.claude|\\.chai-bot)/|\\.md$|^(?:Dockerfile|Containerfile)\\b|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|renovate\\.json)$'))
          || "Containerfile.operator".pathChanged()
          || ".tekton/pipelines/common-operator-build.yaml".pathChanged()
          || ".tekton/hypershift-operator-main-pull-request.yaml".pathChanged()
          || ".tekton/hypershift-operator-main-pull-request-from-main.yaml".pathChanged())
+      && !".tekton/pipelines/common-operator-build.yaml".pathChanged()
+      && !".tekton/hypershift-operator-main-pull-request.yaml".pathChanged()
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: hypershift-operator

--- a/.tekton/hypershift-operator-main-pull-request-from-main.yaml
+++ b/.tekton/hypershift-operator-main-pull-request-from-main.yaml
@@ -13,7 +13,6 @@ metadata:
       && target_branch == "main"
       && (files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib|hack|\\.tekton|\\.github|\\.claude|\\.chai-bot)/|\\.md$|^(?:Dockerfile|Containerfile)\\b|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|renovate\\.json)$'))
          || "Containerfile.operator".pathChanged()
-         || ".tekton/pipelines/common-operator-build.yaml".pathChanged()
          || ".tekton/hypershift-operator-main-pull-request.yaml".pathChanged()
          || ".tekton/hypershift-operator-main-pull-request-from-main.yaml".pathChanged())
       && !".tekton/pipelines/common-operator-build.yaml".pathChanged()

--- a/.tekton/hypershift-operator-main-pull-request.yaml
+++ b/.tekton/hypershift-operator-main-pull-request.yaml
@@ -11,12 +11,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && ".tekton/***".pathChanged()
-      && (files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib|hack|\\.tekton|\\.github|\\.claude|\\.chai-bot)/|\\.md$|^(?:Dockerfile|Containerfile)\\b|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|renovate\\.json)$'))
-         || "Containerfile.operator".pathChanged()
-         || ".tekton/pipelines/common-operator-build.yaml".pathChanged()
-         || ".tekton/hypershift-operator-main-pull-request.yaml".pathChanged()
-         || ".tekton/hypershift-operator-main-pull-request-from-main.yaml".pathChanged())
+      && (".tekton/pipelines/common-operator-build.yaml".pathChanged()
+         || ".tekton/hypershift-operator-main-pull-request.yaml".pathChanged())
     pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
   creationTimestamp:
   labels:

--- a/.tekton/hypershift-shared-ingress-main-pull-request-from-main.yaml
+++ b/.tekton/hypershift-shared-ingress-main-pull-request-from-main.yaml
@@ -11,10 +11,11 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && !".tekton/***".pathChanged()
       && ( "shared-ingress/***".pathChanged() ||
            ".tekton/hypershift-shared-ingress*".pathChanged() ||
            ".tekton/pipelines/common-operator-build.yaml".pathChanged() )
+      && !".tekton/pipelines/common-operator-build.yaml".pathChanged()
+      && !".tekton/hypershift-shared-ingress-main-pull-request.yaml".pathChanged()
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: hypershift-shared-ingress

--- a/.tekton/hypershift-shared-ingress-main-pull-request-from-main.yaml
+++ b/.tekton/hypershift-shared-ingress-main-pull-request-from-main.yaml
@@ -11,18 +11,16 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && ".tekton/***".pathChanged()
-      && ( "control-plane-operator/***".pathChanged() ||
-           "support/***".pathChanged() ||
-           ".tekton/control-plane-operator*".pathChanged() ||
-           "/Containerfile.control-plane-operator".pathChanged() )
-    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
+      && !".tekton/***".pathChanged()
+      && ( "shared-ingress/***".pathChanged() ||
+           ".tekton/hypershift-shared-ingress*".pathChanged() ||
+           ".tekton/pipelines/common-operator-build.yaml".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: control-plane-operator
-    appstudio.openshift.io/component: control-plane-operator-main
+    appstudio.openshift.io/application: hypershift-shared-ingress
+    appstudio.openshift.io/component: hypershift-shared-ingress-main
     pipelines.appstudio.openshift.io/type: build
-  name: control-plane-operator-main-on-pull-request
+  name: hypershift-shared-ingress-main-on-pr-from-main
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -31,20 +29,31 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-main:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
     value:
     - linux/x86_64
   - name: dockerfile
-    value: /Containerfile.control-plane
+    value: /Containerfile
   - name: path-context
-    value: .
+    value: shared-ingress
+  - name: prefetch-input
+    value: '[{"type": "rpm", "path": "shared-ingress"}]'
+  - name: dev-package-managers
+    value: "true"
   pipelineRef:
-    name: hypershift-common-operator-build
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift/hypershift.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/pipelines/common-operator-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-control-plane-operator-main
+    serviceAccountName: build-pipeline-hypershift-shared-ingress-main
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/hypershift-shared-ingress-main-pull-request-from-main.yaml
+++ b/.tekton/hypershift-shared-ingress-main-pull-request-from-main.yaml
@@ -12,8 +12,7 @@ metadata:
       event == "pull_request"
       && target_branch == "main"
       && ( "shared-ingress/***".pathChanged() ||
-           ".tekton/hypershift-shared-ingress*".pathChanged() ||
-           ".tekton/pipelines/common-operator-build.yaml".pathChanged() )
+           ".tekton/hypershift-shared-ingress*".pathChanged() )
       && !".tekton/pipelines/common-operator-build.yaml".pathChanged()
       && !".tekton/hypershift-shared-ingress-main-pull-request.yaml".pathChanged()
   creationTimestamp:

--- a/.tekton/hypershift-shared-ingress-main-pull-request.yaml
+++ b/.tekton/hypershift-shared-ingress-main-pull-request.yaml
@@ -11,6 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
+      && ".tekton/***".pathChanged()
       && ( "shared-ingress/***".pathChanged() ||
            ".tekton/hypershift-shared-ingress*".pathChanged() ||
            ".tekton/pipelines/common-operator-build.yaml".pathChanged() )

--- a/.tekton/hypershift-shared-ingress-main-pull-request.yaml
+++ b/.tekton/hypershift-shared-ingress-main-pull-request.yaml
@@ -11,10 +11,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && ".tekton/***".pathChanged()
-      && ( "shared-ingress/***".pathChanged() ||
-           ".tekton/hypershift-shared-ingress*".pathChanged() ||
-           ".tekton/pipelines/common-operator-build.yaml".pathChanged() )
+      && (".tekton/pipelines/common-operator-build.yaml".pathChanged()
+         || ".tekton/hypershift-shared-ingress-main-pull-request.yaml".pathChanged())
     pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
   creationTimestamp:
   labels:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ CODESPELL_BIN := codespell
 GITLINT_VER := 0.19.1
 GITLINT_BIN := gitlint
 PYYAML_VER := 6.0.3
+PYTEST_VER := 8.3.5
 
 PYTHON_VENV := $(TOOLS_BIN_DIR)/python-venv
 PYTHON_VENV_STAMP := $(PYTHON_VENV)/.installed
@@ -672,8 +673,10 @@ verify-docs-nav: $(PYTHON_VENV_STAMP) ## Verify docs nav entries are sorted alph
 .PHONY: verify-tekton-pipeline-pairs
 verify-tekton-pipeline-pairs: $(PYTHON_VENV_STAMP) ## Verify paired Tekton PipelineRun files (PR-branch vs main-branch pipeline) stay in sync.
 	@if [ -x $(PYTHON_VENV)/bin/python3 ]; then \
+		$(PYTHON_VENV)/bin/python3 -m pytest -q hack/verify-tekton-pipeline-pairs_test.py && \
 		$(PYTHON_VENV)/bin/python3 hack/verify-tekton-pipeline-pairs.py; \
 	else \
+		PYTHONPATH=$(PYTHON_VENV) python3 -m pytest -q hack/verify-tekton-pipeline-pairs_test.py && \
 		PYTHONPATH=$(PYTHON_VENV) python3 hack/verify-tekton-pipeline-pairs.py; \
 	fi
 
@@ -726,13 +729,15 @@ $(PYTHON_VENV_STAMP):
 		uv pip install --python=$(PYTHON_VENV)/bin/python \
 			codespell==$(CODESPELL_VER) \
 			gitlint==$(GITLINT_VER) \
-			pyyaml==$(PYYAML_VER); \
+			pyyaml==$(PYYAML_VER) \
+			pytest==$(PYTEST_VER); \
 	else \
 		mkdir -p $(PYTHON_VENV) && \
 		python3 -m pip install --target=$(PYTHON_VENV) \
 			codespell==$(CODESPELL_VER) \
 			gitlint==$(GITLINT_VER) \
-			pyyaml==$(PYYAML_VER) --upgrade && \
+			pyyaml==$(PYYAML_VER) \
+			pytest==$(PYTEST_VER) --upgrade && \
 		for cmd in $(CODESPELL_BIN) $(GITLINT_BIN); do \
 			mv $(PYTHON_VENV)/bin/$$cmd $(PYTHON_VENV)/$$cmd.py && \
 			printf '#!/bin/sh\nexport PYTHONPATH="%s$${PYTHONPATH:+:$$PYTHONPATH}"\nexec python3 "%s/%s.py" "$$@"\n' \

--- a/Makefile
+++ b/Makefile
@@ -671,7 +671,11 @@ verify-docs-nav: $(PYTHON_VENV_STAMP) ## Verify docs nav entries are sorted alph
 
 .PHONY: verify-tekton-pipeline-pairs
 verify-tekton-pipeline-pairs: $(PYTHON_VENV_STAMP) ## Verify paired Tekton PipelineRun files (PR-branch vs main-branch pipeline) stay in sync.
-	@python3 hack/verify-tekton-pipeline-pairs.py
+	@if [ -x $(PYTHON_VENV)/bin/python3 ]; then \
+		$(PYTHON_VENV)/bin/python3 hack/verify-tekton-pipeline-pairs.py; \
+	else \
+		PYTHONPATH=$(PYTHON_VENV) python3 hack/verify-tekton-pipeline-pairs.py; \
+	fi
 
 .PHONY: verify-codespell
 verify-codespell: codespell ## Verify codespell.

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ verify-crd-schema: $(CRD_SCHEMA_CHECK) ## Verify CRD schemas for breaking change
 verify-parallel: verify-codespell verify-codecov verify-api-deps verify-crd-schema lint cpo-container-sync run-gitlint verify-docs-nav verify-tekton-pipeline-pairs
 
 .PHONY: verify-ci
-verify-ci: generate update staticcheck fmt vet verify-api-deps verify-crd-schema verify-docs-nav ## Run the same checks as the GHA verify workflow.
+verify-ci: generate update staticcheck fmt vet verify-api-deps verify-crd-schema verify-docs-nav verify-tekton-pipeline-pairs ## Run the same checks as the GHA verify workflow.
 	$(MAKE) verify-git-clean
 
 .PHONY: verify
@@ -670,7 +670,7 @@ verify-docs-nav: $(PYTHON_VENV_STAMP) ## Verify docs nav entries are sorted alph
 	fi
 
 .PHONY: verify-tekton-pipeline-pairs
-verify-tekton-pipeline-pairs: ## Verify paired Tekton PipelineRun files (PR-branch vs main-branch pipeline) stay in sync.
+verify-tekton-pipeline-pairs: $(PYTHON_VENV_STAMP) ## Verify paired Tekton PipelineRun files (PR-branch vs main-branch pipeline) stay in sync.
 	@python3 hack/verify-tekton-pipeline-pairs.py
 
 .PHONY: verify-codespell

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ verify-crd-schema: $(CRD_SCHEMA_CHECK) ## Verify CRD schemas for breaking change
 		--crd-dir=karpenter-operator/controllers/karpenter/assets/zz_generated.crd-manifests
 
 .PHONY: verify-parallel
-verify-parallel: verify-codespell verify-codecov verify-api-deps verify-crd-schema lint cpo-container-sync run-gitlint verify-docs-nav
+verify-parallel: verify-codespell verify-codecov verify-api-deps verify-crd-schema lint cpo-container-sync run-gitlint verify-docs-nav verify-tekton-pipeline-pairs
 
 .PHONY: verify-ci
 verify-ci: generate update staticcheck fmt vet verify-api-deps verify-crd-schema verify-docs-nav ## Run the same checks as the GHA verify workflow.
@@ -668,6 +668,10 @@ verify-docs-nav: $(PYTHON_VENV_STAMP) ## Verify docs nav entries are sorted alph
 	else \
 		PYTHONPATH=$(PYTHON_VENV) python3 hack/verify-docs-nav-order.py; \
 	fi
+
+.PHONY: verify-tekton-pipeline-pairs
+verify-tekton-pipeline-pairs: ## Verify paired Tekton PipelineRun files (PR-branch vs main-branch pipeline) stay in sync.
+	@python3 hack/verify-tekton-pipeline-pairs.py
 
 .PHONY: verify-codespell
 verify-codespell: codespell ## Verify codespell.

--- a/hack/verify-tekton-pipeline-pairs.py
+++ b/hack/verify-tekton-pipeline-pairs.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Verify that paired Tekton PipelineRun files (PR-branch vs main-branch pipeline)
+stay in sync.
+
+Each pull-request PipelineRun that uses a local pipeline annotation
+(pipelinesascode.tekton.dev/pipeline) has a paired "-from-main" variant that
+resolves the same pipeline via a git resolver pointing at the main branch.
+The two files in each pair MUST be identical except for the expected
+differences:
+  1. metadata.name  (different suffix)
+  2. The pipelinesascode.tekton.dev/pipeline annotation (present vs absent)
+  3. The CEL filter's .tekton guard  (".tekton/***".pathChanged() vs negated)
+  4. spec.pipelineRef  (name-based vs git resolver)
+
+This script exits 0 if all pairs are consistent, 1 otherwise.
+"""
+import sys
+import os
+import re
+import copy
+
+# Requires PyYAML – available in most CI images; stdlib fallback not attempted.
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML is required.  pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+
+TEKTON_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                          ".tekton")
+
+# Expected pipeline source for the git-resolver variant.
+EXPECTED_GIT_RESOLVER = {
+    "url": "https://github.com/openshift/hypershift.git",
+    "revision": "main",
+    "pathInRepo": ".tekton/pipelines/common-operator-build.yaml",
+}
+
+
+def find_pairs():
+    """Return list of (original_path, from_main_path) tuples."""
+    pairs = []
+    for name in sorted(os.listdir(TEKTON_DIR)):
+        if name.endswith("-pull-request.yaml"):
+            from_main = name.replace("-pull-request.yaml",
+                                     "-pull-request-from-main.yaml")
+            from_main_path = os.path.join(TEKTON_DIR, from_main)
+            if os.path.exists(from_main_path):
+                pairs.append((os.path.join(TEKTON_DIR, name), from_main_path))
+    return pairs
+
+
+def load(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def normalise_cel(cel_text):
+    """Strip the .tekton/*** guard clause from a CEL expression to get the
+    'base' filter that should be identical between the two files."""
+    if cel_text is None:
+        return ""
+    # Remove the guard lines (handles both && ".tekton/***".pathChanged()
+    # and && !".tekton/***".pathChanged())
+    normalized = re.sub(
+        r'\s*&&\s*!?"\s*\.tekton/\*\*\*\s*"\.pathChanged\(\)\s*', ' ',
+        cel_text,
+    )
+    # Collapse whitespace for comparison.
+    return " ".join(normalized.split())
+
+
+def normalise_pipelineref(doc):
+    """Return a copy of the doc with pipelineRef normalised out so we can
+    compare the rest."""
+    d = copy.deepcopy(doc)
+    d.get("spec", {}).pop("pipelineRef", None)
+    return d
+
+
+def check_pair(orig_path, from_main_path):
+    """Return list of error strings (empty = OK)."""
+    errors = []
+    orig = load(orig_path)
+    fm = load(from_main_path)
+
+    orig_name = os.path.basename(orig_path)
+    fm_name = os.path.basename(from_main_path)
+
+    # ---- 1.  Annotations ----
+    orig_annot = dict(orig.get("metadata", {}).get("annotations", {}))
+    fm_annot = dict(fm.get("metadata", {}).get("annotations", {}))
+
+    # Original MUST have the pipeline annotation.
+    if "pipelinesascode.tekton.dev/pipeline" not in orig_annot:
+        errors.append(f"{orig_name}: missing pipelinesascode.tekton.dev/pipeline annotation")
+
+    # From-main MUST NOT have the pipeline annotation.
+    if "pipelinesascode.tekton.dev/pipeline" in fm_annot:
+        errors.append(f"{fm_name}: must NOT have pipelinesascode.tekton.dev/pipeline annotation")
+
+    # ---- 2.  CEL expression base must match ----
+    orig_cel = orig_annot.get("pipelinesascode.tekton.dev/on-cel-expression", "")
+    fm_cel = fm_annot.get("pipelinesascode.tekton.dev/on-cel-expression", "")
+
+    # Original must contain the positive guard.
+    if '".tekton/***".pathChanged()' not in orig_cel:
+        errors.append(f"{orig_name}: CEL missing '.tekton/***'.pathChanged() guard")
+
+    # From-main must contain the negated guard.
+    if '!".tekton/***".pathChanged()' not in fm_cel:
+        errors.append(f"{fm_name}: CEL missing negated '.tekton/***'.pathChanged() guard")
+
+    # After stripping the guard, the base expression must be identical.
+    orig_base = normalise_cel(orig_cel)
+    fm_base = normalise_cel(fm_cel)
+    if orig_base != fm_base:
+        errors.append(
+            f"CEL base mismatch between {orig_name} and {fm_name}:\n"
+            f"  original: {orig_base}\n"
+            f"  from-main: {fm_base}"
+        )
+
+    # ---- 3.  Compare everything else (minus expected diffs) ----
+    # Strip annotations we already checked.
+    for key in ("pipelinesascode.tekton.dev/on-cel-expression",
+                "pipelinesascode.tekton.dev/pipeline"):
+        orig_annot.pop(key, None)
+        fm_annot.pop(key, None)
+
+    if orig_annot != fm_annot:
+        errors.append(
+            f"Annotation mismatch (excluding CEL and pipeline) between "
+            f"{orig_name} and {fm_name}"
+        )
+
+    # Labels must match.
+    orig_labels = orig.get("metadata", {}).get("labels", {})
+    fm_labels = fm.get("metadata", {}).get("labels", {})
+    if orig_labels != fm_labels:
+        errors.append(f"Label mismatch between {orig_name} and {fm_name}")
+
+    # Namespace must match.
+    if orig.get("metadata", {}).get("namespace") != fm.get("metadata", {}).get("namespace"):
+        errors.append(f"Namespace mismatch between {orig_name} and {fm_name}")
+
+    # ---- 4.  spec (minus pipelineRef) must match ----
+    orig_spec = normalise_pipelineref(orig)
+    fm_spec = normalise_pipelineref(fm)
+    if orig_spec.get("spec") != fm_spec.get("spec"):
+        errors.append(
+            f"spec mismatch (excluding pipelineRef) between "
+            f"{orig_name} and {fm_name}"
+        )
+
+    # ---- 5.  Validate from-main pipelineRef uses git resolver ----
+    fm_ref = fm.get("spec", {}).get("pipelineRef", {})
+    if fm_ref.get("resolver") != "git":
+        errors.append(f"{fm_name}: pipelineRef.resolver must be 'git'")
+    else:
+        params = {p["name"]: p["value"]
+                  for p in fm_ref.get("params", [])}
+        for key, expected in EXPECTED_GIT_RESOLVER.items():
+            if params.get(key) != expected:
+                errors.append(
+                    f"{fm_name}: pipelineRef param '{key}' = {params.get(key)!r}, "
+                    f"expected {expected!r}"
+                )
+
+    return errors
+
+
+def main():
+    pairs = find_pairs()
+    if not pairs:
+        print("WARNING: no PipelineRun pairs found in .tekton/", file=sys.stderr)
+        sys.exit(1)
+
+    all_errors = []
+    for orig, fm in pairs:
+        print(f"Checking pair: {os.path.basename(orig)} <-> {os.path.basename(fm)}")
+        errs = check_pair(orig, fm)
+        all_errors.extend(errs)
+
+    if all_errors:
+        print(f"\n{len(all_errors)} error(s) found:", file=sys.stderr)
+        for e in all_errors:
+            print(f"  - {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\nAll {len(pairs)} pipeline pair(s) are consistent.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/verify-tekton-pipeline-pairs.py
+++ b/hack/verify-tekton-pipeline-pairs.py
@@ -9,7 +9,7 @@ The two files in each pair MUST be identical except for the expected
 differences:
   1. metadata.name  (different suffix)
   2. The pipelinesascode.tekton.dev/pipeline annotation (present vs absent)
-  3. The CEL filter's .tekton guard  (".tekton/***".pathChanged() vs negated)
+  3. The CEL filter's pipeline-file guards (specific pathChanged() vs negated)
   4. spec.pipelineRef  (name-based vs git resolver)
 
 This script exits 0 if all pairs are consistent, 1 otherwise.
@@ -67,6 +67,23 @@ def find_orphaned_from_main():
     return orphans
 
 
+def find_orphaned_pull_requests():
+    """Return list of -pull-request.yaml filenames that have a local pipeline
+    annotation but no matching -from-main.yaml counterpart."""
+    orphans = []
+    for name in sorted(os.listdir(TEKTON_DIR)):
+        if name.endswith("-pull-request.yaml"):
+            from_main = name.replace("-pull-request.yaml",
+                                     "-pull-request-from-main.yaml")
+            if not os.path.exists(os.path.join(TEKTON_DIR, from_main)):
+                # Only flag as orphan if the file uses a local pipeline annotation.
+                doc = load(os.path.join(TEKTON_DIR, name))
+                annot = doc.get("metadata", {}).get("annotations", {})
+                if ANN_PIPELINE in annot:
+                    orphans.append(name)
+    return orphans
+
+
 def load(path):
     try:
         with open(path) as f:
@@ -77,15 +94,33 @@ def load(path):
 
 
 def normalise_cel(cel_text):
-    """Strip the .tekton/*** guard clause from a CEL expression to get the
-    'base' filter that should be identical between the two files."""
+    """Strip .tekton pipeline-file guard clauses from a CEL expression.
+
+    Handles three guard forms:
+      1. Legacy wildcard:  && ".tekton/***".pathChanged()  (positive or negated)
+      2. Specific negated: && !".tekton/<file>.yaml".pathChanged()
+      3. PR-branch block:  && (".tekton/<a>".pathChanged() || ".tekton/<b>".pathChanged())
+    """
     if cel_text is None:
         return ""
-    # Remove the guard lines (handles both && ".tekton/***".pathChanged()
-    # and && !".tekton/***".pathChanged())
+    # 1. Remove legacy '.tekton/***' guard (positive or negated).
     normalized = re.sub(
         r'\s*&&\s*!?"\s*\.tekton/\*\*\*\s*"\.pathChanged\(\)\s*', ' ',
         cel_text,
+    )
+    # 2. Remove PR-branch guard block:
+    #    && ("<common>".pathChanged() || "<self>".pathChanged())
+    normalized = re.sub(
+        r'\s*&&\s*\(\s*"\.tekton/[^"]+\.yaml"\.pathChanged\(\)\s*'
+        r'\|\|\s*"\.tekton/[^"]+\.yaml"\.pathChanged\(\)\s*\)',
+        ' ',
+        normalized,
+    )
+    # 3. Remove specific negated guards: && !"<file>".pathChanged()
+    normalized = re.sub(
+        r'\s*&&\s*!"\.tekton/[^"]+\.yaml"\.pathChanged\(\)',
+        ' ',
+        normalized,
     )
     # Collapse whitespace for comparison.
     return " ".join(normalized.split())
@@ -120,26 +155,36 @@ def check_pair(orig_path, from_main_path):
     if ANN_PIPELINE in fm_annot:
         errors.append(f"{fm_name}: must NOT have {ANN_PIPELINE} annotation")
 
-    # ---- 2.  CEL expression base must match ----
+    # ---- 2.  CEL pipeline-file guards ----
     orig_cel = orig_annot.get(ANN_CEL_EXPRESSION, "")
     fm_cel = fm_annot.get(ANN_CEL_EXPRESSION, "")
 
-    # Original must contain the positive guard.
-    if '".tekton/***".pathChanged()' not in orig_cel:
-        errors.append(f"{orig_name}: CEL missing '.tekton/***'.pathChanged() guard")
+    common_pipeline = ".tekton/pipelines/common-operator-build.yaml"
+    orig_pipeline_file = f".tekton/{orig_name}"
 
-    # From-main must contain the negated guard.
-    if '!".tekton/***".pathChanged()' not in fm_cel:
-        errors.append(f"{fm_name}: CEL missing negated '.tekton/***'.pathChanged() guard")
-
-    # After stripping the guard, the base expression must be identical.
-    orig_base = normalise_cel(orig_cel)
-    fm_base = normalise_cel(fm_cel)
-    if orig_base != fm_base:
+    # PR-branch must trigger on common pipeline or self-file changes.
+    if f'"{common_pipeline}".pathChanged()' not in orig_cel:
         errors.append(
-            f"CEL base mismatch between {orig_name} and {fm_name}:\n"
-            f"  original: {orig_base}\n"
-            f"  from-main: {fm_base}"
+            f"{orig_name}: CEL missing common pipeline guard "
+            f"(\"{common_pipeline}\".pathChanged())"
+        )
+    if f'"{orig_pipeline_file}".pathChanged()' not in orig_cel:
+        errors.append(
+            f"{orig_name}: CEL missing self-file guard "
+            f"(\"{orig_pipeline_file}\".pathChanged())"
+        )
+
+    # From-main must contain negated guards for both the common pipeline
+    # and the corresponding PR-branch pipeline file.
+    if f'!"{common_pipeline}".pathChanged()' not in fm_cel:
+        errors.append(
+            f"{fm_name}: CEL missing negated common pipeline guard "
+            f"(!\"{common_pipeline}\".pathChanged())"
+        )
+    if f'!"{orig_pipeline_file}".pathChanged()' not in fm_cel:
+        errors.append(
+            f"{fm_name}: CEL missing negated PR-branch pipeline guard "
+            f"(!\"{orig_pipeline_file}\".pathChanged())"
         )
 
     # ---- 3.  Compare everything else (minus expected diffs) ----
@@ -207,6 +252,14 @@ def main():
         all_errors.append(
             f"{orphan}: orphaned -from-main file with no matching "
             f"-pull-request.yaml"
+        )
+
+    # Detect pull-request files (with local pipeline annotation) that are
+    # missing a matching -from-main counterpart.
+    for orphan in find_orphaned_pull_requests():
+        all_errors.append(
+            f"{orphan}: pull-request file with local pipeline annotation "
+            f"has no matching -from-main.yaml counterpart"
         )
 
     for orig, fm in pairs:

--- a/hack/verify-tekton-pipeline-pairs.py
+++ b/hack/verify-tekton-pipeline-pairs.py
@@ -30,6 +30,10 @@ except ImportError:
 TEKTON_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                           ".tekton")
 
+# Annotation key constants to reduce typo risk.
+ANN_PIPELINE = "pipelinesascode.tekton.dev/pipeline"
+ANN_CEL_EXPRESSION = "pipelinesascode.tekton.dev/on-cel-expression"
+
 # Expected pipeline source for the git-resolver variant.
 EXPECTED_GIT_RESOLVER = {
     "url": "https://github.com/openshift/hypershift.git",
@@ -51,9 +55,25 @@ def find_pairs():
     return pairs
 
 
+def find_orphaned_from_main():
+    """Return list of -from-main filenames without a matching -pull-request.yaml."""
+    orphans = []
+    for name in sorted(os.listdir(TEKTON_DIR)):
+        if name.endswith("-pull-request-from-main.yaml"):
+            original = name.replace("-pull-request-from-main.yaml",
+                                    "-pull-request.yaml")
+            if not os.path.exists(os.path.join(TEKTON_DIR, original)):
+                orphans.append(name)
+    return orphans
+
+
 def load(path):
-    with open(path) as f:
-        return yaml.safe_load(f)
+    try:
+        with open(path) as f:
+            return yaml.safe_load(f)
+    except (OSError, yaml.YAMLError) as exc:
+        print(f"ERROR: failed to load {path}: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 def normalise_cel(cel_text):
@@ -93,16 +113,16 @@ def check_pair(orig_path, from_main_path):
     fm_annot = dict(fm.get("metadata", {}).get("annotations", {}))
 
     # Original MUST have the pipeline annotation.
-    if "pipelinesascode.tekton.dev/pipeline" not in orig_annot:
-        errors.append(f"{orig_name}: missing pipelinesascode.tekton.dev/pipeline annotation")
+    if ANN_PIPELINE not in orig_annot:
+        errors.append(f"{orig_name}: missing {ANN_PIPELINE} annotation")
 
     # From-main MUST NOT have the pipeline annotation.
-    if "pipelinesascode.tekton.dev/pipeline" in fm_annot:
-        errors.append(f"{fm_name}: must NOT have pipelinesascode.tekton.dev/pipeline annotation")
+    if ANN_PIPELINE in fm_annot:
+        errors.append(f"{fm_name}: must NOT have {ANN_PIPELINE} annotation")
 
     # ---- 2.  CEL expression base must match ----
-    orig_cel = orig_annot.get("pipelinesascode.tekton.dev/on-cel-expression", "")
-    fm_cel = fm_annot.get("pipelinesascode.tekton.dev/on-cel-expression", "")
+    orig_cel = orig_annot.get(ANN_CEL_EXPRESSION, "")
+    fm_cel = fm_annot.get(ANN_CEL_EXPRESSION, "")
 
     # Original must contain the positive guard.
     if '".tekton/***".pathChanged()' not in orig_cel:
@@ -124,8 +144,7 @@ def check_pair(orig_path, from_main_path):
 
     # ---- 3.  Compare everything else (minus expected diffs) ----
     # Strip annotations we already checked.
-    for key in ("pipelinesascode.tekton.dev/on-cel-expression",
-                "pipelinesascode.tekton.dev/pipeline"):
+    for key in (ANN_CEL_EXPRESSION, ANN_PIPELINE):
         orig_annot.pop(key, None)
         fm_annot.pop(key, None)
 
@@ -146,12 +165,16 @@ def check_pair(orig_path, from_main_path):
         errors.append(f"Namespace mismatch between {orig_name} and {fm_name}")
 
     # ---- 4.  spec (minus pipelineRef) must match ----
-    orig_spec = normalise_pipelineref(orig)
-    fm_spec = normalise_pipelineref(fm)
-    if orig_spec.get("spec") != fm_spec.get("spec"):
+    orig_spec_data = normalise_pipelineref(orig).get("spec", {})
+    fm_spec_data = normalise_pipelineref(fm).get("spec", {})
+    if orig_spec_data != fm_spec_data:
+        differing = sorted(
+            k for k in set(orig_spec_data) | set(fm_spec_data)
+            if orig_spec_data.get(k) != fm_spec_data.get(k)
+        )
         errors.append(
             f"spec mismatch (excluding pipelineRef) between "
-            f"{orig_name} and {fm_name}"
+            f"{orig_name} and {fm_name}: differing fields: {', '.join(differing)}"
         )
 
     # ---- 5.  Validate from-main pipelineRef uses git resolver ----
@@ -178,6 +201,14 @@ def main():
         sys.exit(1)
 
     all_errors = []
+
+    # Detect orphaned -from-main files without a matching pull-request file.
+    for orphan in find_orphaned_from_main():
+        all_errors.append(
+            f"{orphan}: orphaned -from-main file with no matching "
+            f"-pull-request.yaml"
+        )
+
     for orig, fm in pairs:
         print(f"Checking pair: {os.path.basename(orig)} <-> {os.path.basename(fm)}")
         errs = check_pair(orig, fm)

--- a/hack/verify-tekton-pipeline-pairs_test.py
+++ b/hack/verify-tekton-pipeline-pairs_test.py
@@ -1,0 +1,60 @@
+"""Tests for verify-tekton-pipeline-pairs.py — covers normalise_cel()."""
+import importlib.util
+import os
+import sys
+
+import pytest
+
+# Import the verify script as a module (filename contains hyphens).
+_script = os.path.join(os.path.dirname(__file__), "verify-tekton-pipeline-pairs.py")
+_spec = importlib.util.spec_from_file_location("verify_tekton", _script)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+normalise_cel = _mod.normalise_cel
+
+
+class TestNormaliseCel:
+    """Unit tests for normalise_cel()."""
+
+    def test_strips_positive_guard(self):
+        cel = 'event == "push" && ".tekton/***".pathChanged()'
+        assert '".tekton/***".pathChanged()' not in normalise_cel(cel)
+
+    def test_strips_negated_guard(self):
+        cel = 'event == "push" && !".tekton/***".pathChanged()'
+        assert '".tekton/***".pathChanged()' not in normalise_cel(cel)
+
+    def test_positive_and_negated_produce_same_base(self):
+        pos = 'event == "push" && ".tekton/***".pathChanged()'
+        neg = 'event == "push" && !".tekton/***".pathChanged()'
+        assert normalise_cel(pos) == normalise_cel(neg)
+
+    def test_preserves_non_guard_content(self):
+        cel = 'event == "push" && ".tekton/***".pathChanged()'
+        assert 'event == "push"' in normalise_cel(cel)
+
+    def test_none_input_returns_empty(self):
+        assert normalise_cel(None) == ""
+
+    def test_empty_string_returns_empty(self):
+        assert normalise_cel("") == ""
+
+    def test_no_guard_clause_unchanged(self):
+        cel = 'event == "pull_request"'
+        assert normalise_cel(cel) == cel
+
+    def test_multiline_block_style(self):
+        cel = (
+            'event == "pull_request"\n'
+            '&& ".tekton/***".pathChanged()\n'
+        )
+        result = normalise_cel(cel)
+        assert 'event == "pull_request"' in result
+        assert '".tekton/***".pathChanged()' not in result
+
+    def test_whitespace_collapsed(self):
+        cel = '  event == "push"   &&   ".tekton/***".pathChanged()  '
+        result = normalise_cel(cel)
+        # No leading/trailing whitespace or double spaces.
+        assert result == result.strip()
+        assert "  " not in result

--- a/hack/verify-tekton-pipeline-pairs_test.py
+++ b/hack/verify-tekton-pipeline-pairs_test.py
@@ -58,3 +58,39 @@ class TestNormaliseCel:
         # No leading/trailing whitespace or double spaces.
         assert result == result.strip()
         assert "  " not in result
+
+    def test_strips_specific_negated_guard(self):
+        cel = (
+            'event == "pull_request" && target_branch == "main"'
+            ' && !".tekton/pipelines/common-operator-build.yaml".pathChanged()'
+            ' && !".tekton/foo-pull-request.yaml".pathChanged()'
+        )
+        result = normalise_cel(cel)
+        assert '".tekton/pipelines/common-operator-build.yaml"' not in result
+        assert '".tekton/foo-pull-request.yaml"' not in result
+        assert 'event == "pull_request"' in result
+
+    def test_strips_pr_branch_guard_block(self):
+        cel = (
+            'event == "pull_request"\n'
+            '&& target_branch == "main"\n'
+            '&& (".tekton/pipelines/common-operator-build.yaml".pathChanged()\n'
+            '   || ".tekton/foo-pull-request.yaml".pathChanged())'
+        )
+        result = normalise_cel(cel)
+        assert '".tekton/pipelines/common-operator-build.yaml"' not in result
+        assert '".tekton/foo-pull-request.yaml"' not in result
+        assert 'event == "pull_request"' in result
+
+    def test_specific_guards_both_directions_same_base(self):
+        pr_branch = (
+            'event == "pull_request" && target_branch == "main"'
+            ' && (".tekton/pipelines/common-operator-build.yaml".pathChanged()'
+            ' || ".tekton/foo-pull-request.yaml".pathChanged())'
+        )
+        from_main = (
+            'event == "pull_request" && target_branch == "main"'
+            ' && !".tekton/pipelines/common-operator-build.yaml".pathChanged()'
+            ' && !".tekton/foo-pull-request.yaml".pathChanged()'
+        )
+        assert normalise_cel(pr_branch) == normalise_cel(from_main)


### PR DESCRIPTION
## What this PR does / why we need it:

Duplicates tekton pipelines using the common pipeline. 
- One copy runs the common pipeline from main
- The other copy runs the common pipeline from the pr

This makes it no longer necessary to rebase PRs just because we needed to fix the enterprise contract. Once the enterprise contract is fixed and merged, the other PRs need only retest

## Which issue(s) this PR fixes:

Fixes  [CNTRLPLANE-4213](https://redhat.atlassian.net/browse/CNTRLPLANE-4213)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull-request build pipelines for additional control-plane, HyperShift, shared-ingress, webhook, and runner components targeting `main`.
  * Builds now cancel superseded runs and retain a limited number of recent results.
  * Pipeline triggers use more precise path matching for source and CI configuration changes.

* **Bug Fixes**
  * Improved consistency between paired pull-request pipelines.
  * Corrected control-plane operator container change detection.

* **Tests**
  * Added automated validation and unit tests for pipeline configuration integrity.
  * Integrated verification into standard CI checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->