### PR TITLE
NO-JIRA: test(e2e): allow more time for control plane pod restarts

### DIFF
--- a/test/e2e/v2/tests/control_plane_tls_operator_test.go
+++ b/test/e2e/v2/tests/control_plane_tls_operator_test.go
@@ -265,7 +265,7 @@ func waitForAppPodRestart(
 		newPodUID = string(readyPod.UID)
 		g.Expect(newPodUID).NotTo(Equal(previousUID),
 			"%s pod UID should have changed after TLS config mutation (still %s)", appLabel, previousUID)
-	}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+	}, 5*time.Minute, 5*time.Second).Should(Succeed(),
 		"%s pod should restart and become ready after TLS config mutation", appLabel)
 	return newPodUID
 }


### PR DESCRIPTION
## What this PR does

Increases the control plane pod restart wait from two minutes to five minutes for TLS profile mutation tests.

## Failure analysis

The Azure self-managed job recently failed twice with the same assertion while waiting for the kube-apiserver pod UID to change after a TLS profile mutation:

- Modern profile transition: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/8966/pull-ci-openshift-hypershift-main-e2e-v2-azure-self-managed/2092584387362164736
- Intermediate profile downgrade: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/9389/pull-ci-openshift-hypershift-main-e2e-v2-azure-self-managed/2092635111177588736

In the currently retained Prow window, the suite reached these tests ten times and hit this exact timeout twice. Successful runs show TLS configuration propagation taking approximately 130-141 seconds and the complete Konnectivity mutation specs taking approximately 323-333 seconds. A two-minute restart deadline is therefore tight relative to normal control plane reconciliation and rollout latency, especially while other lifecycle groups load the shared management cluster.

There is also a stale-pod selection issue that can contribute to this timeout. `waitForAppPodRestart` selects the first ready pod and only afterward checks whether its UID differs from the pre-mutation UID. During a rolling update, an old ready pod can coexist with its replacement, so list ordering can cause the helper to keep selecting the stale pod even when a new ready pod exists. Correcting that behavior affects pod-selection semantics, particularly for multi-replica control planes, and will be proposed separately with dedicated regression coverage.

This PR intentionally limits itself to the low-risk timeout adjustment.

## Testing

- `make e2ev2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the waiting period for application pod restarts in end-to-end tests, reducing failures caused by slow restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->