### PR TITLE
OCPBUGS-115269: openstack: Start populating cacert in clouds.yaml

### DIFF
--- a/cmd/cluster/openstack/create.go
+++ b/cmd/cluster/openstack/create.go
@@ -358,11 +358,14 @@ func extractCloud(cloudsYAMLPath, caCertPath, cloudName string) ([]byte, []byte,
 		if caCertPath == "" {
 			caCertPath = cloud["cacert"].(string)
 		}
-		// Always unset this key if present since it's not used and can therefore be confusing. We
-		// set '[Global] ca-file' in the cloud provider and CSI configs, which means takes priority
+	}
+
+	if caCertPath != "" {
+		// This config option may be ignored, depending on the component. We currently set
+		// '[Global] ca-file' in the cloud provider and Cinder CSI configs, which takes priority
 		// over configuration sourced from clouds.yaml
-		// https://github.com/kubernetes/cloud-provider-openstack/blob/v1.31.0/pkg/client/client.go#L228
-		delete(cloud, "cacert")
+		// https://github.com/kubernetes/cloud-provider-openstack/blob/v1.36.0/pkg/client/client.go#L231
+		cloud["cacert"] = "/etc/openstack/ca.crt"
 	}
 
 	var caCert []byte

--- a/cmd/cluster/openstack/create_test.go
+++ b/cmd/cluster/openstack/create_test.go
@@ -258,6 +258,7 @@ func TestExtractCloud(t *testing.T) {
 					"auth": map[string]any{
 						"auth_url": "fakeAuthURL",
 					},
+					"cacert": "/etc/openstack/ca.crt",
 				},
 			},
 		})
@@ -298,6 +299,7 @@ func TestExtractCloud(t *testing.T) {
 					"auth": map[string]any{
 						"auth_url": "fakeAuthURL",
 					},
+					"cacert": "/etc/openstack/ca.crt",
 				},
 			},
 		})

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
@@ -51,8 +51,7 @@ func getCloudConfig(platformSpec *hyperv1.OpenStackPlatformSpec, credentialsSecr
 	config += "use-clouds = true\n"
 	config += "clouds-file = " + CloudCredentialsDir + "/" + CloudsSecretKey + "\n"
 	config += "cloud = " + platformSpec.IdentityRef.CloudName + "\n"
-	// This takes priority over the 'cacert' value in 'clouds.yaml' and we therefore
-	// unset that when creating the initial secret.
+	// This takes priority over the 'cacert' value in 'clouds.yaml'
 	if caCertData != nil {
 		config += "ca-file = " + CADir + "/" + CABundleKey + "\n"
 	}


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

Previously we unset this since all components were overriding via a separate config option. This is no [longer true for the Manila CSI driver][1]. Start setting it to a well-known path.

[1]: https://github.com/openshift/csi-operator/pull/373

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes OCPBUGS-115269

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - OpenStack cloud configurations now consistently reference `/etc/openstack/ca.crt` for certificate verification.
  - Explicit CA certificate settings take precedence over values provided in `clouds.yaml`.
  - Generated configurations now retain certificate settings instead of omitting them.
  - Improved handling for both CA certificates discovered from cloud configuration and explicitly supplied certificate paths.
  - Updated configuration guidance to accurately describe certificate precedence and ensure reliable TLS verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->