### PR TITLE
OCPBUGS-114735: fix support for Azure sovereign etcd backup endpoints

### DIFF
--- a/etcd-upload/azure_uploader.go
+++ b/etcd-upload/azure_uploader.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/openshift/hypershift/support/azureutil"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/msi-dataplane/pkg/dataplane"
-	"github.com/openshift/hypershift/support/azureutil"
 )
 
 const (
@@ -186,14 +187,4 @@ func newManagedIdentityCredential(ctx context.Context, credentialsFile string) (
 
 func etagPtr(e azcore.ETag) *azcore.ETag {
 	return &e
-}
-
-// newAzureBlobUploaderWithClient creates an AzureBlobUploader with a provided client (for testing).
-func newAzureBlobUploaderWithClient(container, serviceURL, encryptionScope string, client AzureBlobUploadAPI) *AzureBlobUploader {
-	return &AzureBlobUploader{
-		container:       container,
-		serviceURL:      serviceURL,
-		encryptionScope: encryptionScope,
-		client:          client,
-	}
 }

--- a/etcd-upload/azure_uploader.go
+++ b/etcd-upload/azure_uploader.go
@@ -7,10 +7,12 @@ import (
 	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/msi-dataplane/pkg/dataplane"
+	"github.com/openshift/hypershift/support/azureutil"
 )
 
 const (
@@ -24,7 +26,7 @@ const (
 // AzureBlobUploader uploads etcd snapshots to Azure Blob Storage.
 type AzureBlobUploader struct {
 	container       string
-	storageAccount  string
+	serviceURL      string
 	encryptionScope string
 	client          AzureBlobUploadAPI
 }
@@ -48,7 +50,7 @@ type azureCredentialsFile struct {
 //   - "managed-identity": uses msi-dataplane with a certificate file from CSI mount (ARO HCP)
 //
 // If credentialsFile is empty, falls back to DefaultAzureCredential regardless of authType.
-func NewAzureBlobUploader(ctx context.Context, container, storageAccount, credentialsFile, encryptionScope, authType string) (*AzureBlobUploader, error) {
+func NewAzureBlobUploader(ctx context.Context, container, storageAccount, credentialsFile, encryptionScope, authType, cloudName string) (*AzureBlobUploader, error) {
 	if container == "" {
 		return nil, fmt.Errorf("--container is required for AzureBlob storage type")
 	}
@@ -56,12 +58,19 @@ func NewAzureBlobUploader(ctx context.Context, container, storageAccount, creden
 		return nil, fmt.Errorf("--storage-account is required for AzureBlob storage type")
 	}
 
-	cred, err := newAzureCredential(ctx, credentialsFile, authType)
+	cloudConfig, err := azureutil.GetAzureCloudConfiguration(cloudName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Azure cloud configuration: %w", err)
+	}
+	cred, err := newAzureCredential(ctx, credentialsFile, authType, cloudConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load Azure credentials: %w", err)
 	}
 
-	serviceURL := fmt.Sprintf("https://%s.blob.core.windows.net", storageAccount)
+	serviceURL, err := azureBlobServiceURL(storageAccount, cloudName)
+	if err != nil {
+		return nil, err
+	}
 	client, err := azblob.NewClient(serviceURL, cred, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Azure Blob client: %w", err)
@@ -69,10 +78,18 @@ func NewAzureBlobUploader(ctx context.Context, container, storageAccount, creden
 
 	return &AzureBlobUploader{
 		container:       container,
-		storageAccount:  storageAccount,
+		serviceURL:      serviceURL,
 		encryptionScope: encryptionScope,
 		client:          client,
 	}, nil
+}
+
+func azureBlobServiceURL(storageAccount, cloudName string) (string, error) {
+	blobDNSSuffix, err := azureutil.GetAzureBlobDNSSuffix(cloudName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get Azure Blob DNS suffix: %w", err)
+	}
+	return fmt.Sprintf("https://%s.%s", storageAccount, blobDNSSuffix), nil
 }
 
 // Upload uploads a snapshot file to Azure Blob Storage with conditional write and optional CMK encryption.
@@ -102,7 +119,7 @@ func (u *AzureBlobUploader) Upload(ctx context.Context, snapshotPath string, key
 		return nil, fmt.Errorf("failed to upload to Azure Blob %s/%s: %w", u.container, key, err)
 	}
 
-	url := fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s", u.storageAccount, u.container, key)
+	url := fmt.Sprintf("%s/%s/%s", u.serviceURL, u.container, key)
 	return &UploadResult{URL: url}, nil
 }
 
@@ -111,9 +128,11 @@ func (u *AzureBlobUploader) Upload(ctx context.Context, snapshotPath string, key
 // If credentialsFile is provided:
 //   - authType "client-secret": reads a JSON file with clientId/clientSecret/tenantId
 //   - authType "managed-identity": uses msi-dataplane to load a certificate credential (ARO HCP)
-func newAzureCredential(ctx context.Context, credentialsFile, authType string) (azcore.TokenCredential, error) {
+func newAzureCredential(ctx context.Context, credentialsFile, authType string, cloudConfig cloud.Configuration) (azcore.TokenCredential, error) {
 	if credentialsFile == "" {
-		cred, err := azidentity.NewDefaultAzureCredential(nil)
+		cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
+			ClientOptions: azcore.ClientOptions{Cloud: cloudConfig},
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create default Azure credential: %w", err)
 		}
@@ -124,7 +143,7 @@ func newAzureCredential(ctx context.Context, credentialsFile, authType string) (
 	case AuthTypeManagedIdentity:
 		return newManagedIdentityCredential(ctx, credentialsFile)
 	case AuthTypeClientSecret, "":
-		return newClientSecretCredential(credentialsFile)
+		return newClientSecretCredential(credentialsFile, cloudConfig)
 	default:
 		return nil, fmt.Errorf("unsupported auth type: %q (must be %q or %q)", authType, AuthTypeClientSecret, AuthTypeManagedIdentity)
 	}
@@ -132,7 +151,7 @@ func newAzureCredential(ctx context.Context, credentialsFile, authType string) (
 
 // newClientSecretCredential reads a JSON file with clientId/clientSecret/tenantId
 // and returns a ClientSecretCredential.
-func newClientSecretCredential(credentialsFile string) (azcore.TokenCredential, error) {
+func newClientSecretCredential(credentialsFile string, cloudConfig cloud.Configuration) (azcore.TokenCredential, error) {
 	data, err := os.ReadFile(credentialsFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read credentials file %q: %w", credentialsFile, err)
@@ -143,7 +162,9 @@ func newClientSecretCredential(credentialsFile string) (azcore.TokenCredential, 
 		return nil, fmt.Errorf("failed to parse credentials file: %w", err)
 	}
 
-	credential, err := azidentity.NewClientSecretCredential(creds.TenantID, creds.ClientID, creds.ClientSecret, nil)
+	credential, err := azidentity.NewClientSecretCredential(creds.TenantID, creds.ClientID, creds.ClientSecret, &azidentity.ClientSecretCredentialOptions{
+		ClientOptions: azcore.ClientOptions{Cloud: cloudConfig},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Azure credential: %w", err)
 	}
@@ -168,10 +189,10 @@ func etagPtr(e azcore.ETag) *azcore.ETag {
 }
 
 // newAzureBlobUploaderWithClient creates an AzureBlobUploader with a provided client (for testing).
-func newAzureBlobUploaderWithClient(container, storageAccount, encryptionScope string, client AzureBlobUploadAPI) *AzureBlobUploader { //nolint:unparam // parameter kept for API consistency
+func newAzureBlobUploaderWithClient(container, serviceURL, encryptionScope string, client AzureBlobUploadAPI) *AzureBlobUploader {
 	return &AzureBlobUploader{
 		container:       container,
-		storageAccount:  storageAccount,
+		serviceURL:      serviceURL,
 		encryptionScope: encryptionScope,
 		client:          client,
 	}

--- a/etcd-upload/azure_uploader_test.go
+++ b/etcd-upload/azure_uploader_test.go
@@ -27,11 +27,20 @@ func (m *mockAzureBlobClient) UploadFile(ctx context.Context, containerName stri
 	return azblob.UploadFileResponse{}, nil
 }
 
+func newAzureBlobUploaderWithClient(encryptionScope string, client AzureBlobUploadAPI) *AzureBlobUploader {
+	return &AzureBlobUploader{
+		container:       "my-container",
+		serviceURL:      "https://mystorageaccount.blob.core.windows.net",
+		encryptionScope: encryptionScope,
+		client:          client,
+	}
+}
+
 func TestAzureBlobUploader(t *testing.T) {
 	t.Run("When uploading successfully it should return the correct Azure Blob URL", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := &mockAzureBlobClient{}
-		uploader := newAzureBlobUploaderWithClient("my-container", "https://mystorageaccount.blob.core.windows.net", "", mock)
+		uploader := newAzureBlobUploaderWithClient("", mock)
 		snapshotPath := createTempSnapshot(t)
 
 		result, err := uploader.Upload(context.Background(), snapshotPath, "backups/12345.db")
@@ -42,7 +51,7 @@ func TestAzureBlobUploader(t *testing.T) {
 	t.Run("When uploading it should set IfNoneMatch for conditional write", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := &mockAzureBlobClient{}
-		uploader := newAzureBlobUploaderWithClient("my-container", "https://mystorageaccount.blob.core.windows.net", "", mock)
+		uploader := newAzureBlobUploaderWithClient("", mock)
 		snapshotPath := createTempSnapshot(t)
 
 		_, err := uploader.Upload(context.Background(), snapshotPath, "backups/12345.db")
@@ -56,7 +65,7 @@ func TestAzureBlobUploader(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := &mockAzureBlobClient{}
 		encryptionScope := "my-encryption-scope"
-		uploader := newAzureBlobUploaderWithClient("my-container", "https://mystorageaccount.blob.core.windows.net", encryptionScope, mock)
+		uploader := newAzureBlobUploaderWithClient(encryptionScope, mock)
 		snapshotPath := createTempSnapshot(t)
 
 		_, err := uploader.Upload(context.Background(), snapshotPath, "backups/12345.db")
@@ -69,7 +78,7 @@ func TestAzureBlobUploader(t *testing.T) {
 	t.Run("When no encryption scope is provided it should not set CPKScopeInfo", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := &mockAzureBlobClient{}
-		uploader := newAzureBlobUploaderWithClient("my-container", "https://mystorageaccount.blob.core.windows.net", "", mock)
+		uploader := newAzureBlobUploaderWithClient("", mock)
 		snapshotPath := createTempSnapshot(t)
 
 		_, err := uploader.Upload(context.Background(), snapshotPath, "backups/12345.db")
@@ -84,7 +93,7 @@ func TestAzureBlobUploader(t *testing.T) {
 				return azblob.UploadFileResponse{}, fmt.Errorf("ConditionNotMet: The condition specified using HTTP conditional header(s) is not met")
 			},
 		}
-		uploader := newAzureBlobUploaderWithClient("my-container", "https://mystorageaccount.blob.core.windows.net", "", mock)
+		uploader := newAzureBlobUploaderWithClient("", mock)
 		snapshotPath := createTempSnapshot(t)
 
 		_, err := uploader.Upload(context.Background(), snapshotPath, "backups/12345.db")
@@ -95,10 +104,44 @@ func TestAzureBlobUploader(t *testing.T) {
 	t.Run("When snapshot file does not exist it should return an error", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := &mockAzureBlobClient{}
-		uploader := newAzureBlobUploaderWithClient("my-container", "https://mystorageaccount.blob.core.windows.net", "", mock)
+		uploader := newAzureBlobUploaderWithClient("", mock)
 
 		_, err := uploader.Upload(context.Background(), "/nonexistent/snapshot.db", "backups/12345.db")
 		g.Expect(err).To(HaveOccurred())
+	})
+}
+
+func TestNewAzureBlobUploader(t *testing.T) {
+	t.Run("When required options are provided it should return a configured uploader", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		uploader, err := NewAzureBlobUploader(context.Background(), "my-container", "mystorageaccount", "", "my-scope", AuthTypeClientSecret, "")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(uploader).ToNot(BeNil())
+		g.Expect(uploader.container).To(Equal("my-container"))
+		g.Expect(uploader.encryptionScope).To(Equal("my-scope"))
+		g.Expect(uploader.serviceURL).To(Equal("https://mystorageaccount.blob.core.windows.net"))
+		g.Expect(uploader.client).ToNot(BeNil())
+	})
+
+	t.Run("When container is empty it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		_, err := NewAzureBlobUploader(context.Background(), "", "mystorageaccount", "", "", "", "")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("--container is required"))
+	})
+
+	t.Run("When storage account is empty it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		_, err := NewAzureBlobUploader(context.Background(), "my-container", "", "", "", "", "")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("--storage-account is required"))
+	})
+
+	t.Run("When cloud name is invalid it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		_, err := NewAzureBlobUploader(context.Background(), "my-container", "mystorageaccount", "", "", "", "InvalidCloud")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to get Azure cloud configuration"))
 	})
 }
 
@@ -191,5 +234,22 @@ func TestAzureCredential(t *testing.T) {
 		credential, err := newAzureCredential(context.Background(), credFile, AuthTypeClientSecret, cloud.AzurePublic)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(credential).ToNot(BeNil())
+	})
+
+	t.Run("When auth type is client-secret and file is missing it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		_, err := newAzureCredential(context.Background(), "/nonexistent/client-secret-creds.json", AuthTypeClientSecret, cloud.AzurePublic)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to read credentials file"))
+	})
+
+	t.Run("When auth type is client-secret and JSON is invalid it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		credFile := filepath.Join(t.TempDir(), "invalid-client-secret-creds.json")
+		g.Expect(os.WriteFile(credFile, []byte("not-json"), 0644)).To(Succeed())
+
+		_, err := newAzureCredential(context.Background(), credFile, AuthTypeClientSecret, cloud.AzurePublic)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to parse credentials file"))
 	})
 }

--- a/etcd-upload/azure_uploader_test.go
+++ b/etcd-upload/azure_uploader_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 )
 
@@ -30,7 +31,7 @@ func TestAzureBlobUploader(t *testing.T) {
 	t.Run("When uploading successfully it should return the correct Azure Blob URL", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := &mockAzureBlobClient{}
-		uploader := newAzureBlobUploaderWithClient("my-container", "mystorageaccount", "", mock)
+		uploader := newAzureBlobUploaderWithClient("my-container", "https://mystorageaccount.blob.core.windows.net", "", mock)
 		snapshotPath := createTempSnapshot(t)
 
 		result, err := uploader.Upload(context.Background(), snapshotPath, "backups/12345.db")
@@ -41,7 +42,7 @@ func TestAzureBlobUploader(t *testing.T) {
 	t.Run("When uploading it should set IfNoneMatch for conditional write", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := &mockAzureBlobClient{}
-		uploader := newAzureBlobUploaderWithClient("my-container", "mystorageaccount", "", mock)
+		uploader := newAzureBlobUploaderWithClient("my-container", "https://mystorageaccount.blob.core.windows.net", "", mock)
 		snapshotPath := createTempSnapshot(t)
 
 		_, err := uploader.Upload(context.Background(), snapshotPath, "backups/12345.db")
@@ -55,7 +56,7 @@ func TestAzureBlobUploader(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := &mockAzureBlobClient{}
 		encryptionScope := "my-encryption-scope"
-		uploader := newAzureBlobUploaderWithClient("my-container", "mystorageaccount", encryptionScope, mock)
+		uploader := newAzureBlobUploaderWithClient("my-container", "https://mystorageaccount.blob.core.windows.net", encryptionScope, mock)
 		snapshotPath := createTempSnapshot(t)
 
 		_, err := uploader.Upload(context.Background(), snapshotPath, "backups/12345.db")
@@ -68,7 +69,7 @@ func TestAzureBlobUploader(t *testing.T) {
 	t.Run("When no encryption scope is provided it should not set CPKScopeInfo", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := &mockAzureBlobClient{}
-		uploader := newAzureBlobUploaderWithClient("my-container", "mystorageaccount", "", mock)
+		uploader := newAzureBlobUploaderWithClient("my-container", "https://mystorageaccount.blob.core.windows.net", "", mock)
 		snapshotPath := createTempSnapshot(t)
 
 		_, err := uploader.Upload(context.Background(), snapshotPath, "backups/12345.db")
@@ -83,7 +84,7 @@ func TestAzureBlobUploader(t *testing.T) {
 				return azblob.UploadFileResponse{}, fmt.Errorf("ConditionNotMet: The condition specified using HTTP conditional header(s) is not met")
 			},
 		}
-		uploader := newAzureBlobUploaderWithClient("my-container", "mystorageaccount", "", mock)
+		uploader := newAzureBlobUploaderWithClient("my-container", "https://mystorageaccount.blob.core.windows.net", "", mock)
 		snapshotPath := createTempSnapshot(t)
 
 		_, err := uploader.Upload(context.Background(), snapshotPath, "backups/12345.db")
@@ -94,11 +95,34 @@ func TestAzureBlobUploader(t *testing.T) {
 	t.Run("When snapshot file does not exist it should return an error", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := &mockAzureBlobClient{}
-		uploader := newAzureBlobUploaderWithClient("my-container", "mystorageaccount", "", mock)
+		uploader := newAzureBlobUploaderWithClient("my-container", "https://mystorageaccount.blob.core.windows.net", "", mock)
 
 		_, err := uploader.Upload(context.Background(), "/nonexistent/snapshot.db", "backups/12345.db")
 		g.Expect(err).To(HaveOccurred())
 	})
+}
+
+func TestAzureBlobServiceURL(t *testing.T) {
+	tests := []struct {
+		cloud   string
+		wantURL string
+	}{
+		{cloud: "", wantURL: "https://testaccount.blob.core.windows.net"},
+		{cloud: "AzurePublicCloud", wantURL: "https://testaccount.blob.core.windows.net"},
+		{cloud: "AzureUSGovernmentCloud", wantURL: "https://testaccount.blob.core.usgovcloudapi.net"},
+		{cloud: "AzureChinaCloud", wantURL: "https://testaccount.blob.core.chinacloudapi.cn"},
+		{cloud: "AzureGermanCloud", wantURL: "https://testaccount.blob.core.cloudapi.de"},
+		{cloud: "AzureBleuCloud", wantURL: "https://testaccount.blob.core.sovcloud-api.fr"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.cloud, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			got, err := azureBlobServiceURL("testaccount", tt.cloud)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(got).To(Equal(tt.wantURL))
+		})
+	}
 }
 
 func TestAzureCredential(t *testing.T) {
@@ -123,7 +147,7 @@ func TestAzureCredential(t *testing.T) {
 
 		// msi-dataplane will parse the JSON but fail on the invalid certificate.
 		// This proves the managed-identity path is reached and the file is consumed.
-		_, err = newAzureCredential(context.Background(), credFile, AuthTypeManagedIdentity)
+		_, err = newAzureCredential(context.Background(), credFile, AuthTypeManagedIdentity, cloud.AzurePublic)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("managed identity credential"))
 	})
@@ -131,7 +155,7 @@ func TestAzureCredential(t *testing.T) {
 	t.Run("When auth type is managed-identity and credentials file is missing it should return an error", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
-		_, err := newAzureCredential(context.Background(), "/nonexistent/creds.json", AuthTypeManagedIdentity)
+		_, err := newAzureCredential(context.Background(), "/nonexistent/creds.json", AuthTypeManagedIdentity, cloud.AzurePublic)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("managed identity credential"))
 	})
@@ -140,7 +164,7 @@ func TestAzureCredential(t *testing.T) {
 		// When no credentials file is provided, authType is ignored and
 		// DefaultAzureCredential is used. This matches the behavior where
 		// the controller doesn't pass --credentials-file.
-		_, err := newAzureCredential(context.Background(), "", AuthTypeManagedIdentity)
+		_, err := newAzureCredential(context.Background(), "", AuthTypeManagedIdentity, cloud.AzurePublic)
 		// DefaultAzureCredential will fail in a test environment (no Azure identity),
 		// but the error should NOT mention "managed identity credential".
 		if err != nil {
@@ -164,7 +188,7 @@ func TestAzureCredential(t *testing.T) {
 		credFile := filepath.Join(t.TempDir(), "client-secret-creds.json")
 		g.Expect(os.WriteFile(credFile, data, 0644)).To(Succeed())
 
-		credential, err := newAzureCredential(context.Background(), credFile, AuthTypeClientSecret)
+		credential, err := newAzureCredential(context.Background(), credFile, AuthTypeClientSecret, cloud.AzurePublic)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(credential).ToNot(BeNil())
 	})

--- a/etcd-upload/etcdupload.go
+++ b/etcd-upload/etcdupload.go
@@ -27,10 +27,16 @@ type options struct {
 	storageAccount  string
 	encryptionScope string
 	authType        string
+	azureCloud      string
 }
 
 func NewStartCommand() *cobra.Command {
-	opts := options{}
+	opts := options{
+		azureCloud: os.Getenv("AZURE_CLOUD_NAME"),
+	}
+	if opts.azureCloud == "" {
+		opts.azureCloud = "AzurePublicCloud"
+	}
 
 	cmd := &cobra.Command{
 		Use:          "etcd-upload",
@@ -60,6 +66,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.storageAccount, "azure-storage-account", "", "[Azure] Storage Account name")
 	cmd.Flags().StringVar(&opts.encryptionScope, "azure-encryption-scope", "", "[Azure] encryption scope for server-side encryption (optional)")
 	cmd.Flags().StringVar(&opts.authType, "azure-auth-type", "client-secret", "[Azure] authentication type: client-secret (default) or managed-identity (ARO HCP)")
+	cmd.Flags().StringVar(&opts.azureCloud, "azure-cloud", opts.azureCloud, "[Azure] cloud environment")
 
 	_ = cmd.MarkFlagRequired("snapshot-path")
 	_ = cmd.MarkFlagRequired("storage-type")
@@ -103,7 +110,7 @@ func newUploader(ctx context.Context, opts options) (Uploader, error) {
 	case "S3":
 		return NewS3Uploader(ctx, opts.bucket, opts.region, opts.credentialsFile, opts.kmsKeyARN)
 	case "AzureBlob":
-		return NewAzureBlobUploader(ctx, opts.container, opts.storageAccount, opts.credentialsFile, opts.encryptionScope, opts.authType)
+		return NewAzureBlobUploader(ctx, opts.container, opts.storageAccount, opts.credentialsFile, opts.encryptionScope, opts.authType, opts.azureCloud)
 	default:
 		return nil, fmt.Errorf("unsupported storage type: %q (must be S3 or AzureBlob)", opts.storageType)
 	}

--- a/etcd-upload/etcdupload_test.go
+++ b/etcd-upload/etcdupload_test.go
@@ -25,11 +25,19 @@ func TestNewStartCommand(t *testing.T) {
 
 	t.Run("When created it should register all optional flags", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		optionalFlags := []string{"aws-bucket", "aws-region", "credentials-file", "aws-kms-key-arn", "azure-container", "azure-storage-account", "azure-encryption-scope", "azure-auth-type"}
+		optionalFlags := []string{"aws-bucket", "aws-region", "credentials-file", "aws-kms-key-arn", "azure-container", "azure-storage-account", "azure-encryption-scope", "azure-auth-type", "azure-cloud"}
 		for _, name := range optionalFlags {
 			g.Expect(cmd.Flags().Lookup(name)).ToNot(BeNil(), "expected flag %q to exist", name)
 		}
 	})
+}
+
+func TestAzureCloudFlagDefaultsFromEnvironment(t *testing.T) {
+	t.Setenv("AZURE_CLOUD_NAME", "AzureUSGovernmentCloud")
+	cmd := NewStartCommand()
+
+	g := NewGomegaWithT(t)
+	g.Expect(cmd.Flags().Lookup("azure-cloud").DefValue).To(Equal("AzureUSGovernmentCloud"))
 }
 
 func TestNewUploader(t *testing.T) {
@@ -56,6 +64,19 @@ func TestNewUploader(t *testing.T) {
 		_, err := newUploader(context.Background(), opts)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("unsupported auth type"))
+	})
+
+	t.Run("When Azure cloud is invalid it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		opts := options{
+			storageType:    "AzureBlob",
+			container:      "test",
+			storageAccount: "testacc",
+			azureCloud:     "InvalidCloud",
+		}
+		_, err := newUploader(context.Background(), opts)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unknown Azure cloud"))
 	})
 }
 

--- a/etcd-upload/etcdupload_test.go
+++ b/etcd-upload/etcdupload_test.go
@@ -30,14 +30,23 @@ func TestNewStartCommand(t *testing.T) {
 			g.Expect(cmd.Flags().Lookup(name)).ToNot(BeNil(), "expected flag %q to exist", name)
 		}
 	})
+
+	t.Run("When AZURE_CLOUD_NAME is unset it should default azure-cloud to AzurePublicCloud", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		t.Setenv("AZURE_CLOUD_NAME", "")
+		localCmd := NewStartCommand()
+		g.Expect(localCmd.Flags().Lookup("azure-cloud").DefValue).To(Equal("AzurePublicCloud"))
+	})
 }
 
 func TestAzureCloudFlagDefaultsFromEnvironment(t *testing.T) {
-	t.Setenv("AZURE_CLOUD_NAME", "AzureUSGovernmentCloud")
-	cmd := NewStartCommand()
+	t.Run("When AZURE_CLOUD_NAME is set it should use it as the azure-cloud default", func(t *testing.T) {
+		t.Setenv("AZURE_CLOUD_NAME", "AzureUSGovernmentCloud")
+		cmd := NewStartCommand()
 
-	g := NewGomegaWithT(t)
-	g.Expect(cmd.Flags().Lookup("azure-cloud").DefValue).To(Equal("AzureUSGovernmentCloud"))
+		g := NewGomegaWithT(t)
+		g.Expect(cmd.Flags().Lookup("azure-cloud").DefValue).To(Equal("AzureUSGovernmentCloud"))
+	})
 }
 
 func TestNewUploader(t *testing.T) {
@@ -77,6 +86,59 @@ func TestNewUploader(t *testing.T) {
 		_, err := newUploader(context.Background(), opts)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("unknown Azure cloud"))
+	})
+
+	t.Run("When storage type is S3 and bucket is missing it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		opts := options{
+			storageType: "S3",
+			region:      "us-east-1",
+		}
+		_, err := newUploader(context.Background(), opts)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("--bucket is required"))
+	})
+}
+
+func TestRun(t *testing.T) {
+	t.Run("When snapshot file is missing it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		err := run(context.Background(), options{
+			snapshotPath: "/nonexistent/snapshot.db",
+			storageType:  "S3",
+			keyPrefix:    "backups",
+		})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("snapshot file not accessible"))
+	})
+
+	t.Run("When storage type is invalid it should return an error after validating snapshot path", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		snapshotPath := createTempSnapshot(t)
+		err := run(context.Background(), options{
+			snapshotPath: snapshotPath,
+			storageType:  "InvalidType",
+			keyPrefix:    "backups/",
+		})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unsupported storage type"))
+	})
+
+	t.Run("When upload fails it should return a wrapped upload error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		snapshotPath := createTempSnapshot(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := run(ctx, options{
+			snapshotPath: snapshotPath,
+			storageType:  "S3",
+			bucket:       "my-bucket",
+			region:       "us-east-1",
+			keyPrefix:    "backups/",
+		})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to upload snapshot"))
 	})
 }
 

--- a/etcd-upload/s3_uploader_test.go
+++ b/etcd-upload/s3_uploader_test.go
@@ -115,3 +115,29 @@ func TestS3Uploader(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 	})
 }
+
+func TestNewS3Uploader(t *testing.T) {
+	t.Run("When required options are provided it should return a configured uploader", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		uploader, err := NewS3Uploader(context.Background(), "my-bucket", "us-east-1", "", "")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(uploader).ToNot(BeNil())
+		g.Expect(uploader.bucket).To(Equal("my-bucket"))
+		g.Expect(uploader.region).To(Equal("us-east-1"))
+		g.Expect(uploader.client).ToNot(BeNil())
+	})
+
+	t.Run("When bucket is empty it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		_, err := NewS3Uploader(context.Background(), "", "us-east-1", "", "")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("--bucket is required"))
+	})
+
+	t.Run("When region is empty it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		_, err := NewS3Uploader(context.Background(), "my-bucket", "", "", "")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("--region is required"))
+	})
+}

--- a/hypershift-operator/controllers/etcdbackup/reconciler.go
+++ b/hypershift-operator/controllers/etcdbackup/reconciler.go
@@ -799,6 +799,10 @@ func (r *HCPEtcdBackupReconciler) createBackupJob(ctx context.Context, backup *h
 	if err != nil {
 		return fmt.Errorf("failed to build upload args: %w", err)
 	}
+	azureCloud := ""
+	if backup.Spec.Storage.StorageType == hyperv1.AzureBlobBackupStorage && hcp.Spec.Platform.Azure != nil {
+		azureCloud = hcp.Spec.Platform.Azure.Cloud
+	}
 
 	jobLabels := map[string]string{
 		LabelApp:          LabelName,
@@ -878,7 +882,7 @@ func (r *HCPEtcdBackupReconciler) createBackupJob(ctx context.Context, backup *h
 						},
 					},
 					Containers: []corev1.Container{
-						r.buildUploadContainer(cpoImage, uploadArgs, creds),
+						r.buildUploadContainer(cpoImage, uploadArgs, creds, azureCloud),
 					},
 				},
 			},
@@ -972,7 +976,7 @@ func (r *HCPEtcdBackupReconciler) buildJobVolumes(creds resolvedCredentials) []c
 	return volumes
 }
 
-func (r *HCPEtcdBackupReconciler) buildUploadContainer(image string, args []string, creds resolvedCredentials) corev1.Container {
+func (r *HCPEtcdBackupReconciler) buildUploadContainer(image string, args []string, creds resolvedCredentials, azureCloud string) corev1.Container {
 	container := corev1.Container{
 		Name:    "upload",
 		Image:   image,
@@ -995,15 +999,19 @@ func (r *HCPEtcdBackupReconciler) buildUploadContainer(image string, args []stri
 	}
 
 	if creds.needsProjectedToken() {
-		container.Env = []corev1.EnvVar{
-			{Name: "AWS_ROLE_ARN", Value: creds.RoleARN},
-			{Name: "AWS_WEB_IDENTITY_TOKEN_FILE", Value: mountPathAWSIAMToken + "/token"},
-		}
+		container.Env = append(container.Env,
+			corev1.EnvVar{Name: "AWS_ROLE_ARN", Value: creds.RoleARN},
+			corev1.EnvVar{Name: "AWS_WEB_IDENTITY_TOKEN_FILE", Value: mountPathAWSIAMToken + "/token"},
+		)
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 			Name:      volumeAWSIAMToken,
 			MountPath: mountPathAWSIAMToken,
 			ReadOnly:  true,
 		})
+	}
+
+	if azureCloud != "" {
+		container.Env = append(container.Env, corev1.EnvVar{Name: "AZURE_CLOUD_NAME", Value: azureCloud})
 	}
 
 	return container

--- a/hypershift-operator/controllers/etcdbackup/reconciler_test.go
+++ b/hypershift-operator/controllers/etcdbackup/reconciler_test.go
@@ -1369,6 +1369,12 @@ func TestCreateBackupJob(t *testing.T) {
 			},
 		}
 		hcp := newHostedControlPlane()
+		hcp.Spec.Platform = hyperv1.PlatformSpec{
+			Type: hyperv1.AzurePlatform,
+			Azure: &hyperv1.AzurePlatformSpec{
+				Cloud: "AzureUSGovernmentCloud",
+			},
+		}
 		pullSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pullSecretName,
@@ -1399,6 +1405,7 @@ func TestCreateBackupJob(t *testing.T) {
 		g.Expect(upload.Command).To(ContainElements("etcd-upload", "--storage-type", "AzureBlob"))
 		g.Expect(upload.Command).To(ContainElements("--azure-container", "my-container"))
 		g.Expect(upload.Command).To(ContainElements("--azure-storage-account", "mystorageaccount"))
+		g.Expect(upload.Env).To(ContainElement(corev1.EnvVar{Name: "AZURE_CLOUD_NAME", Value: "AzureUSGovernmentCloud"}))
 
 		// Verify credential volume uses Azure secret
 		credVolume := jobList.Items[0].Spec.Template.Spec.Volumes[2]

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -413,6 +413,24 @@ func GetKeyVaultDNSSuffixFromCloudType(cloud string) (string, error) {
 	return GetKeyVaultDNSSuffix(cloud, hyperv1.AzureKMSKeyVaultTypeKeyVault)
 }
 
+// GetAzureBlobDNSSuffix returns the cloud-specific DNS suffix for Azure Blob Storage.
+func GetAzureBlobDNSSuffix(cloud string) (string, error) {
+	switch strings.ToUpper(cloud) {
+	case "", "AZURECLOUD", "AZUREPUBLICCLOUD":
+		return azurePublicBlobDNSSuffix, nil
+	case "AZUREGOVERNMENTCLOUD", "AZUREUSGOVERNMENT", "AZUREUSGOVERNMENTCLOUD":
+		return azureGovernmentBlobDNSSuffix, nil
+	case "AZURECHINACLOUD":
+		return azureChinaBlobDNSSuffix, nil
+	case "AZUREGERMANCLOUD":
+		return azureGermanBlobDNSSuffix, nil
+	case "AZUREBLEUCLOUD":
+		return azureBleuBlobDNSSuffix, nil
+	default:
+		return "", fmt.Errorf("unknown Azure cloud %q", cloud)
+	}
+}
+
 // GetKeyVaultDNSSuffix returns the cloud-specific DNS suffix for Azure Key Vault or Managed HSM.
 // An empty keyVaultType is treated as KeyVault for compatibility with existing API objects.
 // Supporting another cloud requires adding its suffix here, allowing it in GetAzureEncryptionKeyInfo,

--- a/support/azureutil/azureutil_test.go
+++ b/support/azureutil/azureutil_test.go
@@ -1200,6 +1200,37 @@ func TestNewARMClientOptions(t *testing.T) {
 	}
 }
 
+func TestGetAzureBlobDNSSuffix(t *testing.T) {
+	tests := []struct {
+		name       string
+		cloud      string
+		wantSuffix string
+		wantErr    bool
+	}{
+		{name: "When cloud is empty, it should return the public suffix", wantSuffix: "blob.core.windows.net"},
+		{name: "When cloud is public, it should return the public suffix", cloud: "AzurePublicCloud", wantSuffix: "blob.core.windows.net"},
+		{name: "When cloud is government, it should return the government suffix", cloud: "AzureUSGovernmentCloud", wantSuffix: "blob.core.usgovcloudapi.net"},
+		{name: "When cloud is China, it should return the China suffix", cloud: "AzureChinaCloud", wantSuffix: "blob.core.chinacloudapi.cn"},
+		{name: "When cloud is German, it should return the German suffix", cloud: "AzureGermanCloud", wantSuffix: "blob.core.cloudapi.de"},
+		{name: "When cloud is Bleu, it should return the Bleu suffix", cloud: "AzureBleuCloud", wantSuffix: "blob.core.sovcloud-api.fr"},
+		{name: "When cloud is Azure Stack, it should return an error", cloud: "AzureStackCloud", wantErr: true},
+		{name: "When cloud is unknown, it should return an error", cloud: "UnknownCloud", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, err := GetAzureBlobDNSSuffix(tt.cloud)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.wantSuffix))
+		})
+	}
+}
+
 func TestGetAzureCloudConfiguration(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/support/azureutil/constants.go
+++ b/support/azureutil/constants.go
@@ -37,4 +37,9 @@ const (
 	azureGermanManagedHSMDNSSuffix     = "managedhsm.microsoftazure.de"
 	azureBleuKeyVaultDNSSuffix         = "vault.sovcloud-api.fr"
 	azureBleuManagedHSMDNSSuffix       = "managedhsm.sovcloud-api.fr"
+	azurePublicBlobDNSSuffix           = "blob.core.windows.net"
+	azureGovernmentBlobDNSSuffix       = "blob.core.usgovcloudapi.net"
+	azureChinaBlobDNSSuffix            = "blob.core.chinacloudapi.cn"
+	azureGermanBlobDNSSuffix           = "blob.core.cloudapi.de"
+	azureBleuBlobDNSSuffix             = "blob.core.sovcloud-api.fr"
 )


### PR DESCRIPTION
## Summary

Fix etcd backup uploads and reported snapshot URLs for every fixed-endpoint Azure cloud supported by HyperShift:

- Azure Public
- Azure US Government
- Azure China
- Azure German
- Azure Bleu

## What changed

- Resolve the Azure Blob DNS suffix from the HostedControlPlane cloud instead of hard-coding `blob.core.windows.net`.
- Use the resolved service URL for both the Blob client and the returned snapshot URL.
- Configure default and client-secret Azure credentials with the matching cloud authority.
- Propagate `spec.platform.azure.cloud` through `AZURE_CLOUD_NAME`; this avoids passing an unknown CLI flag to older payload CPO images.
- Reject unknown clouds and Azure Stack, whose storage endpoint is deployment-specific.

## Validation

- `go test ./etcd-upload ./support/azureutil ./hypershift-operator/controllers/etcdbackup`
- `make run-gitlint`

## Related

- openshift/azure-kubernetes-kms#54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for uploading etcd backups to multiple Azure cloud environments, including public, government, China, German, and Bleu clouds.
  * Added an `--azure-cloud` option and `AZURE_CLOUD_NAME` environment variable for selecting the Azure environment.
  * Azure Blob endpoints are now resolved automatically for the selected cloud.

* **Bug Fixes**
  * Invalid Azure cloud values now produce a clear error instead of using an incorrect endpoint.
  * Preserved AWS web-identity environment settings when configuring backup uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->