### PR TITLE
OCPBUGS-85085: fix(karpenter): default kubelet MaxPods to 250 on OpenshiftEC2NodeClass

### DIFF
--- a/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
+++ b/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
@@ -623,6 +623,44 @@ func TestReconcileEC2NodeClass(t *testing.T) {
 			},
 		},
 		{
+			name: "When Kubelet.MaxPods is explicitly set it should not be overridden with the default",
+			spec: hyperkarpenterv1.OpenshiftEC2NodeClassSpec{
+				Kubelet: hyperkarpenterv1.KubeletConfiguration{
+					MaxPods: 110,
+				},
+			},
+			expectedSpec: awskarpenterv1.EC2NodeClassSpec{
+				SubnetSelectorTerms: []awskarpenterv1.SubnetSelectorTerm{
+					{
+						Tags: map[string]string{
+							"kubernetes.io/role/internal-elb":                    "1",
+							fmt.Sprintf("kubernetes.io/cluster/%s", testInfraID): "*",
+						},
+					},
+				},
+				SecurityGroupSelectorTerms: []awskarpenterv1.SecurityGroupSelectorTerm{
+					{
+						Tags: map[string]string{
+							"karpenter.sh/discovery": testInfraID,
+						},
+					},
+				},
+				BlockDeviceMappings: []*awskarpenterv1.BlockDeviceMapping{
+					{
+						DeviceName: ptr.To("/dev/xvda"),
+						EBS: &awskarpenterv1.BlockDevice{
+							VolumeSize: ptr.To(resource.MustParse("120Gi")),
+							VolumeType: ptr.To("gp3"),
+							Encrypted:  ptr.To(true),
+						},
+					},
+				},
+				Kubelet: &awskarpenterv1.KubeletConfiguration{
+					MaxPods: ptr.To(int32(110)),
+				},
+			},
+		},
+		{
 			name: "when CapacityReservationSelectorTerms are not set it should not set them on EC2NodeClass",
 			spec: hyperkarpenterv1.OpenshiftEC2NodeClassSpec{},
 			expectedSpec: awskarpenterv1.EC2NodeClassSpec{
@@ -678,6 +716,11 @@ func TestReconcileEC2NodeClass(t *testing.T) {
 				{
 					ID: "ami-123",
 				},
+			}
+
+			// MaxPods defaults to 250 unless the OpenshiftEC2NodeClass spec sets it explicitly.
+			if tc.spec.Kubelet.MaxPods == 0 {
+				tc.expectedSpec.Kubelet = &awskarpenterv1.KubeletConfiguration{MaxPods: ptr.To(int32(250))}
 			}
 
 			g.Expect(ec2NodeClass.Spec).To(Equal(tc.expectedSpec))

--- a/karpenter-operator/controllers/nodeclass/karpenter_util.go
+++ b/karpenter-operator/controllers/nodeclass/karpenter_util.go
@@ -14,6 +14,11 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+// openshiftDefaultMaxPods is the kubelet max-pods default for OpenShift nodes.
+// Karpenter's uses a AWS ENI-based formula by default, we need to overwrite this to OpenShift's
+// fixed max-pods count.
+const openshiftDefaultMaxPods = 250
+
 func karpenterBlockDeviceMappingFromNodeClassSpec(spec hyperkarpenterv1.OpenshiftEC2NodeClassSpec) []*awskarpenterv1.BlockDeviceMapping {
 	if spec.BlockDeviceMappings == nil {
 		return nil
@@ -160,13 +165,10 @@ func volumeTypeToKarpenter(vt hyperkarpenterv1.VolumeType) *string {
 }
 
 func karpenterKubeletConfigurationFromNodeClassSpec(spec hyperkarpenterv1.OpenshiftEC2NodeClassSpec) *awskarpenterv1.KubeletConfiguration {
-	if !spec.Kubelet.HasTypedFields() {
-		return nil
-	}
 	return &awskarpenterv1.KubeletConfiguration{
 		ImageGCHighThresholdPercent: spec.Kubelet.ImageGCHighThresholdPercent,
 		ImageGCLowThresholdPercent:  spec.Kubelet.ImageGCLowThresholdPercent,
-		MaxPods:                     ptrIfNonZero(spec.Kubelet.MaxPods),
+		MaxPods:                     maxPodsOrDefault(spec.Kubelet.MaxPods),
 		CPUCFSQuota:                 spec.Kubelet.CPUCFSQuota,
 		EvictionHard:                evictionThresholdMapToStringMap(spec.Kubelet.EvictionHard),
 		EvictionSoft:                evictionThresholdMapToStringMap(spec.Kubelet.EvictionSoft),
@@ -176,6 +178,14 @@ func karpenterKubeletConfigurationFromNodeClassSpec(spec hyperkarpenterv1.Opensh
 		SystemReserved:              spec.Kubelet.SystemReserved,
 		KubeReserved:                spec.Kubelet.KubeReserved,
 	}
+}
+
+// maxPodsOrDefault returns maxPods if explicitly set, or openshiftDefaultMaxPods otherwise.
+func maxPodsOrDefault(maxPods int32) *int32 {
+	if maxPods == 0 {
+		return ptr.To(int32(openshiftDefaultMaxPods))
+	}
+	return ptr.To(maxPods)
 }
 
 // evictionThresholdMapToStringMap converts our EvictionThreshold map to a plain string map.

--- a/karpenter-operator/controllers/nodeclass/karpenter_util_test.go
+++ b/karpenter-operator/controllers/nodeclass/karpenter_util_test.go
@@ -21,9 +21,9 @@ func TestKarpenterKubeletConfigurationFromNodeClassSpec(t *testing.T) {
 		expected *awskarpenterv1.KubeletConfiguration
 	}{
 		{
-			name:     "When Kubelet is nil, it should return nil",
+			name:     "When Kubelet is nil, it should default MaxPods to 250",
 			spec:     hyperkarpenterv1.OpenshiftEC2NodeClassSpec{},
-			expected: nil,
+			expected: &awskarpenterv1.KubeletConfiguration{MaxPods: ptr.To(int32(250))},
 		},
 		{
 			name: "When all karpenter-mapped fields are set, it should map them",
@@ -92,13 +92,25 @@ func TestKarpenterKubeletConfigurationFromNodeClassSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "When only overflow fields are set, it should return nil",
+			name: "When other fields are set but MaxPods isn't, it should default MaxPods to 250",
+			spec: hyperkarpenterv1.OpenshiftEC2NodeClassSpec{
+				Kubelet: hyperkarpenterv1.KubeletConfiguration{
+					PodsPerCore: 10,
+				},
+			},
+			expected: &awskarpenterv1.KubeletConfiguration{
+				MaxPods:     ptr.To(int32(250)),
+				PodsPerCore: ptr.To(int32(10)),
+			},
+		},
+		{
+			name: "When only overflow fields are set, it should default MaxPods to 250",
 			spec: hyperkarpenterv1.OpenshiftEC2NodeClassSpec{
 				Kubelet: hyperkarpenterv1.KubeletConfiguration{
 					Overflow: runtime.RawExtension{Raw: []byte(`{"podPidsLimit":4096}`)},
 				},
 			},
-			expected: nil,
+			expected: &awskarpenterv1.KubeletConfiguration{MaxPods: ptr.To(int32(250))},
 		},
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it:

Default MaxPods to 250 whenever the OpenshiftEC2NodeClass spec doesn't set it explicitly.
Karpenter currently uses an AWS ENI-based calculation for max pods instead of using the default of 250 in OpenShift. This causes karpenter to underestimate the capacity the node actually has.

We're also fixing this in the AWS provider but as the karpenter provider image is AFAIU part of the OpenShift payload releasing the fix only there is a bit more effort compared to a fix in this operator and a simple upgrade of the operator alone.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-85085

## Special notes for your reviewer:

Related PR: https://github.com/openshift/aws-karpenter-provider-aws/pull/40

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenShift node classes now default kubelet maximum pods to 250 when no value is specified.
  * Explicit `MaxPods` values, such as 110, are preserved during reconciliation.
  * Kubelet configuration is consistently generated when related settings are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->