### PR TITLE
HYPERFLEET-1579: Add OCIPlatform feature gate

### DIFF
--- a/api/hypershift/v1beta1/featuregates/featureGate-Hypershift-Default.yaml
+++ b/api/hypershift/v1beta1/featuregates/featureGate-Hypershift-Default.yaml
@@ -38,6 +38,9 @@
                     },
                     {
                         "name": "HCPUserFacingOperatorLogs"
+                    },
+                    {
+                        "name": "OCIPlatform"
                     }
                 ],
                 "enabled": [

--- a/api/hypershift/v1beta1/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/api/hypershift/v1beta1/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -57,6 +57,9 @@
                     },
                     {
                         "name": "HCPUserFacingOperatorLogs"
+                    },
+                    {
+                        "name": "OCIPlatform"
                     }
                 ],
                 "version": ""

--- a/api/hypershift/v1beta1/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/api/hypershift/v1beta1/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -38,6 +38,9 @@
                     },
                     {
                         "name": "HCPUserFacingOperatorLogs"
+                    },
+                    {
+                        "name": "OCIPlatform"
                     }
                 ],
                 "enabled": [

--- a/api/hypershift/v1beta1/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/api/hypershift/v1beta1/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -54,6 +54,9 @@
                     },
                     {
                         "name": "HCPUserFacingOperatorLogs"
+                    },
+                    {
+                        "name": "OCIPlatform"
                     }
                 ],
                 "version": ""

--- a/cmd/install/assets/crds/hypershift-operator/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -38,6 +38,9 @@
                     },
                     {
                         "name": "HCPUserFacingOperatorLogs"
+                    },
+                    {
+                        "name": "OCIPlatform"
                     }
                 ],
                 "enabled": [

--- a/cmd/install/assets/crds/hypershift-operator/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -57,6 +57,9 @@
                     },
                     {
                         "name": "HCPUserFacingOperatorLogs"
+                    },
+                    {
+                        "name": "OCIPlatform"
                     }
                 ],
                 "version": ""

--- a/cmd/install/assets/crds/hypershift-operator/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -38,6 +38,9 @@
                     },
                     {
                         "name": "HCPUserFacingOperatorLogs"
+                    },
+                    {
+                        "name": "OCIPlatform"
                     }
                 ],
                 "enabled": [

--- a/cmd/install/assets/crds/hypershift-operator/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -54,6 +54,9 @@
                     },
                     {
                         "name": "HCPUserFacingOperatorLogs"
+                    },
+                    {
+                        "name": "OCIPlatform"
                     }
                 ],
                 "version": ""

--- a/docs/content/how-to/feature-gates.md
+++ b/docs/content/how-to/feature-gates.md
@@ -22,7 +22,7 @@ These gates apply to the following scenarios:
 - A feature that impacts HyperShift Operator install (e.g. new CRDs are required for CPOv2)
 - A feature that impacts the whole cluster fleet (e.g. fleet-wide shared ingress to be validated in targeted environments)
 - A feature that impacts individual clusters (e.g. introduce using CPOv2 for some HostedClusters)
-- A feature that impacts the HyperShift API (e.g. introduce a new provider like OpenStack, or a new field like AWS tenancy)
+- A feature that impacts the HyperShift API (e.g. introduce a new provider like OpenStack, GCP or OCI, or a new field like AWS tenancy)
 
 All management cluster feature gates are grouped under a single `TechPreviewNoUpgrade` feature set. To enable them, pass `--tech-preview-no-upgrade` at install time:
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -24905,7 +24905,7 @@ These gates apply to the following scenarios:
 - A feature that impacts HyperShift Operator install (e.g. new CRDs are required for CPOv2)
 - A feature that impacts the whole cluster fleet (e.g. fleet-wide shared ingress to be validated in targeted environments)
 - A feature that impacts individual clusters (e.g. introduce using CPOv2 for some HostedClusters)
-- A feature that impacts the HyperShift API (e.g. introduce a new provider like OpenStack, or a new field like AWS tenancy)
+- A feature that impacts the HyperShift API (e.g. introduce a new provider like OpenStack, GCP or OCI, or a new field like AWS tenancy)
 
 All management cluster feature gates are grouped under a single `TechPreviewNoUpgrade` feature set. To enable them, pass `--tech-preview-no-upgrade` at install time:
 

--- a/hypershift-operator/featuregate/feature.go
+++ b/hypershift-operator/featuregate/feature.go
@@ -54,6 +54,12 @@ const (
 	// alpha: v0.1.49
 	// default: OCP 5.0
 	OSStreams featuregate.Feature = "OSStreams"
+
+	// OCIPlatform gates Oracle Cloud Infrastructure (OCI) platform fields on the HostedCluster API.
+	// owner: openshift-hyperfleet
+	// alpha: v0.1.83
+	// beta: x.y.z
+	OCIPlatform featuregate.Feature = "OCIPlatform"
 )
 
 // Initialize new features here
@@ -67,6 +73,7 @@ var (
 	karpenterOperatorFeature       = featuregates.NewFeature(KarpenterOperator, featuregates.WithEnableForFeatureSets(configv1.TechPreviewNoUpgrade))
 	etcdShardingFeature            = featuregates.NewFeature(EtcdSharding, featuregates.WithEnableForFeatureSets(configv1.TechPreviewNoUpgrade))
 	osStreamsFeature               = featuregates.NewFeature(OSStreams, featuregates.WithEnableForFeatureSets(configv1.TechPreviewNoUpgrade, configv1.Default))
+	ociPlatformFeature             = featuregates.NewFeature(OCIPlatform, featuregates.WithEnableForFeatureSets(configv1.TechPreviewNoUpgrade))
 )
 
 func init() {
@@ -78,6 +85,7 @@ func init() {
 	allFeatures.AddFeature(karpenterOperatorFeature)
 	allFeatures.AddFeature(etcdShardingFeature)
 	allFeatures.AddFeature(osStreamsFeature)
+	allFeatures.AddFeature(ociPlatformFeature)
 
 	// Default to configuring the Default featureset
 	ConfigureFeatureSet(string(configv1.Default))

--- a/hypershift-operator/featuregate/feature_test.go
+++ b/hypershift-operator/featuregate/feature_test.go
@@ -87,6 +87,46 @@ func TestGCPPlatformFeatureGate(t *testing.T) {
 	}
 }
 
+func TestOCIPlatformFeatureGate(t *testing.T) {
+	testcases := []struct {
+		name                string
+		featureSet          configv1.FeatureSet
+		expectedOCIPlatform bool
+	}{
+		{
+			name:                "Default feature set should disable OCIPlatform",
+			featureSet:          configv1.Default,
+			expectedOCIPlatform: false,
+		},
+		{
+			name:                "TechPreviewNoUpgrade feature set should enable OCIPlatform",
+			featureSet:          configv1.TechPreviewNoUpgrade,
+			expectedOCIPlatform: true,
+		},
+		{
+			name:                "DevPreviewNoUpgrade feature set should disable OCIPlatform",
+			featureSet:          configv1.DevPreviewNoUpgrade,
+			expectedOCIPlatform: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Configure the feature set
+			featuregate.ConfigureFeatureSet(string(tc.featureSet))
+
+			// Check if OCIPlatform feature gate is enabled/disabled as expected
+			actualOCIPlatform := featuregate.Gate().Enabled(featuregate.OCIPlatform)
+			assert.Equal(t, tc.expectedOCIPlatform, actualOCIPlatform,
+				"OCIPlatform feature gate enabled state should match expected value for feature set %s", tc.featureSet)
+
+			// Verify the feature set is correctly configured
+			assert.Equal(t, tc.featureSet, featuregate.FeatureSet(),
+				"Feature set should be correctly configured")
+		})
+	}
+}
+
 func TestAllHypershiftOperatorFeatureGates(t *testing.T) {
 	testcases := []struct {
 		name       string
@@ -103,6 +143,7 @@ func TestAllHypershiftOperatorFeatureGates(t *testing.T) {
 				"HCPEtcdBackup":           false,
 				"KarpenterOperator":       false,
 				"OSStreams":               true,
+				"OCIPlatform":             false,
 			},
 		},
 		{
@@ -115,6 +156,7 @@ func TestAllHypershiftOperatorFeatureGates(t *testing.T) {
 				"HCPEtcdBackup":           true,
 				"KarpenterOperator":       true,
 				"OSStreams":               true,
+				"OCIPlatform":             true,
 			},
 		},
 		{
@@ -127,6 +169,7 @@ func TestAllHypershiftOperatorFeatureGates(t *testing.T) {
 				"HCPEtcdBackup":           false,
 				"KarpenterOperator":       false,
 				"OSStreams":               false,
+				"OCIPlatform":             false,
 			},
 		},
 	}
@@ -171,6 +214,12 @@ func TestAllHypershiftOperatorFeatureGates(t *testing.T) {
 			assert.Equal(t, tc.expected["OSStreams"], actualOSStreams,
 				"OSStreams should be %v for feature set %s",
 				tc.expected["OSStreams"], tc.featureSet)
+
+			// Test OCIPlatform
+			actualOCIPlatform := featuregate.Gate().Enabled(featuregate.OCIPlatform)
+			assert.Equal(t, tc.expected["OCIPlatform"], actualOCIPlatform,
+				"OCIPlatform should be %v for feature set %s",
+				tc.expected["OCIPlatform"], tc.featureSet)
 		})
 	}
 }
@@ -183,4 +232,5 @@ func TestFeatureGateConstants(t *testing.T) {
 	assert.Equal(t, "HCPEtcdBackup", string(featuregate.HCPEtcdBackup))
 	assert.Equal(t, "KarpenterOperator", string(featuregate.KarpenterOperator))
 	assert.Equal(t, "OSStreams", string(featuregate.OSStreams))
+	assert.Equal(t, "OCIPlatform", string(featuregate.OCIPlatform))
 }


### PR DESCRIPTION
## What this PR does / why we need it:
This PR declares the OCIPlatform feature gate as first part of the OCI platform support. HyperShift currently has no OCI platform, and every OCI field that gets added to the API needs to sit behind a feature gate.

OCIPlatform is registered under `TechPreviewNoUpgrade` and listed as disabled by default across all four `featureGate-*.yaml `variants.

## Which issue(s) this PR fixes:
Fixes: https://redhat.atlassian.net/browse/HYPERFLEET-1579

## Special notes for your reviewer:
- No CRD schema changes
- Docs (feature-gates.md) updated to list OCI alongside OpenStack/GCP as requiring --tech-preview-no-upgrade.
- Reference: prototype on openshift-hyperfleet/hypershift branch platform-oci

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OCI platform support behind a feature gate.
  * Enabled OCI platform support for the TechPreviewNoUpgrade feature set.
* **Configuration**
  * Updated default configurations to keep OCI platform support disabled unless explicitly enabled.
* **Documentation**
  * Updated feature-gate examples to include OCI alongside other supported providers.
* **Tests**
  * Added coverage validating OCI platform feature-gate behavior across supported feature sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->