### PR TITLE
GCP-1122: chore: add pvasant to gcp-reviewers alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -85,6 +85,7 @@ aliases:
     - gbarabasz
     - jimdaga
     - patjlm
+    - pvasant
   powervs-reviewers:
     - alishaIBM
     - bkhadars


### PR DESCRIPTION
## Summary
- Add `pvasant` (Priyadarshini Vasanthakumar) to the `gcp-reviewers` alias in `OWNERS_ALIASES`
- Part of onboarding tracked in [GCP-1122](https://redhat.atlassian.net/browse/GCP-1122)

## Test plan
- [ ] Verify `pvasant` appears in the `gcp-reviewers` alias
- [ ] Verify alphabetical ordering is preserved

Always review AI generated responses prior to use.
Generated with AI assistance via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reviewer alias configuration to include an additional Google Cloud reviewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->