### PR TITLE
OCPBUGS-113712: preserve immutable AWS load balancer annotations

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
@@ -1451,7 +1451,6 @@ func TestReconcileAPIServerService(t *testing.T) {
 				kasPublicService(func(s *corev1.Service) {
 					s.Spec.Type = corev1.ServiceTypeClusterIP
 					delete(s.Annotations, "external-dns.alpha.kubernetes.io/hostname")
-					delete(s.Annotations, "service.beta.kubernetes.io/aws-load-balancer-type")
 				}),
 				kasPrivateService(withCrossZoneAnnotation),
 			},

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_When_AWS_private_cluster_uses_KAS_LoadBalancer__it_should_configure_internal_router.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_When_AWS_private_cluster_uses_KAS_LoadBalancer__it_should_configure_internal_router.yaml
@@ -99,6 +99,8 @@ services:
     status:
       loadBalancer: {}
   - metadata:
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-type: nlb
       labels:
         app: kube-apiserver
         hypershift.openshift.io/control-plane-component: kube-apiserver

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -31,6 +31,9 @@ func kasLabels() map[string]string {
 }
 
 func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy, owner *metav1.OwnerReference, apiServerServicePort int, apiAllowedCIDRBlocks []string, hcp *hyperv1.HostedControlPlane) error {
+	// CreateOrUpdate leaves ResourceVersion empty only when it did not find an
+	// existing object and will create the Service.
+	isCreate := svc.ResourceVersion == ""
 	isPublic := netutil.IsPublicHCP(hcp)
 	isPrivate := netutil.IsPrivateHCP(hcp)
 	k8sutil.EnsureOwnerRef(svc, owner)
@@ -65,17 +68,19 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 		svc.Annotations = map[string]string{}
 	}
 
-	// Remove stale AWS NLB annotation before reconciling.
-	// It will be re-added only when the service is actually a LoadBalancer.
-	delete(svc.Annotations, AWSNLBAnnotation)
-
 	switch strategy.Type {
 	case hyperv1.LoadBalancer:
+		// AWS requires the load balancer type annotation to remain unchanged after
+		// Service creation. The cluster-wide ValidatingAdmissionPolicy
+		// "openshift-cloud-controller-manager-cloud-provider-aws" (OCPBUGS-16728)
+		// blocks any UPDATE that adds, removes, or changes this annotation. Seed it
+		// only on CREATE, which the policy does not match, even for private services
+		// that may become public LoadBalancer services when endpoint access changes.
+		if isCreate && hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
+			svc.Annotations[AWSNLBAnnotation] = "nlb"
+		}
 		if isPublic {
 			svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-			if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
-				svc.Annotations[AWSNLBAnnotation] = "nlb"
-			}
 			if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
 				svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
 			}
@@ -191,6 +196,9 @@ func ReconcileServiceStatus(svc *corev1.Service, strategy *hyperv1.ServicePublis
 }
 
 func ReconcilePrivateService(svc *corev1.Service, hcp *hyperv1.HostedControlPlane, owner *metav1.OwnerReference) error {
+	// CreateOrUpdate leaves ResourceVersion empty only when it did not find an
+	// existing object and will create the Service.
+	isCreate := svc.ResourceVersion == ""
 	k8sutil.EnsureOwnerRef(svc, owner)
 	svc.Spec.Selector = kasLabels()
 
@@ -231,7 +239,9 @@ func ReconcilePrivateService(svc *corev1.Service, hcp *hyperv1.HostedControlPlan
 		// AWS Load Balancer Controller annotation for cross-zone load balancing (EKS Auto Mode).
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"] = "load_balancing.cross_zone.enabled=true"
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "true"
-		svc.Annotations[AWSNLBAnnotation] = "nlb"
+		if isCreate && hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
+			svc.Annotations[AWSNLBAnnotation] = "nlb"
+		}
 	}
 	svc.Spec.Ports[0] = portSpec
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
@@ -18,13 +18,17 @@ import (
 func TestReconcileService(t *testing.T) {
 
 	testCases := []struct {
-		name          string
-		platform      hyperv1.PlatformType
-		strategy      hyperv1.ServicePublishingStrategy
-		apiServerPort int
-		svc_in        corev1.Service
-		svc_out       corev1.Service
-		err           error
+		name                   string
+		platform               hyperv1.PlatformType
+		strategy               hyperv1.ServicePublishingStrategy
+		endpointAccess         hyperv1.AWSEndpointAccessType
+		apiServerPort          int
+		checkNLBAnnotation     bool
+		wantNLBAnnotation      bool
+		wantNLBAnnotationValue string
+		svc_in                 corev1.Service
+		svc_out                corev1.Service
+		err                    error
 	}{
 		{
 			name:          "IBM Cloud, NodePort strategy, NodePort service, expected to fill port number from strategy",
@@ -82,10 +86,13 @@ func TestReconcileService(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:          "Non-IBM Cloud, Route strategy, ClusterIP service, expected to fill port value only",
-			platform:      hyperv1.AWSPlatform,
-			strategy:      hyperv1.ServicePublishingStrategy{Type: hyperv1.Route},
-			apiServerPort: 1125,
+			name:               "When creating an AWS Route service, it should not add the NLB annotation",
+			platform:           hyperv1.AWSPlatform,
+			strategy:           hyperv1.ServicePublishingStrategy{Type: hyperv1.Route},
+			endpointAccess:     hyperv1.Public,
+			apiServerPort:      1125,
+			checkNLBAnnotation: true,
+			wantNLBAnnotation:  false,
 			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeClusterIP,
 			}},
@@ -102,14 +109,126 @@ func TestReconcileService(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "Invalid strategy",
+			name:                   "When creating a private AWS LoadBalancer service, it should seed the NLB annotation for future endpoint transitions",
+			platform:               hyperv1.AWSPlatform,
+			strategy:               hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer},
+			endpointAccess:         hyperv1.Private,
+			apiServerPort:          6443,
+			checkNLBAnnotation:     true,
+			wantNLBAnnotation:      true,
+			wantNLBAnnotationValue: "nlb",
+			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "client"},
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:                   "When updating a legacy AWS Route service, it should preserve the NLB annotation",
+			platform:               hyperv1.AWSPlatform,
+			strategy:               hyperv1.ServicePublishingStrategy{Type: hyperv1.Route},
+			endpointAccess:         hyperv1.Public,
+			apiServerPort:          6443,
+			checkNLBAnnotation:     true,
+			wantNLBAnnotation:      true,
+			wantNLBAnnotationValue: "nlb",
+			svc_in: corev1.Service{ObjectMeta: v1.ObjectMeta{
+				ResourceVersion: "1",
+				Annotations: map[string]string{
+					AWSNLBAnnotation: "nlb",
+				},
+			}, Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "client"},
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:               "When updating an AWS LoadBalancer service without an annotation, it should not add one",
+			platform:           hyperv1.AWSPlatform,
+			strategy:           hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer},
+			endpointAccess:     hyperv1.Public,
+			apiServerPort:      6443,
+			checkNLBAnnotation: true,
+			wantNLBAnnotation:  false,
+			svc_in: corev1.Service{ObjectMeta: v1.ObjectMeta{
+				ResourceVersion: "1",
+				Annotations:     map[string]string{},
+			}, Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "client"},
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:                   "When updating an AWS service with a non-NLB annotation, it should preserve its value",
+			platform:               hyperv1.AWSPlatform,
+			strategy:               hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer},
+			endpointAccess:         hyperv1.Public,
+			apiServerPort:          6443,
+			checkNLBAnnotation:     true,
+			wantNLBAnnotation:      true,
+			wantNLBAnnotationValue: "clb",
+			svc_in: corev1.Service{ObjectMeta: v1.ObjectMeta{
+				ResourceVersion: "1",
+				Annotations: map[string]string{
+					AWSNLBAnnotation: "clb",
+				},
+			}, Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "client"},
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:     "When using an invalid publishing strategy, it should return an error",
 			strategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.None},
 			err:      fmt.Errorf("invalid publishing strategy for Kube API server service: None"),
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			hcp := hyperv1.HostedControlPlane{Spec: hyperv1.HostedControlPlaneSpec{Platform: hyperv1.PlatformSpec{Type: tc.platform}}}
+			platform := hyperv1.PlatformSpec{Type: tc.platform}
+			if tc.endpointAccess != "" {
+				platform.AWS = &hyperv1.AWSPlatformSpec{EndpointAccess: tc.endpointAccess}
+			}
+			hcp := hyperv1.HostedControlPlane{Spec: hyperv1.HostedControlPlaneSpec{Platform: platform}}
 
 			err := ReconcileService(&tc.svc_in, &tc.strategy, &v1.OwnerReference{}, tc.apiServerPort, []string{}, &hcp)
 
@@ -118,6 +237,13 @@ func TestReconcileService(t *testing.T) {
 				g.Expect(err).To(BeNil())
 				g.Expect(tc.svc_in.Spec.Type).To(Equal(tc.svc_out.Spec.Type))
 				g.Expect(tc.svc_in.Spec.Ports).To(Equal(tc.svc_out.Spec.Ports))
+				if tc.checkNLBAnnotation {
+					if tc.wantNLBAnnotation {
+						g.Expect(tc.svc_in.Annotations).To(HaveKeyWithValue(AWSNLBAnnotation, tc.wantNLBAnnotationValue))
+					} else {
+						g.Expect(tc.svc_in.Annotations).ToNot(HaveKey(AWSNLBAnnotation))
+					}
+				}
 			} else {
 				g.Expect(tc.err.Error()).To(Equal(err.Error()))
 			}
@@ -189,6 +315,7 @@ func TestReconcilePrivateService(t *testing.T) {
 		hcp                     *hyperv1.HostedControlPlane
 		expectAzureILB          bool
 		expectAWSAnnotations    bool
+		expectAWSNLBAnnotation  bool
 		expectedPort            int32
 		expectIPFamilyDualStack bool
 	}{
@@ -254,6 +381,7 @@ func TestReconcilePrivateService(t *testing.T) {
 			},
 			expectAzureILB:          false,
 			expectAWSAnnotations:    true,
+			expectAWSNLBAnnotation:  true,
 			expectedPort:            int32(config.KASSVCPort),
 			expectIPFamilyDualStack: true,
 		},
@@ -329,9 +457,67 @@ func TestReconcilePrivateService(t *testing.T) {
 				g.Expect(svc.Annotations).To(HaveKeyWithValue(awsCrossZoneAnnotation, "true"))
 				g.Expect(svc.Annotations).To(HaveKeyWithValue(awsLBAttributesAnnotation, "load_balancing.cross_zone.enabled=true"))
 				g.Expect(svc.Annotations).To(HaveKeyWithValue(awsInternalAnnotation, "true"))
-				g.Expect(svc.Annotations).To(HaveKeyWithValue(awsNLBAnnotation, "nlb"))
+				if tc.expectAWSNLBAnnotation {
+					g.Expect(svc.Annotations).To(HaveKeyWithValue(awsNLBAnnotation, "nlb"))
+				} else {
+					g.Expect(svc.Annotations).ToNot(HaveKey(awsNLBAnnotation))
+				}
 				// Non-Azure should NOT have Azure ILB annotation
 				g.Expect(svc.Annotations).ToNot(HaveKey(azureILBAnnotation))
+			}
+		})
+	}
+}
+
+func TestReconcilePrivateServiceAWSNLBAnnotation(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name            string
+		resourceVersion string
+		annotationValue string
+		wantAnnotation  bool
+		wantValue       string
+	}{
+		{
+			name:           "When creating an AWS private service, it should set the NLB annotation",
+			wantAnnotation: true,
+			wantValue:      "nlb",
+		},
+		{
+			name:            "When updating an AWS private service without an annotation, it should not add one",
+			resourceVersion: "1",
+			wantAnnotation:  false,
+		},
+		{
+			name:            "When updating an AWS private service with a non-NLB annotation, it should preserve its value",
+			resourceVersion: "1",
+			annotationValue: "clb",
+			wantAnnotation:  true,
+			wantValue:       "clb",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			hcp := &hyperv1.HostedControlPlane{Spec: hyperv1.HostedControlPlaneSpec{
+				Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform},
+			}}
+			svc := &corev1.Service{ObjectMeta: v1.ObjectMeta{
+				ResourceVersion: tc.resourceVersion,
+				Annotations:     map[string]string{},
+			}}
+			if tc.annotationValue != "" {
+				svc.Annotations[AWSNLBAnnotation] = tc.annotationValue
+			}
+
+			err := ReconcilePrivateService(svc, hcp, &v1.OwnerReference{})
+			g.Expect(err).ToNot(HaveOccurred())
+			if tc.wantAnnotation {
+				g.Expect(svc.Annotations).To(HaveKeyWithValue(AWSNLBAnnotation, tc.wantValue))
+			} else {
+				g.Expect(svc.Annotations).ToNot(HaveKey(AWSNLBAnnotation))
 			}
 		})
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

The AWS cloud controller requires `service.beta.kubernetes.io/aws-load-balancer-type` to remain unchanged after Service creation. CPO was deleting the annotation during reconciliation, causing the cluster-wide ValidatingAdmissionPolicy to block KAS Service updates.

This change seeds the NLB annotation on creation for AWS KAS LoadBalancer strategies, including private Services that may later become public, and preserves existing annotation values during updates. Fresh Route Services remain unannotated while legacy Services reconcile without admission failures.

## Which issue(s) this PR fixes:

Fixes [OCPBUGS-113712](https://redhat.atlassian.net/browse/OCPBUGS-113712)

## Special notes for your reviewer:

The annotation is intentionally treated as create-time immutable state. This preserves supported AWS endpoint-access transitions without weakening the CCO admission policy or deleting live KAS Services.

The CCO ValidatingAdmissionPolicy matches Service `UPDATE` operations only, not `CREATE`. CREATE-time annotation seeding is therefore allowed.

Focused tests:
- `go test ./control-plane-operator/controllers/hostedcontrolplane/kas`
- `go test ./control-plane-operator/controllers/hostedcontrolplane/infra`

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved AWS Network Load Balancer settings for API server services during updates.
  * Ensured private services retain the correct load balancer configuration if later exposed publicly.
  * Prevented existing load balancer annotations from being unnecessarily removed or overwritten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin