### PR TITLE
CNTRLPLANE-3755: fix(e2e): add version gating to EnsureCAPIFinalizers tests

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1113,6 +1113,7 @@ func EnsureFeatureGateStatus(t *testing.T, ctx context.Context, guestClient crcl
 
 func EnsureCAPIFinalizers(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureCAPIFinalizers", func(t *testing.T) {
+		AtLeast(t, Version422)
 		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 
 		for _, name := range hcc.CAPIComponents {

--- a/test/e2e/v2/tests/hosted_cluster_health_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_health_test.go
@@ -84,6 +84,7 @@ func EnsureCAPIFinalizersTest(getTestCtx internal.TestContextGetter) {
 	When("CAPI components are deployed", func() {
 		It("should have component finalizers on all CAPI deployments", func() {
 			tc := getTestCtx()
+			tc.SkipIfVersionBelow(e2eutil.Version422)
 			Expect(hcc.CAPIComponents).NotTo(BeEmpty(),
 				"expected CAPI components to be defined in HostedControlPlaneConfiguration")
 			for _, name := range hcc.CAPIComponents {


### PR DESCRIPTION
The EnsureCAPIFinalizers tests check for the presence of the
hypershift.openshift.io/component-finalizer on CAPI deployments,
a feature introduced in 4.22. Without version gating, the tests
fail on clusters running 4.18-4.21 which lack this feature.

## Changes
- v1 e2e: Add `AtLeast(t, Version422)` to `test/e2e/util/util.go`
- v2 e2e: Add `tc.SkipIfVersionBelow(e2eutil.Version422)` to `test/e2e/v2/tests/hosted_cluster_health_test.go`

## Testing
This fixes e2e-aws-backport job failures on release branches 4.18-4.21 where the finalizer feature doesn't exist.

## Related:
- [CNTRLPLANE-3755](https://redhat.atlassian.net/browse/CNTRLPLANE-3755)
- [openshift/release#82169](https://github.com/openshift/release/pull/82169) - The release PR that will benefit from this fix. The pj-rehearse e2e-aws-backport job was passing for 4.22+ version but below 4.22 its failing due to single test: TestCreateCluster/Main/EnsureCAPIFinalizers
 The assertion error is:
`
CAPI deployment 'cluster-api' is expected to have finalizer: [hypershift.openshift.io/component-finalizer](http://hypershift.openshift.io/component-finalizer)`
  **Passed JOB:** https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/82169/rehearse-82169-pull-ci-openshift-hypershift-release-4.22-e2e-aws-backport/2087851636117475328
  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/82169/rehearse-82169-pull-ci-openshift-hypershift-release-5.1-e2e-aws-backport/2087850468045754368
  
  **Failed JOB:** https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/82169/rehearse-82169-pull-ci-openshift-hypershift-release-4.21-e2e-aws-backport/2087881548169744384 
  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/82169/rehearse-82169-pull-ci-openshift-hypershift-release-4.20-e2e-aws-backport/2087881542650040320