### PR TITLE
CNTRLPLANE-3998: warn when deprecated kube-apiserver verbosity annotation is set

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -266,6 +266,21 @@ const (
 	// cluster's shared ingress. Status reflects observed state: True means
 	// public endpoints are reachable, False means they are not.
 	PublicEndpointExposed ConditionType = "PublicEndpointExposed"
+
+	// HostedClusterConfigurationDeprecated indicates whether any deprecated
+	// mechanism is being used to configure the hosted cluster. It is intentionally
+	// generic so that a single condition can surface any deprecated configuration
+	// surface as they are added; the message identifies the specific deprecated
+	// mechanism in use.
+	// **True** (reason DeprecatedConfigurationInUse) means a deprecated
+	// configuration mechanism is set. For example, the deprecated
+	// hypershift.openshift.io/kube-apiserver-verbosity-level annotation fires this
+	// whenever the annotation is present, even if
+	// spec.operatorConfiguration.kubeAPIServer.logLevel is also set and taking
+	// precedence, so that users are guided to migrate to the logLevel field and
+	// remove the annotation.
+	// **False** (reason AsExpected) means no deprecated configuration is in use.
+	HostedClusterConfigurationDeprecated ConditionType = "HostedClusterConfigurationDeprecated"
 )
 
 // Reasons for PublicEndpointExposed condition.
@@ -283,13 +298,19 @@ const (
 
 // Reasons.
 const (
-	StatusUnknownReason         = "StatusUnknown"
-	AsExpectedReason            = "AsExpected"
-	NotFoundReason              = "NotFound"
-	WaitingForAvailableReason   = "WaitingForAvailable"
-	SecretNotFoundReason        = "SecretNotFound"
-	WaitingForGracePeriodReason = "WaitingForGracePeriod"
-	BlockedReason               = "Blocked"
+	StatusUnknownReason = "StatusUnknown"
+	AsExpectedReason    = "AsExpected"
+	// DeprecatedConfigurationInUseReason is used with the
+	// HostedClusterConfigurationDeprecated condition when a deprecated configuration
+	// mechanism is set. It indicates the deprecated mechanism is present; it does not
+	// imply the mechanism is currently driving configuration, since a non-deprecated
+	// field may take precedence over it.
+	DeprecatedConfigurationInUseReason = "DeprecatedConfigurationInUse"
+	NotFoundReason                     = "NotFound"
+	WaitingForAvailableReason          = "WaitingForAvailable"
+	SecretNotFoundReason               = "SecretNotFound"
+	WaitingForGracePeriodReason        = "WaitingForGracePeriod"
+	BlockedReason                      = "Blocked"
 
 	InfraStatusFailureReason           = "InfraStatusFailure"
 	WaitingOnInfrastructureReadyReason = "WaitingOnInfrastructureReady"

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -548,6 +548,39 @@ func (r *HostedControlPlaneReconciler) reconcileKASStatus(ctx context.Context, h
 	return nil
 }
 
+// reconcileDeprecatedConfigurationStatus surfaces a generic warning condition whenever a
+// deprecated mechanism is used to configure the hosted control plane. Each deprecation
+// check appends a message to the collected list; if any fire, the condition is set to True
+// with the messages joined together, otherwise it is set to False. This makes it easy to
+// add new deprecation checks over time. Today the only such mechanism is the
+// hypershift.openshift.io/kube-apiserver-verbosity-level annotation, which fires whenever
+// the annotation is present, even if spec.operatorConfiguration.kubeAPIServer.logLevel is
+// also set and taking precedence, so that users are guided to remove the deprecated
+// annotation entirely. The condition is message-only: it does not affect verbosity
+// resolution, config hashes, or rollouts.
+func (r *HostedControlPlaneReconciler) reconcileDeprecatedConfigurationStatus(hostedControlPlane *hyperv1.HostedControlPlane) {
+	var deprecationMessages []string
+
+	if _, hasVerbosityAnnotation := hostedControlPlane.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation]; hasVerbosityAnnotation {
+		deprecationMessages = append(deprecationMessages, fmt.Sprintf("The deprecated %q annotation is set; migrate to spec.operatorConfiguration.kubeAPIServer.logLevel and remove the annotation", hyperv1.KubeAPIServerVerbosityLevelAnnotation))
+	}
+
+	newCondition := metav1.Condition{
+		Type:    string(hyperv1.HostedClusterConfigurationDeprecated),
+		Status:  metav1.ConditionFalse,
+		Reason:  hyperv1.AsExpectedReason,
+		Message: "No deprecated configuration is in use",
+	}
+	if len(deprecationMessages) > 0 {
+		newCondition.Status = metav1.ConditionTrue
+		newCondition.Reason = hyperv1.DeprecatedConfigurationInUseReason
+		newCondition.Message = strings.Join(deprecationMessages, "; ")
+	}
+
+	newCondition.ObservedGeneration = hostedControlPlane.Generation
+	meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, newCondition)
+}
+
 func (r *HostedControlPlaneReconciler) reconcileDegradedStatus(ctx context.Context, hostedControlPlane *hyperv1.HostedControlPlane) error {
 	condition := metav1.Condition{
 		Type:               string(hyperv1.HostedControlPlaneDegraded),
@@ -645,6 +678,8 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if err := r.reconcileKASStatus(ctx, hostedControlPlane); err != nil {
 		return ctrl.Result{}, err
 	}
+
+	r.reconcileDeprecatedConfigurationStatus(hostedControlPlane)
 
 	if err := r.reconcileDegradedStatus(ctx, hostedControlPlane); err != nil {
 		return ctrl.Result{}, err

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -3517,6 +3517,87 @@ func TestReconcileKASStatus(t *testing.T) {
 	}
 }
 
+func TestReconcileDeprecatedConfigurationStatus(t *testing.T) {
+	testCases := []struct {
+		name              string
+		hcp               *hyperv1.HostedControlPlane
+		expectedCondition metav1.Condition
+	}{
+		{
+			name: "When the logLevel field is set and the deprecated annotation is also present, it should still set the condition to True with DeprecatedConfigurationInUse reason",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 3,
+					Annotations: map[string]string{
+						hyperv1.KubeAPIServerVerbosityLevelAnnotation: "5",
+					},
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					OperatorConfiguration: &hyperv1.OperatorConfiguration{
+						KubeAPIServer: hyperv1.KubeAPIServerOperatorSpec{
+							ComponentLogLevelSpec: hyperv1.ComponentLogLevelSpec{
+								LogLevel: hyperv1.Debug,
+							},
+						},
+					},
+				},
+			},
+			expectedCondition: metav1.Condition{
+				Type:               string(hyperv1.HostedClusterConfigurationDeprecated),
+				Status:             metav1.ConditionTrue,
+				Reason:             hyperv1.DeprecatedConfigurationInUseReason,
+				ObservedGeneration: 3,
+			},
+		},
+		{
+			name: "When the logLevel field is unset and the deprecated annotation is present, it should set the condition to True with DeprecatedConfigurationInUse reason",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 5,
+					Annotations: map[string]string{
+						hyperv1.KubeAPIServerVerbosityLevelAnnotation: "5",
+					},
+				},
+			},
+			expectedCondition: metav1.Condition{
+				Type:               string(hyperv1.HostedClusterConfigurationDeprecated),
+				Status:             metav1.ConditionTrue,
+				Reason:             hyperv1.DeprecatedConfigurationInUseReason,
+				ObservedGeneration: 5,
+			},
+		},
+		{
+			name: "When neither the logLevel field nor the deprecated annotation is set, it should set the condition to False with AsExpected reason",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 7,
+				},
+			},
+			expectedCondition: metav1.Condition{
+				Type:               string(hyperv1.HostedClusterConfigurationDeprecated),
+				Status:             metav1.ConditionFalse,
+				Reason:             hyperv1.AsExpectedReason,
+				ObservedGeneration: 7,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			r := &HostedControlPlaneReconciler{}
+			r.reconcileDeprecatedConfigurationStatus(tc.hcp)
+
+			cond := meta.FindStatusCondition(tc.hcp.Status.Conditions, string(hyperv1.HostedClusterConfigurationDeprecated))
+			g.Expect(cond).ToNot(BeNil())
+			g.Expect(cond.Status).To(Equal(tc.expectedCondition.Status))
+			g.Expect(cond.Reason).To(Equal(tc.expectedCondition.Reason))
+			g.Expect(cond.ObservedGeneration).To(Equal(tc.expectedCondition.ObservedGeneration))
+		})
+	}
+}
+
 func TestReconcileDegradedStatus(t *testing.T) {
 	testNamespace := "test-namespace"
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment.go
@@ -214,7 +214,6 @@ func resolveKASVerbosity(hcp *hyperv1.HostedControlPlane) int {
 	// Fallback: deprecated annotation (raw integer)
 	if v := hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation]; v != "" {
 		if parsed, err := strconv.Atoi(v); err == nil {
-			// TODO(CNTRLPLANE-3998): Emit deprecation warning condition on HCP status
 			return parsed
 		}
 	}

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -46358,6 +46358,21 @@ has been created for the specified Internal Load Balancer in the management VPC<
 control plane.
 When this is false for too long and there&rsquo;s no clear indication in the &ldquo;Reason&rdquo;, please check the remaining more granular conditions.</p>
 </td>
+</tr><tr><td><p>&#34;HostedClusterConfigurationDeprecated&#34;</p></td>
+<td><p>HostedClusterConfigurationDeprecated indicates whether any deprecated
+mechanism is being used to configure the hosted cluster. It is intentionally
+generic so that a single condition can surface any deprecated configuration
+surface as they are added; the message identifies the specific deprecated
+mechanism in use.
+<strong>True</strong> (reason DeprecatedConfigurationInUse) means a deprecated
+configuration mechanism is set. For example, the deprecated
+hypershift.openshift.io/kube-apiserver-verbosity-level annotation fires this
+whenever the annotation is present, even if
+spec.operatorConfiguration.kubeAPIServer.logLevel is also set and taking
+precedence, so that users are guided to migrate to the logLevel field and
+remove the annotation.
+<strong>False</strong> (reason AsExpected) means no deprecated configuration is in use.</p>
+</td>
 </tr><tr><td><p>&#34;Degraded&#34;</p></td>
 <td><p>HostedClusterDegraded indicates whether the HostedCluster is encountering
 an error that may require user intervention to resolve.</p>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -6460,6 +6460,21 @@ has been created for the specified Internal Load Balancer in the management VPC<
 control plane.
 When this is false for too long and there&rsquo;s no clear indication in the &ldquo;Reason&rdquo;, please check the remaining more granular conditions.</p>
 </td>
+</tr><tr><td><p>&#34;HostedClusterConfigurationDeprecated&#34;</p></td>
+<td><p>HostedClusterConfigurationDeprecated indicates whether any deprecated
+mechanism is being used to configure the hosted cluster. It is intentionally
+generic so that a single condition can surface any deprecated configuration
+surface as they are added; the message identifies the specific deprecated
+mechanism in use.
+<strong>True</strong> (reason DeprecatedConfigurationInUse) means a deprecated
+configuration mechanism is set. For example, the deprecated
+hypershift.openshift.io/kube-apiserver-verbosity-level annotation fires this
+whenever the annotation is present, even if
+spec.operatorConfiguration.kubeAPIServer.logLevel is also set and taking
+precedence, so that users are guided to migrate to the logLevel field and
+remove the annotation.
+<strong>False</strong> (reason AsExpected) means no deprecated configuration is in use.</p>
+</td>
 </tr><tr><td><p>&#34;Degraded&#34;</p></td>
 <td><p>HostedClusterDegraded indicates whether the HostedCluster is encountering
 an error that may require user intervention to resolve.</p>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -840,6 +840,9 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	// Aggregate deprecated-configuration warnings from the HostedCluster and the HCP.
+	r.reconcileDeprecatedConfigurationStatus(hcluster, hcp)
+
 	// Copy the platform status from the hostedcontrolplane
 	if hcp != nil {
 		hcluster.Status.Platform = hcp.Status.Platform
@@ -1593,6 +1596,52 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		log.Info("reconciliation completed with errors", "summary", msg)
 	}
 	return result, report.aggregate()
+}
+
+// reconcileDeprecatedConfigurationStatus aggregates deprecated-configuration warnings
+// from two sources and surfaces them on the generic HostedClusterConfigurationDeprecated
+// condition: mechanisms visible only on the HostedCluster, and those detected by the HCP
+// controller (which reports them on the HCP's own copy of the condition). If any fire, the
+// condition is True with all messages joined together; otherwise it is False. When the HCP
+// does not yet exist and there are no HostedCluster-only warnings, the condition is left
+// Unknown, since the HCP-sourced warnings cannot be evaluated yet. Each HostedCluster-only
+// deprecation check appends its message to the list, so new checks are easy to add.
+func (r *HostedClusterReconciler) reconcileDeprecatedConfigurationStatus(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) {
+	var messages []string
+
+	// HostedCluster-only deprecation checks go here as they are added, e.g.:
+	// if <deprecated hcluster field/annotation is set> {
+	//     messages = append(messages, "...")
+	// }
+
+	// Fold in deprecations detected by the HCP controller.
+	if hcp != nil {
+		if c := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.HostedClusterConfigurationDeprecated)); c != nil && c.Status == metav1.ConditionTrue && c.Message != "" {
+			messages = append(messages, c.Message)
+		}
+	}
+
+	condition := metav1.Condition{
+		Type:               string(hyperv1.HostedClusterConfigurationDeprecated),
+		ObservedGeneration: hcluster.Generation,
+	}
+	switch {
+	case len(messages) > 0:
+		condition.Status = metav1.ConditionTrue
+		condition.Reason = hyperv1.DeprecatedConfigurationInUseReason
+		condition.Message = strings.Join(messages, "; ")
+	case hcp == nil:
+		// No HostedCluster-only warnings and the HCP is not available yet, so the
+		// HCP-sourced warnings cannot be evaluated.
+		condition.Status = metav1.ConditionUnknown
+		condition.Reason = hyperv1.StatusUnknownReason
+		condition.Message = "The hosted control plane is not found"
+	default:
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = hyperv1.AsExpectedReason
+		condition.Message = "No deprecated configuration is in use"
+	}
+	meta.SetStatusCondition(&hcluster.Status.Conditions, condition)
 }
 
 // reconcileCoreHCPChain reconciles the core HCP chain: reconcile the HCP object,

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -9524,3 +9524,84 @@ func TestDestroyGracePeriod(t *testing.T) {
 		})
 	}
 }
+
+func TestReconcileDeprecatedConfigurationStatus(t *testing.T) {
+	const hcpDeprecationMessage = "The deprecated annotation is set; migrate to the field"
+
+	testCases := []struct {
+		name            string
+		hcp             *hyperv1.HostedControlPlane
+		expectedStatus  metav1.ConditionStatus
+		expectedReason  string
+		expectedMessage string
+	}{
+		{
+			name:            "When the HCP is not found yet, it should set the condition to Unknown",
+			hcp:             nil,
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  hyperv1.StatusUnknownReason,
+			expectedMessage: "The hosted control plane is not found",
+		},
+		{
+			name: "When the HCP reports a deprecated configuration, it should aggregate the message and set the condition to True",
+			hcp: &hyperv1.HostedControlPlane{
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    string(hyperv1.HostedClusterConfigurationDeprecated),
+							Status:  metav1.ConditionTrue,
+							Reason:  hyperv1.DeprecatedConfigurationInUseReason,
+							Message: hcpDeprecationMessage,
+						},
+					},
+				},
+			},
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  hyperv1.DeprecatedConfigurationInUseReason,
+			expectedMessage: hcpDeprecationMessage,
+		},
+		{
+			name: "When the HCP reports no deprecated configuration, it should set the condition to False",
+			hcp: &hyperv1.HostedControlPlane{
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(hyperv1.HostedClusterConfigurationDeprecated),
+							Status: metav1.ConditionFalse,
+							Reason: hyperv1.AsExpectedReason,
+						},
+					},
+				},
+			},
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  hyperv1.AsExpectedReason,
+			expectedMessage: "No deprecated configuration is in use",
+		},
+		{
+			name:            "When the HCP is present but has no deprecation condition, it should set the condition to False",
+			hcp:             &hyperv1.HostedControlPlane{},
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  hyperv1.AsExpectedReason,
+			expectedMessage: "No deprecated configuration is in use",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hcluster := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 9},
+			}
+			r := &HostedClusterReconciler{}
+			r.reconcileDeprecatedConfigurationStatus(hcluster, tc.hcp)
+
+			cond := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.HostedClusterConfigurationDeprecated))
+			g.Expect(cond).ToNot(BeNil())
+			g.Expect(cond.Status).To(Equal(tc.expectedStatus))
+			g.Expect(cond.Reason).To(Equal(tc.expectedReason))
+			g.Expect(cond.Message).To(Equal(tc.expectedMessage))
+			g.Expect(cond.ObservedGeneration).To(Equal(hcluster.Generation))
+		})
+	}
+}

--- a/hypershift-operator/controllers/hostedcluster/reconcile_legacy.go
+++ b/hypershift-operator/controllers/hostedcluster/reconcile_legacy.go
@@ -521,6 +521,9 @@ func (r *HostedClusterReconciler) reconcileLegacy(ctx context.Context, req ctrl.
 		}
 	}
 
+	// Aggregate deprecated-configuration warnings from the HostedCluster and the HCP.
+	r.reconcileDeprecatedConfigurationStatus(hcluster, hcp)
+
 	// Copy the platform status from the hostedcontrolplane
 	if hcp != nil {
 		hcluster.Status.Platform = hcp.Status.Platform

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -266,6 +266,21 @@ const (
 	// cluster's shared ingress. Status reflects observed state: True means
 	// public endpoints are reachable, False means they are not.
 	PublicEndpointExposed ConditionType = "PublicEndpointExposed"
+
+	// HostedClusterConfigurationDeprecated indicates whether any deprecated
+	// mechanism is being used to configure the hosted cluster. It is intentionally
+	// generic so that a single condition can surface any deprecated configuration
+	// surface as they are added; the message identifies the specific deprecated
+	// mechanism in use.
+	// **True** (reason DeprecatedConfigurationInUse) means a deprecated
+	// configuration mechanism is set. For example, the deprecated
+	// hypershift.openshift.io/kube-apiserver-verbosity-level annotation fires this
+	// whenever the annotation is present, even if
+	// spec.operatorConfiguration.kubeAPIServer.logLevel is also set and taking
+	// precedence, so that users are guided to migrate to the logLevel field and
+	// remove the annotation.
+	// **False** (reason AsExpected) means no deprecated configuration is in use.
+	HostedClusterConfigurationDeprecated ConditionType = "HostedClusterConfigurationDeprecated"
 )
 
 // Reasons for PublicEndpointExposed condition.
@@ -283,13 +298,19 @@ const (
 
 // Reasons.
 const (
-	StatusUnknownReason         = "StatusUnknown"
-	AsExpectedReason            = "AsExpected"
-	NotFoundReason              = "NotFound"
-	WaitingForAvailableReason   = "WaitingForAvailable"
-	SecretNotFoundReason        = "SecretNotFound"
-	WaitingForGracePeriodReason = "WaitingForGracePeriod"
-	BlockedReason               = "Blocked"
+	StatusUnknownReason = "StatusUnknown"
+	AsExpectedReason    = "AsExpected"
+	// DeprecatedConfigurationInUseReason is used with the
+	// HostedClusterConfigurationDeprecated condition when a deprecated configuration
+	// mechanism is set. It indicates the deprecated mechanism is present; it does not
+	// imply the mechanism is currently driving configuration, since a non-deprecated
+	// field may take precedence over it.
+	DeprecatedConfigurationInUseReason = "DeprecatedConfigurationInUse"
+	NotFoundReason                     = "NotFound"
+	WaitingForAvailableReason          = "WaitingForAvailable"
+	SecretNotFoundReason               = "SecretNotFound"
+	WaitingForGracePeriodReason        = "WaitingForGracePeriod"
+	BlockedReason                      = "Blocked"
 
 	InfraStatusFailureReason           = "InfraStatusFailure"
 	WaitingOnInfrastructureReadyReason = "WaitingOnInfrastructureReady"


### PR DESCRIPTION
## What this PR does / why we need it:

[OCPSTRAT-3156](https://redhat.atlassian.net/browse/OCPSTRAT-3156) introduced `spec.operatorConfiguration.kubeAPIServer.logLevel` as
the first-class replacement for the deprecated
`hypershift.openshift.io/kube-apiserver-verbosity-level` annotation. The new
field takes precedence; the annotation remains only as a fallback. Until now
there was no signal to users still relying on the deprecated annotation.

This PR adds a dedicated `KubeAPIServerConfigurationDeprecated` status condition:
- **True** (reason `DeprecatedConfigurationInUse`) whenever the annotation is
  present — even if `logLevel` is also set and taking precedence — so users are
  guided to migrate to the field and remove the deprecated annotation entirely.
- **False** (reason `AsExpected`) when the annotation is absent.

The condition is derived in the HCP controller from the HCP annotations and
propagated to HostedCluster status via both the default and legacy reconcile
allowlists. Verbosity resolution is unchanged, so there is **no config-hash or
rollout impact**.

## Which issue(s) this PR fixes:
Fixes [CNTRLPLANE-3998](https://redhat.atlassian.net/browse/CNTRLPLANE-3998)

## Special notes for your reviewer:

- The condition fires on the annotation's *presence* (not only when it is in
  effect), so users are guided to remove the deprecated annotation regardless of
  whether the `logLevel` field currently overrides it.
- Both `hcpConditions` allowlists (`hostedcluster_controller.go` and
  `reconcile_legacy.go`) were updated so behavior is identical whether or not
  `HYPERSHIFT_RECONCILE_LEGACY=1` is set.
- The two `docs/content/reference/*.md` changes are auto-generated API reference
  from the new condition's doc comment. `make pre-commit` passes.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added status reporting for deprecated Kubernetes API server verbosity configuration.
  * Included migration guidance when deprecated configuration is detected.
  * Propagated deprecation status and messages from HostedControlPlane to HostedCluster resources.

* **Bug Fixes**
  * Improved visibility into deprecated configuration while preserving existing API server verbosity behavior.
  * Accurately reports deprecated-configuration status across current and legacy reconciliation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->