### PR TITLE
OCPBUGS-113712: fix(kas): preserve AWS NLB annotation to avoid VAP rejection

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -65,9 +65,12 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 		svc.Annotations = map[string]string{}
 	}
 
-	// Remove stale AWS NLB annotation before reconciling.
-	// It will be re-added only when the service is actually a LoadBalancer.
-	delete(svc.Annotations, AWSNLBAnnotation)
+	// NOTE: Do not delete AWSNLBAnnotation from existing services.
+	// The cluster-wide ValidatingAdmissionPolicy
+	// "openshift-cloud-controller-manager-cloud-provider-aws" (OCPBUGS-16728)
+	// blocks any UPDATE that adds, removes, or changes this annotation.
+	// Removing it here would cause an infinite reconciliation error loop.
+	// A stale annotation on a ClusterIP service is harmless.
 
 	switch strategy.Type {
 	case hyperv1.LoadBalancer:

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
@@ -125,6 +125,51 @@ func TestReconcileService(t *testing.T) {
 	}
 }
 
+func TestReconcileServicePreservesNLBAnnotation(t *testing.T) {
+	// Regression test for OCPBUGS-113712: the cluster-wide ValidatingAdmissionPolicy
+	// "openshift-cloud-controller-manager-cloud-provider-aws" blocks any Service UPDATE
+	// that removes the aws-load-balancer-type annotation. When an existing service already
+	// has the annotation (legacy or set by an older CPO) and the strategy is not LoadBalancer,
+	// the reconciler must preserve it to avoid an infinite error loop.
+	testCases := []struct {
+		name     string
+		strategy hyperv1.ServicePublishingStrategy
+	}{
+		{
+			name:     "When AWS Route strategy with existing NLB annotation it should preserve the annotation",
+			strategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route},
+		},
+		{
+			name:     "When AWS NodePort strategy with existing NLB annotation it should preserve the annotation",
+			strategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.NodePort, NodePort: &hyperv1.NodePortPublishingStrategy{Port: 31000}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			hcp := hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform},
+				},
+			}
+			// Simulate an existing service that already has the NLB annotation (legacy state).
+			svc := &corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						AWSNLBAnnotation: "nlb",
+					},
+				},
+			}
+
+			err := ReconcileService(svc, &tc.strategy, &v1.OwnerReference{}, 6443, []string{}, &hcp)
+			g.Expect(err).To(BeNil())
+			// The annotation must be preserved to avoid triggering the ValidatingAdmissionPolicy.
+			g.Expect(svc.Annotations).To(HaveKeyWithValue(AWSNLBAnnotation, "nlb"),
+				"NLB annotation must not be removed — the ValidatingAdmissionPolicy blocks its removal")
+		})
+	}
+}
+
 func TestReconcileServiceAzureInternalLB(t *testing.T) {
 	// The main KAS service (kube-apiserver-azure-lb) should never have the internal LB
 	// annotation. For Azure Private, this service becomes ClusterIP because isPublic=false.


### PR DESCRIPTION
## What this PR does / why we need it

The cluster-wide `ValidatingAdmissionPolicy` `openshift-cloud-controller-manager-cloud-provider-aws` ([OCPBUGS-16728](https://redhat.atlassian.net/browse/OCPBUGS-16728)) blocks any Service UPDATE that adds, removes, or changes the `service.beta.kubernetes.io/aws-load-balancer-type` annotation.

PR #7993 ([CNTRLPLANE-2946](https://redhat.atlassian.net/browse/CNTRLPLANE-2946)) unconditionally deletes this annotation before reconciling, then conditionally re-adds it only for `LoadBalancer + AWS + public`. When the strategy is `Route` or `NodePort`, the annotation is removed but never re-added, triggering the VAP and causing an **infinite reconciliation error loop** for affected HostedControlPlanes.

### Root cause

Two independent fixes conflict:

| Fix | What it does | Where |
|-----|-------------|-------|
| VAP (OCPBUGS-16728) | Blocks any UPDATE that changes the NLB annotation — prevents LB type changes that leak cloud resources | cluster-cloud-controller-manager-operator PR#362 |
| PR #7993 ([CNTRLPLANE-2946](https://redhat.atlassian.net/browse/CNTRLPLANE-2946)) | Unconditionally `delete()`s the annotation, re-adds only for LoadBalancer+AWS+public | HyperShift CPO `kas/service.go` |

### The conflict scenario

1. HCP on AWS with strategy `Route` — `kube-apiserver` Service has stale `aws-load-balancer-type: nlb` annotation (set by older CPO or during initial creation)
2. CPO deletes the annotation in-memory (cleanup step)
3. Strategy is `Route` → annotation is NOT re-added
4. CPO sends UPDATE → VAP detects annotation removal → **DENIED**
5. Reconciler errors, retries → infinite loop

### Fix

Remove the unconditional `delete()`. A stale NLB annotation on a ClusterIP service is harmless — Kubernetes ignores it. The annotation is still correctly set for `LoadBalancer + AWS + public` services.

### Follow-up

The VAP binding has no `namespaceSelector` — it applies to all namespaces including HyperShift control-plane namespaces. A follow-up should be filed against CCCMO to add namespace exclusions for `hypershift.openshift.io/hosted-control-plane` labeled namespaces.

## Which issue(s) this PR fixes

https://redhat.atlassian.net/browse/OCPBUGS-113712

## Checklist

- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved existing AWS Network Load Balancer annotations during service reconciliation.
  - Prevented reconciliation failures caused by cloud-provider admission policy restrictions.
  - Maintained reliable service updates for AWS Route and NodePort configurations.

- **Tests**
  - Added coverage verifying successful reconciliation while retaining existing load balancer annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->