### PR TITLE
CNTRLPLANE-3951: fix(e2e): accept node deletion as success in TestSpotTerminationHandler

### DIFF
--- a/test/e2e/nodepool_spot_termination_handler_test.go
+++ b/test/e2e/nodepool_spot_termination_handler_test.go
@@ -20,7 +20,9 @@ import (
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -276,27 +278,35 @@ func (s *SpotTerminationHandlerTest) Run(t *testing.T, nodePool hyperv1.NodePool
 		}
 		t.Logf("Successfully sent EC2 Rebalance Recommendation event to SQS queue")
 
-		// Step 6: Wait for the node to have the rebalance recommendation taint
-		t.Logf("Waiting for node %s to have taint prefix %s", spotNode.Name, rebalanceRecommendationTaintKey)
-		e2eutil.EventuallyObject(t, s.ctx, fmt.Sprintf("Waiting for node %s to have rebalance recommendation taint", spotNode.Name),
-			func(ctx context.Context) (*corev1.Node, error) {
-				node := &corev1.Node{}
-				err := s.hostedClusterClient.Get(ctx, crclient.ObjectKey{Name: spotNode.Name}, node)
-				return node, err
-			},
-			[]e2eutil.Predicate[*corev1.Node]{
-				func(node *corev1.Node) (bool, string, error) {
-					for _, taint := range node.Spec.Taints {
-						if strings.HasPrefix(taint.Key, rebalanceRecommendationTaintKey) {
-							return true, fmt.Sprintf("Node has taint %s with effect %s", taint.Key, taint.Effect), nil
-						}
-					}
-					return false, "Node does not have aws-node-termination-handler taint", nil
-				},
-			},
-			e2eutil.WithInterval(5*time.Second), e2eutil.WithTimeout(15*time.Minute),
-		)
-		t.Logf("Node %s has the rebalance recommendation taint", spotNode.Name)
+		// Step 6: Wait for the termination handler pipeline to act on the node.
+		// Success is taint-applied or node-deleted; enable-spot has no real spot market, so a missing node unambiguously means the pipeline completed.
+		// We use a plain poll rather than EventuallyObject because the latter treats not-found as a transient error to retry,
+		// which is precisely the terminal state we want to accept.
+		t.Logf("Waiting for node %s to be tainted or remediated (taint key %s)", spotNode.Name, rebalanceRecommendationTaintKey)
+		err = wait.PollUntilContextTimeout(s.ctx, 5*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+			node := &corev1.Node{}
+			getErr := s.hostedClusterClient.Get(ctx, crclient.ObjectKey{Name: spotNode.Name}, node)
+			if apierrors.IsNotFound(getErr) {
+				// The node was deleted after being tainted; the remediation pipeline completed.
+				t.Logf("Node %s no longer exists; termination handler pipeline remediated it (taint applied then Machine deleted)", spotNode.Name)
+				return true, nil
+			}
+			if getErr != nil {
+				// Transient error talking to the guest API server; keep polling.
+				t.Logf("Transient error getting node %s, retrying: %v", spotNode.Name, getErr)
+				return false, nil //nolint:nilerr
+			}
+			for _, taint := range node.Spec.Taints {
+				if taint.Key == rebalanceRecommendationTaintKey {
+					t.Logf("Node %s has rebalance recommendation taint %s with effect %s", spotNode.Name, taint.Key, taint.Effect)
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+		if err != nil {
+			t.Fatalf("timed out waiting for node %s to be tainted or remediated by the termination handler: %v", spotNode.Name, err)
+		}
 
 		// Step 7: Clean up - remove the SQS queue URL from spec
 		t.Logf("Cleaning up: removing SQS queue URL from HostedCluster spec")


### PR DESCRIPTION
### Why this fix is needed / What changes

- `TestSpotTerminationHandler` was a CI flake because step 6 waited up to
15 minutes, while the taint window is variable: long enough to pass on a quiet cluster, short enough to miss under CI load when the API server or controller queues are congested.

### Why the taint window is that short

- The `spotremediation` controller (HCCO) watches guest nodes and deletes the
backing CAPI Machine the moment it sees any `aws-node-termination-handler/*`
taint. This is intentional; it is how spot interruptions are remediated.
- The 5s poll interval in the old code reliably loses the race against a
sub-second controller reconcile, producing a `nodes not found` error that
`EventuallyObject` treats as transient and retries until the 15m deadline.

### Why "node not found" is the correct terminal state

- The NodePools in this test use the `enable-spot` annotation, which sets
the `interruptible-instance` label but does not set `SpotMarketOptions`;
these are ordinary on-demand instances. They cannot vanish independently of
our pipeline. When the node is gone, it means:

  `SQS event → NTH taint applied → spotremediation deleted the Machine → Node gone`

- That is the full success path. Observing the taint directly is also a valid
success (caught before deletion), but it is not required.

---

### Fix

- Replace the `EventuallyObject` call in step 6 with
`wait.PollUntilContextTimeout` (same pattern as `autoscaling_test.go:435`).
Each poll tick accepts: taint present **or** node not found → success; any
other API error → transient retry; node present without taint → keep
polling. 
- A genuinely broken NTH (node stays alive, no taint) still exhausts
the 15m timeout and fails correctly.

- Net change: two imports, one rewritten poll block, distinct log lines per
success branch so CI readers can tell which path passed.

### Special notes for the reviewer:
- The EventuallyObject replacement is not just a style choice; it's structurally required. EventuallyObject cannot express "not-found = success" because its getter contract treats any error as a transient retry, and the predicate layer panics on a zero object. 
- There is no way to signal "done" through a fetch error in that API. `wait.PollUntilContextTimeout` is the minimal alternative that lets a single tick inspect the error type and return true from it.

- "Why not just handle it inside the predicate?" 
  - The predicate never runs if the getter errors, so there's nowhere to put the IsNotFound check within EventuallyObject.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] make verify, make test - [PASS]
- [x] go test ./control-plane-operator/hostedclusterconfigoperator/controllers/spotremediation/... [PASS] 
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for spot node termination handling.
  * Validation now recognizes node deletion or the exact rebalance recommendation taint as successful remediation outcomes.
  * Not-found responses are treated as completed remediation, while other API errors are retried.
  * Tests continue to fail when remediation does not complete within the timeout.
  * Improved handling of asynchronous remediation outcomes for more reliable validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->