### PR TITLE
NO-JIRA: feat(azure): Add scripts to setup credentials and check resources

### DIFF
--- a/contrib/managed-azure/README.md
+++ b/contrib/managed-azure/README.md
@@ -94,6 +94,21 @@ For subsequent clusters, run the script without this flag to skip the one-time s
 
 You can comment out steps from setup_all.sh to run only what you want.
 
+### Verifying Resources
+
+To check that all required Azure resources exist, use the health check script:
+
+```
+# Check everything
+../contrib/managed-azure/check_resources.sh
+
+# Check only one-time setup resources
+../contrib/managed-azure/check_resources.sh --first-time
+
+# Check only per-cluster resources
+../contrib/managed-azure/check_resources.sh --cluster
+```
+
 ## Microsoft Velero Extension
 
 We already include the managed identity/service principal related with Velero, so you just need to execute these commands:

--- a/contrib/managed-azure/README.md
+++ b/contrib/managed-azure/README.md
@@ -1,4 +1,5 @@
 # General
+
 This directory contains several developer-focused scripts and instructions related to setting up an AKS management cluster and create a HostedCluster replicating what we do in ARO environments.
 
 If you do have issues with these scripts or need further help. Please reach out to #project-hypershift on Red Hat Slack.
@@ -6,6 +7,21 @@ If you do have issues with these scripts or need further help. Please reach out 
 Steps:
 
 Create a ServicePrincipal to let hypershift cli create the HostedCluster infra for you.
+
+## Automated (Recommended)
+
+If you already have a service principal, you can use the helper script to generate the credentials file:
+
+```bash
+export AZURE_SP_NAME="your-sp-name"
+../contrib/managed-azure/setup_azure_creds.sh
+```
+
+This will look up the SP, reset its credentials, and write `azure-creds.json`. If the SP doesn't exist or `AZURE_SP_NAME` is not set, the script prints instructions to create one.
+
+> **Note**: The script resets the SP credentials, which **invalidates any previous client secret**. It will prompt for confirmation before proceeding. If multiple SPs match the given name, the script will error and ask you to resolve the ambiguity.
+
+## Manual
 
 ```
 SP_DETAILS=$(az ad sp create-for-rbac --name "${PREFIX}-sp" --role Contributor --scopes "/subscriptions/$SUBSCRIPTION_ID" -o json)
@@ -64,11 +80,12 @@ Run it
 
 When setting up your first cluster, use the `--first-time` flag to create the one-time setup resources that should be reused across multiple clusters to avoid Azure quota issues:
 
-```
+```bash
 ../contrib/managed-azure/setup_all.sh --first-time
 ```
 
 The `--first-time` flag automatically handles the creation of:
+
 - Service principals and Key Vault ([setup_MIv3_kv.sh](./setup_MIv3_kv.sh))
 - OIDC issuer ([setup_oidc_provider.sh](./setup_oidc_provider.sh))
 - Data plane identities ([setup_dataplane_identities.sh](./setup_dataplane_identities.sh))
@@ -105,6 +122,7 @@ To delete both the hosted cluster and AKS management cluster along with all asso
 ```
 
 This script will:
+
 1. Delete the hosted cluster and its managed resources
 2. Delete the AKS management cluster and resource group
 3. Clean up customer VNET and NSG resource groups
@@ -122,6 +140,7 @@ If you need more granular control, you can run the individual deletion scripts:
 ```
 
 This deletes:
+
 - The hosted cluster itself
 - Managed resource group (contains cluster resources)
 - Customer VNET resource group
@@ -134,6 +153,7 @@ This deletes:
 ```
 
 This deletes:
+
 - The AKS management cluster
 - AKS resource group
 - AKS-specific Key Vault role assignments

--- a/contrib/managed-azure/check_resources.sh
+++ b/contrib/managed-azure/check_resources.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+set -o nounset
+
+# Verifies that all required Azure resources exist for the managed-azure HyperShift setup.
+# Run from your dev/ directory (where user-vars.sh lives).
+#
+# Usage:
+#   ../contrib/managed-azure/check_resources.sh [--first-time] [--cluster]
+#
+# Flags:
+#   --first-time   Check one-time setup resources (Key Vault, SPs, OIDC, managed identities)
+#   --cluster      Check per-cluster resources (AKS, DNS, HyperShift operator, hosted cluster)
+#   (no flags)     Check everything
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -f "${SCRIPT_DIR}/vars.sh" ]]; then
+    source "${SCRIPT_DIR}/vars.sh"
+else
+    echo "Error: vars.sh not found. Run this from your dev/ directory."
+    exit 1
+fi
+
+# Check Azure login
+if ! az account show >/dev/null 2>&1; then
+    echo "Error: Not logged into Azure. Run 'az login' first."
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+WARN=0
+
+pass() {
+    echo "  ✓ $1"
+    PASS=$((PASS + 1))
+}
+fail() {
+    echo "  ✗ $1"
+    FAIL=$((FAIL + 1))
+}
+warn() {
+    echo "  ⚠ $1"
+    WARN=$((WARN + 1))
+}
+
+check_resource() {
+    local label="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+check_local_file() {
+    local label="$1"
+    local path="$2"
+    if [[ -f "$path" ]]; then
+        pass "$label ($path)"
+    else
+        fail "$label ($path)"
+    fi
+}
+
+CHECK_FIRST_TIME=false
+CHECK_CLUSTER=false
+
+for arg in "$@"; do
+    case "$arg" in
+    --first-time) CHECK_FIRST_TIME=true ;;
+    --cluster) CHECK_CLUSTER=true ;;
+    *)
+        echo "Unknown flag: $arg"
+        exit 1
+        ;;
+    esac
+done
+
+# Default: check everything
+if ! $CHECK_FIRST_TIME && ! $CHECK_CLUSTER; then
+    CHECK_FIRST_TIME=true
+    CHECK_CLUSTER=true
+fi
+
+echo ""
+echo "=== Azure Credentials (setup_azure_creds.sh) ==="
+check_local_file "Azure credentials" "${AZURE_CREDS}"
+
+if $CHECK_FIRST_TIME; then
+    echo ""
+    echo "=== Key Vault (setup_MIv3_kv.sh) ==="
+    check_resource "Key Vault '${PREFIX}'" \
+        az keyvault show --name "${PREFIX}" --resource-group "${PERSISTENT_RG_NAME}"
+
+    echo ""
+    echo "=== Control Plane Service Principals (setup_MIv3_kv.sh) ==="
+    for sp in "cloud-provider-${PREFIX}" "cpo-${PREFIX}" "azure-disk-${PREFIX}" \
+        "azure-file-${PREFIX}" "ciro-${PREFIX}" "ingress-${PREFIX}" \
+        "cncc-${PREFIX}" "nodepool-mgmt-${PREFIX}" "velero-${PREFIX}"; do
+        SP_MATCHES=$(az ad sp list --display-name "$sp" --query "[?displayName=='$sp'].appId" -o tsv 2>/dev/null)
+        SP_COUNT=$(echo "$SP_MATCHES" | grep -c . 2>/dev/null || echo 0)
+        if [[ "$SP_COUNT" -eq 1 ]]; then
+            pass "SP '$sp'"
+        elif [[ "$SP_COUNT" -gt 1 ]]; then
+            fail "SP '$sp' (multiple matches found — expected exactly 1)"
+        else
+            fail "SP '$sp'"
+        fi
+    done
+
+    echo ""
+    echo "=== Key Vault Certificates & Secrets (setup_MIv3_kv.sh) ==="
+    if az keyvault show --name "${PREFIX}" --resource-group "${PERSISTENT_RG_NAME}" >/dev/null 2>&1; then
+        KV_CERTS=$(az keyvault certificate list --vault-name "${PREFIX}" --query "[].name" -o tsv 2>&1)
+        if [[ $? -ne 0 ]]; then
+            fail "Key Vault certificates (query failed: $KV_CERTS)"
+        else
+            for cert in "cloud-provider-${PREFIX}" "cpo-${PREFIX}" "azure-disk-${PREFIX}" \
+                "azure-file-${PREFIX}" "ciro-${PREFIX}" "ingress-${PREFIX}" \
+                "cncc-${PREFIX}" "nodepool-mgmt-${PREFIX}" "velero-${PREFIX}"; do
+                if echo "$KV_CERTS" | grep -qx "$cert"; then
+                    pass "Certificate '$cert'"
+                else
+                    fail "Certificate '$cert'"
+                fi
+            done
+        fi
+
+        KV_SECRETS=$(az keyvault secret list --vault-name "${PREFIX}" --query "[].name" -o tsv 2>&1)
+        if [[ $? -ne 0 ]]; then
+            fail "Key Vault secrets (query failed: $KV_SECRETS)"
+        else
+            for secret in "cloud-provider-${PREFIX}-json" "cpo-${PREFIX}-json" "azure-disk-${PREFIX}-json" \
+                "azure-file-${PREFIX}-json" "ciro-${PREFIX}-json" "ingress-${PREFIX}-json" \
+                "cncc-${PREFIX}-json" "nodepool-mgmt-${PREFIX}-json" "velero-${PREFIX}-json"; do
+                if echo "$KV_SECRETS" | grep -qx "$secret"; then
+                    pass "Secret '$secret'"
+                else
+                    fail "Secret '$secret'"
+                fi
+            done
+        fi
+    else
+        fail "Key Vault not accessible — cannot check secrets"
+    fi
+
+    echo ""
+    echo "=== Control Plane Output File (setup_MIv3_kv.sh) ==="
+    check_local_file "cp-output.json" "${CP_OUTPUT_FILE}"
+
+    echo ""
+    echo "=== OIDC Provider (setup_oidc_provider.sh) ==="
+    check_resource "Storage Account '${OIDC_ISSUER_NAME}'" \
+        az storage account show --name "${OIDC_ISSUER_NAME}" --resource-group "${PERSISTENT_RG_NAME}"
+
+    BLOB_COUNT=$(az storage blob list --account-name "${OIDC_ISSUER_NAME}" --container-name "${OIDC_ISSUER_NAME}" --query "length([])" -o tsv 2>/dev/null)
+    if [[ -n "$BLOB_COUNT" && "$BLOB_COUNT" -ge 2 ]] 2>/dev/null; then
+        pass "OIDC discovery documents ($BLOB_COUNT blobs)"
+    else
+        fail "OIDC discovery documents (expected >= 2, got ${BLOB_COUNT:-0})"
+    fi
+
+    check_local_file "SA signing private key" "${SA_TOKEN_ISSUER_PRIVATE_KEY_PATH}"
+    check_local_file "SA signing public key" "${SA_TOKEN_ISSUER_PUBLIC_KEY_PATH}"
+
+    echo ""
+    echo "=== Data Plane Managed Identities (setup_dataplane_identities.sh) ==="
+    for mi in "azure-disk-MI-${PREFIX}" "azure-file-MI-${PREFIX}" "image-registry-MI-${PREFIX}"; do
+        check_resource "MI '$mi'" \
+            az identity show --name "$mi" --resource-group "${PERSISTENT_RG_NAME}"
+    done
+
+    echo ""
+    echo "=== Data Plane Federated Credentials (setup_dataplane_identities.sh) ==="
+    for mi in "azure-disk-MI-${PREFIX}" "azure-file-MI-${PREFIX}" "image-registry-MI-${PREFIX}"; do
+        FC_COUNT=$(az identity federated-credential list --identity-name "$mi" --resource-group "${PERSISTENT_RG_NAME}" --query "length([])" -o tsv 2>/dev/null)
+        if [[ -n "$FC_COUNT" && "$FC_COUNT" -ge 1 ]] 2>/dev/null; then
+            pass "Federated credential on '$mi'"
+        else
+            fail "Federated credential on '$mi'"
+        fi
+    done
+
+    echo ""
+    echo "=== Data Plane Output File (setup_dataplane_identities.sh) ==="
+    check_local_file "dp-output.json" "${DP_OUTPUT_FILE}"
+
+    echo ""
+    echo "=== AKS Managed Identities (setup_aks_mi.sh) ==="
+    check_resource "MI '${PREFIX}-aks-mi'" \
+        az identity show --name "${PREFIX}-aks-mi" --resource-group "${PERSISTENT_RG_NAME}"
+    check_resource "MI '${PREFIX}-aks-kubelet-mi'" \
+        az identity show --name "${PREFIX}-aks-kubelet-mi" --resource-group "${PERSISTENT_RG_NAME}"
+fi
+
+if $CHECK_CLUSTER; then
+    echo ""
+    echo "=== AKS Cluster (setup_aks_cluster.sh) ==="
+    check_resource "Resource Group '${AKS_RG}'" \
+        az group show --name "${AKS_RG}"
+    check_resource "AKS Cluster '${AKS_CLUSTER_NAME}'" \
+        az aks show --name "${AKS_CLUSTER_NAME}" --resource-group "${AKS_RG}"
+
+    echo ""
+    echo "=== DNS (setup_external_dns.sh) ==="
+    check_resource "DNS Zone '${MGMT_DNS_ZONE_NAME}'" \
+        az network dns zone show --name "${MGMT_DNS_ZONE_NAME}" --resource-group "${PERSISTENT_RG_NAME}"
+
+    DNS_SP_NAME="${PREFIX}-ExternalDnsServicePrincipal"
+    SP_MATCHES=$(az ad sp list --display-name "$DNS_SP_NAME" --query "[?displayName=='$DNS_SP_NAME'].appId" -o tsv 2>/dev/null)
+    SP_COUNT=$(echo "$SP_MATCHES" | grep -c . 2>/dev/null || echo 0)
+    if [[ "$SP_COUNT" -eq 1 ]]; then
+        pass "SP '$DNS_SP_NAME'"
+    elif [[ "$SP_COUNT" -gt 1 ]]; then
+        fail "SP '$DNS_SP_NAME' (multiple matches found — expected exactly 1)"
+    else
+        fail "SP '$DNS_SP_NAME'"
+    fi
+
+    check_local_file "External DNS credentials" "${EXTERNAL_DNS_SERVICE_PRINCIPAL_FILEPATH}"
+
+    echo ""
+    echo "=== HyperShift Operator (setup_install_ho_on_aks.sh) ==="
+    if kubectl cluster-info >/dev/null 2>&1; then
+        HO_PODS=$(kubectl get pods -n hypershift --no-headers 2>/dev/null | grep -c "Running")
+        if [[ "$HO_PODS" -ge 1 ]]; then
+            pass "HyperShift operator pods running ($HO_PODS)"
+        else
+            fail "HyperShift operator pods not running"
+        fi
+    else
+        fail "Cannot reach cluster — unable to check operator"
+    fi
+
+    echo ""
+    echo "=== Hosted Cluster (create_basic_hosted_cluster.sh) ==="
+    CLUSTER_NAME="${PREFIX}-hc"
+    if kubectl cluster-info >/dev/null 2>&1; then
+        HC_STATUS=$(kubectl get hostedcluster "${CLUSTER_NAME}" -n clusters -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)
+        if [[ "$HC_STATUS" == "True" ]]; then
+            pass "HostedCluster '${CLUSTER_NAME}' is Available"
+        elif [[ -n "$HC_STATUS" ]]; then
+            warn "HostedCluster '${CLUSTER_NAME}' exists but not yet Available (status: $HC_STATUS)"
+        else
+            HC_EXISTS=$(kubectl get hostedcluster "${CLUSTER_NAME}" -n clusters 2>/dev/null)
+            if [[ -n "$HC_EXISTS" ]]; then
+                warn "HostedCluster '${CLUSTER_NAME}' exists but status unknown"
+            else
+                fail "HostedCluster '${CLUSTER_NAME}' not found"
+            fi
+        fi
+    else
+        fail "Cannot reach cluster — unable to check hosted cluster"
+    fi
+fi
+
+echo ""
+echo "==============================="
+echo "Results: $PASS passed, $FAIL failed, $WARN warnings"
+echo "==============================="
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi

--- a/contrib/managed-azure/setup_azure_creds.sh
+++ b/contrib/managed-azure/setup_azure_creds.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+set -o nounset
+set -o pipefail
+
+# This script creates the azure-creds.json file from an existing Azure Service Principal.
+# It resets the SP credentials to generate a new client secret.
+#
+# Prerequisites:
+#   - Azure CLI logged in (az login)
+#   - AZURE_SP_NAME environment variable set to the display name of your SP
+#
+# Usage:
+#   export AZURE_SP_NAME="my-prefix-sp"
+#   ./setup_azure_creds.sh
+#
+# Output:
+#   ./azure-creds.json
+
+AZURE_CREDS_OUTPUT="${AZURE_CREDS_OUTPUT:-./azure-creds.json}"
+
+# Check prerequisites
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but not found. Install it and re-run."
+  exit 1
+fi
+
+# Check Azure login
+if ! az account show >/dev/null 2>&1; then
+  echo "Error: Not logged into Azure. Run 'az login' first."
+  exit 1
+fi
+
+# Check AZURE_SP_NAME is set
+if [[ -z "${AZURE_SP_NAME:-}" ]]; then
+  echo "Error: AZURE_SP_NAME is not set."
+  echo ""
+  echo "Usage:"
+  echo "  export AZURE_SP_NAME=\"your-sp-name\""
+  echo "  ./setup_azure_creds.sh"
+  echo ""
+  echo "If you don't have a service principal yet, create one:"
+  echo ""
+  echo "  SUBSCRIPTION_ID=\$(az account show --query id -o tsv)"
+  echo "  az ad sp create-for-rbac --name \"your-sp-name\" \\"
+  echo "    --role Contributor --scopes \"/subscriptions/\$SUBSCRIPTION_ID\""
+  echo ""
+  echo "Then request these permissions from your admin (DPTP request for Red Hat):"
+  echo "  1. Microsoft Graph 'Application.ReadWrite.OwnedBy' on the SP"
+  echo "  2. 'User Access Administrator' role at the subscription level"
+  echo ""
+  echo "Once the SP is ready, re-run this script with AZURE_SP_NAME set."
+  exit 1
+fi
+
+# Look up the SP — require an exact display name match and exactly one result.
+# Split az and jq so we can check each exit code independently.
+SP_LIST_STDERR=$(mktemp)
+SP_LIST_JSON=$(az ad sp list --display-name "${AZURE_SP_NAME}" -o json 2>"$SP_LIST_STDERR")
+if [[ $? -ne 0 ]]; then
+  echo "Error: Failed to look up service principal '${AZURE_SP_NAME}'."
+  cat "$SP_LIST_STDERR"
+  rm -f "$SP_LIST_STDERR"
+  exit 1
+fi
+rm -f "$SP_LIST_STDERR"
+
+SP_MATCHES=$(echo "$SP_LIST_JSON" | jq -r --arg name "${AZURE_SP_NAME}" '.[] | select(.displayName == $name) | .appId')
+if [[ $? -ne 0 ]]; then
+  echo "Error: Failed to parse service principal lookup response."
+  exit 1
+fi
+
+SP_COUNT=$(echo "$SP_MATCHES" | grep -c . 2>/dev/null || echo 0)
+
+if [[ -z "$SP_MATCHES" ]]; then
+  echo "Error: Service principal '${AZURE_SP_NAME}' not found."
+  echo ""
+  echo "To create it:"
+  echo ""
+  echo "  SUBSCRIPTION_ID=\$(az account show --query id -o tsv)"
+  echo "  az ad sp create-for-rbac --name \"${AZURE_SP_NAME}\" \\"
+  echo "    --role Contributor --scopes \"/subscriptions/\$SUBSCRIPTION_ID\""
+  echo ""
+  echo "Then request these permissions from your admin (DPTP request for Red Hat):"
+  echo "  1. Microsoft Graph 'Application.ReadWrite.OwnedBy' on the SP"
+  echo "  2. 'User Access Administrator' role at the subscription level"
+  echo ""
+  echo "Once the SP is ready, re-run this script."
+  exit 1
+fi
+
+if [[ "$SP_COUNT" -gt 1 ]]; then
+  echo "Error: Multiple service principals found matching '${AZURE_SP_NAME}':"
+  echo "$SP_MATCHES"
+  echo ""
+  echo "Please ensure the display name is unique or delete duplicates."
+  exit 1
+fi
+
+CLIENT_ID="$SP_MATCHES"
+
+# Get subscription and tenant info
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+TENANT_ID=$(az account show --query tenantId -o tsv)
+
+echo "Found service principal '${AZURE_SP_NAME}' (appId: ${CLIENT_ID})"
+
+# Preflight checks before confirmation — fail early before any destructive action.
+CREDS_OUTPUT_DIR=$(dirname "${AZURE_CREDS_OUTPUT}")
+if [[ ! -d "$CREDS_OUTPUT_DIR" ]]; then
+  echo "Error: Output directory '${CREDS_OUTPUT_DIR}' does not exist."
+  exit 1
+fi
+
+CREDS_TMPFILE=$(mktemp "${AZURE_CREDS_OUTPUT}.XXXXXX")
+if [ $? -ne 0 ]; then
+  echo "Error: Cannot create temporary file in '${CREDS_OUTPUT_DIR}'. Check permissions."
+  exit 1
+fi
+chmod 0600 "$CREDS_TMPFILE"
+trap 'rm -f "$CREDS_TMPFILE"' EXIT
+
+echo ""
+echo "WARNING: This will reset the SP credentials, invalidating any existing client secret."
+read -p "Continue? (yes/no): " -r
+if [[ ! $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then
+  echo "Aborted."
+  exit 0
+fi
+
+echo "Resetting credentials to generate a new client secret..."
+
+# Reset credentials — redirect stderr to a temp file so Azure CLI warnings
+# (e.g. "The output includes credentials...") don't break JSON parsing,
+# but we can still show the error if the command fails.
+SP_STDERR=$(mktemp)
+trap 'rm -f "$SP_STDERR" "$CREDS_TMPFILE"' EXIT
+SP_DETAILS=$(az ad sp credential reset --id "$CLIENT_ID" -o json 2>"$SP_STDERR")
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to reset credentials for SP '${AZURE_SP_NAME}'."
+  cat "$SP_STDERR"
+  echo ""
+  echo "You may not have permission to reset this SP's credentials."
+  echo "Check that you own this SP or ask your admin for help."
+  exit 1
+fi
+
+CLIENT_SECRET=$(echo "$SP_DETAILS" | jq -r '.password')
+
+if [[ -z "$CLIENT_SECRET" || "$CLIENT_SECRET" == "null" ]]; then
+  echo "Error: Failed to extract client secret from credential reset response."
+  exit 1
+fi
+
+# Write the credentials file through the pre-created temp file.
+jq -n \
+  --arg subscriptionId "${SUBSCRIPTION_ID}" \
+  --arg tenantId "${TENANT_ID}" \
+  --arg clientId "${CLIENT_ID}" \
+  --arg clientSecret "${CLIENT_SECRET}" \
+  '{subscriptionId: $subscriptionId, tenantId: $tenantId, clientId: $clientId, clientSecret: $clientSecret}' \
+  >"$CREDS_TMPFILE"
+
+if [ $? -ne 0 ]; then
+  rm -f "$CREDS_TMPFILE"
+  echo "Error: Failed to write credentials file."
+  exit 1
+fi
+
+mv "$CREDS_TMPFILE" "${AZURE_CREDS_OUTPUT}"
+if [ $? -ne 0 ]; then
+  rm -f "$CREDS_TMPFILE"
+  echo "Error: Failed to move credentials file to ${AZURE_CREDS_OUTPUT}."
+  exit 1
+fi
+
+echo ""
+echo "Azure credentials written to: ${AZURE_CREDS_OUTPUT}"
+echo ""
+echo "Set this in your user-vars.sh:"
+echo "  export AZURE_CREDS=\"${AZURE_CREDS_OUTPUT}\""


### PR DESCRIPTION
## What this PR does / why we need it:
To run the azure setup scripts in `contrib/managed-azure` a JSON with credentials is required and the README has instructions to manually create it.
Add a script `setup-azure-creds.sh` to automate the process.

Additionally, add a resources check script that gives a quick overview of which resources were installed correctly and which failed.

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Azure service principal credential setup with login validation, credential rotation, secure storage, and configurable output locations.
  * Added managed-Azure deployment verification covering required resources, identities, cluster health, generated files, and authentication.
  * Added verification modes for all resources, first-time setup, or individual clusters.

* **Documentation**
  * Added automated and manual Azure credential setup instructions.
  * Documented credential-reset warnings, verification commands, setup steps, and cleanup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->