### PR TITLE
ACM-41685: Enable PQC crypto policy in hypershift-cli image

### DIFF
--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -19,8 +19,12 @@ RUN make product-cli-release && \
     # Remove OS/arch subdirectories, keep only flat tar.gz files \
     find ./bin -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} +
 
+# PQC-enabled crypto policy for ACM 5.0 / MCE 5.0 (OpenSSL DEFAULT:PQ).
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest AS policy
+
 FROM registry.redhat.io/ubi9/nginx-124:latest
 
+COPY --from=policy /etc/crypto-policies /etc/crypto-policies
 COPY --from=builder /hypershift/bin/ /opt/app-root/src/
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Jira: [ACM-41685](https://redhat.atlassian.net/browse/ACM-41685)

## Summary

- Enable PQC (`DEFAULT:PQ`) in `Containerfile.cli` by copying crypto policies from `registry.redhat.io/ubi9/ubi-minimal-pqc:latest` into the `nginx-124` runtime stage
- Part of parent [ACM-41562](https://redhat.atlassian.net/browse/ACM-41562) / [ACM-40663](https://redhat.atlassian.net/browse/ACM-40663) (PQC base images for ACM/MCE 5.0)
- Sibling operator change: ACM-41684

There is no PQC-enabled `nginx-124` base image, so this follows the crypto-policy overlay pattern used elsewhere (e.g. kubevirt-plugin).

## Test plan

- [ ] Konflux build for hypershift-cli succeeds
- [ ] Verify CLI image serves artifacts in regular mode with no regression
- [ ] Verify CLI image in FIPS mode with no regression
- [ ] Link testing card to [OCPSTRAT-3113](https://issues.redhat.com/browse/OCPSTRAT-3113)

Made with [Cursor](https://cursor.com)