### PR TITLE
ACM-41684: Switch hypershift-operator runtime to PQC base image

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -9,7 +9,7 @@ RUN make hypershift \
   && make hypershift-operator \
   && make karpenter-operator
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786380870
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 COPY --from=builder /hypershift/bin/hypershift \
   /hypershift/bin/hypershift-operator \
   /hypershift/bin/karpenter-operator \


### PR DESCRIPTION
Jira: [ACM-41684](https://redhat.atlassian.net/browse/ACM-41684)

## Summary

- Switch `Containerfile.operator` runtime stage from `ubi9/ubi-minimal` to `registry.redhat.io/ubi9/ubi-minimal-pqc:latest`
- Part of parent [ACM-41562](https://redhat.atlassian.net/browse/ACM-41562) / [ACM-40663](https://redhat.atlassian.net/browse/ACM-40663) (PQC base images for ACM/MCE 5.0)
- Companion PR to `release-5.0` backport

## Test plan

- [ ] Konflux build for hypershift-operator succeeds
- [ ] Verify operator runs in regular mode with no regression
- [ ] Verify operator runs in FIPS mode with no regression
- [ ] Link testing card to [OCPSTRAT-3113](https://issues.redhat.com/browse/OCPSTRAT-3113)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s runtime container image to a post-quantum cryptography–ready base image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->