### PR TITLE
CNTRLPLANE-4207: Balance Azure v2 lifecycle test shards

### DIFF
--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -10,12 +10,15 @@ import (
 	"path/filepath"
 	"strings"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -342,33 +345,80 @@ func (a *AzurePlatformConfig) TestMatrix() TestMatrix {
 	return TestMatrix{
 		Parallel: []TestGroup{
 			{
-				Name:        "public",
-				Variant:     "public",
-				LabelFilter: "self-managed-azure-public || nodepool-lifecycle || nodepool-arm64 || secret-encryption || control-plane-workloads || hosted-cluster-security || nodepool-osimagestream",
-				Skip:        "KAS allowed CIDRs",
-			},
-			{
 				Name:        "private",
 				Variant:     "private",
 				LabelFilter: "self-managed-azure-private || hosted-cluster-compliance",
 			},
-			{
-				Name:        "oauth-lb",
-				Variant:     "oauth-lb",
-				LabelFilter: "self-managed-azure-oauth-lb || hosted-cluster-health || hosted-cluster-metrics || hosted-cluster-image-registry",
-			},
-			{
-				Name:        "autoscaling",
-				Variant:     "autoscaling",
-				LabelFilter: "nodepool-autoscaling",
-			},
-			{
-				Name:        "external-oidc",
-				Variant:     "external-oidc",
-				LabelFilter: "external-oidc || global-pull-secret",
-			},
 		},
 		Sequential: []SequentialGroup{
+			{
+				Name: "public",
+				Steps: []TestGroup{
+					{
+						Name:        "public",
+						Variant:     "public",
+						LabelFilter: "self-managed-azure-public || nodepool-arm64 || secret-encryption || control-plane-workloads || hosted-cluster-security || nodepool-osimagestream",
+						Skip:        "KAS allowed CIDRs",
+					},
+					{
+						Name:    "public-nodepool-rollouts",
+						Variant: "public",
+						LabelFilter: "nodepool-vm-size-rollout || nodepool-replace-version-upgrade || nodepool-inplace-version-upgrade || " +
+							"nodepool-n1-release || nodepool-n2-release || nodepool-auto-repair || nodepool-disk-encryption || nodepool-osimagestream-upgrade",
+					},
+				},
+			},
+			{
+				Name: "autoscaling",
+				Steps: []TestGroup{
+					{
+						Name:        "autoscaling-nodepool-machineconfig",
+						Variant:     "autoscaling",
+						LabelFilter: "nodepool-machineconfig-rollout",
+					},
+					{
+						Name:        "autoscaling-balancing",
+						Variant:     "autoscaling",
+						LabelFilter: "nodepool-autoscaling-balancing",
+					},
+				},
+			},
+			{
+				Name: "oauth-lb",
+				Steps: []TestGroup{
+					{
+						Name:        "oauth-lb",
+						Variant:     "oauth-lb",
+						LabelFilter: "self-managed-azure-oauth-lb || hosted-cluster-health || hosted-cluster-metrics || hosted-cluster-image-registry",
+					},
+					{
+						Name:    "oauth-lb-nodepool-config",
+						Variant: "oauth-lb",
+						LabelFilter: "nodepool-nto-replace-rollout || nodepool-nto-inplace-rollout || " +
+							"nodepool-performance-profile || nodepool-mirror-config",
+					},
+				},
+			},
+			{
+				Name: "external-oidc",
+				Steps: []TestGroup{
+					{
+						Name:        "external-oidc",
+						Variant:     "external-oidc",
+						LabelFilter: "external-oidc || global-pull-secret",
+					},
+					{
+						Name:        "external-oidc-autoscaling",
+						Variant:     "external-oidc",
+						LabelFilter: "nodepool-autoscaling-scale-up-down",
+					},
+					{
+						Name:        "external-oidc-trust-bundle",
+						Variant:     "external-oidc",
+						LabelFilter: "nodepool-trust-bundle",
+					},
+				},
+			},
 			{
 				Name: "upgrade-and-chaos",
 				Steps: []TestGroup{

--- a/test/e2e/v2/tests/azure_test_matrix_test.go
+++ b/test/e2e/v2/tests/azure_test_matrix_test.go
@@ -1,0 +1,178 @@
+//go:build e2ev2
+
+package tests
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/test/e2e/v2/lifecycle"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+func TestAzureTestMatrix(t *testing.T) {
+	g := NewWithT(t)
+	suiteConfig, _ := ginkgo.GinkgoConfiguration()
+	if os.Getenv("E2E_HOSTED_CLUSTER_NAME") != "" || suiteConfig.LabelFilter != "" ||
+		len(suiteConfig.FocusStrings) > 0 || len(suiteConfig.SkipStrings) > 0 {
+		t.Skip("Azure test matrix validation requires an unfiltered test invocation")
+	}
+
+	report := ginkgo.PreviewSpecs("hypershift-e2e")
+	g.Expect(report.SpecReports).NotTo(BeEmpty(), "unfiltered Ginkgo preview must contain registered specs")
+	matrix := lifecycle.NewAzurePlatformConfig("").TestMatrix()
+
+	previousFilters := []string{
+		"self-managed-azure-public || nodepool-lifecycle || nodepool-arm64 || secret-encryption || control-plane-workloads || hosted-cluster-security || nodepool-osimagestream",
+		"self-managed-azure-private || hosted-cluster-compliance",
+		"self-managed-azure-oauth-lb || hosted-cluster-health || hosted-cluster-metrics || hosted-cluster-image-registry",
+		"nodepool-autoscaling",
+		"external-oidc || global-pull-secret",
+		"control-plane-upgrade",
+		"control-plane-pki-operator",
+		"etcd-chaos",
+	}
+
+	previousSelection := selectedSpecs(g, report.SpecReports, previousFilters)
+	currentSelection := selectedSpecs(g, report.SpecReports, testMatrixFilters(matrix))
+
+	g.Expect(currentSelection).To(Equal(previousSelection),
+		"the Azure matrix must select every previously selected spec exactly once")
+	for spec, count := range previousSelection {
+		g.Expect(count).To(Equal(1), "previous Azure matrix selected spec %q more than once", spec)
+	}
+	for spec, count := range currentSelection {
+		g.Expect(count).To(Equal(1), "current Azure matrix selects spec %q more than once", spec)
+	}
+
+	junitFiles := testMatrixJUnitFiles(matrix)
+	g.Expect(junitFiles).To(HaveEach(Not(BeEmpty())),
+		"every Azure test group must define a JUnit filename")
+	g.Expect(uniqueStrings(junitFiles)).To(HaveLen(len(junitFiles)),
+		"every Azure test group must use a unique JUnit filename")
+
+	groupNames := testMatrixGroupNames(matrix)
+	g.Expect(groupNames).To(HaveEach(Not(BeEmpty())),
+		"every Azure test group must define a name for artifact namespacing")
+	g.Expect(uniqueStrings(groupNames)).To(HaveLen(len(groupNames)),
+		"every Azure test group name must be unique for supplemental JUnit reports")
+
+	variantLanes := testMatrixVariantLanes(matrix)
+	expectedVariantLanes := map[string][]string{
+		"private":       {"parallel:private"},
+		"public":        {"sequential:public"},
+		"autoscaling":   {"sequential:autoscaling"},
+		"oauth-lb":      {"sequential:oauth-lb"},
+		"external-oidc": {"sequential:external-oidc"},
+		"upgrade":       {"sequential:upgrade-and-chaos"},
+	}
+	g.Expect(variantLanes).To(Equal(expectedVariantLanes),
+		"every Azure variant must be assigned to its intended execution lane")
+	for variant, lanes := range variantLanes {
+		g.Expect(lanes).To(HaveLen(1),
+			"hosted-cluster variant %q must appear in exactly one concurrent execution lane", variant)
+	}
+}
+
+func selectedSpecs(g Gomega, specs types.SpecReports, filters []string) map[string]int {
+	parsedFilters := make([]types.LabelFilter, 0, len(filters))
+	for _, filter := range filters {
+		parsed, err := types.ParseLabelFilter(filter)
+		g.Expect(err).NotTo(HaveOccurred(), "label filter %q must parse", filter)
+		parsedFilters = append(parsedFilters, parsed)
+	}
+
+	selected := map[string]int{}
+	for _, spec := range specs {
+		for _, filter := range parsedFilters {
+			if filter(spec.Labels()) {
+				id := net.JoinHostPort(spec.LeafNodeLocation.FileName, strconv.Itoa(spec.LeafNodeLocation.LineNumber)) + ": " + spec.FullText()
+				selected[id]++
+			}
+		}
+	}
+	return selected
+}
+
+func testMatrixFilters(matrix lifecycle.TestMatrix) []string {
+	var filters []string
+	for _, group := range matrix.Parallel {
+		filters = append(filters, group.LabelFilter)
+	}
+	for _, sequentialGroup := range matrix.Sequential {
+		for _, step := range sequentialGroup.Steps {
+			filters = append(filters, step.LabelFilter)
+		}
+	}
+	return filters
+}
+
+func testMatrixJUnitFiles(matrix lifecycle.TestMatrix) []string {
+	var files []string
+	for _, group := range matrix.Parallel {
+		files = append(files, group.JUnitFile())
+	}
+	for _, sequentialGroup := range matrix.Sequential {
+		for _, step := range sequentialGroup.Steps {
+			files = append(files, step.JUnitFile())
+		}
+	}
+	return files
+}
+
+func testMatrixGroupNames(matrix lifecycle.TestMatrix) []string {
+	var names []string
+	for _, group := range matrix.Parallel {
+		names = append(names, group.Name)
+	}
+	for _, sequentialGroup := range matrix.Sequential {
+		for _, step := range sequentialGroup.Steps {
+			names = append(names, step.Name)
+		}
+	}
+	return names
+}
+
+func testMatrixVariantLanes(matrix lifecycle.TestMatrix) map[string][]string {
+	lanes := map[string][]string{}
+	for _, group := range matrix.Parallel {
+		lanes[group.Variant] = append(lanes[group.Variant], "parallel:"+group.Name)
+	}
+	for _, sequentialGroup := range matrix.Sequential {
+		lane := "sequential:" + sequentialGroup.Name
+		for _, step := range sequentialGroup.Steps {
+			if !contains(lanes[step.Variant], lane) {
+				lanes[step.Variant] = append(lanes[step.Variant], lane)
+			}
+		}
+	}
+	return lanes
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func contains(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/v2/tests/nodepool_autoscaling_test.go
+++ b/test/e2e/v2/tests/nodepool_autoscaling_test.go
@@ -37,12 +37,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
+
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // AutoscalingScaleUpDownTest tests autoscaling scale-up and scale-down behavior
 func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
-	It("should scale up when workload increases and scale down when workload decreases", func() {
+	It("should scale up when workload increases and scale down when workload decreases", Label("nodepool-autoscaling-scale-up-down"), func() {
 		testCtx := getTestCtx()
 		hc, err := testCtx.GetHostedCluster()
 		Expect(err).NotTo(HaveOccurred())
@@ -107,7 +108,7 @@ func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 // It configures the HostedCluster with the Random expander so the cluster autoscaler
 // distributes scale-up events across NodePools instead of favoring one.
 func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
-	It("should balance pods across multiple autoscaling NodePools", func() {
+	It("should balance pods across multiple autoscaling NodePools", Label("nodepool-autoscaling-balancing"), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -146,27 +147,6 @@ func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 				"cleanup: failed to reset autoscaler config on HostedCluster")
 		})
 
-		// Wait for autoscaler deployment to pick up the new config
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, "autoscaler deployment to have balancing config",
-			func(ctx context.Context) (*appsv1.Deployment, error) {
-				dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
-					Namespace: cpNamespace, Name: "cluster-autoscaler",
-				}}
-				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(dep), dep)
-				return dep, err
-			},
-			[]e2eutil.Predicate[*appsv1.Deployment]{func(dep *appsv1.Deployment) (bool, string, error) {
-				for _, arg := range dep.Spec.Template.Spec.Containers[0].Args {
-					if strings.Contains(arg, balancingLabel) {
-						return dep.Status.ReadyReplicas > 0, fmt.Sprintf("ready replicas: %d", dep.Status.ReadyReplicas), nil
-					}
-				}
-				return false, "balancing-ignore-label not found in autoscaler args", nil
-			}},
-			e2eutil.WithInterval(10*time.Second),
-			e2eutil.WithTimeout(5*time.Minute),
-		)
-
 		// Find the default NodePool to copy platform config
 		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
 		Expect(defaultNP).NotTo(BeNil(), "default NodePool should exist")
@@ -196,6 +176,28 @@ func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 		DeferCleanup(func() {
 			cleanupNodePool(ctx, testCtx.MgmtClient, autoscalingNP2)
 		})
+
+		// The autoscaler is enabled only when an autoscaling NodePool exists.
+		// Create the NodePools before waiting for the configured deployment.
+		e2eutil.EventuallyObject(GinkgoTB(), ctx, "autoscaler deployment to have balancing config",
+			func(ctx context.Context) (*appsv1.Deployment, error) {
+				dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+					Namespace: cpNamespace, Name: "cluster-autoscaler",
+				}}
+				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(dep), dep)
+				return dep, err
+			},
+			[]e2eutil.Predicate[*appsv1.Deployment]{func(dep *appsv1.Deployment) (bool, string, error) {
+				for _, arg := range dep.Spec.Template.Spec.Containers[0].Args {
+					if strings.Contains(arg, balancingLabel) {
+						return dep.Status.ReadyReplicas > 0, fmt.Sprintf("ready replicas: %d", dep.Status.ReadyReplicas), nil
+					}
+				}
+				return false, "balancing-ignore-label not found in autoscaler args", nil
+			}},
+			e2eutil.WithInterval(10*time.Second),
+			e2eutil.WithTimeout(5*time.Minute),
+		)
 
 		np1LabelSelector := e2eutil.WithClientOptions(crclient.MatchingLabelsSelector{
 			Selector: labels.SelectorFromSet(labels.Set{hyperv1.NodePoolLabel: autoscalingNP1.Name}),
@@ -358,11 +360,19 @@ func cleanupNodePool(ctx context.Context, client crclient.Client, np *hyperv1.No
 	GinkgoHelper()
 
 	err := client.Delete(ctx, np)
-	if err != nil && !apierrors.IsNotFound(err) {
-		GinkgoWriter.Printf("Warning: failed to delete NodePool %s: %v\n", np.Name, err)
-	} else if err == nil {
-		GinkgoWriter.Printf("Deleted NodePool %s\n", np.Name)
+	if apierrors.IsNotFound(err) {
+		return
 	}
+	if err != nil {
+		GinkgoWriter.Printf("Warning: failed to delete NodePool %s: %v\n", np.Name, err)
+		return
+	}
+	GinkgoWriter.Printf("Deleting NodePool %s\n", np.Name)
+
+	e2eutil.EventuallyNotFound(GinkgoTB(), ctx, client, np,
+		e2eutil.WithTimeout(nodePoolUpgradeTimeout(np.Spec.Platform.Type)),
+		e2eutil.WithInterval(15*time.Second),
+	)
 }
 
 // cleanupWorkload deletes a Job workload if it exists

--- a/test/e2e/v2/tests/nodepool_lifecycle_test.go
+++ b/test/e2e/v2/tests/nodepool_lifecycle_test.go
@@ -87,7 +87,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolLifecycle] N
 // creates a verification DaemonSet in the hosted cluster, and waits for config update
 // complete and DaemonSet rollout.
 func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
-	It("should roll out a MachineConfig change via Replace upgrade strategy", func() {
+	It("should roll out a MachineConfig change via Replace upgrade strategy", Label("nodepool-machineconfig-rollout"), func() {
 		testCtx := getTestCtx()
 		// https://issues.redhat.com/browse/CNV-38196
 		testCtx.SkipIfPlatform(hyperv1.KubevirtPlatform)
@@ -187,7 +187,7 @@ func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 // patches the NodePool's TuningConfig, creates a verification DaemonSet,
 // and waits for rollout via Replace upgrade strategy.
 func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
-	It("should roll out an NTO Tuned config change via Replace upgrade strategy", func() {
+	It("should roll out an NTO Tuned config change via Replace upgrade strategy", Label("nodepool-nto-replace-rollout"), func() {
 		testCtx := getTestCtx()
 
 		// https://issues.redhat.com/browse/CNV-38196, https://issues.redhat.com/browse/OSASINFRA-3566
@@ -257,7 +257,7 @@ func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 
 // NodePoolNTOInPlaceTest applies an NTO Tuned config with InPlace upgrade type.
 func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
-	It("should roll out an NTO Tuned config change via InPlace upgrade strategy", func() {
+	It("should roll out an NTO Tuned config change via InPlace upgrade strategy", Label("nodepool-nto-inplace-rollout"), func() {
 		testCtx := getTestCtx()
 
 		// https://issues.redhat.com/browse/CNV-38196, https://issues.redhat.com/browse/OSASINFRA-3566
@@ -322,7 +322,7 @@ func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 // NodePoolReplaceUpgradeTest creates a NodePool at previous release image, waits for nodes,
 // upgrades to latest image, and waits for version to update via Replace upgrade strategy.
 func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
-	It("should upgrade a NodePool from previous to latest release via Replace strategy", func() {
+	It("should upgrade a NodePool from previous to latest release via Replace strategy", Label("nodepool-replace-version-upgrade"), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -410,7 +410,7 @@ func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 // NodePoolInPlaceUpgradeTest creates a NodePool at previous release image, waits for nodes,
 // upgrades to latest image via InPlace upgrade strategy.
 func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
-	It("should upgrade a NodePool from previous to latest release via InPlace strategy", func() {
+	It("should upgrade a NodePool from previous to latest release via InPlace strategy", Label("nodepool-inplace-version-upgrade"), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -492,7 +492,7 @@ func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 // (AWS) or VM size (Azure) to trigger a rolling upgrade, and verifies the machine specs
 // after upgrade. Only runs on AWS and Azure platforms.
 func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
-	It("should perform a rolling upgrade when instance type or VM size changes", func() {
+	It("should perform a rolling upgrade when instance type or VM size changes", Label("nodepool-vm-size-rollout"), func() {
 		testCtx := getTestCtx()
 
 		testCtx.SkipIfNotPlatform(hyperv1.AWSPlatform, hyperv1.AzurePlatform)
@@ -588,7 +588,7 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 
 // NodePoolPrevReleaseN1Test creates a NodePool at N-1 release image and waits for nodes ready.
 func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
-	It("should create a NodePool at N-1 release and have ready nodes", func() {
+	It("should create a NodePool at N-1 release and have ready nodes", Label("nodepool-n1-release"), func() {
 		testCtx := getTestCtx()
 
 		n1Image := internal.GetEnvVarValue("E2E_N1_RELEASE_IMAGE")
@@ -627,7 +627,7 @@ func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
 
 // NodePoolPrevReleaseN2Test creates a NodePool at N-2 release image and waits for nodes ready.
 func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
-	It("should create a NodePool at N-2 release and have ready nodes", func() {
+	It("should create a NodePool at N-2 release and have ready nodes", Label("nodepool-n2-release"), func() {
 		testCtx := getTestCtx()
 
 		n2Image := internal.GetEnvVarValue("E2E_N2_RELEASE_IMAGE")
@@ -668,7 +668,7 @@ func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
 // verifies the KubeletConfig gets mirrored to the hosted cluster's openshift-config-managed
 // namespace, then removes the config and verifies cleanup. Only for 4.18+.
 func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
-	It("should mirror KubeletConfig to the hosted cluster and clean up on removal", func() {
+	It("should mirror KubeletConfig to the hosted cluster and clean up on removal", Label("nodepool-mirror-config"), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -802,7 +802,7 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 // exists in the hosted cluster, removes the trust bundle, verifies CPO deployment no longer
 // mounts it, waits for another update cycle, and verifies user-ca-bundle is deleted (4.22+).
 func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
-	It("should propagate and remove additional trust bundle to/from the hosted cluster", func() {
+	It("should propagate and remove additional trust bundle to/from the hosted cluster", Label("nodepool-trust-bundle"), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -1012,7 +1012,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 // patches the NodePool's TuningConfig, verifies the PerformanceProfile ConfigMap and
 // status ConfigMap are created in the control plane namespace, and verifies cleanup.
 func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
-	It("should create and manage NTO PerformanceProfile via NodePool TuningConfig", func() {
+	It("should create and manage NTO PerformanceProfile via NodePool TuningConfig", Label("nodepool-performance-profile"), func() {
 		testCtx := getTestCtx()
 
 		// https://issues.redhat.com/browse/OSASINFRA-3566
@@ -1177,7 +1177,7 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 // NodePoolAutoRepairTest is a skeleton for platform-specific auto-repair tests.
 // The full implementation requires cloud SDK dependencies for instance termination.
 func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
-	It("should auto-repair a NodePool when a node is terminated", func() {
+	It("should auto-repair a NodePool when a node is terminated", Label("nodepool-auto-repair"), func() {
 		Skip("auto-repair instance termination not yet implemented for v2 framework")
 
 		testCtx := getTestCtx()
@@ -1222,7 +1222,7 @@ func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
 
 // NodePoolDiskEncryptionTest is a skeleton for Azure disk encryption tests.
 func NodePoolDiskEncryptionTest(getTestCtx internal.TestContextGetter) {
-	It("should create a NodePool with Azure DiskEncryptionSet and verify it is applied", func() {
+	It("should create a NodePool with Azure DiskEncryptionSet and verify it is applied", Label("nodepool-disk-encryption"), func() {
 		testCtx := getTestCtx()
 
 		testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)

--- a/test/e2e/v2/tests/nodepool_osimagestream_test.go
+++ b/test/e2e/v2/tests/nodepool_osimagestream_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/blang/semver"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -36,7 +35,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/blang/semver"
 )
 
 const (
@@ -674,7 +676,7 @@ func NodePoolOSImageStreamExplicitDefaultNoRolloutTest(getTestCtx internal.TestC
 // reports the version-derived stream after upgrade. The RHEL version follows the
 // release version: upgrading to OCP 5.0+ results in rhel-10.
 func NodePoolOSImageStreamUpgradeVerificationTest(getTestCtx internal.TestContextGetter) {
-	It("When a NodePool is upgraded, it should report the correct osImageStream in status", func() {
+	It("When a NodePool is upgraded, it should report the correct osImageStream in status", Label("nodepool-osimagestream-upgrade"), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()


### PR DESCRIPTION
## What this PR does / why we need it:

Balances long-running Azure v2 NodePool lifecycle and autoscaling specs across the existing hosted clusters so the test phase is no longer serialized behind the public lane.

- Adds fine-grained labels for independently schedulable NodePool specs.
- Uses one sequential execution lane per hosted-cluster variant to prevent concurrent mutation of the same cluster.
- Runs configuration-specific checks before NodePool-scoped tests and HostedCluster-wide mutations.
- Waits for NodePool deletion between sequential steps and namespaces supplemental informing JUnit reports by test group.
- Adds an invariant test proving the new matrix selects the same Azure specs exactly once, uses unique JUnit files, and assigns each variant to one concurrent lane.

The documentation follow-up is tracked separately in [#9504](https://github.com/openshift/hypershift/pull/9504).

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-4207](https://redhat.atlassian.net/browse/CNTRLPLANE-4207)

## Special notes for your reviewer:

The CI runtime acceptance criteria require evidence from at least five successful runs. Local validation covered matrix selection, lifecycle package tests, v2 test and runner compilation, codespell, gitlint, and push-time changed-package verification.

The existing release-image-dependent NodePool specs retain their prior skip behavior when their optional `E2E_*_RELEASE_IMAGE` inputs are unavailable.

## Checklist:

- Subject and description added to both, commit and PR.
- Relevant issues have been referenced.
- Documentation is covered by follow-up PR #9504.
- This change includes unit tests.

Always review AI generated responses prior to use.