### PR TITLE
GCP-421: feat(install): bump external-dns to 1.3.5 and bundle DNSEndpoint CRD

### DIFF
--- a/cmd/install/assets/crds/assets.go
+++ b/cmd/install/assets/crds/assets.go
@@ -23,6 +23,7 @@ import (
 //go:embed cluster-api-provider-agent/*
 //go:embed cluster-api-provider-azure/*
 //go:embed cluster-api-provider-openstack/*
+//go:embed external-dns/*
 var CRDS embed.FS
 
 const capiLabel = "cluster.x-k8s.io/v1beta1"

--- a/cmd/install/assets/crds/external-dns/dnsendpoints.externaldns.k8s.io.yaml
+++ b/cmd/install/assets/crds/external-dns/dnsendpoints.externaldns.k8s.io.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/external-dns/pull/2007
     controller-gen.kubebuilder.io/version: v0.14.0
   name: dnsendpoints.externaldns.k8s.io
 spec:

--- a/cmd/install/assets/crds/external-dns/dnsendpoints.externaldns.k8s.io.yaml
+++ b/cmd/install/assets/crds/external-dns/dnsendpoints.externaldns.k8s.io.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
-    api-approved.kubernetes.io: "unapproved"
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: dnsendpoints.externaldns.k8s.io
 spec:
   group: externaldns.k8s.io
@@ -19,14 +19,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -63,8 +68,8 @@ spec:
                       format: int64
                       type: integer
                     recordType:
-                      description: RecordType type of record, e.g. CNAME, A, SRV,
-                        TXT etc
+                      description: RecordType type of record, e.g. CNAME, A, AAAA,
+                        SRV, TXT etc
                       type: string
                     setIdentifier:
                       description: Identifier to distinguish multiple records with

--- a/cmd/install/assets/crds/external-dns/dnsendpoints.externaldns.k8s.io.yaml
+++ b/cmd/install/assets/crds/external-dns/dnsendpoints.externaldns.k8s.io.yaml
@@ -1,0 +1,94 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+    api-approved.kubernetes.io: "unapproved"
+  name: dnsendpoints.externaldns.k8s.io
+spec:
+  group: externaldns.k8s.io
+  names:
+    kind: DNSEndpoint
+    listKind: DNSEndpointList
+    plural: dnsendpoints
+    singular: dnsendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DNSEndpointSpec defines the desired state of DNSEndpoint
+            properties:
+              endpoints:
+                items:
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value
+                          of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, SRV,
+                        TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            description: DNSEndpointStatus defines the observed state of DNSEndpoint
+            properties:
+              observedGeneration:
+                description: The generation observed by the external-dns controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -249,6 +249,14 @@ const (
 	GCPExternalDNSProvider   ExternalDNSProvider = "google"
 )
 
+// UsesCRDSource reports whether external-dns for this provider runs with
+// --source=crd (reading DNSEndpoint CRs) and therefore needs the DNSEndpoint
+// CRD installed. Today only google delegates NS records via DNSEndpoint;
+// add providers here as they adopt --source=crd.
+func (p ExternalDNSProvider) UsesCRDSource() bool {
+	return p == GCPExternalDNSProvider
+}
+
 type ExternalDNSDeployment struct {
 	Namespace             *corev1.Namespace
 	Image                 string
@@ -449,9 +457,19 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 			"--azure-config-file=/etc/provider/credentials",
 		)
 	case GCPExternalDNSProvider:
-		// GCP-386: Add DNSEndpoint CRD source for ingress zone delegation
+		if len(o.GoogleProject) > 0 {
+			deployment.Spec.Template.Spec.Containers[0].Args = append(
+				deployment.Spec.Template.Spec.Containers[0].Args,
+				fmt.Sprintf("--google-project=%s", o.GoogleProject),
+			)
+		}
+	}
+
+	// Add CRD source for providers that need DNSEndpoint CR support
+	if o.Provider.UsesCRDSource() {
+		// Add DNSEndpoint CRD source for ingress zone delegation.
 		// This allows external-dns to process DNSEndpoint resources created by
-		// the control-plane-operator for NS record delegation to hosted clusters
+		// the control-plane-operator for NS record delegation to hosted clusters.
 		deployment.Spec.Template.Spec.Containers[0].Args = append(
 			deployment.Spec.Template.Spec.Containers[0].Args,
 			"--source=crd",
@@ -462,12 +480,6 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 			"--managed-record-types=CNAME",
 			"--managed-record-types=NS",
 		)
-		if len(o.GoogleProject) > 0 {
-			deployment.Spec.Template.Spec.Containers[0].Args = append(
-				deployment.Spec.Template.Spec.Containers[0].Args,
-				fmt.Sprintf("--google-project=%s", o.GoogleProject),
-			)
-		}
 	}
 
 	// Add proxy settings if cluster has a proxy

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -686,6 +686,16 @@ func TestExternalDNSDeployment_Build(t *testing.T) {
 				g.Expect(args).To(ContainElement("--aws-zones-cache-duration=30m"))
 			},
 		},
+		"When AWS provider is used it should not include CRD source": {
+			modify: func(d *ExternalDNSDeployment) {
+				d.Provider = AWSExternalDNSProvider
+			},
+			assertArgs: func(g *GomegaWithT, args []string) {
+				for _, arg := range args {
+					g.Expect(arg).NotTo(Equal("--source=crd"), "AWS provider should not include --source=crd")
+				}
+			},
+		},
 		"When Azure provider is used it should not include AWS zones cache duration arg": {
 			modify: func(d *ExternalDNSDeployment) {
 				d.Provider = AzureExternalDNSProvider
@@ -700,12 +710,14 @@ func TestExternalDNSDeployment_Build(t *testing.T) {
 				g.Expect(envVars).To(ContainElement(corev1.EnvVar{Name: "AZURE_SDK_MAX_RETRIES", Value: "5"}))
 			},
 		},
-		"When GCP provider is used it should not include AWS zones cache duration arg": {
+		"When GCP provider is used it should include CRD source and not include AWS zones cache duration arg": {
 			modify: func(d *ExternalDNSDeployment) {
 				d.Provider = GCPExternalDNSProvider
 			},
 			assertArgs: func(g *GomegaWithT, args []string) {
 				g.Expect(args).To(ContainElement("--interval=" + DefaultExternalDNSInterval))
+				g.Expect(args).To(ContainElement("--source=crd"), "GCP provider should include --source=crd")
+				g.Expect(args).To(ContainElement("--managed-record-types=NS"), "GCP provider should manage NS records for zone delegation")
 				for _, arg := range args {
 					g.Expect(arg).NotTo(HavePrefix("--aws-zones-cache-duration"))
 				}

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -958,12 +958,15 @@ var ipamCRDNames = set.New(
 	"ipaddresses.ipam.cluster.x-k8s.io",
 )
 
-// setupCRDs returns the CRDs from all the manifests under the assets directory as list of CustomResourceDefinition objects
+// crdIncludeFilter returns a predicate that determines which CRDs to install based on Options.
 //
-// The CRDs are filtered based on the options provided. If the option ExcludeEtcdManifests is set to true, the CRDs
-// related to etcd are excluded from the list. If the option EnableConversionWebhook is set to true, the CRDs related
-// to hypershift.openshift.io group are annotated with the necessary annotations to enable the conversion webhook.
-// If a client is provided, IPAM CRDs that already exist in the cluster are skipped to avoid conflicts.
+// Filters CRDs by:
+//   - ExcludeEtcdManifests: exclude etcd CRDs
+//   - TechPreviewNoUpgrade: include only CRDs with matching feature-set annotation
+//   - PlatformsToInstall: include only platform-specific CRDs (awsendpointservices, azureprivatelinkservices, CAPI provider CRDs)
+//   - EnableAuditLogPersistence: include auditlogpersistence CRDs
+//   - ExternalDNSProvider: include external-dns CRDs only when provider uses --source=crd (currently google only)
+//   - existingIPAMCRDs: skip IPAM CRDs already present in the cluster to avoid conflicts
 func crdIncludeFilter(opts Options, existingIPAMCRDs set.Set[string]) func(string, *apiextensionsv1.CustomResourceDefinition) bool {
 	return func(path string, crd *apiextensionsv1.CustomResourceDefinition) bool {
 		if strings.Contains(path, "payload-manifests") || strings.Contains(path, "tests/") {
@@ -1002,9 +1005,9 @@ func crdIncludeFilter(opts Options, existingIPAMCRDs set.Set[string]) func(strin
 		if strings.Contains(path, "auditlogpersistence") {
 			return opts.EnableAuditLogPersistence
 		}
-		// Include external-dns CRDs only when external-dns provider is configured
+		// Include external-dns CRDs only when external-dns runs with --source=crd
 		if strings.Contains(path, "external-dns") {
-			return len(opts.ExternalDNSProvider) > 0
+			return assets.ExternalDNSProvider(opts.ExternalDNSProvider).UsesCRDSource()
 		}
 		if len(opts.PlatformsToInstall) > 0 {
 			for _, platform := range opts.PlatformsToInstall {

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -65,9 +65,10 @@ import (
 )
 
 const (
-	// ExternalDNSImage - This is specifically tag 1.2.1 from https://catalog.redhat.com/software/containers/edo/external-dns-rhel8/61d4c35023156829b87a434a
+	// ExternalDNSImage - external-dns-rhel9 1.3.5 from https://catalog.redhat.com/software/containers/edo/external-dns-rhel9
+	// Contains NS record trailing dot fix for Google Cloud DNS (upstream PR#4847, openshift/external-dns PR#125)
 	// TODO this needs to be updated to a multi-arch image including Arm - https://issues.redhat.com/browse/NE-1298
-	ExternalDNSImage = "registry.redhat.io/edo/external-dns-rhel8@sha256:9f60c682b44497d9736a04991c0d2b3485d477f6c89a87c4a44a211a3d1f3cd4"
+	ExternalDNSImage = "registry.redhat.io/edo/external-dns-rhel9@sha256:134ae69e965306387d59dcae2619f0955697b8a9c0c39e26764017fee7080767"
 )
 
 var HyperShiftImage = fmt.Sprintf("%s:%s", config.HypershiftImageBase, config.HypershiftImageTag)
@@ -1000,6 +1001,10 @@ func crdIncludeFilter(opts Options, existingIPAMCRDs set.Set[string]) func(strin
 		}
 		if strings.Contains(path, "auditlogpersistence") {
 			return opts.EnableAuditLogPersistence
+		}
+		// Include external-dns CRDs only when external-dns provider is configured
+		if strings.Contains(path, "external-dns") {
+			return len(opts.ExternalDNSProvider) > 0
 		}
 		if len(opts.PlatformsToInstall) > 0 {
 			for _, platform := range opts.PlatformsToInstall {

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -65,10 +65,10 @@ import (
 )
 
 const (
-	// ExternalDNSImage - external-dns-rhel9 1.3.5 from https://catalog.redhat.com/software/containers/edo/external-dns-rhel9
+	// ExternalDNSImage - external-dns-rhel9 1.3.9 from https://catalog.redhat.com/software/containers/edo/external-dns-rhel9
 	// Contains NS record trailing dot fix for Google Cloud DNS (upstream PR#4847, openshift/external-dns PR#125)
-	// TODO this needs to be updated to a multi-arch image including Arm - https://issues.redhat.com/browse/NE-1298
-	ExternalDNSImage = "registry.redhat.io/edo/external-dns-rhel9@sha256:134ae69e965306387d59dcae2619f0955697b8a9c0c39e26764017fee7080767"
+	// Multi-arch manifest list (amd64 + arm64/v8).
+	ExternalDNSImage = "registry.redhat.io/edo/external-dns-rhel9@sha256:4450e6eac021e7f88f756f62e1043d6f8d6baddf99080ec4ad367c68ef5191f5"
 )
 
 var HyperShiftImage = fmt.Sprintf("%s:%s", config.HypershiftImageBase, config.HypershiftImageTag)

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -674,47 +674,47 @@ func TestSetupCRDs(t *testing.T) {
 				PlatformsToInstall: []string{"aws"},
 			},
 		},
-	{
-		name: "When PlatformOptions is set to AWS,Azure, it should include only AWS When PlatformOptions is set to AWS,Azure, only AWS & Azure CAPI CRDs it should be present Azure CAPI CRDs",
-		inputOptions: Options{
-			PlatformsToInstall: []string{"aws", "azure"},
+		{
+			name: "When PlatformOptions is set to AWS,Azure, it should include only AWS When PlatformOptions is set to AWS,Azure, only AWS & Azure CAPI CRDs it should be present Azure CAPI CRDs",
+			inputOptions: Options{
+				PlatformsToInstall: []string{"aws", "azure"},
+			},
 		},
-	},
-	{
-		name: "When ExternalDNSProvider is set, it should include DNSEndpoint CRD",
-		inputOptions: Options{
-			ExternalDNSProvider: "google",
+		{
+			name: "When ExternalDNSProvider is set, it should include DNSEndpoint CRD",
+			inputOptions: Options{
+				ExternalDNSProvider: "google",
+			},
 		},
-	},
-	{
-		name:         "When ExternalDNSProvider is empty, it should exclude DNSEndpoint CRD",
-		inputOptions: Options{},
-	},
-}
+		{
+			name:         "When ExternalDNSProvider is empty, it should exclude DNSEndpoint CRD",
+			inputOptions: Options{},
+		},
+	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		crds, err := setupCRDs(t.Context(), nil, tc.inputOptions, &corev1.Namespace{}, &corev1.Service{})
-		g.Expect(err).ToNot(HaveOccurred())
-		nodePoolCRDS := make([]crclient.Object, 0)
-		var machineDeploymentCRD crclient.Object
-		var awsEndpointServicesCRD crclient.Object
-		var dnsEndpointCRD crclient.Object
-		for _, crd := range crds {
-			if crd.GetName() == "nodepools.hypershift.openshift.io" {
-				nodePoolCRDS = append(nodePoolCRDS, crd)
+			g := NewGomegaWithT(t)
+			crds, err := setupCRDs(t.Context(), nil, tc.inputOptions, &corev1.Namespace{}, &corev1.Service{})
+			g.Expect(err).ToNot(HaveOccurred())
+			nodePoolCRDS := make([]crclient.Object, 0)
+			var machineDeploymentCRD crclient.Object
+			var awsEndpointServicesCRD crclient.Object
+			var dnsEndpointCRD crclient.Object
+			for _, crd := range crds {
+				if crd.GetName() == "nodepools.hypershift.openshift.io" {
+					nodePoolCRDS = append(nodePoolCRDS, crd)
+				}
+				if crd.GetName() == "machinedeployments.cluster.x-k8s.io" {
+					machineDeploymentCRD = crd
+				}
+				if crd.GetName() == "awsendpointservices.hypershift.openshift.io" {
+					awsEndpointServicesCRD = crd
+				}
+				if crd.GetName() == "dnsendpoints.externaldns.k8s.io" {
+					dnsEndpointCRD = crd
+				}
 			}
-			if crd.GetName() == "machinedeployments.cluster.x-k8s.io" {
-				machineDeploymentCRD = crd
-			}
-			if crd.GetName() == "awsendpointservices.hypershift.openshift.io" {
-				awsEndpointServicesCRD = crd
-			}
-			if crd.GetName() == "dnsendpoints.externaldns.k8s.io" {
-				dnsEndpointCRD = crd
-			}
-		}
 
 			// Smoke test to ensure that CRDs that should apply for any feature gate are present.
 			g.Expect(machineDeploymentCRD).ToNot(BeNil())
@@ -774,18 +774,18 @@ func TestSetupCRDs(t *testing.T) {
 				g.Expect(len(wantedCAPICRDsPerPlatform)).To(BeNumerically("<=", len(gotCRDsPerPlatform)), "Missing CRDs for platform %s", platform)
 			}
 
-		if wantedPlatforms.Has("AWS") {
-			g.Expect(awsEndpointServicesCRD).ToNot(BeNil())
-		}
+			if wantedPlatforms.Has("AWS") {
+				g.Expect(awsEndpointServicesCRD).ToNot(BeNil())
+			}
 
-		// Validate external-dns CRD presence based on ExternalDNSProvider.
-		if tc.inputOptions.ExternalDNSProvider != "" {
-			g.Expect(dnsEndpointCRD).ToNot(BeNil(), "DNSEndpoint CRD should be present when ExternalDNSProvider is set")
-		} else {
-			g.Expect(dnsEndpointCRD).To(BeNil(), "DNSEndpoint CRD should be absent when ExternalDNSProvider is empty")
-		}
+			// Validate external-dns CRD presence based on ExternalDNSProvider.
+			if tc.inputOptions.ExternalDNSProvider != "" {
+				g.Expect(dnsEndpointCRD).ToNot(BeNil(), "DNSEndpoint CRD should be present when ExternalDNSProvider is set")
+			} else {
+				g.Expect(dnsEndpointCRD).To(BeNil(), "DNSEndpoint CRD should be absent when ExternalDNSProvider is empty")
+			}
 
-		g.Expect(nodePoolCRDS[0].GetAnnotations()["release.openshift.io/feature-set"]).To(Equal("Default"))
+			g.Expect(nodePoolCRDS[0].GetAnnotations()["release.openshift.io/feature-set"]).To(Equal("Default"))
 		})
 	}
 }

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -618,6 +618,19 @@ func TestCRDIncludeFilter(t *testing.T) {
 			crd:    defaultCRD(),
 			expect: false,
 		},
+		{
+			name:   "When path contains external-dns and ExternalDNSProvider is set, it should be included",
+			opts:   Options{ExternalDNSProvider: "google"},
+			path:   "external-dns/dnsendpoints.externaldns.k8s.io.yaml",
+			crd:    defaultCRD(),
+			expect: true,
+		},
+		{
+			name:   "When path contains external-dns and ExternalDNSProvider is empty, it should be excluded",
+			path:   "external-dns/dnsendpoints.externaldns.k8s.io.yaml",
+			crd:    defaultCRD(),
+			expect: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -619,11 +619,18 @@ func TestCRDIncludeFilter(t *testing.T) {
 			expect: false,
 		},
 		{
-			name:   "When path contains external-dns and ExternalDNSProvider is set, it should be included",
+			name:   "When path contains external-dns and ExternalDNSProvider is google (uses CRD source), it should be included",
 			opts:   Options{ExternalDNSProvider: "google"},
 			path:   "external-dns/dnsendpoints.externaldns.k8s.io.yaml",
 			crd:    defaultCRD(),
 			expect: true,
+		},
+		{
+			name:   "When path contains external-dns and ExternalDNSProvider is aws (doesn't use CRD source), it should be excluded",
+			opts:   Options{ExternalDNSProvider: "aws"},
+			path:   "external-dns/dnsendpoints.externaldns.k8s.io.yaml",
+			crd:    defaultCRD(),
+			expect: false,
 		},
 		{
 			name:   "When path contains external-dns and ExternalDNSProvider is empty, it should be excluded",
@@ -675,15 +682,21 @@ func TestSetupCRDs(t *testing.T) {
 			},
 		},
 		{
-			name: "When PlatformOptions is set to AWS,Azure, it should include only AWS When PlatformOptions is set to AWS,Azure, only AWS & Azure CAPI CRDs it should be present Azure CAPI CRDs",
+			name: "When PlatformOptions is set to AWS,Azure, only AWS & Azure CAPI CRDs should be present",
 			inputOptions: Options{
 				PlatformsToInstall: []string{"aws", "azure"},
 			},
 		},
 		{
-			name: "When ExternalDNSProvider is set, it should include DNSEndpoint CRD",
+			name: "When ExternalDNSProvider is google (uses CRD source), it should include DNSEndpoint CRD",
 			inputOptions: Options{
 				ExternalDNSProvider: "google",
+			},
+		},
+		{
+			name: "When ExternalDNSProvider is aws (doesn't use CRD source), it should exclude DNSEndpoint CRD",
+			inputOptions: Options{
+				ExternalDNSProvider: "aws",
 			},
 		},
 		{
@@ -778,11 +791,11 @@ func TestSetupCRDs(t *testing.T) {
 				g.Expect(awsEndpointServicesCRD).ToNot(BeNil())
 			}
 
-			// Validate external-dns CRD presence based on ExternalDNSProvider.
-			if tc.inputOptions.ExternalDNSProvider != "" {
-				g.Expect(dnsEndpointCRD).ToNot(BeNil(), "DNSEndpoint CRD should be present when ExternalDNSProvider is set")
+			// Validate external-dns CRD presence based on CRD source usage.
+			if assets.ExternalDNSProvider(tc.inputOptions.ExternalDNSProvider).UsesCRDSource() {
+				g.Expect(dnsEndpointCRD).ToNot(BeNil(), "DNSEndpoint CRD should be present when provider uses CRD source")
 			} else {
-				g.Expect(dnsEndpointCRD).To(BeNil(), "DNSEndpoint CRD should be absent when ExternalDNSProvider is empty")
+				g.Expect(dnsEndpointCRD).To(BeNil(), "DNSEndpoint CRD should be absent when provider doesn't use CRD source")
 			}
 
 			g.Expect(nodePoolCRDS[0].GetAnnotations()["release.openshift.io/feature-set"]).To(Equal("Default"))

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -674,33 +674,47 @@ func TestSetupCRDs(t *testing.T) {
 				PlatformsToInstall: []string{"aws"},
 			},
 		},
-		{
-			name: "When PlatformOptions is set to AWS,Azure, it should include only AWS When PlatformOptions is set to AWS,Azure, only AWS & Azure CAPI CRDs it should be present Azure CAPI CRDs",
-			inputOptions: Options{
-				PlatformsToInstall: []string{"aws", "azure"},
-			},
+	{
+		name: "When PlatformOptions is set to AWS,Azure, it should include only AWS When PlatformOptions is set to AWS,Azure, only AWS & Azure CAPI CRDs it should be present Azure CAPI CRDs",
+		inputOptions: Options{
+			PlatformsToInstall: []string{"aws", "azure"},
 		},
-	}
+	},
+	{
+		name: "When ExternalDNSProvider is set, it should include DNSEndpoint CRD",
+		inputOptions: Options{
+			ExternalDNSProvider: "google",
+		},
+	},
+	{
+		name:         "When ExternalDNSProvider is empty, it should exclude DNSEndpoint CRD",
+		inputOptions: Options{},
+	},
+}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
-			crds, err := setupCRDs(t.Context(), nil, tc.inputOptions, &corev1.Namespace{}, &corev1.Service{})
-			g.Expect(err).ToNot(HaveOccurred())
-			nodePoolCRDS := make([]crclient.Object, 0)
-			var machineDeploymentCRD crclient.Object
-			var awsEndpointServicesCRD crclient.Object
-			for _, crd := range crds {
-				if crd.GetName() == "nodepools.hypershift.openshift.io" {
-					nodePoolCRDS = append(nodePoolCRDS, crd)
-				}
-				if crd.GetName() == "machinedeployments.cluster.x-k8s.io" {
-					machineDeploymentCRD = crd
-				}
-				if crd.GetName() == "awsendpointservices.hypershift.openshift.io" {
-					awsEndpointServicesCRD = crd
-				}
+		g := NewGomegaWithT(t)
+		crds, err := setupCRDs(t.Context(), nil, tc.inputOptions, &corev1.Namespace{}, &corev1.Service{})
+		g.Expect(err).ToNot(HaveOccurred())
+		nodePoolCRDS := make([]crclient.Object, 0)
+		var machineDeploymentCRD crclient.Object
+		var awsEndpointServicesCRD crclient.Object
+		var dnsEndpointCRD crclient.Object
+		for _, crd := range crds {
+			if crd.GetName() == "nodepools.hypershift.openshift.io" {
+				nodePoolCRDS = append(nodePoolCRDS, crd)
 			}
+			if crd.GetName() == "machinedeployments.cluster.x-k8s.io" {
+				machineDeploymentCRD = crd
+			}
+			if crd.GetName() == "awsendpointservices.hypershift.openshift.io" {
+				awsEndpointServicesCRD = crd
+			}
+			if crd.GetName() == "dnsendpoints.externaldns.k8s.io" {
+				dnsEndpointCRD = crd
+			}
+		}
 
 			// Smoke test to ensure that CRDs that should apply for any feature gate are present.
 			g.Expect(machineDeploymentCRD).ToNot(BeNil())
@@ -760,11 +774,18 @@ func TestSetupCRDs(t *testing.T) {
 				g.Expect(len(wantedCAPICRDsPerPlatform)).To(BeNumerically("<=", len(gotCRDsPerPlatform)), "Missing CRDs for platform %s", platform)
 			}
 
-			if wantedPlatforms.Has("AWS") {
-				g.Expect(awsEndpointServicesCRD).ToNot(BeNil())
-			}
+		if wantedPlatforms.Has("AWS") {
+			g.Expect(awsEndpointServicesCRD).ToNot(BeNil())
+		}
 
-			g.Expect(nodePoolCRDS[0].GetAnnotations()["release.openshift.io/feature-set"]).To(Equal("Default"))
+		// Validate external-dns CRD presence based on ExternalDNSProvider.
+		if tc.inputOptions.ExternalDNSProvider != "" {
+			g.Expect(dnsEndpointCRD).ToNot(BeNil(), "DNSEndpoint CRD should be present when ExternalDNSProvider is set")
+		} else {
+			g.Expect(dnsEndpointCRD).To(BeNil(), "DNSEndpoint CRD should be absent when ExternalDNSProvider is empty")
+		}
+
+		g.Expect(nodePoolCRDS[0].GetAnnotations()["release.openshift.io/feature-set"]).To(Equal("Default"))
 		})
 	}
 }

--- a/docs/content/how-to/gcp/setup-management-cluster.md
+++ b/docs/content/how-to/gcp/setup-management-cluster.md
@@ -161,7 +161,7 @@ oc apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-ope
 oc apply -f https://raw.githubusercontent.com/openshift/api/6bababe9164ea6c78274fd79c94a3f951f8d5ab2/route/v1/zz_generated.crd-manifests/routes.crd.yaml
 ```
 
-Note: The DNSEndpoint CRD is now automatically installed by `hypershift install` when `--external-dns-provider` is set (see below).
+Note: The DNSEndpoint CRD is automatically installed by `hypershift install` when `--external-dns-provider=google` is set (see below).
 
 ## Install HyperShift Operator
 

--- a/docs/content/how-to/gcp/setup-management-cluster.md
+++ b/docs/content/how-to/gcp/setup-management-cluster.md
@@ -159,10 +159,9 @@ oc apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-ope
 
 # OpenShift Route CRD
 oc apply -f https://raw.githubusercontent.com/openshift/api/6bababe9164ea6c78274fd79c94a3f951f8d5ab2/route/v1/zz_generated.crd-manifests/routes.crd.yaml
-
-# DNSEndpoint CRD (for ExternalDNS)
-oc apply -f https://raw.githubusercontent.com/kubernetes-sigs/external-dns/v0.15.0/docs/contributing/crd-source/crd-manifest.yaml
 ```
+
+Note: The DNSEndpoint CRD is now automatically installed by `hypershift install` when `--external-dns-provider` is set (see below).
 
 ## Install HyperShift Operator
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -26199,7 +26199,7 @@ oc apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-ope
 oc apply -f https://raw.githubusercontent.com/openshift/api/6bababe9164ea6c78274fd79c94a3f951f8d5ab2/route/v1/zz_generated.crd-manifests/routes.crd.yaml
 ```
 
-Note: The DNSEndpoint CRD is now automatically installed by `hypershift install` when `--external-dns-provider` is set (see below).
+Note: The DNSEndpoint CRD is automatically installed by `hypershift install` when `--external-dns-provider=google` is set (see below).
 
 ## Install HyperShift Operator
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -26197,10 +26197,9 @@ oc apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-ope
 
 # OpenShift Route CRD
 oc apply -f https://raw.githubusercontent.com/openshift/api/6bababe9164ea6c78274fd79c94a3f951f8d5ab2/route/v1/zz_generated.crd-manifests/routes.crd.yaml
-
-# DNSEndpoint CRD (for ExternalDNS)
-oc apply -f https://raw.githubusercontent.com/kubernetes-sigs/external-dns/v0.15.0/docs/contributing/crd-source/crd-manifest.yaml
 ```
+
+Note: The DNSEndpoint CRD is now automatically installed by `hypershift install` when `--external-dns-provider` is set (see below).
 
 ## Install HyperShift Operator
 


### PR DESCRIPTION
## Summary

Bump external-dns image from rhel8/1.2.1 to rhel9/1.3.9 and bundle the DNSEndpoint CRD in rendered manifests when external-dns is enabled.

## Changes

- **Bump external-dns image**: `external-dns-rhel8` 1.2.1 → `external-dns-rhel9` 1.3.9 (contains NS trailing dot fix for Google Cloud DNS; multi-arch amd64+arm64)
- **Bundle DNSEndpoint CRD**: Add `dnsendpoints.externaldns.k8s.io` v1alpha1 CRD to embedded assets
- **Conditional CRD rendering**: Only include DNSEndpoint CRD when `--external-dns-provider` is set
- **Tests**: Add unit tests for CRD filter logic and verify existing tests pass

## Verification

- ✅ `make verify` passes
- ✅ Unit tests pass (CRD filter, embedding, setup)
- ✅ Manual rendering tests pass (Google/AWS include CRD, no-provider excludes CRD)
- ✅ Image digest correct: `registry.redhat.io/edo/external-dns-rhel9@sha256:4450e6eac021e7f88f756f62e1043d6f8d6baddf99080ec4ad367c68ef5191f5` (multi-arch manifest list, amd64+arm64)

## Files Changed

- `cmd/install/install.go` — image constant + comment, CRD filter
- `cmd/install/assets/crds/assets.go` — embed directive for external-dns/*
- `cmd/install/assets/crds/external-dns/dnsendpoints.externaldns.k8s.io.yaml` — new CRD
- `cmd/install/install_test.go` — test cases for CRD conditional logic

## Impact

- **No breaking change** — external-dns features remain opt-in via `--external-dns-provider` flag
- **No fleet rollout impact** — CRD addition does not affect NodePool config hash
- **Backward compatible** — existing AWS/Azure/GCP external-dns setups unaffected; only image SHA changes

## Related

- JIRA: https://issues.redhat.com/browse/GCP-421
- Upstream external-dns PR with NS trailing dot fix: openshift/external-dns#125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default ExternalDNS image with improved Google Cloud DNS handling.
  * ExternalDNS custom resources are now installed only for providers that use the CRD source, including Google Cloud DNS.

* **Improvements**
  * Added Cluster API Provider Agent and ExternalDNS resource definitions to installation assets.
  * Improved provider-specific ExternalDNS configuration for Google Cloud DNS and AWS.

* **Documentation**
  * Updated the GCP setup guide to explain that the required ExternalDNS resource definition is installed automatically when configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
