### PR TITLE
CNTRLPLANE-4041: add new release branches to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,9 @@
         "release-4.19",
         "release-4.20",
         "release-4.21",
-        "release-4.22"
+        "release-4.22",
+        "release-4.23",
+        "release-5.0"
     ],
     "tekton": {
         "branchConcurrentLimit": 10,
@@ -47,7 +49,9 @@
                 "release-4.19",
                 "release-4.20",
                 "release-4.21",
-                "release-4.22"
+                "release-4.22",
+                "release-4.23",
+                "release-5.0"
             ],
             "matchUpdateTypes": [
                 "patch"


### PR DESCRIPTION
For the OCP 5.0 branching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `release-4.23` and `release-5.0` to supported update and security maintenance branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->