### PR TITLE
OCPBUGS-114459: recognize domain-specific test fields

### DIFF
--- a/hack/tools/hypershiftlinter/analyzers/testcasename/testcasename.go
+++ b/hack/tools/hypershiftlinter/analyzers/testcasename/testcasename.go
@@ -191,7 +191,7 @@ func isTestFieldName(name string) bool {
 	testFieldNames := []string{
 		"want", "expected", "expectError", "expectErr", "wantErr",
 		"args", "input", "output", "result", "fields", "setup",
-		"assertion", "validate", "check",
+		"assertion", "validate", "check", "ips",
 	}
 	return slices.Contains(testFieldNames, name)
 }

--- a/hack/tools/hypershiftlinter/analyzers/testcasename/testdata/src/a/bad/bad_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/testcasename/testdata/src/a/bad/bad_test.go
@@ -110,3 +110,25 @@ func TestWithSetupField(t *testing.T) {
 		_ = tt
 	}
 }
+
+func TestWithDomainSpecificField(t *testing.T) {
+	tests := []struct {
+		name string
+		ips  []string
+	}{
+		{
+			name: "ipv4-only", // want `test case name "ipv4-only" must match format "When <condition>, it should <expected behavior>"`
+			ips:  []string{"127.0.0.1"},
+		},
+		{
+			name: "dual-stack", // want `test case name "dual-stack" must match format "When <condition>, it should <expected behavior>"`
+			ips:  []string{"127.0.0.1", "2001:db8::1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = tt.ips
+		})
+	}
+}

--- a/hack/tools/hypershiftlinter/analyzers/testcasename/testdata/src/a/good/good_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/testcasename/testdata/src/a/good/good_test.go
@@ -103,6 +103,17 @@ func TestPlainLookupMap(t *testing.T) {
 	_ = fixtures
 }
 
+func TestAnonymousFixtureStruct(t *testing.T) {
+	fixture := struct {
+		name string
+		host string
+	}{
+		name: "ipv4-only",
+		host: "localhost",
+	}
+	_ = fixture
+}
+
 func TestNameFromVariable(t *testing.T) {
 	testName := "some dynamic name"
 	tests := []struct {


### PR DESCRIPTION
## What this PR does / why we need it:

This is preventive hardening for future table-driven tests. The current codebase has no existing bad test cases to fix. If a future anonymous test table uses a domain-specific field such as:

```go
name: "ipv4-only"
ips:  []string{"127.0.0.1"}
```

the `testcasename` analyzer currently misses the case because `ips` is not recognized as a test field. This change recognizes `ips` and validates the case name against the TESTING.md convention. No existing tests are affected; the regression coverage demonstrates the future invalid case and preserves the ordinary fixture guard.

## Which issue(s) this PR fixes:
Fixes https://redhat.atlassian.net/browse/OCPBUGS-114459

## Special notes for your reviewer:

- This is preventive hardening, not a fix for an existing invalid test case.
- The classifier recognizes `ips` alongside `name`; ordinary anonymous fixture structs without recognized test fields remain ignored.
- `make test-linter` passes.
- `make run-gitlint` passes.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

