### PR TITLE
[release-5.0] OCPBUGS-114435: fix(konnectivity): enable --sync-forever to restore lost agent-server tunnels

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/AROSwift/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/AROSwift/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 12905ab0076d334392ac03961f017375c5b825ce48143a439114d045a392b54f
+    hypershift.openshift.io/desired-state-hash: de36575be3d464cfd2dbc3740388589bab3c302f2fb6cba4d5442f251f4ada26
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: konnectivity-agent
@@ -100,6 +100,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-forever
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/GCP/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/GCP/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 899eca11e0ecf38e53d71dd11dfed3baf50f339b47d559c7c2afc8a1b1795492
+    hypershift.openshift.io/desired-state-hash: 7be4bbfe10bcc0e28780ffc6c06d0f425cd78d7e921a43f190627a42d257c3f1
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: konnectivity-agent
@@ -100,6 +100,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-forever
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/IBMCloud/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/IBMCloud/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 12905ab0076d334392ac03961f017375c5b825ce48143a439114d045a392b54f
+    hypershift.openshift.io/desired-state-hash: de36575be3d464cfd2dbc3740388589bab3c302f2fb6cba4d5442f251f4ada26
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: konnectivity-agent
@@ -100,6 +100,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-forever
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/ModernTLS/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/ModernTLS/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 12905ab0076d334392ac03961f017375c5b825ce48143a439114d045a392b54f
+    hypershift.openshift.io/desired-state-hash: de36575be3d464cfd2dbc3740388589bab3c302f2fb6cba4d5442f251f4ada26
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: konnectivity-agent
@@ -100,6 +100,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-forever
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 12905ab0076d334392ac03961f017375c5b825ce48143a439114d045a392b54f
+    hypershift.openshift.io/desired-state-hash: de36575be3d464cfd2dbc3740388589bab3c302f2fb6cba4d5442f251f4ada26
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: konnectivity-agent
@@ -100,6 +100,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-forever
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 12905ab0076d334392ac03961f017375c5b825ce48143a439114d045a392b54f
+    hypershift.openshift.io/desired-state-hash: de36575be3d464cfd2dbc3740388589bab3c302f2fb6cba4d5442f251f4ada26
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: konnectivity-agent
@@ -100,6 +100,7 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        - --sync-forever
         - --v
         - "3"
         - --agent-identifiers

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/konnectivity-agent/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/konnectivity-agent/deployment.yaml
@@ -39,6 +39,10 @@ spec:
         - 5s
         - --sync-interval-cap
         - 30s
+        # --sync-forever is a stopgap until the OCP fork rebases upstream PR
+        # https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/643,
+        # which adds lease-based server counting (--count-server-leases).
+        - --sync-forever
         - --v
         - "3"
         command:

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
@@ -159,6 +159,10 @@ func buildKonnectivityWorkerAgentContainer(image, host string, port int32, proxy
 			"5s",
 			"--sync-interval-cap",
 			"30s",
+			// --sync-forever is a stopgap until the OCP fork rebases upstream PR
+			// https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/643,
+			// which adds lease-based server counting (--count-server-leases).
+			"--sync-forever",
 			"--v",
 			"3",
 		}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile_test.go
@@ -1,0 +1,39 @@
+package konnectivity
+
+import (
+	"slices"
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestReconcileAgentDaemonSet(t *testing.T) {
+	testCases := []struct {
+		name string
+	}{
+		{
+			name: "When ReconcileAgentDaemonSet is called, it should include --sync-forever in the agent args",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			daemonset := &appsv1.DaemonSet{}
+			params := &KonnectivityParams{
+				Image:           "konnectivity-agent-image",
+				ExternalAddress: "konnectivity-server",
+				ExternalPort:    8091,
+			}
+
+			ReconcileAgentDaemonSet(daemonset, params, hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform}, configv1.ProxyStatus{})
+
+			args := daemonset.Spec.Template.Spec.Containers[0].Args
+			if !slices.Contains(args, "--sync-forever") {
+				t.Errorf("expected konnectivity-agent container args to contain --sync-forever, got: %v", args)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Manual cherry-pick of #9260 to release-5.0 (Jira OCPBUGS-114435).

The automated cherrypick-robot did not produce a PR for this branch — the `/jira backport` command's leading comma caused an empty `/cherrypick` invocation to error out, and no PR was ever opened for release-5.0.

Cherry-pick applied cleanly, no conflicts.

Original PR: #9260