### PR TITLE
NO-JIRA: spread AKS nodes across availability zones

### DIFF
--- a/contrib/managed-azure/setup_aks_cluster.sh
+++ b/contrib/managed-azure/setup_aks_cluster.sh
@@ -23,15 +23,50 @@ az group create \
 export AKS_CP_MI_ID=$(az identity show --name $AKS_CP_MI_NAME --resource-group $PERSISTENT_RG_NAME --query id -o tsv)
 export AKS_KUBELET_MI_ID=$(az identity show --name $AKS_KUBELET_MI_NAME --resource-group $PERSISTENT_RG_NAME --query id -o tsv)
 
-# Create AKS Cluster
+# Node VM size for the AKS cluster.
+NODE_VM_SIZE="Standard_D4s_v5"
+
+# `az aks list-vm-skus` lives in the aks-preview extension, not the core CLI.
+# Ensure it is installed (and current) so this script does not rely on Azure
+# CLI's dynamic-install behavior, which is disabled in some environments/CI.
+az extension add --name aks-preview --upgrade
+
+# Discover which availability zones support the node VM size in this region,
+# using the AKS-specific SKU list (authoritative for AKS node pools; general
+# `az vm list-skus` may report zones that AKS won't accept). The nodes are then
+# spread across those zones.
+#
+# This matters because the hypershift-sharedingress router runs 2 replicas with a
+# required pod anti-affinity on topology.kubernetes.io/zone: it needs at least 2
+# zones, or the second replica stays Pending ("didn't match pod anti-affinity
+# rules"). Zone and SKU availability varies by region and subscription, so we
+# fail fast with a clear message rather than create a cluster the router cannot
+# schedule on.
+AVAILABLE_ZONES=$(az aks list-vm-skus \
+--location "${LOCATION}" \
+--size "${NODE_VM_SIZE}" \
+--zone \
+--query "[?name=='${NODE_VM_SIZE}'].locationInfo[0].zones[]" \
+-o tsv | sort -u | tr '\n' ' ')
+
+ZONE_COUNT=$(echo ${AVAILABLE_ZONES} | wc -w | tr -d ' ')
+if [[ "${ZONE_COUNT}" -lt 2 ]]; then
+	echo "ERROR: ${NODE_VM_SIZE} in ${LOCATION} exposes ${ZONE_COUNT} availability zone(s) for this subscription; the hypershift-sharedingress router requires at least 2. Pick a region/VM size with multiple zones (e.g. eastus)." >&2
+	exit 1
+fi
+
+# Create AKS Cluster.
+# ${AVAILABLE_ZONES} is intentionally unquoted so it expands to one value per
+# zone after --zones (e.g. "--zones 1 2 3").
 az aks create \
 --resource-group ${AKS_RG} \
 --name ${AKS_CLUSTER_NAME} \
 --node-count 3 \
+--zones ${AVAILABLE_ZONES} \
 --generate-ssh-keys \
 --load-balancer-sku standard \
 --os-sku AzureLinux \
---node-vm-size Standard_D4s_v5 \
+--node-vm-size ${NODE_VM_SIZE} \
 --enable-fips-image \
 --enable-addons azure-keyvault-secrets-provider \
 --enable-secret-rotation \


### PR DESCRIPTION
## What this PR does / why we need it:

The `contrib/managed-azure` setup created the AKS management cluster with `az aks create --node-count 3` and **no `--zones`**, so all three nodes landed in a single availability zone (labeled `0`).

The `hypershift-sharedingress` router runs 2 replicas with a **required** pod anti-affinity on `topology.kubernetes.io/zone`. With only one zone available, the second replica can never satisfy the anti-affinity and stays `Pending` ("didn't match pod anti-affinity rules") on every newly created cluster, leaving the router degraded until a zoned node pool is added by hand.

This PR discovers the availability zones that support the node VM size in the target region via `az aks list-vm-skus` (authoritative for AKS node pools, unlike the general `az vm list-skus`) and passes them to `az aks create --zones`, spreading the three nodes across those zones. Because zone and SKU availability varies by region and subscription, the script fails fast with a clear message when fewer than 2 zones are available rather than creating a cluster the router cannot schedule on. This satisfies the router anti-affinity out of the box and removes the need for the manual `az aks nodepool add --zones` workaround.

## Which issue(s) this PR fixes:

NO-JIRA — no Jira ticket associated with this change.

## Special notes for your reviewer:

- Zone detection is dynamic rather than hardcoded: `az aks list-vm-skus --location "${LOCATION}" --size "${NODE_VM_SIZE}"` returns the zones AKS will actually accept for that SKU in that region/subscription, so the setup works beyond `eastus` and does not silently break if a region/subscription exposes different zones.
- Fails fast: if fewer than 2 zones are available for the SKU, the script exits with an actionable error instead of creating a cluster where the router can never schedule.
- The `${AVAILABLE_ZONES}` expansion into `--zones` is intentionally unquoted so it splits into one argument per zone.
- Affects new clusters only (`az aks create`); it cannot retrofit zones onto an existing single-zone node pool.
- Scripts-only change under `contrib/managed-azure/`; no Go code, unit tests, or product docs are affected. Verified with `bash -n`.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced. (NO-JIRA — none)
- [ ] This change includes docs.
- [ ] This change includes unit tests. (N/A — shell script under contrib/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * AKS cluster setup now automatically detects availability zones that support the selected VM size in the target Azure region.
  * Clusters are created across all compatible zones instead of relying on a fixed set of zones.
  * Setup now stops with a clear error when fewer than two compatible zones are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->