### PR TITLE
OCPBUGS-114014: add Agent CAPI pause step to cross-cluster migration

### DIFF
--- a/docs/content/how-to/disaster-recovery/platform-guides/agent.md
+++ b/docs/content/how-to/disaster-recovery/platform-guides/agent.md
@@ -148,41 +148,11 @@ oc patch clusterdeployment -n <HC_NAMESPACE>-<HC_NAME> <CLUSTERDEPLOYMENT_NAME> 
       --type=merge -p '{"spec":{"preserveOnDelete":false}}'
     ```
 
-## Pre-Backup Steps (Agent Only)
+## Cross-Cluster Migration: CAPI Pause
 
-Before creating a backup for an Agent HostedCluster, pause the AgentMachine and AgentCluster CAPI resources to prevent the provider from reconciling during the backup:
+During cross-cluster migration, the AgentMachine and AgentCluster CAPI resources must be paused on the **source** cluster before restoring on the destination cluster. This prevents the Agent CAPI provider from reconciling while both clusters have copies of the same resources, avoiding race conditions and accidental agent unbinding.
 
-```bash
-# Pause AgentMachine CRs
-oc annotate agentmachine -n <HC_NAMESPACE>-<HC_NAME> \
-  cluster.x-k8s.io/paused=true --all
-
-# Pause AgentCluster CRs
-oc annotate agentcluster -n <HC_NAMESPACE>-<HC_NAME> \
-  cluster.x-k8s.io/paused=true --all
-```
-
-After the backup is complete, **unpause immediately** — do not keep the resources paused longer than necessary:
-
-```bash
-oc annotate agentmachine -n <HC_NAMESPACE>-<HC_NAME> \
-  cluster.x-k8s.io/paused- --all
-
-oc annotate agentcluster -n <HC_NAMESPACE>-<HC_NAME> \
-  cluster.x-k8s.io/paused- --all
-```
-
-## Post-Restore Steps (Agent Only)
-
-After restoring, the AgentMachine and AgentCluster CRs will be in a paused state (because the backup captured them while paused). Unpause them to allow the CAPI provider to resume reconciliation:
-
-```bash
-oc annotate agentmachine -n <HC_NAMESPACE>-<HC_NAME> \
-  cluster.x-k8s.io/paused- --all
-
-oc annotate agentcluster -n <HC_NAMESPACE>-<HC_NAME> \
-  cluster.x-k8s.io/paused- --all
-```
+This step is documented in the [Cross-cluster Migration procedure](../scenarios/cross-cluster-migration.md#step-1-pause-agent-capi-resources-on-the-source-cluster-agent-only) as Phase 2, Step 1.
 
 ## Restore Caveats
 

--- a/docs/content/how-to/disaster-recovery/scenarios/cross-cluster-migration.md
+++ b/docs/content/how-to/disaster-recovery/scenarios/cross-cluster-migration.md
@@ -81,7 +81,16 @@ The destination Management cluster must have:
 - A DataProtectionApplication (DPA) configured pointing to the same backup storage location.
 - The HyperShift Operator installed and running.
 
-### 5. ExternalDNS Operator (Public / PublicAndPrivate clusters)
+### 5. Backup Available on Destination Cluster
+
+The backup you intend to restore **must exist** on the destination Management cluster. Since both clusters share the same backup storage location (see prerequisite 3), the backup created on the source cluster will be visible on the destination cluster once the DPA is correctly configured. Verify with:
+
+```bash
+export KUBECONFIG=<DEST_MGMT_KUBECONFIG>
+oc get backup -n openshift-adp
+```
+
+### 6. ExternalDNS Operator (Public / PublicAndPrivate clusters)
 
 If the HostedCluster uses `Public` or `PublicAndPrivate` endpoint access, the destination Management cluster must have the ExternalDNS Operator configured with the same domain.
 
@@ -148,7 +157,29 @@ The count should drop to the baseline (typically 2 SOA/NS records).
 
 ### Phase 2: Restore (on Destination Management Cluster)
 
-#### Step 1: Prepare the Destination Cluster
+#### Step 1: Pause Agent CAPI Resources on the Source Cluster (Agent Only)
+
+!!! note
+
+    This step is **only required for the Agent platform**. Skip it for AWS, Azure, KubeVirt, and OpenStack.
+
+Before restoring on the destination cluster, pause the AgentMachine and AgentCluster resources on the **source** cluster to prevent the Agent CAPI provider from reconciling while both clusters have copies of the same resources. This avoids race conditions and prevents accidental agent unbinding.
+
+```bash
+export KUBECONFIG=<SOURCE_MGMT_KUBECONFIG>
+
+# Pause AgentMachine CRs
+oc annotate agentmachine -n <HC_NAMESPACE>-<HC_NAME> \
+  cluster.x-k8s.io/paused=true --all
+
+# Pause AgentCluster CRs
+oc annotate agentcluster -n <HC_NAMESPACE>-<HC_NAME> \
+  cluster.x-k8s.io/paused=true --all
+```
+
+If the source cluster is already unavailable, skip this step.
+
+#### Step 2: Prepare the Destination Cluster
 
 ```bash
 export KUBECONFIG=<DEST_MGMT_KUBECONFIG>
@@ -164,7 +195,7 @@ oc get backup -n openshift-adp
 
     If the backup does not appear, verify that the DPA on the destination cluster points to the same BackupStorageLocation as the source cluster.
 
-#### Step 2: Create the Restore
+#### Step 3: Create the Restore
 
 ```yaml
 apiVersion: velero.io/v1
@@ -188,21 +219,21 @@ spec:
   - backuprepositories.velero.io
 ```
 
-#### Step 3: Monitor the Restore
+#### Step 4: Monitor the Restore
 
 ```bash
 watch "oc get restore -n openshift-adp <HC_NAME>-restore -o jsonpath='{.status}' | jq"
 oc logs -n openshift-adp -ldeploy=velero -f
 ```
 
-#### Step 4: Update DNS Records
+#### Step 5: Update DNS Records
 
 After the restore creates new infrastructure endpoints on the destination cluster, update your DNS records to point the fixed hostnames to the new endpoints:
 
 1. Get the new Load Balancer / Route addresses from the destination cluster.
 2. Update DNS records for each fixed hostname (APIServer, OAuthServer, OIDC, Konnectivity, Ignition).
 
-#### Step 5: Platform-Specific Post-Restore Actions
+#### Step 6: Platform-Specific Post-Restore Actions
 
 | Platform | Action Required |
 | ---------- | ---------------- |

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -22739,41 +22739,11 @@ oc patch clusterdeployment -n <HC_NAMESPACE>-<HC_NAME> <CLUSTERDEPLOYMENT_NAME> 
       --type=merge -p '{"spec":{"preserveOnDelete":false}}'
     ```
 
-## Pre-Backup Steps (Agent Only)
+## Cross-Cluster Migration: CAPI Pause
 
-Before creating a backup for an Agent HostedCluster, pause the AgentMachine and AgentCluster CAPI resources to prevent the provider from reconciling during the backup:
+During cross-cluster migration, the AgentMachine and AgentCluster CAPI resources must be paused on the **source** cluster before restoring on the destination cluster. This prevents the Agent CAPI provider from reconciling while both clusters have copies of the same resources, avoiding race conditions and accidental agent unbinding.
 
-```bash
-# Pause AgentMachine CRs
-oc annotate agentmachine -n <HC_NAMESPACE>-<HC_NAME> \
-  cluster.x-k8s.io/paused=true --all
-
-# Pause AgentCluster CRs
-oc annotate agentcluster -n <HC_NAMESPACE>-<HC_NAME> \
-  cluster.x-k8s.io/paused=true --all
-```
-
-After the backup is complete, **unpause immediately** — do not keep the resources paused longer than necessary:
-
-```bash
-oc annotate agentmachine -n <HC_NAMESPACE>-<HC_NAME> \
-  cluster.x-k8s.io/paused- --all
-
-oc annotate agentcluster -n <HC_NAMESPACE>-<HC_NAME> \
-  cluster.x-k8s.io/paused- --all
-```
-
-## Post-Restore Steps (Agent Only)
-
-After restoring, the AgentMachine and AgentCluster CRs will be in a paused state (because the backup captured them while paused). Unpause them to allow the CAPI provider to resume reconciliation:
-
-```bash
-oc annotate agentmachine -n <HC_NAMESPACE>-<HC_NAME> \
-  cluster.x-k8s.io/paused- --all
-
-oc annotate agentcluster -n <HC_NAMESPACE>-<HC_NAME> \
-  cluster.x-k8s.io/paused- --all
-```
+This step is documented in the Cross-cluster Migration procedure as Phase 2, Step 1.
 
 ## Restore Caveats
 
@@ -23521,7 +23491,16 @@ The destination Management cluster must have:
 - A DataProtectionApplication (DPA) configured pointing to the same backup storage location.
 - The HyperShift Operator installed and running.
 
-### 5. ExternalDNS Operator (Public / PublicAndPrivate clusters)
+### 5. Backup Available on Destination Cluster
+
+The backup you intend to restore **must exist** on the destination Management cluster. Since both clusters share the same backup storage location (see prerequisite 3), the backup created on the source cluster will be visible on the destination cluster once the DPA is correctly configured. Verify with:
+
+```bash
+export KUBECONFIG=<DEST_MGMT_KUBECONFIG>
+oc get backup -n openshift-adp
+```
+
+### 6. ExternalDNS Operator (Public / PublicAndPrivate clusters)
 
 If the HostedCluster uses `Public` or `PublicAndPrivate` endpoint access, the destination Management cluster must have the ExternalDNS Operator configured with the same domain.
 
@@ -23588,7 +23567,29 @@ The count should drop to the baseline (typically 2 SOA/NS records).
 
 ### Phase 2: Restore (on Destination Management Cluster)
 
-#### Step 1: Prepare the Destination Cluster
+#### Step 1: Pause Agent CAPI Resources on the Source Cluster (Agent Only)
+
+!!! note
+
+    This step is **only required for the Agent platform**. Skip it for AWS, Azure, KubeVirt, and OpenStack.
+
+Before restoring on the destination cluster, pause the AgentMachine and AgentCluster resources on the **source** cluster to prevent the Agent CAPI provider from reconciling while both clusters have copies of the same resources. This avoids race conditions and prevents accidental agent unbinding.
+
+```bash
+export KUBECONFIG=<SOURCE_MGMT_KUBECONFIG>
+
+# Pause AgentMachine CRs
+oc annotate agentmachine -n <HC_NAMESPACE>-<HC_NAME> \
+  cluster.x-k8s.io/paused=true --all
+
+# Pause AgentCluster CRs
+oc annotate agentcluster -n <HC_NAMESPACE>-<HC_NAME> \
+  cluster.x-k8s.io/paused=true --all
+```
+
+If the source cluster is already unavailable, skip this step.
+
+#### Step 2: Prepare the Destination Cluster
 
 ```bash
 export KUBECONFIG=<DEST_MGMT_KUBECONFIG>
@@ -23604,7 +23605,7 @@ oc get backup -n openshift-adp
 
     If the backup does not appear, verify that the DPA on the destination cluster points to the same BackupStorageLocation as the source cluster.
 
-#### Step 2: Create the Restore
+#### Step 3: Create the Restore
 
 ```yaml
 apiVersion: velero.io/v1
@@ -23628,21 +23629,21 @@ spec:
   - backuprepositories.velero.io
 ```
 
-#### Step 3: Monitor the Restore
+#### Step 4: Monitor the Restore
 
 ```bash
 watch "oc get restore -n openshift-adp <HC_NAME>-restore -o jsonpath='{.status}' | jq"
 oc logs -n openshift-adp -ldeploy=velero -f
 ```
 
-#### Step 4: Update DNS Records
+#### Step 5: Update DNS Records
 
 After the restore creates new infrastructure endpoints on the destination cluster, update your DNS records to point the fixed hostnames to the new endpoints:
 
 1. Get the new Load Balancer / Route addresses from the destination cluster.
 2. Update DNS records for each fixed hostname (APIServer, OAuthServer, OIDC, Konnectivity, Ignition).
 
-#### Step 5: Platform-Specific Post-Restore Actions
+#### Step 6: Platform-Specific Post-Restore Actions
 
 | Platform | Action Required |
 | ---------- | ---------------- |


### PR DESCRIPTION
## Summary

Add an explicit step to pause AgentMachine and AgentCluster CAPI resources on the source cluster before restoring on the destination cluster during cross-cluster migration.

## Problem

During cross-cluster migration, the Agent CAPI provider on the source cluster continues reconciling AgentMachine and AgentCluster resources while the destination cluster creates its own copies. This causes:

- **Race conditions**: two CAPI providers managing the same agents
- **Accidental agent unbinding**: deleting the source HC triggers `unbindAgents`, destroying workloads

The Agent CAPI provider controllers (`agentmachine_controller.go:138`, `agentcluster_controller.go:116`) only check the `cluster.x-k8s.io/paused` annotation on the individual object — they do **not** check `Cluster.Spec.Paused`. Pausing the HostedCluster or CAPI Cluster does not propagate to AgentMachine/AgentCluster.

## Changes

### `scenarios/cross-cluster-migration.md`
- **New Phase 2 Step 1**: Pause AgentMachine/AgentCluster on source cluster before restore (Agent platform only, skipped if source unavailable)
- **New prerequisite 5**: Backup must exist on destination cluster
- Renumbered Phase 2 steps (2→3, 3→4, 4→5, 5→6)

### `platform-guides/agent.md`
- Replaced pre-backup/post-restore pause sections with a reference to the cross-cluster migration procedure
- The pause is not a pre-backup or post-restore step — it is a pre-restore step on the source cluster

## Jira
[OCPBUGS-114014](https://issues.redhat.com/browse/OCPBUGS-114014)

## References
- Agent CAPI provider source: [agentmachine_controller.go](https://github.com/openshift/cluster-api-provider-agent/blob/master/controllers/agentmachine_controller.go#L138)
- CAPI `IsPaused()` checks both `Cluster.Spec.Paused` and annotation, but Agent provider does not use `IsPaused()`
- Slack discussion with Crystal (Assisted Service team) confirming the need for pause


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated disaster recovery guidance with cross-cluster migration instructions.
  - Added a prerequisite to verify that the restore backup is available on the destination cluster.
  - Clarified that AgentMachine and AgentCluster resources must be paused on the source cluster before restoration.
  - Linked related guides to the detailed migration procedure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->