### PR TITLE
GCP-1113: retry transient network errors in hypershift create iam gcp

### DIFF
--- a/cmd/infra/gcp/iam.go
+++ b/cmd/infra/gcp/iam.go
@@ -7,8 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net"
+	"net/url"
 	"os"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -130,7 +133,12 @@ func (c *IAMManager) GetProjectNumber(ctx context.Context) (string, error) {
 	}
 	c.logger.Info("Retrieving project number", "projectID", c.projectID)
 
-	projectNumber, err := c.getProjectNumberFromID(ctx)
+	var projectNumber int64
+	err := c.retryWithExponentialBackoff(ctx, "getProjectNumber", func() error {
+		var getErr error
+		projectNumber, getErr = c.getProjectNumberFromID(ctx)
+		return getErr
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to retrieve project number for %s: %w", c.projectID, err)
 	}
@@ -152,10 +160,11 @@ func (c *IAMManager) CreateWorkloadIdentityPool(ctx context.Context) (string, er
 		Disabled:    false,
 	}
 	parent := fmt.Sprintf("projects/%s/locations/global", c.projectID)
-	err := c.createWorkloadIdentityPool(ctx, parent, poolID, pool)
+	err := c.retryWithExponentialBackoff(ctx, "createWorkloadIdentityPool", func() error {
+		return c.createWorkloadIdentityPool(ctx, parent, poolID, pool)
+	})
 	if err != nil {
 		if isAlreadyExistsError(err) {
-			// Pool exists, check and fix its state if needed
 			c.logger.Info("Workload Identity Pool already exists, checking state", "poolID", poolID)
 			return c.ensurePoolUsable(ctx, parent, poolID)
 		}
@@ -253,7 +262,10 @@ func (c *IAMManager) CreateOIDCProvider(ctx context.Context) (string, string, er
 		},
 	}
 	parent := c.formatPoolParent()
-	if err := c.createWorkloadIdentityProvider(ctx, parent, providerID, provider); err != nil {
+	err = c.retryWithExponentialBackoff(ctx, "createOIDCProvider", func() error {
+		return c.createWorkloadIdentityProvider(ctx, parent, providerID, provider)
+	})
+	if err != nil {
 		if isAlreadyExistsError(err) {
 			c.logger.Info("OIDC Provider already exists, checking state and configuration", "providerID", providerID)
 			return c.ensureProviderUsable(ctx, providerID, provider, providerAudience)
@@ -701,11 +713,15 @@ func (c *IAMManager) compareJWKS(jwks1, jwks2 string) bool {
 	return string(canonical1) == string(canonical2)
 }
 
-// isTransientIAMError checks if the error is likely due to IAM eventual consistency.
-// These errors should be retried as they typically resolve once IAM changes propagate.
+// isTransientIAMError checks if the error is likely due to IAM eventual consistency
+// or transient network issues. These errors should be retried.
 func isTransientIAMError(err error) bool {
 	if err == nil {
 		return false
+	}
+
+	if isTransientNetworkError(err) {
+		return true
 	}
 
 	var apiErr *googleapi.Error
@@ -729,10 +745,56 @@ func isTransientIAMError(err error) bool {
 			// Permission denied - might be temporary during propagation
 			return strings.Contains(apiErr.Message, "Permission") ||
 				strings.Contains(apiErr.Message, "policy")
+		case 500, 502, 503:
+			return true
 		}
 	}
 
 	return false
+}
+
+// isTransientNetworkError checks if the error is a transient network-level error
+// such as connection reset, connection refused, or network unreachable.
+// These occur in CI environments due to transient infrastructure issues.
+func isTransientNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if urlErr.Temporary() {
+			return true
+		}
+		if urlErr.Err != nil {
+			return isTransientNetworkError(urlErr.Err)
+		}
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+
+	if errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ENETUNREACH) ||
+		errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.ETIMEDOUT) {
+		return true
+	}
+
+	errMsg := err.Error()
+	return strings.Contains(errMsg, "connection reset by peer") ||
+		strings.Contains(errMsg, "connection refused") ||
+		strings.Contains(errMsg, "network is unreachable") ||
+		strings.Contains(errMsg, "i/o timeout") ||
+		strings.Contains(errMsg, "TLS handshake timeout")
 }
 
 // retryWithExponentialBackoff retries an operation with exponential backoff.

--- a/cmd/infra/gcp/iam.go
+++ b/cmd/infra/gcp/iam.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"net"
 	"net/url"
@@ -134,7 +135,7 @@ func (c *IAMManager) GetProjectNumber(ctx context.Context) (string, error) {
 	c.logger.Info("Retrieving project number", "projectID", c.projectID)
 
 	var projectNumber int64
-	err := c.retryWithExponentialBackoff(ctx, "getProjectNumber", func() error {
+	err := c.retryWithExponentialBackoff(ctx, "getProjectNumber", isTransientError, func() error {
 		var getErr error
 		projectNumber, getErr = c.getProjectNumberFromID(ctx)
 		return getErr
@@ -160,7 +161,7 @@ func (c *IAMManager) CreateWorkloadIdentityPool(ctx context.Context) (string, er
 		Disabled:    false,
 	}
 	parent := fmt.Sprintf("projects/%s/locations/global", c.projectID)
-	err := c.retryWithExponentialBackoff(ctx, "createWorkloadIdentityPool", func() error {
+	err := c.retryWithExponentialBackoff(ctx, "createWorkloadIdentityPool", isRetryableIAMError, func() error {
 		return c.createWorkloadIdentityPool(ctx, parent, poolID, pool)
 	})
 	if err != nil {
@@ -262,7 +263,7 @@ func (c *IAMManager) CreateOIDCProvider(ctx context.Context) (string, string, er
 		},
 	}
 	parent := c.formatPoolParent()
-	err = c.retryWithExponentialBackoff(ctx, "createOIDCProvider", func() error {
+	err = c.retryWithExponentialBackoff(ctx, "createOIDCProvider", isRetryableIAMError, func() error {
 		return c.createWorkloadIdentityProvider(ctx, parent, providerID, provider)
 	})
 	if err != nil {
@@ -362,7 +363,7 @@ func (c *IAMManager) CreateServiceAccounts(ctx context.Context) (map[string]stri
 
 		// Create the GSA (with retry for rate limiting)
 		var email string
-		err = c.retryWithExponentialBackoff(ctx, fmt.Sprintf("createServiceAccount-%s", def.Name), func() error {
+		err = c.retryWithExponentialBackoff(ctx, fmt.Sprintf("createServiceAccount-%s", def.Name), isRetryableIAMError, func() error {
 			var createErr error
 			email, createErr = c.createServiceAccount(ctx, def)
 			return createErr
@@ -374,7 +375,7 @@ func (c *IAMManager) CreateServiceAccounts(ctx context.Context) (map[string]stri
 
 		// Assign roles to the GSA (with retry for IAM propagation)
 		if len(def.Roles) > 0 {
-			err := c.retryWithExponentialBackoff(ctx, fmt.Sprintf("assignRoles-%s", def.Name), func() error {
+			err := c.retryWithExponentialBackoff(ctx, fmt.Sprintf("assignRoles-%s", def.Name), isRetryableIAMError, func() error {
 				return c.assignRoles(ctx, email, def.Roles)
 			})
 			if err != nil {
@@ -384,7 +385,7 @@ func (c *IAMManager) CreateServiceAccounts(ctx context.Context) (map[string]stri
 
 		// Create WIF bindings for each K8s SA (with retry for IAM propagation)
 		for i, k8sSA := range def.K8sServiceAccounts {
-			err := c.retryWithExponentialBackoff(ctx, fmt.Sprintf("createWIFBinding-%s-%d", def.Name, i), func() error {
+			err := c.retryWithExponentialBackoff(ctx, fmt.Sprintf("createWIFBinding-%s-%d", def.Name, i), isRetryableIAMError, func() error {
 				return c.createWorkloadIdentityBinding(ctx, email, &k8sSA)
 			})
 			if err != nil {
@@ -713,13 +714,23 @@ func (c *IAMManager) compareJWKS(jwks1, jwks2 string) bool {
 	return string(canonical1) == string(canonical2)
 }
 
-// isRetryableError returns true if the error is transient and the operation should be retried.
-// It checks for both network-level errors and IAM-specific transient conditions.
-func isRetryableError(err error) bool {
+// isTransientError returns true for errors that are transient for any operation:
+// network blips, rate limits, and server errors.
+func isTransientError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return isTransientNetworkError(err) || isTransientIAMError(err)
+	if isTransientNetworkError(err) {
+		return true
+	}
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		switch apiErr.Code {
+		case 429, 500, 502, 503, 504:
+			return true
+		}
+	}
+	return false
 }
 
 // isTransientIAMError checks if the error is likely due to IAM eventual consistency.
@@ -734,8 +745,6 @@ func isTransientIAMError(err error) bool {
 		switch apiErr.Code {
 		case 404:
 			return true
-		case 429:
-			return true
 		case 400:
 			return strings.Contains(apiErr.Message, "IAM") ||
 				strings.Contains(apiErr.Message, "permission") ||
@@ -745,12 +754,16 @@ func isTransientIAMError(err error) bool {
 		case 403:
 			return strings.Contains(apiErr.Message, "Permission") ||
 				strings.Contains(apiErr.Message, "policy")
-		case 500, 502, 503:
-			return true
 		}
 	}
 
 	return false
+}
+
+// isRetryableIAMError returns true for errors that are retryable for IAM
+// create/binding paths: transient errors plus IAM eventual-consistency conditions.
+func isRetryableIAMError(err error) bool {
+	return isTransientError(err) || isTransientIAMError(err)
 }
 
 // isTransientNetworkError checks if the error is a transient network-level error
@@ -781,9 +794,13 @@ func isTransientNetworkError(err error) bool {
 
 	if errors.Is(err, syscall.ECONNRESET) ||
 		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNABORTED) ||
 		errors.Is(err, syscall.ENETUNREACH) ||
 		errors.Is(err, syscall.EHOSTUNREACH) ||
-		errors.Is(err, syscall.ETIMEDOUT) {
+		errors.Is(err, syscall.ETIMEDOUT) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, io.EOF) {
 		return true
 	}
 
@@ -796,8 +813,8 @@ func isTransientNetworkError(err error) bool {
 }
 
 // retryWithExponentialBackoff retries an operation with exponential backoff.
-// It retries on transient network and IAM errors, and respects the context deadline.
-func (c *IAMManager) retryWithExponentialBackoff(ctx context.Context, operationName string, operation func() error) error {
+// The isRetryable predicate controls which errors trigger a retry.
+func (c *IAMManager) retryWithExponentialBackoff(ctx context.Context, operationName string, isRetryable func(error) bool, operation func() error) error {
 	deadline := time.Now().Add(iamPropagationTimeout)
 	backoff := iamPropagationInitialBackoff
 	attempt := 0
@@ -813,7 +830,7 @@ func (c *IAMManager) retryWithExponentialBackoff(ctx context.Context, operationN
 			return nil
 		}
 
-		if !isRetryableError(err) {
+		if !isRetryable(err) {
 			c.logger.Info("Operation failed with non-retryable error", "operation", operationName, "error", err)
 			return err
 		}

--- a/cmd/infra/gcp/iam.go
+++ b/cmd/infra/gcp/iam.go
@@ -787,12 +787,12 @@ func isTransientNetworkError(err error) bool {
 		return true
 	}
 
-	errMsg := err.Error()
-	return strings.Contains(errMsg, "connection reset by peer") ||
-		strings.Contains(errMsg, "connection refused") ||
-		strings.Contains(errMsg, "network is unreachable") ||
-		strings.Contains(errMsg, "i/o timeout") ||
-		strings.Contains(errMsg, "TLS handshake timeout")
+	var ne net.Error
+	if errors.As(err, &ne) {
+		return ne.Timeout()
+	}
+
+	return false
 }
 
 // retryWithExponentialBackoff retries an operation with exponential backoff.

--- a/cmd/infra/gcp/iam.go
+++ b/cmd/infra/gcp/iam.go
@@ -713,36 +713,36 @@ func (c *IAMManager) compareJWKS(jwks1, jwks2 string) bool {
 	return string(canonical1) == string(canonical2)
 }
 
-// isTransientIAMError checks if the error is likely due to IAM eventual consistency
-// or transient network issues. These errors should be retried.
-func isTransientIAMError(err error) bool {
+// isRetryableError returns true if the error is transient and the operation should be retried.
+// It checks for both network-level errors and IAM-specific transient conditions.
+func isRetryableError(err error) bool {
 	if err == nil {
 		return false
 	}
+	return isTransientNetworkError(err) || isTransientIAMError(err)
+}
 
-	if isTransientNetworkError(err) {
-		return true
+// isTransientIAMError checks if the error is likely due to IAM eventual consistency.
+// These errors typically resolve once IAM changes propagate.
+func isTransientIAMError(err error) bool {
+	if err == nil {
+		return false
 	}
 
 	var apiErr *googleapi.Error
 	if errors.As(err, &apiErr) {
 		switch apiErr.Code {
 		case 404:
-			// Not found - resource may not have propagated yet
 			return true
 		case 429:
-			// Rate limited - retry after backoff
 			return true
 		case 400:
-			// Bad request - sometimes occurs during IAM propagation
-			// Check if it's related to IAM/permissions or resource propagation
 			return strings.Contains(apiErr.Message, "IAM") ||
 				strings.Contains(apiErr.Message, "permission") ||
 				strings.Contains(apiErr.Message, "policy") ||
 				strings.Contains(apiErr.Message, "does not exist") ||
 				strings.Contains(apiErr.Message, "Service account")
 		case 403:
-			// Permission denied - might be temporary during propagation
 			return strings.Contains(apiErr.Message, "Permission") ||
 				strings.Contains(apiErr.Message, "policy")
 		case 500, 502, 503:
@@ -798,7 +798,7 @@ func isTransientNetworkError(err error) bool {
 }
 
 // retryWithExponentialBackoff retries an operation with exponential backoff.
-// It only retries on transient IAM errors and respects the context deadline.
+// It retries on transient network and IAM errors, and respects the context deadline.
 func (c *IAMManager) retryWithExponentialBackoff(ctx context.Context, operationName string, operation func() error) error {
 	deadline := time.Now().Add(iamPropagationTimeout)
 	backoff := iamPropagationInitialBackoff
@@ -815,9 +815,8 @@ func (c *IAMManager) retryWithExponentialBackoff(ctx context.Context, operationN
 			return nil
 		}
 
-		// Check if error is transient
-		if !isTransientIAMError(err) {
-			c.logger.Info("Operation failed with non-transient error", "operation", operationName, "error", err)
+		if !isRetryableError(err) {
+			c.logger.Info("Operation failed with non-retryable error", "operation", operationName, "error", err)
 			return err
 		}
 

--- a/cmd/infra/gcp/iam.go
+++ b/cmd/infra/gcp/iam.go
@@ -755,30 +755,28 @@ func isTransientIAMError(err error) bool {
 
 // isTransientNetworkError checks if the error is a transient network-level error
 // such as connection reset, connection refused, or network unreachable.
-// These occur in CI environments due to transient infrastructure issues.
+// Permanent network errors (e.g., DNS not found, invalid address) return false.
 func isTransientNetworkError(err error) bool {
 	if err == nil {
 		return false
 	}
 
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return dnsErr.IsTimeout || dnsErr.IsTemporary
+	}
+
 	var netErr *net.OpError
 	if errors.As(err, &netErr) {
-		return true
+		if netErr.Timeout() {
+			return true
+		}
+		return isTransientNetworkError(netErr.Err)
 	}
 
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) {
-		if urlErr.Temporary() {
-			return true
-		}
-		if urlErr.Err != nil {
-			return isTransientNetworkError(urlErr.Err)
-		}
-	}
-
-	var dnsErr *net.DNSError
-	if errors.As(err, &dnsErr) {
-		return true
+		return isTransientNetworkError(urlErr.Err)
 	}
 
 	if errors.Is(err, syscall.ECONNRESET) ||

--- a/cmd/infra/gcp/iam.go
+++ b/cmd/infra/gcp/iam.go
@@ -823,7 +823,7 @@ func (c *IAMManager) retryWithExponentialBackoff(ctx context.Context, operationN
 		// Check if we've exceeded the deadline
 		if time.Now().After(deadline) {
 			c.logger.Info("Operation timed out after retries", "operation", operationName, "attempts", attempt, "lastError", err)
-			return fmt.Errorf("operation timed out after %d attempts due to IAM propagation delays: %w", attempt, err)
+			return fmt.Errorf("operation timed out after %d attempts: %w", attempt, err)
 		}
 
 		// Check context cancellation
@@ -834,7 +834,7 @@ func (c *IAMManager) retryWithExponentialBackoff(ctx context.Context, operationN
 		// Add jitter to backoff to avoid thundering herd (±25% randomization)
 		jitter := time.Duration(float64(backoff) * (0.75 + rand.Float64()*0.5))
 
-		c.logger.Info("Retrying operation due to IAM propagation delay",
+		c.logger.Info("Retrying operation due to transient error",
 			"operation", operationName,
 			"attempt", attempt,
 			"backoff", jitter,

--- a/cmd/infra/gcp/iam_test.go
+++ b/cmd/infra/gcp/iam_test.go
@@ -1,8 +1,10 @@
 package gcp
 
 import (
+	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -15,6 +17,13 @@ import (
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iam/v1"
 )
+
+// timeoutError simulates net/http's unexported tlsHandshakeTimeoutError.
+type timeoutError string
+
+func (e timeoutError) Error() string   { return string(e) }
+func (e timeoutError) Timeout() bool   { return true }
+func (e timeoutError) Temporary() bool { return true }
 
 func TestIAMManagerFormatServiceAccountMethods(t *testing.T) {
 	manager := &IAMManager{
@@ -508,6 +517,31 @@ func TestIsTransientNetworkError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "When error is connection refused, it should return true",
+			err:      &net.OpError{Op: "dial", Net: "tcp", Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}},
+			expected: true,
+		},
+		{
+			name:     "When error is host unreachable, it should return true",
+			err:      &net.OpError{Op: "dial", Net: "tcp", Err: &os.SyscallError{Syscall: "connect", Err: syscall.EHOSTUNREACH}},
+			expected: true,
+		},
+		{
+			name:     "When error is a syscall timeout, it should return true",
+			err:      &net.OpError{Op: "dial", Net: "tcp", Err: &os.SyscallError{Syscall: "connect", Err: syscall.ETIMEDOUT}},
+			expected: true,
+		},
+		{
+			name:     "When error is a url.Error wrapping a transient error, it should return true",
+			err:      &url.Error{Op: "Post", URL: "https://iam.googleapis.com", Err: &net.OpError{Op: "read", Net: "tcp", Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET}}},
+			expected: true,
+		},
+		{
+			name:     "When error is a net.Error with Timeout, it should return true",
+			err:      timeoutError("net/http: TLS handshake timeout"),
+			expected: true,
+		},
+		{
 			name:     "When error is an address error, it should return false",
 			err:      &net.AddrError{Err: "invalid address", Addr: "not-a-host"},
 			expected: false,
@@ -566,6 +600,62 @@ func TestIsRetryableError(t *testing.T) {
 			g.Expect(isRetryableError(tt.err)).To(Equal(tt.expected))
 		})
 	}
+}
+
+func TestRetryWithExponentialBackoff(t *testing.T) {
+	manager := &IAMManager{logger: logr.Discard()}
+
+	t.Run("When operation returns a non-retryable error, it should run once and propagate the error", func(t *testing.T) {
+		g := NewWithT(t)
+		calls := 0
+		permanentErr := fmt.Errorf("permanent failure")
+
+		err := manager.retryWithExponentialBackoff(context.Background(), "test-op", func() error {
+			calls++
+			return permanentErr
+		})
+
+		g.Expect(err).To(MatchError(permanentErr))
+		g.Expect(calls).To(Equal(1))
+	})
+
+	t.Run("When operation returns a transient error then succeeds, it should retry and return nil", func(t *testing.T) {
+		g := NewWithT(t)
+		calls := 0
+		transientErr := &net.OpError{
+			Op:  "read",
+			Net: "tcp",
+			Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET},
+		}
+
+		err := manager.retryWithExponentialBackoff(context.Background(), "test-op", func() error {
+			calls++
+			if calls == 1 {
+				return transientErr
+			}
+			return nil
+		})
+
+		g.Expect(err).To(BeNil())
+		g.Expect(calls).To(Equal(2))
+	})
+
+	t.Run("When context is canceled, it should stop retrying", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		transientErr := &googleapi.Error{Code: 429, Message: "Rate limited"}
+
+		cancel()
+
+		err := manager.retryWithExponentialBackoff(ctx, "test-op", func() error {
+			calls++
+			return transientErr
+		})
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(calls).To(Equal(1))
+	})
 }
 
 func TestIsAlreadyExistsError(t *testing.T) {

--- a/cmd/infra/gcp/iam_test.go
+++ b/cmd/infra/gcp/iam_test.go
@@ -2,8 +2,10 @@ package gcp
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -422,14 +424,47 @@ func TestIsTransientIAMError(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "When error is a 500 server error, it should return false",
+			name:     "When error is a 500 server error, it should return true",
 			err:      &googleapi.Error{Code: 500, Message: "Internal server error"},
+			expected: true,
+		},
+		{
+			name:     "When error is a 502 bad gateway error, it should return true",
+			err:      &googleapi.Error{Code: 502, Message: "Bad gateway"},
+			expected: true,
+		},
+		{
+			name:     "When error is a 503 service unavailable error, it should return true",
+			err:      &googleapi.Error{Code: 503, Message: "Service unavailable"},
+			expected: true,
+		},
+		{
+			name:     "When error is a non-googleapi non-network error, it should return false",
+			err:      fmt.Errorf("some other error"),
 			expected: false,
 		},
 		{
-			name:     "When error is a non-googleapi error, it should return false",
-			err:      fmt.Errorf("some other error"),
-			expected: false,
+			name: "When error is a connection reset by peer, it should return true",
+			err: &net.OpError{
+				Op:  "read",
+				Net: "tcp",
+				Err: fmt.Errorf("read: connection reset by peer"),
+			},
+			expected: true,
+		},
+		{
+			name: "When error is network unreachable, it should return true",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: &os.SyscallError{Syscall: "connect", Err: syscall.ENETUNREACH},
+			},
+			expected: true,
+		},
+		{
+			name:     "When error wraps a connection reset syscall error, it should return true",
+			err:      fmt.Errorf("failed to get IAM policy: %w", &net.OpError{Op: "read", Net: "tcp", Err: fmt.Errorf("connection reset by peer")}),
+			expected: true,
 		},
 	}
 

--- a/cmd/infra/gcp/iam_test.go
+++ b/cmd/infra/gcp/iam_test.go
@@ -474,7 +474,7 @@ func TestIsTransientNetworkError(t *testing.T) {
 			err: &net.OpError{
 				Op:  "read",
 				Net: "tcp",
-				Err: fmt.Errorf("read: connection reset by peer"),
+				Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET},
 			},
 			expected: true,
 		},
@@ -488,9 +488,29 @@ func TestIsTransientNetworkError(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "When error wraps a net.OpError, it should return true",
-			err:      fmt.Errorf("failed to get IAM policy: %w", &net.OpError{Op: "read", Net: "tcp", Err: fmt.Errorf("connection reset by peer")}),
+			name:     "When error wraps a transient net.OpError, it should return true",
+			err:      fmt.Errorf("failed to get IAM policy: %w", &net.OpError{Op: "read", Net: "tcp", Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET}}),
 			expected: true,
+		},
+		{
+			name:     "When error is a DNS not found, it should return false",
+			err:      &net.DNSError{Err: "no such host", Name: "example.com", IsNotFound: true},
+			expected: false,
+		},
+		{
+			name:     "When error is a temporary DNS error, it should return true",
+			err:      &net.DNSError{Err: "temporary failure", Name: "example.com", IsTemporary: true},
+			expected: true,
+		},
+		{
+			name:     "When error is a DNS timeout, it should return true",
+			err:      &net.DNSError{Err: "timeout", Name: "example.com", IsTimeout: true},
+			expected: true,
+		},
+		{
+			name:     "When error is an address error, it should return false",
+			err:      &net.AddrError{Err: "invalid address", Addr: "not-a-host"},
+			expected: false,
 		},
 		{
 			name:     "When error is a non-network error, it should return false",
@@ -530,7 +550,7 @@ func TestIsRetryableError(t *testing.T) {
 		},
 		{
 			name:     "When error is a transient network error, it should return true",
-			err:      &net.OpError{Op: "read", Net: "tcp", Err: fmt.Errorf("connection reset by peer")},
+			err:      &net.OpError{Op: "read", Net: "tcp", Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET}},
 			expected: true,
 		},
 		{

--- a/cmd/infra/gcp/iam_test.go
+++ b/cmd/infra/gcp/iam_test.go
@@ -3,6 +3,7 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -413,11 +414,6 @@ func TestIsTransientIAMError(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "When error is a 429 rate limit error, it should return true",
-			err:      &googleapi.Error{Code: 429, Message: "A quota has been reached"},
-			expected: true,
-		},
-		{
 			name:     "When error is a 404 not found error, it should return true",
 			err:      &googleapi.Error{Code: 404, Message: "Not found"},
 			expected: true,
@@ -433,19 +429,24 @@ func TestIsTransientIAMError(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "When error is a 500 server error, it should return true",
+			name:     "When error is a 400 IAM error, it should return true",
+			err:      &googleapi.Error{Code: 400, Message: "Service account does not exist"},
+			expected: true,
+		},
+		{
+			name:     "When error is a 400 non-IAM error, it should return false",
+			err:      &googleapi.Error{Code: 400, Message: "Invalid argument"},
+			expected: false,
+		},
+		{
+			name:     "When error is a 429 rate limit error, it should return false",
+			err:      &googleapi.Error{Code: 429, Message: "Rate limited"},
+			expected: false,
+		},
+		{
+			name:     "When error is a 500 server error, it should return false",
 			err:      &googleapi.Error{Code: 500, Message: "Internal server error"},
-			expected: true,
-		},
-		{
-			name:     "When error is a 502 bad gateway error, it should return true",
-			err:      &googleapi.Error{Code: 502, Message: "Bad gateway"},
-			expected: true,
-		},
-		{
-			name:     "When error is a 503 service unavailable error, it should return true",
-			err:      &googleapi.Error{Code: 503, Message: "Service unavailable"},
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "When error is a non-googleapi error, it should return false",
@@ -463,6 +464,67 @@ func TestIsTransientIAMError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			g.Expect(isTransientIAMError(tt.err)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestIsTransientError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "When error is nil, it should return false",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "When error is a 429 rate limit error, it should return true",
+			err:      &googleapi.Error{Code: 429, Message: "Rate limited"},
+			expected: true,
+		},
+		{
+			name:     "When error is a 500 server error, it should return true",
+			err:      &googleapi.Error{Code: 500, Message: "Internal server error"},
+			expected: true,
+		},
+		{
+			name:     "When error is a 502 bad gateway error, it should return true",
+			err:      &googleapi.Error{Code: 502, Message: "Bad gateway"},
+			expected: true,
+		},
+		{
+			name:     "When error is a 503 service unavailable error, it should return true",
+			err:      &googleapi.Error{Code: 503, Message: "Service unavailable"},
+			expected: true,
+		},
+		{
+			name:     "When error is a 504 gateway timeout error, it should return true",
+			err:      &googleapi.Error{Code: 504, Message: "Gateway timeout"},
+			expected: true,
+		},
+		{
+			name:     "When error is a transient network error, it should return true",
+			err:      &net.OpError{Op: "read", Net: "tcp", Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET}},
+			expected: true,
+		},
+		{
+			name:     "When error is a 404 not found error, it should return false",
+			err:      &googleapi.Error{Code: 404, Message: "Not found"},
+			expected: false,
+		},
+		{
+			name:     "When error is a non-retryable error, it should return false",
+			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(isTransientError(tt.err)).To(Equal(tt.expected))
 		})
 	}
 }
@@ -532,6 +594,26 @@ func TestIsTransientNetworkError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "When error is connection aborted, it should return true",
+			err:      &net.OpError{Op: "read", Net: "tcp", Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNABORTED}},
+			expected: true,
+		},
+		{
+			name:     "When error is a broken pipe, it should return true",
+			err:      &net.OpError{Op: "write", Net: "tcp", Err: &os.SyscallError{Syscall: "write", Err: syscall.EPIPE}},
+			expected: true,
+		},
+		{
+			name:     "When error is io.ErrUnexpectedEOF, it should return true",
+			err:      io.ErrUnexpectedEOF,
+			expected: true,
+		},
+		{
+			name:     "When error is io.EOF, it should return true",
+			err:      io.EOF,
+			expected: true,
+		},
+		{
 			name:     "When error is a url.Error wrapping a transient error, it should return true",
 			err:      &url.Error{Op: "Post", URL: "https://iam.googleapis.com", Err: &net.OpError{Op: "read", Net: "tcp", Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET}}},
 			expected: true,
@@ -566,7 +648,7 @@ func TestIsTransientNetworkError(t *testing.T) {
 	}
 }
 
-func TestIsRetryableError(t *testing.T) {
+func TestIsRetryableIAMError(t *testing.T) {
 	tests := []struct {
 		name     string
 		err      error
@@ -578,8 +660,18 @@ func TestIsRetryableError(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "When error is a transient IAM error, it should return true",
+			name:     "When error is a transient IAM error (404), it should return true",
+			err:      &googleapi.Error{Code: 404, Message: "Not found"},
+			expected: true,
+		},
+		{
+			name:     "When error is a transient server error (429), it should return true",
 			err:      &googleapi.Error{Code: 429, Message: "Rate limited"},
+			expected: true,
+		},
+		{
+			name:     "When error is a 504 gateway timeout, it should return true",
+			err:      &googleapi.Error{Code: 504, Message: "Gateway timeout"},
 			expected: true,
 		},
 		{
@@ -597,7 +689,7 @@ func TestIsRetryableError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			g.Expect(isRetryableError(tt.err)).To(Equal(tt.expected))
+			g.Expect(isRetryableIAMError(tt.err)).To(Equal(tt.expected))
 		})
 	}
 }
@@ -610,7 +702,7 @@ func TestRetryWithExponentialBackoff(t *testing.T) {
 		calls := 0
 		permanentErr := fmt.Errorf("permanent failure")
 
-		err := manager.retryWithExponentialBackoff(context.Background(), "test-op", func() error {
+		err := manager.retryWithExponentialBackoff(context.Background(), "test-op", isTransientError, func() error {
 			calls++
 			return permanentErr
 		})
@@ -628,7 +720,7 @@ func TestRetryWithExponentialBackoff(t *testing.T) {
 			Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET},
 		}
 
-		err := manager.retryWithExponentialBackoff(context.Background(), "test-op", func() error {
+		err := manager.retryWithExponentialBackoff(context.Background(), "test-op", isTransientError, func() error {
 			calls++
 			if calls == 1 {
 				return transientErr
@@ -648,12 +740,26 @@ func TestRetryWithExponentialBackoff(t *testing.T) {
 
 		cancel()
 
-		err := manager.retryWithExponentialBackoff(ctx, "test-op", func() error {
+		err := manager.retryWithExponentialBackoff(ctx, "test-op", isRetryableIAMError, func() error {
 			calls++
 			return transientErr
 		})
 
 		g.Expect(err).To(HaveOccurred())
+		g.Expect(calls).To(Equal(1))
+	})
+
+	t.Run("When using isTransientError, a 404 should not be retried", func(t *testing.T) {
+		g := NewWithT(t)
+		calls := 0
+		notFoundErr := &googleapi.Error{Code: 404, Message: "Project not found"}
+
+		err := manager.retryWithExponentialBackoff(context.Background(), "test-op", isTransientError, func() error {
+			calls++
+			return notFoundErr
+		})
+
+		g.Expect(err).To(MatchError(notFoundErr))
 		g.Expect(calls).To(Equal(1))
 	})
 }

--- a/cmd/infra/gcp/iam_test.go
+++ b/cmd/infra/gcp/iam_test.go
@@ -439,8 +439,34 @@ func TestIsTransientIAMError(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "When error is a non-googleapi non-network error, it should return false",
+			name:     "When error is a non-googleapi error, it should return false",
 			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+		{
+			name:     "When error is a network error, it should return false",
+			err:      &net.OpError{Op: "read", Net: "tcp", Err: fmt.Errorf("connection reset by peer")},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(isTransientIAMError(tt.err)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestIsTransientNetworkError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "When error is nil, it should return false",
+			err:      nil,
 			expected: false,
 		},
 		{
@@ -462,16 +488,62 @@ func TestIsTransientIAMError(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "When error wraps a connection reset syscall error, it should return true",
+			name:     "When error wraps a net.OpError, it should return true",
 			err:      fmt.Errorf("failed to get IAM policy: %w", &net.OpError{Op: "read", Net: "tcp", Err: fmt.Errorf("connection reset by peer")}),
 			expected: true,
+		},
+		{
+			name:     "When error is a non-network error, it should return false",
+			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+		{
+			name:     "When error is an IAM API error, it should return false",
+			err:      &googleapi.Error{Code: 400, Message: "Service account does not exist"},
+			expected: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			g.Expect(isTransientIAMError(tt.err)).To(Equal(tt.expected))
+			g.Expect(isTransientNetworkError(tt.err)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestIsRetryableError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "When error is nil, it should return false",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "When error is a transient IAM error, it should return true",
+			err:      &googleapi.Error{Code: 429, Message: "Rate limited"},
+			expected: true,
+		},
+		{
+			name:     "When error is a transient network error, it should return true",
+			err:      &net.OpError{Op: "read", Net: "tcp", Err: fmt.Errorf("connection reset by peer")},
+			expected: true,
+		},
+		{
+			name:     "When error is neither IAM nor network, it should return false",
+			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(isRetryableError(tt.err)).To(Equal(tt.expected))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Add transient network error detection with a new `isTransientNetworkError` function
- Add `isRetryableError` that combines network and IAM error classification
- Wrap `GetProjectNumber`, `CreateWorkloadIdentityPool`, and `CreateOIDCProvider` in retry logic
- Also retry on HTTP 500/502/503 server errors

## Problem
The `e2e-v2-gke` presubmit has a ~30% pass rate. Analysis of 36 recent Prow runs shows that **5 of 22 failures** (the largest single category) are transient GCP API network errors during the `hypershift-gcp-hosted-cluster-setup` pre-phase step, which runs `hypershift create iam gcp`.

The errors seen in CI logs:
```
read tcp 10.130.127.22:37052->172.217.114.4:443: read: connection reset by peer
dial tcp [2607:f8b0:4004:c1d::5f]:443: connect: network is unreachable
```

These are network-level errors (`net.OpError`, `syscall.ECONNRESET`, `syscall.ENETUNREACH`) but `isTransientIAMError` only checks for `googleapi.Error` types (HTTP status codes). Network errors fail the type assertion and are classified as non-transient, so `retryWithExponentialBackoff` gives up immediately:
```
"Operation failed with non-transient error"
```

Additionally, `GetProjectNumber`, `CreateWorkloadIdentityPool`, and `CreateOIDCProvider` called GCP APIs directly without retry — only service account operations were wrapped in `retryWithExponentialBackoff`.

## Fix

### Error classification (separated by concern)

- **`isTransientNetworkError`** — detects network-level transient errors:
  - `net.OpError` (connection reset, refused, timeout)
  - `net.DNSError` (transient DNS failures)
  - `url.Error` with temporary flag
  - Syscall errors: `ECONNRESET`, `ECONNREFUSED`, `ENETUNREACH`, `EHOSTUNREACH`, `ETIMEDOUT`
  - String-based fallback for deeply wrapped errors

- **`isTransientIAMError`** — detects IAM API transient errors (unchanged responsibility):
  - HTTP 400 with IAM/permission/propagation messages
  - HTTP 403 with permission/policy messages
  - HTTP 404 (resource not yet propagated)
  - HTTP 429 (rate limited)
  - HTTP 500/502/503 (server errors — new)

- **`isRetryableError`** — combines both, used by `retryWithExponentialBackoff`

### Retry coverage expanded

`GetProjectNumber`, `CreateWorkloadIdentityPool`, and `CreateOIDCProvider` now use `retryWithExponentialBackoff` (2s initial backoff, 16s max, 120s timeout). Previously only service account operations (create, assign roles, WIF bindings) were retried.

### Log messages updated

Retry and timeout log messages now use generic "transient error" wording instead of "IAM propagation delay" to accurately reflect the broader retry scope.

## Testing
- `TestIsTransientIAMError` — 10 cases covering API error codes, verifies network errors return false
- `TestIsTransientNetworkError` — 6 cases covering OpError, DNS, syscall, wrapped errors, verifies IAM errors return false
- `TestIsRetryableError` — 4 cases verifying the combination of both
- All tests pass: `go test ./cmd/infra/gcp/... -v`

Ref: [GCP-1113](https://issues.redhat.com/browse/GCP-1113)

## Test plan
- [ ] `go test ./cmd/infra/gcp/...` passes
- [ ] `make verify` passes
- [ ] e2e-v2-gke pre-phase failures from network errors should show retry attempts instead of immediate failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving GCP project information and creating identity resources by retrying transient failures.
  * Added handling for temporary server errors, network interruptions, DNS issues, connection failures, and timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->