### PR TITLE
NO-JIRA: test(backuprestore): enable SnapshotMoveData in backup configurations

### DIFF
--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -210,6 +211,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 				HCNamespace:       testCtx.ClusterNamespace,
 				StorageLocation:   testCtx.ClusterName,
 				IncludeNamespaces: platformCfg.additionalNamespaces,
+				SnapshotMoveData:  ptr.To(true),
 			}
 			err = backuprestore.RunOADPSchedule(testCtx.Context, GinkgoLogr.WithName("backup-restore"), testCtx.ArtifactDir, scheduleOpts)
 			Expect(err).NotTo(HaveOccurred())
@@ -233,6 +235,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 				HCNamespace:       testCtx.ClusterNamespace,
 				StorageLocation:   testCtx.ClusterName,
 				IncludeNamespaces: platformCfg.additionalNamespaces,
+				SnapshotMoveData:  ptr.To(true),
 			}
 			err = backuprestore.RunOADPBackup(testCtx.Context, GinkgoLogr.WithName("backup-restore"), testCtx.ArtifactDir, backupOpts)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## What this PR does / why we need it:

Add SnapshotMoveData flag to scheduled backup, backup-restore, and etcd snapshot backup test options.

Tests snapshot data migration functionality during backup operations.

This is in line with our docs that recommend using the snapshotMoveData, see [docs](https://hypershift.pages.dev/how-to/disaster-recovery/methods/oadp/)

## Which issue(s) this PR fixes:
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved backup and restore test coverage for snapshot data movement.
  * Added validation that backup storage is ready before scheduled and snapshot backups begin.
  * Expanded etcd snapshot testing for supported AWS and Azure environments, while excluding unsupported platforms.
  * Updated schedule checks to confirm that backups are created successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->