### PR TITLE
OCPBUGS-114408: fix(api): allow spaces in AWS resource tag keys and values

### DIFF
--- a/api/hypershift/v1beta1/aws.go
+++ b/api/hypershift/v1beta1/aws.go
@@ -504,16 +504,16 @@ type AWSRoleCredentials struct {
 type AWSResourceTag struct {
 	// key is the key of the tag.
 	// Must be between 1 and 128 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="key must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="key must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Key string `json:"key"`
 	// value is the value of the tag.
 	// Must be between 1 and 256 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// Some AWS service do not support empty values. Since tags are added to
 	// resources in many services, the length of the tag value must meet the
@@ -522,7 +522,7 @@ type AWSResourceTag struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="value must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="value must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Value string `json:"value"`
 }
 
@@ -532,16 +532,16 @@ type AWSResourceTag struct {
 type AWSClusterResourceTag struct {
 	// key is the key of the tag.
 	// Must be between 1 and 128 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="key must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="key must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Key string `json:"key,omitempty"`
 	// value is the value of the tag.
 	// Must be between 1 and 256 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// Some AWS service do not support empty values. Since tags are added to
 	// resources in many services, the length of the tag value must meet the
@@ -550,7 +550,7 @@ type AWSClusterResourceTag struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="value must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="value must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Value string `json:"value,omitempty"`
 	// overridePolicy controls whether a NodePool-level tag with the same key can
 	// override this HostedCluster-level tag.
@@ -572,16 +572,16 @@ type AWSClusterResourceTag struct {
 type AWSNodePoolResourceTag struct {
 	// key is the key of the tag.
 	// Must be between 1 and 128 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="key must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="key must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Key string `json:"key,omitempty"`
 	// value is the value of the tag.
 	// Must be between 1 and 256 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// Some AWS service do not support empty values. Since tags are added to
 	// resources in many services, the length of the tag value must meet the
@@ -590,7 +590,7 @@ type AWSNodePoolResourceTag struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="value must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="value must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Value string `json:"value,omitempty"`
 }
 

--- a/api/hypershift/v1beta1/endpointservice_types.go
+++ b/api/hypershift/v1beta1/endpointservice_types.go
@@ -54,16 +54,16 @@ type AWSEndpointServiceSpec struct {
 type AWSEndpointServiceResourceTag struct {
 	// key is the key of the tag.
 	// Must be between 1 and 128 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="key must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="key must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Key string `json:"key,omitempty"`
 	// value is the value of the tag.
 	// Must be between 1 and 256 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// Some AWS service do not support empty values. Since tags are added to
 	// resources in many services, the length of the tag value must meet the
@@ -72,7 +72,7 @@ type AWSEndpointServiceResourceTag struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="value must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="value must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Value string `json:"value,omitempty"`
 }
 

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/awsendpointservices.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/awsendpointservices.hypershift.openshift.io/AAA_ungated.yaml
@@ -56,19 +56,19 @@ spec:
                       description: |-
                         key is the key of the tag.
                         Must be between 1 and 128 characters and may only contain letters, digits,
-                        and the characters _ . : / = + - @
+                        spaces, and the characters _ . : / = + - @
                       maxLength: 128
                       minLength: 1
                       type: string
                       x-kubernetes-validations:
-                      - message: 'key must only contain letters, digits, and the characters
-                          _ . : / = + - @'
-                        rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                      - message: 'key must only contain letters, digits, spaces, and
+                          the characters _ . : / = + - @'
+                        rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                     value:
                       description: |-
                         value is the value of the tag.
                         Must be between 1 and 256 characters and may only contain letters, digits,
-                        and the characters _ . : / = + - @
+                        spaces, and the characters _ . : / = + - @
 
                         Some AWS service do not support empty values. Since tags are added to
                         resources in many services, the length of the tag value must meet the
@@ -77,9 +77,9 @@ spec:
                       minLength: 1
                       type: string
                       x-kubernetes-validations:
-                      - message: 'value must only contain letters, digits, and the
-                          characters _ . : / = + - @'
-                        rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                      - message: 'value must only contain letters, digits, spaces,
+                          and the characters _ . : / = + - @'
+                        rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                   required:
                   - key
                   - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -4393,14 +4393,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4418,7 +4418,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4428,8 +4428,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -4384,14 +4384,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4409,7 +4409,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4419,8 +4419,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -4403,14 +4403,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4428,7 +4428,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4438,8 +4438,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/EtcdSharding.yaml
@@ -4855,14 +4855,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4880,7 +4880,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4890,8 +4890,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -4716,14 +4716,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4741,7 +4741,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4751,8 +4751,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
@@ -5138,14 +5138,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -5163,7 +5163,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -5173,8 +5173,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -4856,14 +4856,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4881,7 +4881,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4891,8 +4891,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -4847,14 +4847,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4872,7 +4872,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4882,8 +4882,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -4384,14 +4384,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4409,7 +4409,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4419,8 +4419,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -4450,14 +4450,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4475,7 +4475,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4485,8 +4485,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPUserFacingOperatorLogs.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPUserFacingOperatorLogs.yaml
@@ -4631,14 +4631,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4656,7 +4656,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4666,8 +4666,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -4406,14 +4406,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4431,7 +4431,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4441,8 +4441,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -4402,14 +4402,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4427,7 +4427,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4437,8 +4437,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/IngressComponentRouteLabels.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/IngressComponentRouteLabels.yaml
@@ -4440,14 +4440,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4465,7 +4465,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4475,8 +4475,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryption.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryption.yaml
@@ -4697,14 +4697,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4722,7 +4722,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4732,8 +4732,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkObservabilityInstall.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkObservabilityInstall.yaml
@@ -4406,14 +4406,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4431,7 +4431,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4441,8 +4441,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -4384,14 +4384,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4409,7 +4409,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4419,8 +4419,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
@@ -4424,14 +4424,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4449,7 +4449,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4459,8 +4459,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSGroupPreferences.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSGroupPreferences.yaml
@@ -4424,14 +4424,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4449,7 +4449,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4459,8 +4459,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -4270,14 +4270,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4295,7 +4295,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4305,8 +4305,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -4261,14 +4261,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4286,7 +4286,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4296,8 +4296,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -4280,14 +4280,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4305,7 +4305,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4315,8 +4315,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/EtcdSharding.yaml
@@ -4732,14 +4732,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4757,7 +4757,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4767,8 +4767,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -4593,14 +4593,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4618,7 +4618,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4628,8 +4628,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
@@ -5015,14 +5015,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -5040,7 +5040,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -5050,8 +5050,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -4733,14 +4733,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4758,7 +4758,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4768,8 +4768,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -4724,14 +4724,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4749,7 +4749,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4759,8 +4759,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -4261,14 +4261,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4286,7 +4286,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4296,8 +4296,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -4327,14 +4327,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4352,7 +4352,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4362,8 +4362,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPUserFacingOperatorLogs.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPUserFacingOperatorLogs.yaml
@@ -4508,14 +4508,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4533,7 +4533,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4543,8 +4543,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -4283,14 +4283,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4308,7 +4308,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4318,8 +4318,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -4279,14 +4279,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4304,7 +4304,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4314,8 +4314,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/IngressComponentRouteLabels.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/IngressComponentRouteLabels.yaml
@@ -4317,14 +4317,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4342,7 +4342,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4352,8 +4352,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryption.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryption.yaml
@@ -4574,14 +4574,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4599,7 +4599,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4609,8 +4609,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkObservabilityInstall.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkObservabilityInstall.yaml
@@ -4283,14 +4283,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4308,7 +4308,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4318,8 +4318,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -4261,14 +4261,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4286,7 +4286,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4296,8 +4296,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
@@ -4301,14 +4301,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4326,7 +4326,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4336,8 +4336,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSGroupPreferences.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSGroupPreferences.yaml
@@ -4301,14 +4301,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4326,7 +4326,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4336,8 +4336,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -613,19 +613,19 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             value:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -635,8 +635,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -613,19 +613,19 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             value:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -635,8 +635,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
@@ -646,19 +646,19 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             value:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -668,8 +668,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -613,19 +613,19 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             value:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -635,8 +635,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/cmd/install/assets/crds/hypershift-operator/tests/awsendpointservices.hypershift.openshift.io/stable.awsendpointservices.aws.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/awsendpointservices.hypershift.openshift.io/stable.awsendpointservices.aws.testsuite.yaml
@@ -14,6 +14,16 @@ tests:
           - key: env
             value: prod
 
+  - name: when tag key and value contain spaces it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: AWSEndpointService
+      spec:
+        networkLoadBalancerName: my-nlb
+        resourceTags:
+          - key: "my tag key"
+            value: "my tag value"
+
   - name: when resourceTag key contains invalid characters it should fail
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1
@@ -23,7 +33,7 @@ tests:
         resourceTags:
           - key: "invalid!key"
             value: prod
-    expectedError: "key must only contain letters, digits, and the characters _ . : / = + - @"
+    expectedError: "key must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 
   - name: when resourceTag value contains invalid characters it should fail
     initial: |
@@ -34,4 +44,4 @@ tests:
         resourceTags:
           - key: env
             value: "invalid#value"
-    expectedError: "value must only contain letters, digits, and the characters _ . : / = + - @"
+    expectedError: "value must only contain letters, digits, spaces, and the characters _ . : / = + - @"

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.aws.tags.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.aws.tags.testsuite.yaml
@@ -1,0 +1,154 @@
+apiVersion: apiextensions.k8s.io/v1
+name: "HostedCluster AWS tag validation"
+crdName: hostedclusters.hypershift.openshift.io
+version: v1beta1
+tests:
+  onCreate:
+  - name: when AWS tag key and value contain spaces it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            rolesRef:
+              ingressARN: arn:aws:iam::role
+              imageRegistryARN: arn:aws:iam::role
+              storageARN: arn:aws:iam::role
+              networkARN: arn:aws:iam::role
+              kubeCloudControllerARN: arn:aws:iam::role
+              nodePoolManagementARN: arn:aws:iam::role
+              controlPlaneOperatorARN: arn:aws:iam::role
+            resourceTags:
+              - key: "my tag key"
+                value: "my tag value"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  - name: when AWS tag key contains invalid character it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            rolesRef:
+              ingressARN: arn:aws:iam::role
+              imageRegistryARN: arn:aws:iam::role
+              storageARN: arn:aws:iam::role
+              networkARN: arn:aws:iam::role
+              kubeCloudControllerARN: arn:aws:iam::role
+              nodePoolManagementARN: arn:aws:iam::role
+              controlPlaneOperatorARN: arn:aws:iam::role
+            resourceTags:
+              - key: "env#1"
+                value: "prod"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "key must only contain letters, digits, spaces, and the characters _ . : / = + - @"
+
+  - name: when AWS tag value contains invalid character it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            rolesRef:
+              ingressARN: arn:aws:iam::role
+              imageRegistryARN: arn:aws:iam::role
+              storageARN: arn:aws:iam::role
+              networkARN: arn:aws:iam::role
+              kubeCloudControllerARN: arn:aws:iam::role
+              nodePoolManagementARN: arn:aws:iam::role
+              controlPlaneOperatorARN: arn:aws:iam::role
+            resourceTags:
+              - key: "env"
+                value: "prod!1"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "value must only contain letters, digits, spaces, and the characters _ . : / = + - @"

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.aws.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.aws.testsuite.yaml
@@ -202,7 +202,7 @@ tests:
           servicePublishingStrategy:
             type: Route
             route: {}
-    expectedError: "key must only contain letters, digits, and the characters _ . : / = + - @"
+    expectedError: "key must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 
   - name: when resourceTag value contains invalid characters it should fail
     initial: |
@@ -252,4 +252,4 @@ tests:
           servicePublishingStrategy:
             type: Route
             route: {}
-    expectedError: "value must only contain letters, digits, and the characters _ . : / = + - @"
+    expectedError: "value must only contain letters, digits, spaces, and the characters _ . : / = + - @"

--- a/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.aws.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.aws.testsuite.yaml
@@ -695,6 +695,87 @@ tests:
                 value: prod
           type: AWS
 
+  - name: when tag key contains spaces it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6i.large
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+            resourceTags:
+              - key: "my tag"
+                value: "prod"
+          type: AWS
+
+  - name: when tag value contains spaces it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6i.large
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+            resourceTags:
+              - key: "env"
+                value: "my value"
+          type: AWS
+
+  - name: when tag key and value both contain spaces it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6i.large
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+            resourceTags:
+              - key: "my tag key"
+                value: "my tag value"
+          type: AWS
+
   - name: when resourceTag key contains invalid characters it should fail
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1
@@ -721,7 +802,7 @@ tests:
               - key: "invalid!key"
                 value: prod
           type: AWS
-    expectedError: "key must only contain letters, digits, and the characters _ . : / = + - @"
+    expectedError: "key must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 
   - name: when resourceTag value contains invalid characters it should fail
     initial: |
@@ -749,4 +830,4 @@ tests:
               - key: env
                 value: "invalid#value"
           type: AWS
-    expectedError: "value must only contain letters, digits, and the characters _ . : / = + - @"
+    expectedError: "value must only contain letters, digits, spaces, and the characters _ . : / = + - @"

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/awsendpointservices.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/awsendpointservices.crd.yaml
@@ -58,19 +58,19 @@ spec:
                       description: |-
                         key is the key of the tag.
                         Must be between 1 and 128 characters and may only contain letters, digits,
-                        and the characters _ . : / = + - @
+                        spaces, and the characters _ . : / = + - @
                       maxLength: 128
                       minLength: 1
                       type: string
                       x-kubernetes-validations:
-                      - message: 'key must only contain letters, digits, and the characters
-                          _ . : / = + - @'
-                        rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                      - message: 'key must only contain letters, digits, spaces, and
+                          the characters _ . : / = + - @'
+                        rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                     value:
                       description: |-
                         value is the value of the tag.
                         Must be between 1 and 256 characters and may only contain letters, digits,
-                        and the characters _ . : / = + - @
+                        spaces, and the characters _ . : / = + - @
 
                         Some AWS service do not support empty values. Since tags are added to
                         resources in many services, the length of the tag value must meet the
@@ -79,9 +79,9 @@ spec:
                       minLength: 1
                       type: string
                       x-kubernetes-validations:
-                      - message: 'value must only contain letters, digits, and the
-                          characters _ . : / = + - @'
-                        rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                      - message: 'value must only contain letters, digits, spaces,
+                          and the characters _ . : / = + - @'
+                        rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                   required:
                   - key
                   - value

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -6742,14 +6742,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -6767,7 +6767,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -6777,8 +6777,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -5021,14 +5021,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -5046,7 +5046,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -5056,8 +5056,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -5864,14 +5864,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -5889,7 +5889,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -5899,8 +5899,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -6619,14 +6619,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -6644,7 +6644,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -6654,8 +6654,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
@@ -4898,14 +4898,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -4923,7 +4923,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -4933,8 +4933,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -5741,14 +5741,14 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             overridePolicy:
                               description: |-
                                 overridePolicy controls whether a NodePool-level tag with the same key can
@@ -5766,7 +5766,7 @@ spec:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -5776,8 +5776,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -649,19 +649,19 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             value:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -671,8 +671,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -649,19 +649,19 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             value:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -671,8 +671,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -649,19 +649,19 @@ spec:
                               description: |-
                                 key is the key of the tag.
                                 Must be between 1 and 128 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
                               maxLength: 128
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: 'key must only contain letters, digits, and
-                                  the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                              - message: 'key must only contain letters, digits, spaces,
+                                  and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                             value:
                               description: |-
                                 value is the value of the tag.
                                 Must be between 1 and 256 characters and may only contain letters, digits,
-                                and the characters _ . : / = + - @
+                                spaces, and the characters _ . : / = + - @
 
                                 Some AWS service do not support empty values. Since tags are added to
                                 resources in many services, the length of the tag value must meet the
@@ -671,8 +671,8 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: 'value must only contain letters, digits,
-                                  and the characters _ . : / = + - @'
-                                rule: self.matches('^[0-9A-Za-z_.:/=+@-]+$')
+                                  spaces, and the characters _ . : / = + - @'
+                                rule: self.matches('^[0-9A-Za-z _.:/=+@-]+$')
                           required:
                           - key
                           - value

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -41426,7 +41426,7 @@ string
 <td>
 <p>key is the key of the tag.
 Must be between 1 and 128 characters and may only contain letters, digits,
-and the characters _ . : / = + - @</p>
+spaces, and the characters _ . : / = + - @</p>
 </td>
 </tr>
 <tr>
@@ -41439,7 +41439,7 @@ string
 <td>
 <p>value is the value of the tag.
 Must be between 1 and 256 characters and may only contain letters, digits,
-and the characters _ . : / = + - @</p>
+spaces, and the characters _ . : / = + - @</p>
 <p>Some AWS service do not support empty values. Since tags are added to
 resources in many services, the length of the tag value must meet the
 requirements of all services.</p>
@@ -41854,7 +41854,7 @@ string
 <td>
 <p>key is the key of the tag.
 Must be between 1 and 128 characters and may only contain letters, digits,
-and the characters _ . : / = + - @</p>
+spaces, and the characters _ . : / = + - @</p>
 </td>
 </tr>
 <tr>
@@ -41867,7 +41867,7 @@ string
 <td>
 <p>value is the value of the tag.
 Must be between 1 and 256 characters and may only contain letters, digits,
-and the characters _ . : / = + - @</p>
+spaces, and the characters _ . : / = + - @</p>
 <p>Some AWS service do not support empty values. Since tags are added to
 resources in many services, the length of the tag value must meet the
 requirements of all services.</p>
@@ -42172,7 +42172,7 @@ string
 <td>
 <p>key is the key of the tag.
 Must be between 1 and 128 characters and may only contain letters, digits,
-and the characters _ . : / = + - @</p>
+spaces, and the characters _ . : / = + - @</p>
 </td>
 </tr>
 <tr>
@@ -42185,7 +42185,7 @@ string
 <td>
 <p>value is the value of the tag.
 Must be between 1 and 256 characters and may only contain letters, digits,
-and the characters _ . : / = + - @</p>
+spaces, and the characters _ . : / = + - @</p>
 <p>Some AWS service do not support empty values. Since tags are added to
 resources in many services, the length of the tag value must meet the
 requirements of all services.</p>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1628,7 +1628,7 @@ string
 <td>
 <p>key is the key of the tag.
 Must be between 1 and 128 characters and may only contain letters, digits,
-and the characters _ . : / = + - @</p>
+spaces, and the characters _ . : / = + - @</p>
 </td>
 </tr>
 <tr>
@@ -1641,7 +1641,7 @@ string
 <td>
 <p>value is the value of the tag.
 Must be between 1 and 256 characters and may only contain letters, digits,
-and the characters _ . : / = + - @</p>
+spaces, and the characters _ . : / = + - @</p>
 <p>Some AWS service do not support empty values. Since tags are added to
 resources in many services, the length of the tag value must meet the
 requirements of all services.</p>
@@ -2056,7 +2056,7 @@ string
 <td>
 <p>key is the key of the tag.
 Must be between 1 and 128 characters and may only contain letters, digits,
-and the characters _ . : / = + - @</p>
+spaces, and the characters _ . : / = + - @</p>
 </td>
 </tr>
 <tr>
@@ -2069,7 +2069,7 @@ string
 <td>
 <p>value is the value of the tag.
 Must be between 1 and 256 characters and may only contain letters, digits,
-and the characters _ . : / = + - @</p>
+spaces, and the characters _ . : / = + - @</p>
 <p>Some AWS service do not support empty values. Since tags are added to
 resources in many services, the length of the tag value must meet the
 requirements of all services.</p>
@@ -2374,7 +2374,7 @@ string
 <td>
 <p>key is the key of the tag.
 Must be between 1 and 128 characters and may only contain letters, digits,
-and the characters _ . : / = + - @</p>
+spaces, and the characters _ . : / = + - @</p>
 </td>
 </tr>
 <tr>
@@ -2387,7 +2387,7 @@ string
 <td>
 <p>value is the value of the tag.
 Must be between 1 and 256 characters and may only contain letters, digits,
-and the characters _ . : / = + - @</p>
+spaces, and the characters _ . : / = + - @</p>
 <p>Some AWS service do not support empty values. Since tags are added to
 resources in many services, the length of the tag value must meet the
 requirements of all services.</p>

--- a/test/e2e/v2/tests/hosted_cluster_aws_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_aws_test.go
@@ -48,9 +48,11 @@ import (
 
 func RegisterHostedClusterAWSTests(getTestCtx internal.TestContextGetter) {
 	EnsureDefaultSecurityGroupTagsTest(getTestCtx)
+	EnsureDefaultSecurityGroupTagsWithSpacesTest(getTestCtx)
 	EnsureInfrastructureResourceTagsTest(getTestCtx)
 	AWSCCMWithCustomizationsTest(getTestCtx)
 	AWSResourceTagOverridePolicyTest(getTestCtx)
+	NodePoolDay2TagsWithSpacesTest(getTestCtx)
 }
 
 func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
@@ -472,6 +474,213 @@ func AWSResourceTagOverridePolicyTest(getTestCtx internal.TestContextGetter) {
 			}
 			Expect(inspectedInstances).To(BeNumerically(">=", 1),
 				"expected to inspect at least one EC2 instance but all AWSMachines had nil InstanceID")
+		})
+	})
+}
+
+func EnsureDefaultSecurityGroupTagsWithSpacesTest(getTestCtx internal.TestContextGetter) {
+	When("[Feature:AWSSecurityGroups] a day-2 resource tag with spaces is added to the HostedCluster spec", func() {
+		It("should apply the tag with spaces to the default worker security group via AWS API", Label("AWS"), func() {
+			tc := getTestCtx()
+			tc.SkipIfVersionBelow(e2eutil.Version420)
+			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+
+			Expect(hc.Status.Platform).NotTo(BeNil(),
+				"HostedCluster %s/%s should have platform status", hc.Namespace, hc.Name)
+			Expect(hc.Status.Platform.AWS).NotTo(BeNil(),
+				"HostedCluster %s/%s should have AWS platform status", hc.Namespace, hc.Name)
+			sgID := hc.Status.Platform.AWS.DefaultWorkerSecurityGroupID
+			Expect(sgID).NotTo(BeEmpty(), "HostedCluster status should have DefaultWorkerSecurityGroupID set")
+
+			awsCredsFile := internal.GetEnvVarValue("AWS_GUEST_INFRA_CREDENTIALS_FILE")
+			Expect(awsCredsFile).NotTo(BeEmpty(), "AWS_GUEST_INFRA_CREDENTIALS_FILE must be set for AWS security group tests")
+
+			region := hc.Spec.Platform.AWS.Region
+			Expect(region).NotTo(BeEmpty(), "HostedCluster AWS region should be set")
+
+			tagsPolicy := fmt.Sprintf(`{
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Allow",
+						"Action": [
+							"ec2:CreateTags",
+							"ec2:DeleteTags"
+						],
+						"Resource": "arn:aws:ec2:*:*:security-group/%s"
+					}
+				]
+			}`, sgID)
+
+			Expect(hc.Spec.Platform.AWS.RolesRef.ControlPlaneOperatorARN).NotTo(BeEmpty(),
+				"HostedCluster should have ControlPlaneOperatorARN set")
+
+			cleanup, err := e2eutil.PutRolePolicy(tc.Context, awsCredsFile, region,
+				hc.Spec.Platform.AWS.RolesRef.ControlPlaneOperatorARN, tagsPolicy)
+			Expect(err).NotTo(HaveOccurred(), "failed to put role policy for tagging default security group")
+			DeferCleanup(func() {
+				Expect(cleanup()).To(Succeed(), "failed to cleanup role policy for tagging default security group")
+			})
+
+			day2TagKey := "e2e day2 tag"
+			day2TagValue := "e2e day2 value"
+
+			originalTags := append([]hyperv1.AWSClusterResourceTag(nil), hc.Spec.Platform.AWS.ResourceTags...)
+
+			err = e2eutil.UpdateObject(GinkgoTB(), tc.Context, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+				obj.Spec.Platform.AWS.ResourceTags = append(obj.Spec.Platform.AWS.ResourceTags, hyperv1.AWSClusterResourceTag{
+					Key:   day2TagKey,
+					Value: day2TagValue,
+				})
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to update HostedCluster with day-2 tag containing spaces")
+			DeferCleanup(func() {
+				err := e2eutil.UpdateObject(GinkgoTB(), tc.Context, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+					obj.Spec.Platform.AWS.ResourceTags = append([]hyperv1.AWSClusterResourceTag(nil), originalTags...)
+				})
+				if err != nil && !apierrors.IsNotFound(err) {
+					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to restore HostedCluster AWS resource tags")
+				}
+
+				hcClient, err := tc.GetHostedClusterClient(hc)
+				Expect(err).NotTo(HaveOccurred(),
+					"cleanup: failed to get hosted cluster client for %s/%s", hc.Namespace, hc.Name)
+				Eventually(func(g Gomega) {
+					infra := &configv1.Infrastructure{}
+					g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, infra)).To(Succeed(),
+						"cleanup: failed to get infrastructure/cluster from hosted cluster")
+					g.Expect(infra.Status.PlatformStatus).NotTo(BeNil(),
+						"cleanup: infrastructure/cluster should have platform status")
+					g.Expect(infra.Status.PlatformStatus.AWS).NotTo(BeNil(),
+						"cleanup: infrastructure/cluster should have AWS platform status")
+					g.Expect(infra.Status.PlatformStatus.AWS.ResourceTags).NotTo(
+						ContainElement(configv1.AWSResourceTag{Key: day2TagKey, Value: day2TagValue}),
+						"cleanup: day-2 tag with spaces should be removed from infrastructure resource",
+					)
+				}, 5*time.Minute, 10*time.Second).Should(Succeed())
+			})
+
+			Eventually(func(g Gomega) {
+				sg, err := e2eutil.GetDefaultSecurityGroup(tc.Context, awsCredsFile, region, sgID)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to get default security group")
+				g.Expect(sg.Tags).To(ContainElement(ec2types.Tag{
+					Key:   aws.String(day2TagKey),
+					Value: aws.String(day2TagValue),
+				}), "day-2 tag with spaces should be applied to the default worker security group")
+			}, 10*time.Minute, time.Second).Should(Succeed())
+
+			hcClient, err := tc.GetHostedClusterClient(hc)
+			Expect(err).NotTo(HaveOccurred(),
+				"failed to get hosted cluster client for %s/%s", hc.Namespace, hc.Name)
+			Eventually(func(g Gomega) {
+				infra := &configv1.Infrastructure{}
+				g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, infra)).To(Succeed(),
+					"failed to get infrastructure/cluster from hosted cluster")
+				g.Expect(infra.Status.PlatformStatus).NotTo(BeNil(),
+					"infrastructure/cluster should have platform status")
+				g.Expect(infra.Status.PlatformStatus.AWS).NotTo(BeNil(),
+					"infrastructure/cluster should have AWS platform status")
+				g.Expect(infra.Status.PlatformStatus.AWS.ResourceTags).To(
+					ContainElement(configv1.AWSResourceTag{Key: day2TagKey, Value: day2TagValue}),
+					"day-2 tag with spaces should propagate to the infrastructure resource",
+				)
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
+		})
+	})
+}
+
+func NodePoolDay2TagsWithSpacesTest(getTestCtx internal.TestContextGetter) {
+	When("[Feature:AWSResourceTags] a day-2 NodePool tag with spaces is added", func() {
+		It("should propagate the tag with spaces to AWSMachine and EC2 instances", Label("AWS"), func() {
+			tc := getTestCtx()
+			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
+
+			hc, err := tc.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+
+			ctx := tc.Context
+
+			npList := &hyperv1.NodePoolList{}
+			Expect(tc.MgmtClient.List(ctx, npList, crclient.InNamespace(hc.Namespace))).To(Succeed(),
+				"failed to list NodePools")
+			var defaultNP *hyperv1.NodePool
+			for i := range npList.Items {
+				np := &npList.Items[i]
+				if np.Spec.ClusterName == hc.Name && np.DeletionTimestamp.IsZero() {
+					defaultNP = np
+					break
+				}
+			}
+			Expect(defaultNP).NotTo(BeNil(), "a non-deleting NodePool should exist for HostedCluster %s", hc.Name)
+			Expect(defaultNP.Spec.Platform.AWS).NotTo(BeNil(),
+				"NodePool %s/%s should have AWS platform spec", defaultNP.Namespace, defaultNP.Name)
+
+			day2TagKey := "e2e np space tag"
+			day2TagValue := "e2e np space value"
+
+			originalTags := append([]hyperv1.AWSNodePoolResourceTag(nil), defaultNP.Spec.Platform.AWS.ResourceTags...)
+			err = e2eutil.UpdateObject(GinkgoTB(), ctx, tc.MgmtClient, defaultNP, func(obj *hyperv1.NodePool) {
+				obj.Spec.Platform.AWS.ResourceTags = append(obj.Spec.Platform.AWS.ResourceTags, hyperv1.AWSNodePoolResourceTag{
+					Key:   day2TagKey,
+					Value: day2TagValue,
+				})
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to update NodePool with day-2 tag containing spaces")
+			DeferCleanup(func() {
+				err := e2eutil.UpdateObject(GinkgoTB(), ctx, tc.MgmtClient, defaultNP, func(obj *hyperv1.NodePool) {
+					obj.Spec.Platform.AWS.ResourceTags = append([]hyperv1.AWSNodePoolResourceTag(nil), originalTags...)
+				})
+				if err != nil && !apierrors.IsNotFound(err) {
+					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to restore NodePool AWS resource tags")
+				}
+			})
+
+			awsCredsFile := internal.GetEnvVarValue("AWS_GUEST_INFRA_CREDENTIALS_FILE")
+			Expect(awsCredsFile).NotTo(BeEmpty(), "AWS_GUEST_INFRA_CREDENTIALS_FILE must be set")
+			region := hc.Spec.Platform.AWS.Region
+
+			awsSession := awsutil.NewSession(ctx, "e2e-tag-spaces", awsCredsFile, "", "", region)
+			awsConfig := awsutil.NewConfig()
+			ec2Client := ec2.NewFromConfig(*awsSession, func(o *ec2.Options) {
+				o.Retryer = awsConfig()
+			})
+
+			Eventually(func(g Gomega) {
+				awsMachines := &capiaws.AWSMachineList{}
+				g.Expect(tc.MgmtClient.List(ctx, awsMachines,
+					crclient.InNamespace(tc.ControlPlaneNamespace),
+					crclient.MatchingLabels{capiv1.MachineDeploymentNameLabel: defaultNP.Name})).To(Succeed(),
+					"failed to list AWSMachines for NodePool %s in namespace %s", defaultNP.Name, tc.ControlPlaneNamespace)
+				g.Expect(awsMachines.Items).NotTo(BeEmpty(),
+					"expected at least one AWSMachine for NodePool %s", defaultNP.Name)
+
+				inspectedInstances := 0
+				for _, awsMachine := range awsMachines.Items {
+					g.Expect(awsMachine.Spec.AdditionalTags).To(HaveKeyWithValue(day2TagKey, day2TagValue),
+						"AWSMachine %s should have tag with spaces", awsMachine.Name)
+
+					if awsMachine.Spec.InstanceID == nil {
+						continue
+					}
+					instance, err := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+						InstanceIds: []string{aws.ToString(awsMachine.Spec.InstanceID)},
+					})
+					g.Expect(err).NotTo(HaveOccurred(), "failed to describe EC2 instance %s", aws.ToString(awsMachine.Spec.InstanceID))
+					g.Expect(instance.Reservations).NotTo(BeEmpty(),
+						"expected at least one reservation for EC2 instance %s", aws.ToString(awsMachine.Spec.InstanceID))
+					g.Expect(instance.Reservations[0].Instances).NotTo(BeEmpty(),
+						"expected at least one instance in reservation for %s", aws.ToString(awsMachine.Spec.InstanceID))
+					g.Expect(instance.Reservations[0].Instances[0].Tags).To(ContainElement(ec2types.Tag{
+						Key:   aws.String(day2TagKey),
+						Value: aws.String(day2TagValue),
+					}), "EC2 instance should have tag with spaces")
+					inspectedInstances++
+				}
+				g.Expect(inspectedInstances).To(BeNumerically(">=", 1),
+					"expected to inspect at least one EC2 instance but all AWSMachines had nil InstanceID")
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 	})
 }

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/aws.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/aws.go
@@ -504,16 +504,16 @@ type AWSRoleCredentials struct {
 type AWSResourceTag struct {
 	// key is the key of the tag.
 	// Must be between 1 and 128 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="key must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="key must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Key string `json:"key"`
 	// value is the value of the tag.
 	// Must be between 1 and 256 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// Some AWS service do not support empty values. Since tags are added to
 	// resources in many services, the length of the tag value must meet the
@@ -522,7 +522,7 @@ type AWSResourceTag struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="value must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="value must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Value string `json:"value"`
 }
 
@@ -532,16 +532,16 @@ type AWSResourceTag struct {
 type AWSClusterResourceTag struct {
 	// key is the key of the tag.
 	// Must be between 1 and 128 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="key must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="key must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Key string `json:"key,omitempty"`
 	// value is the value of the tag.
 	// Must be between 1 and 256 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// Some AWS service do not support empty values. Since tags are added to
 	// resources in many services, the length of the tag value must meet the
@@ -550,7 +550,7 @@ type AWSClusterResourceTag struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="value must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="value must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Value string `json:"value,omitempty"`
 	// overridePolicy controls whether a NodePool-level tag with the same key can
 	// override this HostedCluster-level tag.
@@ -572,16 +572,16 @@ type AWSClusterResourceTag struct {
 type AWSNodePoolResourceTag struct {
 	// key is the key of the tag.
 	// Must be between 1 and 128 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="key must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="key must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Key string `json:"key,omitempty"`
 	// value is the value of the tag.
 	// Must be between 1 and 256 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// Some AWS service do not support empty values. Since tags are added to
 	// resources in many services, the length of the tag value must meet the
@@ -590,7 +590,7 @@ type AWSNodePoolResourceTag struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="value must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="value must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Value string `json:"value,omitempty"`
 }
 

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/endpointservice_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/endpointservice_types.go
@@ -54,16 +54,16 @@ type AWSEndpointServiceSpec struct {
 type AWSEndpointServiceResourceTag struct {
 	// key is the key of the tag.
 	// Must be between 1 and 128 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="key must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="key must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Key string `json:"key,omitempty"`
 	// value is the value of the tag.
 	// Must be between 1 and 256 characters and may only contain letters, digits,
-	// and the characters _ . : / = + - @
+	// spaces, and the characters _ . : / = + - @
 	//
 	// Some AWS service do not support empty values. Since tags are added to
 	// resources in many services, the length of the tag value must meet the
@@ -72,7 +72,7 @@ type AWSEndpointServiceResourceTag struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+@-]+$')`,message="value must only contain letters, digits, and the characters _ . : / = + - @"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z _.:/=+@-]+$')`,message="value must only contain letters, digits, spaces, and the characters _ . : / = + - @"
 	Value string `json:"value,omitempty"`
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

AWS permits spaces in both tag keys and tag values (see [AWS tagging docs](https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)), but HyperShift's CRD CEL validation rules rejected them. This made HyperShift more restrictive than the underlying cloud provider, preventing users from applying tags with spaces to their AWS resources.

This PR relaxes the CEL validation regex on all four AWS resource tag types from `^[0-9A-Za-z_.:/=+@-]+$` to `^[0-9A-Za-z _.:/=+@-]+$` (adding a space to the character class), adds envtest coverage for the updated validation rules, and adds v2 e2e tests verifying tags with spaces propagate correctly to both NodePool (EC2 instances) and non-NodePool (default worker security group) AWS resources.

## Which issue(s) this PR fixes:

Fixes [OCPBUGS-114408](https://redhat.atlassian.net/browse/OCPBUGS-114408)

## Special notes for your reviewer:

- This is a validation relaxation — all previously valid values remain valid.
- No serialization or controller changes — only CEL markers, godoc comments, generated CRDs, and tests.
- The deprecated `AWSResourceTag` type is also updated for consistency, though it is not referenced as a field type in any CRD.
- Four tag types updated (8 fields total): `AWSResourceTag`, `AWSClusterResourceTag`, `AWSNodePoolResourceTag`, `AWSEndpointServiceResourceTag`.
- **envtest tests** added for HostedCluster, NodePool, and AWSEndpointService CRDs covering both valid (spaces) and invalid (`#`, `!`) tag characters.
- **v2 e2e tests** added:
  - `EnsureDefaultSecurityGroupTagsWithSpacesTest` — verifies HostedCluster-level tags with spaces propagate to the default worker security group and infrastructure resource.
  - `NodePoolDay2TagsWithSpacesTest` — verifies NodePool-level tags with spaces propagate to AWSMachine `AdditionalTags` and actual EC2 instances.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AWS resource, cluster, node pool, and endpoint service tags now support spaces in tag keys and values.
  - Tags containing spaces are applied and propagated to security groups, NodePool machines, hosted-cluster infrastructure, and EC2 instances.
- **Documentation**
  - Updated tag validation descriptions to accurately describe support for spaces.
- **Tests**
  - Added end-to-end coverage for applying, propagating, and cleaning up tags containing spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->