### PR TITLE
CNTRLPLANE-4208: Right-size Azure v2 e2e worker counts

### DIFF
--- a/test/e2e/v2/cmd/create-guests/main.go
+++ b/test/e2e/v2/cmd/create-guests/main.go
@@ -38,11 +38,11 @@ import (
 	"sync"
 	"time"
 
-	routev1 "github.com/openshift/api/route/v1"
-
-	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/test/e2e/v2/lifecycle"
+
+	configv1 "github.com/openshift/api/config/v1"
+	routev1 "github.com/openshift/api/route/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -276,13 +276,17 @@ func buildCreateArgs(cfg envConfig, ns namedSpec) []string {
 	if ns.ReleaseImage != "" {
 		releaseImage = ns.ReleaseImage
 	}
+	nodeCount := cfg.nodeCount
+	if ns.InitialNodePoolReplicas != nil {
+		nodeCount = *ns.InitialNodePoolReplicas
+	}
 
 	args := []string{
 		"create", "cluster", cfg.platform.Name(),
 		"--name=" + ns.name,
 		"--namespace=" + cfg.namespace,
 		"--infra-id=" + ns.name,
-		"--node-pool-replicas=" + strconv.Itoa(cfg.nodeCount),
+		"--node-pool-replicas=" + strconv.Itoa(nodeCount),
 		"--base-domain=" + cfg.baseDomain,
 		"--pull-secret=" + cfg.pullSecret,
 		"--release-image=" + releaseImage,

--- a/test/e2e/v2/cmd/create-guests/main_test.go
+++ b/test/e2e/v2/cmd/create-guests/main_test.go
@@ -1,0 +1,63 @@
+//go:build e2ev2
+
+package main
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/openshift/hypershift/test/e2e/v2/lifecycle"
+)
+
+func TestBuildCreateArgs(t *testing.T) {
+	t.Parallel()
+
+	override := 2
+	cfg := envConfig{
+		baseDomain:   "example.com",
+		nodeCount:    6,
+		namespace:    "clusters",
+		releaseImage: "release-image",
+		pullSecret:   "/tmp/pull-secret",
+		platform:     lifecycle.NewAzurePlatformConfig(""),
+	}
+
+	tests := []struct {
+		name     string
+		override *int
+		want     int
+	}{
+		{
+			name:     "When ClusterSpec has an initial replica override, it should use that value",
+			override: &override,
+			want:     2,
+		},
+		{
+			name: "When ClusterSpec has no initial replica override, it should use the global node count",
+			want: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ns := namedSpec{
+				ClusterSpec: lifecycle.ClusterSpec{
+					Variant:                 "public",
+					InitialNodePoolReplicas: tt.override,
+				},
+				name: "public-test",
+			}
+			args := buildCreateArgs(cfg, ns)
+			want := "--node-pool-replicas=" + strconv.Itoa(tt.want)
+			for _, arg := range args {
+				if arg == want {
+					return
+				}
+			}
+			t.Errorf("create args %v do not contain %q", args, want)
+		})
+	}
+}

--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -10,12 +10,15 @@ import (
 	"path/filepath"
 	"strings"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -122,34 +125,43 @@ func (a *AzurePlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Clust
 	}
 	publicExtraArgs = append(publicExtraArgs, extraArgs...)
 
+	oneInitialReplica := 1
+	twoInitialReplicas := 2
+
 	return []ClusterSpec{
 		{
-			Variant:   "public",
-			ExtraArgs: publicExtraArgs,
+			Variant:                 "public",
+			ExtraArgs:               publicExtraArgs,
+			InitialNodePoolReplicas: &twoInitialReplicas,
 		},
 		{
-			Variant: "private",
+			Variant:                 "private",
+			InitialNodePoolReplicas: &oneInitialReplica,
 			ExtraArgs: append([]string{
 				"--endpoint-access=Private",
 				"--endpoint-access-private-nat-subnet-id=" + a.privateNATSubnetID,
 			}, extraArgs...),
 		},
 		{
-			Variant:   "oauth-lb",
-			ExtraArgs: append([]string{"--oauth-publishing-strategy=LoadBalancer"}, extraArgs...),
+			Variant:                 "oauth-lb",
+			InitialNodePoolReplicas: &oneInitialReplica,
+			ExtraArgs:               append([]string{"--oauth-publishing-strategy=LoadBalancer"}, extraArgs...),
 		},
 		{
-			Variant:      "upgrade",
-			ReleaseImage: n1Image,
-			ExtraArgs:    append([]string{"--control-plane-availability-policy=HighlyAvailable"}, extraArgs...),
+			Variant:                 "upgrade",
+			ReleaseImage:            n1Image,
+			InitialNodePoolReplicas: &twoInitialReplicas,
+			ExtraArgs:               append([]string{"--control-plane-availability-policy=HighlyAvailable"}, extraArgs...),
 		},
 		{
-			Variant:   "autoscaling",
-			ExtraArgs: extraArgs,
+			Variant:                 "autoscaling",
+			InitialNodePoolReplicas: &oneInitialReplica,
+			ExtraArgs:               extraArgs,
 		},
 		{
-			Variant:   "external-oidc",
-			ExtraArgs: extraArgs,
+			Variant:                 "external-oidc",
+			InitialNodePoolReplicas: &oneInitialReplica,
+			ExtraArgs:               extraArgs,
 		},
 	}
 }

--- a/test/e2e/v2/lifecycle/azure_test.go
+++ b/test/e2e/v2/lifecycle/azure_test.go
@@ -1,0 +1,74 @@
+//go:build e2ev2
+
+package lifecycle
+
+import "testing"
+
+func TestAzurePlatformConfigClusterSpecs(t *testing.T) {
+	t.Parallel()
+
+	specs := (&AzurePlatformConfig{}).ClusterSpecs("release-image", "n1-image")
+	specsByVariant := make(map[string]ClusterSpec, len(specs))
+	for _, spec := range specs {
+		specsByVariant[spec.Variant] = spec
+	}
+
+	tests := []struct {
+		name    string
+		variant string
+		want    int
+	}{
+		{
+			name:    "When public Azure variant is configured, it should request two initial replicas",
+			variant: "public",
+			want:    2,
+		},
+		{
+			name:    "When upgrade Azure variant is configured, it should request two initial replicas",
+			variant: "upgrade",
+			want:    2,
+		},
+		{
+			name:    "When private Azure variant is configured, it should request one initial replica",
+			variant: "private",
+			want:    1,
+		},
+		{
+			name:    "When OAuth LoadBalancer Azure variant is configured, it should request one initial replica",
+			variant: "oauth-lb",
+			want:    1,
+		},
+		{
+			name:    "When autoscaling Azure variant is configured, it should request one initial replica",
+			variant: "autoscaling",
+			want:    1,
+		},
+		{
+			name:    "When external OIDC Azure variant is configured, it should request one initial replica",
+			variant: "external-oidc",
+			want:    1,
+		},
+	}
+
+	if len(specsByVariant) != len(tests) {
+		t.Fatalf("got %d Azure variants, want %d", len(specsByVariant), len(tests))
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec, ok := specsByVariant[tt.variant]
+			if !ok {
+				t.Fatalf("Azure variant %q was not configured", tt.variant)
+			}
+			if spec.InitialNodePoolReplicas == nil {
+				t.Fatalf("Azure variant %q has no initial replica override", tt.variant)
+			}
+			if got := *spec.InitialNodePoolReplicas; got != tt.want {
+				t.Errorf("Azure variant %q requests %d initial replicas, want %d", tt.variant, got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/v2/lifecycle/platform.go
+++ b/test/e2e/v2/lifecycle/platform.go
@@ -17,6 +17,10 @@ type ClusterSpec struct {
 	Variant      string   `json:"variant"`
 	ExtraArgs    []string `json:"extraArgs,omitempty"`
 	ReleaseImage string   `json:"releaseImage,omitempty"` // override (empty = use default)
+
+	// InitialNodePoolReplicas overrides the default initial NodePool replica count.
+	// A nil value uses HYPERSHIFT_NODE_COUNT.
+	InitialNodePoolReplicas *int `json:"initialNodePoolReplicas,omitempty"`
 }
 
 // TestGroup describes one logical group of e2e tests to execute.


### PR DESCRIPTION
## What this PR does / why we need it:

Adds an optional per-variant initial NodePool replica count to the v2 lifecycle ClusterSpec. `create-guests` uses that override when present and retains `HYPERSHIFT_NODE_COUNT` as the fallback. Azure starts public and upgrade with two workers and the remaining variants with one, reducing the initial footprint from 36 workers to 8 when the global count is 6 while preserving AWS behavior.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-4208](https://redhat.atlassian.net/browse/CNTRLPLANE-4208)

## Special notes for your reviewer:

- The change is limited to v2 lifecycle orchestration and does not modify customer-facing APIs, controllers, or generated files.
- Unit tests cover the explicit override, global fallback, and all six Azure variant values.
- Focused race-enabled tests, repository-wide `make test`, `make e2ev2-create-guests`, and the Go + HyperShift pre-commit review passed.
- `make verify` passed generation, dependency, staticcheck, formatting, vet, lint, codespell, gitlint, and docs-nav checks. Its CRD schema check was blocked because this worktree has an invalid branch merge configuration.
- The required five successful Azure CI runs and baseline timing/capacity comparison remain live validation steps.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Cluster creation now supports a tailored initial node count for each cluster configuration.
  - Configurations can specify a starting node count or fall back to the global default.
  - Test plans now validate available cluster variants and apply the selected plan during creation.
  - Azure lifecycle scenarios use validated replica counts for each supported cluster type.

- **Tests**
  - Added coverage for cluster-specific node settings and Azure configuration values across all supported variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->