### PR TITLE
NO-JIRA: test(e2e): select replacement pod after TLS mutation

### DIFF
--- a/test/e2e/v2/tests/control_plane_tls_operator_test.go
+++ b/test/e2e/v2/tests/control_plane_tls_operator_test.go
@@ -228,6 +228,26 @@ func runOpenSSLClient(
 			net.JoinHostPort(connectHost, port), tlsFlag))
 }
 
+func findReadyReplacementPod(pods []corev1.Pod, previousUID string) *corev1.Pod {
+	for i := range pods {
+		pod := &pods[i]
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		if !isPodReady(pod) {
+			continue
+		}
+		if string(pod.UID) == previousUID {
+			continue
+		}
+		return pod
+	}
+	return nil
+}
+
 // waitForAppPodRestart waits until a ready pod with app=<appLabel> exists whose UID
 // differs from previousUID. This avoids TLS probes against a stale pod that has not
 // yet rolled with the updated TLS configuration.
@@ -245,26 +265,11 @@ func waitForAppPodRestart(
 		)).To(Succeed(), "failed to list %s pods", appLabel)
 		g.Expect(podList.Items).NotTo(BeEmpty(), "expected at least one %s pod", appLabel)
 
-		var readyPod *corev1.Pod
-		for i := range podList.Items {
-			pod := &podList.Items[i]
-			if pod.DeletionTimestamp != nil {
-				continue
-			}
-			if pod.Status.Phase != corev1.PodRunning {
-				continue
-			}
-			if !isPodReady(pod) {
-				continue
-			}
-			readyPod = pod
-			break
-		}
-		g.Expect(readyPod).NotTo(BeNil(), "expected a ready running %s pod", appLabel)
+		readyPod := findReadyReplacementPod(podList.Items, previousUID)
+		g.Expect(readyPod).NotTo(BeNil(),
+			"expected a ready running %s pod with a UID different from %s", appLabel, previousUID)
 
 		newPodUID = string(readyPod.UID)
-		g.Expect(newPodUID).NotTo(Equal(previousUID),
-			"%s pod UID should have changed after TLS config mutation (still %s)", appLabel, previousUID)
 	}, 2*time.Minute, 5*time.Second).Should(Succeed(),
 		"%s pod should restart and become ready after TLS config mutation", appLabel)
 	return newPodUID

--- a/test/e2e/v2/tests/control_plane_tls_operator_unit_test.go
+++ b/test/e2e/v2/tests/control_plane_tls_operator_unit_test.go
@@ -1,0 +1,74 @@
+//go:build e2ev2
+
+package tests
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestFindReadyReplacementPod(t *testing.T) {
+	readyPod := func(uid string, ready bool) corev1.Pod {
+		conditionStatus := corev1.ConditionFalse
+		if ready {
+			conditionStatus = corev1.ConditionTrue
+		}
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: types.UID(uid)},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{{
+					Type:   corev1.PodReady,
+					Status: conditionStatus,
+				}},
+				ContainerStatuses: []corev1.ContainerStatus{{Ready: ready}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		pods        []corev1.Pod
+		previousUID string
+		expectedUID string
+	}{
+		{
+			name: "When the stale pod precedes a ready replacement, it should return the replacement",
+			pods: []corev1.Pod{
+				readyPod("stale", true),
+				readyPod("replacement", true),
+			},
+			previousUID: "stale",
+			expectedUID: "replacement",
+		},
+		{
+			name: "When only the stale pod is ready, it should return no pod",
+			pods: []corev1.Pod{
+				readyPod("stale", true),
+				readyPod("replacement", false),
+			},
+			previousUID: "stale",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := findReadyReplacementPod(test.pods, test.previousUID)
+			if test.expectedUID == "" {
+				if pod != nil {
+					t.Fatalf("expected no pod, got UID %s", pod.UID)
+				}
+				return
+			}
+			if pod == nil {
+				t.Fatalf("expected pod UID %s, got no pod", test.expectedUID)
+			}
+			if string(pod.UID) != test.expectedUID {
+				t.Fatalf("expected pod UID %s, got %s", test.expectedUID, pod.UID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Fixes stale-pod selection in the control plane TLS restart wait.

`waitForAppPodRestart` previously selected the first running, ready pod returned by the API and only then asserted that its UID differed from the pod captured before the TLS mutation. During a rolling update, the old ready pod can coexist with its replacement. If the old pod appears first in the list, the helper repeatedly selects it and can time out even though a new ready pod already exists.

This change filters out the pre-mutation UID while selecting a candidate. `Eventually` now retries only when no running, ready replacement is available. Regression coverage verifies both stale-first list ordering and the case where no ready replacement exists yet.

## Relationship to #9422

PR #9422 independently increases the restart timeout from two minutes to five minutes based on observed control plane rollout latency. This PR intentionally retains the existing two-minute timeout so the pod-selection behavior can be reviewed separately. If #9422 merges first, this PR will need to be rebased onto the updated `main` branch before merge.

## Testing

- `GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor go test -tags e2ev2 -run ^'TestFindReadyReplacementPod$' ./test/e2e/v2/tests`\n- `make e2ev2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end validation of control-plane TLS operator pod restarts.
  * Added coverage to confirm the system selects a new, running, ready replacement pod rather than a stale pod.
  * Added checks for scenarios where no valid replacement pod is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->