### PR TITLE
CNTRLPLANE-4216: Migrate Azure VM instance families to Dsv5

### DIFF
--- a/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.autoscaling.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.autoscaling.testsuite.yaml
@@ -48,7 +48,7 @@ tests:
           max: 3
         platform:
           azure:
-            vmSize: Standard_D4s_v4
+            vmSize: Standard_D4s_v5
             image:
               type: AzureMarketplace
               azureMarketplace: {}
@@ -119,7 +119,7 @@ tests:
           max: 3
         platform:
           azure:
-            vmSize: Standard_D4s_v4
+            vmSize: Standard_D4s_v5
             image:
               type: AzureMarketplace
               azureMarketplace: {}

--- a/cmd/util/azure_flag_descriptions.go
+++ b/cmd/util/azure_flag_descriptions.go
@@ -47,7 +47,7 @@ const (
 	DiskEncryptionSetIDDescription = "Full resource ID of an Azure Disk Encryption Set used to encrypt NodePool OS disks with customer-managed keys."
 
 	// VM configuration
-	InstanceTypeDescription = "Azure VM size for NodePool instances (e.g. Standard_D4s_v4, Standard_D8s_v5)."
+	InstanceTypeDescription = "Azure VM size for NodePool instances (e.g. Standard_D4s_v5, Standard_D8s_v5)."
 	RootDiskSizeDescription = "Size of the OS disk in GB for each NodePool VM. Minimum: 16 GB."
 
 	// Disk configuration

--- a/contrib/managed-azure/setup_aks_cluster.sh
+++ b/contrib/managed-azure/setup_aks_cluster.sh
@@ -31,7 +31,7 @@ az aks create \
 --generate-ssh-keys \
 --load-balancer-sku standard \
 --os-sku AzureLinux \
---node-vm-size Standard_D4s_v4 \
+--node-vm-size Standard_D4s_v5 \
 --enable-fips-image \
 --enable-addons azure-keyvault-secrets-provider \
 --enable-secret-rotation \

--- a/docs/content/how-to/azure/autoscaling-self-managed.md
+++ b/docs/content/how-to/azure/autoscaling-self-managed.md
@@ -43,7 +43,7 @@ spec:
     max: 6
   platform:
     azure:
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
       # ... other required fields (image, osDisk) omitted for brevity
 ---
 apiVersion: hypershift.openshift.io/v1beta1
@@ -58,7 +58,7 @@ spec:
     max: 6
   platform:
     azure:
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
       # ... other required fields (image, osDisk) omitted for brevity
 ```
 

--- a/docs/content/how-to/azure/create-azure-cluster-with-options.md
+++ b/docs/content/how-to/azure/create-azure-cluster-with-options.md
@@ -81,7 +81,7 @@ spec:
     azure:
       diskEncryptionSetID: <disk_encryption_set_id>
       diskSizeGB: 120
-      vmsize: Standard_D4s_v4
+      vmsize: Standard_D4s_v5
     type: Azure
   release:
     image: <release_image>
@@ -152,7 +152,7 @@ This section walks through how to:
 1. Set up a new resource group, key vault, and key for etcd encryption using KMSv2
 1. Set up the role assignment between the KMS managed identity (MI) and the key vault
 1. Set up the flags needed when creating the Azure HostedCluster
-1. Verify the etcd encryption is setup and working properly 
+1. Verify the etcd encryption is setup and working properly
 
 !!! important "Managed HSM compatibility"
 
@@ -166,11 +166,11 @@ This section walks through how to:
 There is a `setup_etcd_kv.sh` script in the contrib folder in the HyperShift repo to help automate the first couple of
 steps mentioned above. For Managed HSM, use `setup_etcd_managed_hsm.sh` instead. This guide will manually walk through the Key Vault setup steps below.
 
-1a) Create a resource group for the key vault that will house the key used for etcd encryption. 
+1a) Create a resource group for the key vault that will house the key used for etcd encryption.
 
 !!! note
 
-    It is assumed this key vault is a different key vault, let's call it MI KV, than the one containing all of the 
+    It is assumed this key vault is a different key vault, let's call it MI KV, than the one containing all of the
     managed identities for the control plane. However, the managed identity for KMS is assumed to be in the MI KV.
 
 ```bash
@@ -182,7 +182,7 @@ az group create --name example-kms --location eastus
 az keyvault create --name example-kms --resource-group example-kms --location eastus --enable-rbac-authorization
 ```
 
-1c) Create a key in the etcd encryption key vault and capture the ID in a variable, KEY_ID. This will be passed when 
+1c) Create a key in the etcd encryption key vault and capture the ID in a variable, KEY_ID. This will be passed when
 creating the Azure HostedCluster in a later step below.
 ```bash
 KEY_ID=$(az keyvault key create \
@@ -194,7 +194,7 @@ KEY_ID=$(az keyvault key create \
   -o tsv)
 ```
 
-2) Create a role assignment between the KMS MI and the resource group where the etcd encryption key vault is located so 
+2) Create a role assignment between the KMS MI and the resource group where the etcd encryption key vault is located so
 that it can encrypt & decrypt objects.
 
 ```bash
@@ -210,12 +210,12 @@ az role assignment create --assignee $OBJECT_ID --role "Key Vault Crypto User" \
 `--kms-credentials-secret-name <your KMS credentials secret name>`
 ```
 
-4) Here are some different things you can do to confirm etcd encryption using KMSv2 is set up properly on the 
+4) Here are some different things you can do to confirm etcd encryption using KMSv2 is set up properly on the
 HCP/HostedCluster:
 
 First, confirm the kube-apiserver pod is using the `encryption-provider-config` flag such as:
 ```
---encryption-provider-config=/etc/kubernetes/secret-encryption/config.yaml 
+--encryption-provider-config=/etc/kubernetes/secret-encryption/config.yaml
 ```
 
 If you look at this data, it should contain something like this:
@@ -238,16 +238,16 @@ resources:
   - oauthauthorizetokens.oauth.openshift.io
 ```
 
-Next, confirm the ` azure-kms-provider-active` container in the kube-apiserver pod is running properly, there are no 
-errors in the log, and the config file is using the KMS MI. The config file path can be found in the flag on the 
+Next, confirm the ` azure-kms-provider-active` container in the kube-apiserver pod is running properly, there are no
+errors in the log, and the config file is using the KMS MI. The config file path can be found in the flag on the
 container spec:
 ```
---config-file-path=/etc/kubernetes/azure.json 
+--config-file-path=/etc/kubernetes/azure.json
 ```
 
 If you review this data, you should see the KMS MI credentials secret used within it.
 
-Finally, you can create a secret on the HostedCluster and then check the secret on etcd in the etcd pod on the HCP 
+Finally, you can create a secret on the HostedCluster and then check the secret on etcd in the etcd pod on the HCP
 directly:
 
 1) Create a secret on the HostedCluster. Example `kubectl create secret generic kms-test --from-literal=foo=bar`.
@@ -264,7 +264,7 @@ export ETCDCTL_CERT=/etc/etcd/tls/client/etcd-client.crt
 export ETCDCTL_KEY=/etc/etcd/tls/client/etcd-client.key
 export ETCDCTL_ENDPOINTS=https://etcd-client:2379
 ```
-5) Get the secret created on the HostedCluster `etcdctl get /kubernetes.io/secrets/default/kms-test`. You should see it 
+5) Get the secret created on the HostedCluster `etcdctl get /kubernetes.io/secrets/default/kms-test`. You should see it
 is encrypted with KMSv2 by the azure provider:
 ```
 k8s:enc:kms:v2:azure-8298bce7:

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -9260,7 +9260,7 @@ spec:
     max: 6
   platform:
     azure:
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
       # ... other required fields (image, osDisk) omitted for brevity
 ---
 apiVersion: hypershift.openshift.io/v1beta1
@@ -9275,7 +9275,7 @@ spec:
     max: 6
   platform:
     azure:
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
       # ... other required fields (image, osDisk) omitted for brevity
 ```
 
@@ -9678,7 +9678,7 @@ spec:
     azure:
       diskEncryptionSetID: <disk_encryption_set_id>
       diskSizeGB: 120
-      vmsize: Standard_D4s_v4
+      vmsize: Standard_D4s_v5
     type: Azure
   release:
     image: <release_image>

--- a/hypershift-operator/controllers/nodepool/azure_test.go
+++ b/hypershift-operator/controllers/nodepool/azure_test.go
@@ -746,7 +746,7 @@ func TestAzureMachineTemplate(t *testing.T) {
 								},
 							},
 							SubnetID: "/subscriptions/sub-123/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/subnet-worker",
-							VMSize:   "Standard_D2s_v3",
+							VMSize:   "Standard_D2s_v5",
 							OSDisk: hyperv1.AzureNodePoolOSDisk{
 								SizeGiB:                64,
 								DiskStorageAccountType: "StandardSSD_LRS",
@@ -761,7 +761,7 @@ func TestAzureMachineTemplate(t *testing.T) {
 			expectedTemplateName: "azure-marketplace-template",
 			expectedErr:          false,
 			validateTemplateSpec: true,
-			expectedVMSize:       "Standard_D2s_v3",
+			expectedVMSize:       "Standard_D2s_v5",
 			expectedSubnetName:   "subnet-worker",
 			expectedMarketplace: &capiazure.AzureMarketplaceImage{
 				ImagePlan: capiazure.ImagePlan{
@@ -787,7 +787,7 @@ func TestAzureMachineTemplate(t *testing.T) {
 								ImageID: ptr.To("test-image"),
 							},
 							SubnetID: "invalid-subnet-id",
-							VMSize:   "Standard_D2s_v3",
+							VMSize:   "Standard_D2s_v5",
 							OSDisk: hyperv1.AzureNodePoolOSDisk{
 								SizeGiB:                30,
 								DiskStorageAccountType: "Standard_LRS",
@@ -814,7 +814,7 @@ func TestAzureMachineTemplate(t *testing.T) {
 								ImageID: ptr.To("test-image"),
 							},
 							SubnetID: "/subscriptions/sub-123/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/subnet-worker",
-							VMSize:   "Standard_D2s_v3",
+							VMSize:   "Standard_D2s_v5",
 							OSDisk: hyperv1.AzureNodePoolOSDisk{
 								SizeGiB:                30,
 								DiskStorageAccountType: "Standard_LRS",
@@ -841,7 +841,7 @@ func TestAzureMachineTemplate(t *testing.T) {
 								// ImageID intentionally nil
 							},
 							SubnetID: "/subscriptions/sub-123/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/subnet-worker",
-							VMSize:   "Standard_D2s_v3",
+							VMSize:   "Standard_D2s_v5",
 							OSDisk: hyperv1.AzureNodePoolOSDisk{
 								SizeGiB:                30,
 								DiskStorageAccountType: "Standard_LRS",
@@ -869,7 +869,7 @@ func TestAzureMachineTemplate(t *testing.T) {
 								ImageID: ptr.To("test-image"),
 							},
 							SubnetID:         "/subscriptions/sub-123/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/subnet-worker",
-							VMSize:           "Standard_D2s_v3",
+							VMSize:           "Standard_D2s_v5",
 							EncryptionAtHost: "Enabled",
 							OSDisk: hyperv1.AzureNodePoolOSDisk{
 								SizeGiB:                30,
@@ -887,7 +887,7 @@ func TestAzureMachineTemplate(t *testing.T) {
 			expectedTemplateName: "azure-secure-template",
 			expectedErr:          false,
 			validateTemplateSpec: true,
-			expectedVMSize:       "Standard_D2s_v3",
+			expectedVMSize:       "Standard_D2s_v5",
 			expectedSubnetName:   "subnet-worker",
 			expectedImageID:      ptr.To("test-image"),
 		},

--- a/hypershift-operator/controllers/nodepool/instancetype/azure/provider_test.go
+++ b/hypershift-operator/controllers/nodepool/instancetype/azure/provider_test.go
@@ -61,14 +61,14 @@ func TestTransformSKU_WhenValidInput_ItShouldTransformCorrectly(t *testing.T) {
 		expected *instancetype.InstanceTypeInfo
 	}{
 		{
-			name: "When Standard_D4s_v3 with x64 arch, it should transform correctly",
-			input: makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+			name: "When Standard_D4s_v5 with x64 arch, it should transform correctly",
+			input: makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 				"vCPUs":               "4",
 				"MemoryGB":            "16",
 				"CpuArchitectureType": "x64",
 			}),
 			expected: &instancetype.InstanceTypeInfo{
-				InstanceType:    "Standard_D4s_v3",
+				InstanceType:    "Standard_D4s_v5",
 				VCPU:            4,
 				MemoryMb:        16384,
 				GPU:             0,
@@ -182,7 +182,7 @@ func TestTransformSKU_WhenMissingRequiredFields_ItShouldReturnError(t *testing.T
 		},
 		{
 			name: "When vCPUs capability is missing, it should return error",
-			input: makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+			input: makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 				"MemoryGB":            "16",
 				"CpuArchitectureType": "x64",
 			}),
@@ -190,7 +190,7 @@ func TestTransformSKU_WhenMissingRequiredFields_ItShouldReturnError(t *testing.T
 		},
 		{
 			name: "When MemoryGB capability is missing, it should return error",
-			input: makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+			input: makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 				"vCPUs":               "4",
 				"CpuArchitectureType": "x64",
 			}),
@@ -198,7 +198,7 @@ func TestTransformSKU_WhenMissingRequiredFields_ItShouldReturnError(t *testing.T
 		},
 		{
 			name: "When CpuArchitectureType capability is missing, it should return error",
-			input: makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+			input: makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 				"vCPUs":    "4",
 				"MemoryGB": "16",
 			}),
@@ -206,7 +206,7 @@ func TestTransformSKU_WhenMissingRequiredFields_ItShouldReturnError(t *testing.T
 		},
 		{
 			name: "When vCPUs value is not a valid integer, it should return error",
-			input: makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+			input: makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 				"vCPUs":               "abc",
 				"MemoryGB":            "16",
 				"CpuArchitectureType": "x64",
@@ -215,7 +215,7 @@ func TestTransformSKU_WhenMissingRequiredFields_ItShouldReturnError(t *testing.T
 		},
 		{
 			name: "When MemoryGB value is not a valid float, it should return error",
-			input: makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+			input: makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 				"vCPUs":               "4",
 				"MemoryGB":            "xyz",
 				"CpuArchitectureType": "x64",
@@ -224,7 +224,7 @@ func TestTransformSKU_WhenMissingRequiredFields_ItShouldReturnError(t *testing.T
 		},
 		{
 			name: "When vCPUs value is zero, it should return error",
-			input: makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+			input: makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 				"vCPUs":               "0",
 				"MemoryGB":            "16",
 				"CpuArchitectureType": "x64",
@@ -233,7 +233,7 @@ func TestTransformSKU_WhenMissingRequiredFields_ItShouldReturnError(t *testing.T
 		},
 		{
 			name: "When MemoryGB value is zero, it should return error",
-			input: makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+			input: makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 				"vCPUs":               "4",
 				"MemoryGB":            "0",
 				"CpuArchitectureType": "x64",
@@ -242,7 +242,7 @@ func TestTransformSKU_WhenMissingRequiredFields_ItShouldReturnError(t *testing.T
 		},
 		{
 			name: "When CpuArchitectureType is unsupported, it should return error",
-			input: makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+			input: makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 				"vCPUs":               "4",
 				"MemoryGB":            "16",
 				"CpuArchitectureType": "i386",
@@ -293,13 +293,13 @@ func TestGetInstanceTypeInfo(t *testing.T) {
 		{
 			name: "When VM size exists, it should return info",
 			skus: []*armcompute.ResourceSKU{
-				makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+				makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 					"vCPUs": "4", "MemoryGB": "16", "CpuArchitectureType": "x64",
 				}),
 			},
-			instanceType: "Standard_D4s_v3",
+			instanceType: "Standard_D4s_v5",
 			expected: &instancetype.InstanceTypeInfo{
-				InstanceType:    "Standard_D4s_v3",
+				InstanceType:    "Standard_D4s_v5",
 				VCPU:            4,
 				MemoryMb:        16384,
 				GPU:             0,
@@ -309,7 +309,7 @@ func TestGetInstanceTypeInfo(t *testing.T) {
 		{
 			name: "When VM size not found it should return error",
 			skus: []*armcompute.ResourceSKU{
-				makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+				makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 					"vCPUs": "4", "MemoryGB": "16", "CpuArchitectureType": "x64",
 				}),
 			},
@@ -319,32 +319,32 @@ func TestGetInstanceTypeInfo(t *testing.T) {
 		{
 			name:          "When API returns error it should propagate error",
 			apiErr:        fmt.Errorf("API error: throttling"),
-			instanceType:  "Standard_D4s_v3",
+			instanceType:  "Standard_D4s_v5",
 			expectedError: "failed to load Azure Resource SKUs",
 		},
 		{
 			name: "When SKU has matching name but wrong ResourceType it should return not found",
 			skus: []*armcompute.ResourceSKU{
-				makeSKU("Standard_D4s_v3", "disks", map[string]string{
+				makeSKU("Standard_D4s_v5", "disks", map[string]string{
 					"vCPUs": "4", "MemoryGB": "16", "CpuArchitectureType": "x64",
 				}),
 			},
-			instanceType:  "Standard_D4s_v3",
+			instanceType:  "Standard_D4s_v5",
 			expectedError: "not found",
 		},
 		{
 			name: "When multiple SKUs returned, it should match only virtualMachines type",
 			skus: []*armcompute.ResourceSKU{
-				makeSKU("Standard_D4s_v3", "disks", map[string]string{
+				makeSKU("Standard_D4s_v5", "disks", map[string]string{
 					"vCPUs": "99", "MemoryGB": "99", "CpuArchitectureType": "x64",
 				}),
-				makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+				makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 					"vCPUs": "4", "MemoryGB": "16", "CpuArchitectureType": "x64",
 				}),
 			},
-			instanceType: "Standard_D4s_v3",
+			instanceType: "Standard_D4s_v5",
 			expected: &instancetype.InstanceTypeInfo{
-				InstanceType:    "Standard_D4s_v3",
+				InstanceType:    "Standard_D4s_v5",
 				VCPU:            4,
 				MemoryMb:        16384,
 				GPU:             0,
@@ -375,7 +375,7 @@ func TestVMSizeNotFoundError(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mock := &mockResourceSKUsAPI{
 		skus: []*armcompute.ResourceSKU{
-			makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+			makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 				"vCPUs": "4", "MemoryGB": "16", "CpuArchitectureType": "x64",
 			}),
 		},
@@ -396,7 +396,7 @@ func TestCacheTTLRefresh(t *testing.T) {
 	// Start with one SKU
 	mock := &mockResourceSKUsAPI{
 		skus: []*armcompute.ResourceSKU{
-			makeSKU("Standard_D4s_v3", "virtualMachines", map[string]string{
+			makeSKU("Standard_D4s_v5", "virtualMachines", map[string]string{
 				"vCPUs": "4", "MemoryGB": "16", "CpuArchitectureType": "x64",
 			}),
 		},
@@ -406,7 +406,7 @@ func TestCacheTTLRefresh(t *testing.T) {
 	provider.cacheTTL = 1 * time.Millisecond
 
 	// First call loads the cache
-	result, err := provider.GetInstanceTypeInfo(context.Background(), "Standard_D4s_v3")
+	result, err := provider.GetInstanceTypeInfo(context.Background(), "Standard_D4s_v5")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.VCPU).To(Equal(int32(4)))
 

--- a/hypershift-operator/controllers/nodepool/instancetype/instancetype.go
+++ b/hypershift-operator/controllers/nodepool/instancetype/instancetype.go
@@ -10,7 +10,7 @@ import (
 type Provider interface {
 	// GetInstanceTypeInfo returns the specifications for a given instance type.
 	// The instanceType parameter is the cloud provider specific instance type name
-	// (e.g., "m5.large" for AWS, "Standard_D4s_v3" for Azure).
+	// (e.g., "m5.large" for AWS, "Standard_D4s_v5" for Azure).
 	GetInstanceTypeInfo(ctx context.Context, instanceType string) (*InstanceTypeInfo, error)
 }
 

--- a/hypershift-operator/controllers/nodepool/scale_from_zero_test.go
+++ b/hypershift-operator/controllers/nodepool/scale_from_zero_test.go
@@ -218,7 +218,7 @@ func TestSetScaleFromZeroAnnotationsOnObject(t *testing.T) {
 			}},
 			nodePool:        &hyperv1.NodePool{},
 			object:          &capiv1.MachineDeployment{},
-			machineTemplate: newAzureTemplate("Standard_D4s_v3"),
+			machineTemplate: newAzureTemplate("Standard_D4s_v5"),
 			expectErr:       false,
 			validate: func(g Gomega, md *capiv1.MachineDeployment) {
 				a := md.GetAnnotations()
@@ -242,7 +242,7 @@ func TestSetScaleFromZeroAnnotationsOnObject(t *testing.T) {
 			provider:        nil,
 			nodePool:        &hyperv1.NodePool{},
 			object:          &capiv1.MachineDeployment{},
-			machineTemplate: newAzureTemplate("Standard_D4s_v3"),
+			machineTemplate: newAzureTemplate("Standard_D4s_v5"),
 			expectErr:       false,
 			validate: func(g Gomega, md *capiv1.MachineDeployment) {
 				g.Expect(md.GetAnnotations()).ToNot(HaveKey(cpuKey))

--- a/test/e2e/nodepool_rolling_upgrade_test.go
+++ b/test/e2e/nodepool_rolling_upgrade_test.go
@@ -10,11 +10,14 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -76,7 +79,7 @@ func (k *RollingUpgradeTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodeP
 	case hyperv1.AWSPlatform:
 		nodePool.Spec.Platform.AWS.InstanceType = "m5.large"
 	case hyperv1.AzurePlatform:
-		nodePool.Spec.Platform.Azure.VMSize = "Standard_D2s_v3"
+		nodePool.Spec.Platform.Azure.VMSize = "Standard_D2s_v5"
 	}
 	nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeReplace
 

--- a/test/e2e/v2/tests/nodepool_lifecycle_test.go
+++ b/test/e2e/v2/tests/nodepool_lifecycle_test.go
@@ -22,12 +22,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	ignitionapi "github.com/coreos/ignition/v2/config/v3_2/types"
-	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
@@ -37,6 +34,8 @@ import (
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,9 +44,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/yaml"
+
+	ignitionapi "github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/google/go-cmp/cmp"
 )
 
 // RegisterNodePoolLifecycleTests registers all NodePool lifecycle test cases.
@@ -512,7 +515,7 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 			case hyperv1.AWSPlatform:
 				pool.Spec.Platform.AWS.InstanceType = "m5.large"
 			case hyperv1.AzurePlatform:
-				pool.Spec.Platform.Azure.VMSize = "Standard_D2s_v3"
+				pool.Spec.Platform.Azure.VMSize = "Standard_D2s_v5"
 			}
 		})
 


### PR DESCRIPTION
## What this PR does / why we need it:

Azure Dsv3 and Dsv4 VM families are legacy. This updates all direct HyperShift Dsv3/Dsv4 size references to the corresponding Dsv5 sizes across CLI guidance, managed-Azure setup, NodePool test fixtures, e2e inputs, and documentation. The Dsv5 replacements preserve the vCPU and memory profiles used by the existing D2s and D4s examples and support the required premium storage and accelerated networking features.

This change is limited to `openshift/hypershift`; no `openshift/release` files are included.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-4216

## Special notes for your reviewer:

- The change replaces `Standard_D2s_v3`, `Standard_D4s_v3`, and `Standard_D4s_v4` with their `v5` equivalents.
- Unrelated Esv3/NCv3 SKUs and vendored Azure SDK catalog entries remain unchanged.
- `docs/content/reference/aggregated-docs.md` was regenerated with `make docs-aggregate`.
- Focused tests, formatting, vet, documentation checks, gitlint, and push hooks passed.
- The full `make test` suite was not run for this constants-only update.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [x] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with OpenAI GPT-5.6-Luna via OpenCode