### PR TITLE
OCPBUGS-109595: use RetryWatcher and TCP keepalive for create-guests watch resilience

### DIFF
--- a/test/e2e/v2/cmd/create-guests/main.go
+++ b/test/e2e/v2/cmd/create-guests/main.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -46,9 +47,12 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	toolswatch "k8s.io/client-go/tools/watch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -323,6 +327,10 @@ func newMgmtClient() (crclient.WithWatch, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting management cluster kubeconfig: %w", err)
 	}
+	restConfig.Dial = (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext
 	return crclient.NewWithWatch(restConfig, crclient.Options{Scheme: scheme})
 }
 
@@ -393,56 +401,35 @@ func waitForVersionRollout(ctx context.Context, cl crclient.WithWatch, cfg envCo
 }
 
 func watchForCondition(ctx context.Context, cl crclient.WithWatch, namespace, name string, predicate func(*hyperv1.HostedCluster) bool) error {
-	key := crclient.ObjectKey{Namespace: namespace, Name: name}
-	hc := &hyperv1.HostedCluster{}
-
-	for {
-		if err := cl.Get(ctx, key, hc); err == nil {
-			if predicate(hc) {
-				return nil
-			}
-		}
-
-		hcList := &hyperv1.HostedClusterList{}
-		watcher, err := cl.Watch(ctx, hcList,
-			crclient.InNamespace(namespace),
-			crclient.MatchingFields{"metadata.name": name},
-		)
-		if err != nil {
-			return fmt.Errorf("starting watch for %s/%s: %w", namespace, name, err)
-		}
-
-		closed := false
-		for !closed {
-			select {
-			case <-ctx.Done():
-				watcher.Stop()
-				return fmt.Errorf("timed out waiting for %s/%s: %w", namespace, name, ctx.Err())
-			case event, ok := <-watcher.ResultChan():
-				if !ok {
-					closed = true
-					break
-				}
-				if event.Type == watch.Error {
-					closed = true
-					break
-				}
-				if event.Type != watch.Added && event.Type != watch.Modified {
-					continue
-				}
-				watchedHC, ok := event.Object.(*hyperv1.HostedCluster)
-				if !ok {
-					continue
-				}
-				logClusterProgress(watchedHC)
-				if predicate(watchedHC) {
-					watcher.Stop()
-					return nil
-				}
-			}
-		}
-		watcher.Stop()
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", name).String()
+	lw := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = fieldSelector
+			list := &hyperv1.HostedClusterList{}
+			err := cl.List(ctx, list, &crclient.ListOptions{Raw: &opts, Namespace: namespace})
+			return list, err
+		},
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = fieldSelector
+			list := &hyperv1.HostedClusterList{}
+			return cl.Watch(ctx, list, &crclient.ListOptions{Raw: &opts, Namespace: namespace})
+		},
 	}
+
+	_, err := toolswatch.UntilWithSync(ctx, lw, &hyperv1.HostedCluster{}, nil,
+		func(event watch.Event) (bool, error) {
+			hc, ok := event.Object.(*hyperv1.HostedCluster)
+			if !ok || hc == nil {
+				return false, nil
+			}
+			logClusterProgress(hc)
+			return predicate(hc), nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("waiting for %s/%s: %w", namespace, name, err)
+	}
+	return nil
 }
 
 func logClusterProgress(hc *hyperv1.HostedCluster) {


### PR DESCRIPTION
The hand-rolled watchForCondition loop re-creates watches when the channel closes, but if cl.Watch() itself returns a transient error when establishing the new watch connection, it propagates as a hard failure and terminates the entire CI job. Azure load-balancer idle-timeout drops trigger it: the TCP connection dies after ~4min idle, and the reconnection attempt fails before a new connection is established.

Two changes fix this:

1. TCP keepalive (30s) on the management client rest.Config sends probes that prevent idle connection reaping before the Azure timeout fires.

2. Replace the hand-rolled watch loop with client-go's toolswatch.UntilWithSync, which uses RetryWatcher internally to re-establish watches on any error (connection drops, timeouts, 410 Gone) with backoff.

Out of scope: transport-level retry of write operations and application-level CreateOrUpdate recovery. The hook calls (phases 1, 3, 5, 7) are short-lived requests that aren't susceptible to idle-timeout drops. Making those hooks fully reentrant and retryable at the operation level is a separate concern that requires lifting credential generation out of DeployKeycloak so retries produce identical inputs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when waiting for guest resources to reach their expected conditions.
  - Added more robust management-cluster connectivity with connection timeouts and keepalive settings.
  - Enhanced handling of resource updates, watch events, and transient failures during guest creation.
  - Improved error reporting when a guest resource cannot be found or does not reach the expected state.
  - Reduced the likelihood of stalled operations while waiting for resources to become ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->