### PR TITLE
OCPBUGS-114667: remove redhat-marketplace-catalog from e2e workload validation

### DIFF
--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -616,7 +616,6 @@ func e2eDefaultAnnotations() []string {
 			fmt.Sprintf("%s/packageserver.packageserver=cpu=50m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
 			fmt.Sprintf("%s/certified-operators-catalog.registry=cpu=30m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
 			fmt.Sprintf("%s/community-operators-catalog.registry=cpu=30m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
-			fmt.Sprintf("%s/redhat-marketplace-catalog.registry=cpu=30m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
 			fmt.Sprintf("%s/redhat-operators-catalog.registry=cpu=30m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
 			fmt.Sprintf("%s/hosted-cluster-config-operator.hosted-cluster-config-operator=cpu=100m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
 			fmt.Sprintf("%s/control-plane-pki-operator.control-plane-pki-operator=cpu=30m", hyperv1.ResourceRequestOverrideAnnotationPrefix),

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -128,7 +128,6 @@ var (
 		"certified-operators-catalog": 20,
 		"community-operators-catalog": 20,
 		"redhat-operators-catalog":    20,
-		"redhat-marketplace-catalog":  20,
 		// Temporary workaround for https://issues.redhat.com/browse/OCPBUGS-45182
 		"openstack-manila-csi-controllerplugin": 20,
 		// Temporary workaround for https://issues.redhat.com/browse/CNV-40820
@@ -1689,7 +1688,6 @@ func EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t *testing.T, ctx conte
 			"certified-operators-catalog":            "app",
 			"community-operators-catalog":            "app",
 			"redhat-operators-catalog":               "app",
-			"redhat-marketplace-catalog":             "app",
 			"openstack-cinder-csi-driver-controller": "app",
 			"openstack-manila-csi":                   "app",
 			"karpenter":                              "app",

--- a/test/e2e/v2/internal/workload_registry.go
+++ b/test/e2e/v2/internal/workload_registry.go
@@ -350,14 +350,6 @@ func GetControlPlaneWorkloads() []WorkloadSpec {
 			},
 		},
 		{
-			Type:       "Deployment",
-			Name:       "redhat-marketplace-catalog",
-			MaxVersion: &semver.Version{Major: 4, Minor: 22, Patch: 0},
-			PodSelector: map[string]string{
-				"olm.catalogSource": "redhat-marketplace",
-			},
-		},
-		{
 			Type: "Deployment",
 			Name: "redhat-operators-catalog",
 			PodSelector: map[string]string{

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -898,7 +898,6 @@ func NoCrashingPodsTest(getTestCtx internal.TestContextGetter) {
 			"certified-operators-catalog":           20,
 			"community-operators-catalog":           20,
 			"redhat-operators-catalog":              20,
-			"redhat-marketplace-catalog":            20,
 			"openstack-manila-csi-controllerplugin": 20,
 			"kubevirt-csi":                          20,
 			"aws-ebs-csi-driver-controller":         1,


### PR DESCRIPTION
## Summary
- Remove `redhat-marketplace-catalog` from the v2 e2e control plane workload registry and related validation lists.
- The deployment was removed in #8958 (OCPBUGS-96908), but backup/restore pre-checks still tried to `Get` it and timed out after 15 minutes.

## Test plan
- [ ] `e2e-v2-aws-backuprestore` no longer fails on `redhat-marketplace-catalog` not found
- [ ] Control plane workload e2e tests skip/version-gate correctly without marketplace entry

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-114667

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated end-to-end control-plane workload coverage to remove the retired Red Hat Marketplace catalog workload.
  - Removed its special resource, crash-tolerance, and volume-eviction handling from validation scenarios.
  - Other catalog workload checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->