### PR TITLE
ACM-37663: Rebase hypershift operator runtime image to RHEL 9.8 ELS

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -6,7 +6,7 @@ COPY . .
 
 RUN make build
 
-FROM registry.redhat.io/rhel9-4-els/rhel:9.4
+FROM registry.redhat.io/rhel9-8-els/rhel:9.8
 COPY --from=builder /hypershift/bin/hypershift \
                     /hypershift/bin/hypershift-operator \
                     /hypershift/bin/control-plane-operator \


### PR DESCRIPTION
Jira: [ACM-37663](https://redhat.atlassian.net/browse/ACM-37663)

## Summary
- Rebase `Containerfile.operator` runtime stage from `rhel9-4-els/rhel:9.4` to `rhel9-8-els/rhel:9.8`
- The 9.4 ELS base is no longer supported/receiving updates; MCE 2.8 operator builds need a supported ELS stream for patched OpenSSL and other base packages

## Test plan
- [ ] Comment `/ok-to-test` on Konflux `hypershift-release-mce-28-on-pull-request`
- [ ] Verify operator image build succeeds on `release-4.18`
- [ ] Attach resulting image digest to ACM-37663 for PSIRT validation


Made with [Cursor](https://cursor.com)