### PR TITLE
GCP-883: Optimize GCP PSC NAT allocation

### DIFF
--- a/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller.go
+++ b/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller.go
@@ -301,8 +301,8 @@ func (r *GCPPrivateServiceConnectReconciler) discoverNATSubnet(ctx context.Conte
 		return "", fmt.Errorf("failed to list subnets: %w", err)
 	}
 
-	// Fetch all service attachments once (now with pagination support) before checking subnet usage.
-	// This replaces N individual API calls with a single paginated fetch.
+	// Fetch all service attachments up front (paginated) and build an in-memory set of
+	// in-use NAT subnets, so subnet availability is checked without an API call per candidate.
 	serviceAttachments, err := r.GcpClient.ListServiceAttachments(apiCtx, r.ProjectID, r.Region)
 	if err != nil {
 		return "", fmt.Errorf("failed to list service attachments: %w", err)
@@ -321,7 +321,7 @@ func (r *GCPPrivateServiceConnectReconciler) discoverNATSubnet(ctx context.Conte
 		}
 	}
 
-	// Find the first available PSC subnet in the MC's VPC not already in use.
+	// Find the first available PSC subnet in the management cluster's VPC.
 	for _, subnet := range subnets {
 		if usedSubnets[subnet.Name] {
 			log.V(1).Info("Subnet already in use, trying next", "subnet", subnet.Name)

--- a/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller.go
+++ b/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller.go
@@ -73,11 +73,18 @@ func (a *computeServiceAdapter) ListSubnetworks(ctx context.Context, project, re
 }
 
 func (a *computeServiceAdapter) ListServiceAttachments(ctx context.Context, project, region string) ([]*compute.ServiceAttachment, error) {
-	resp, err := a.svc.ServiceAttachments.List(project, region).Context(ctx).Do()
+	var allItems []*compute.ServiceAttachment
+
+	err := a.svc.ServiceAttachments.List(project, region).Context(ctx).Pages(ctx, func(page *compute.ServiceAttachmentList) error {
+		allItems = append(allItems, page.Items...)
+		return nil
+	})
+
 	if err != nil {
 		return nil, err
 	}
-	return resp.Items, nil
+
+	return allItems, nil
 }
 
 func (a *computeServiceAdapter) GetServiceAttachment(ctx context.Context, project, region, name string) (*compute.ServiceAttachment, error) {
@@ -267,31 +274,6 @@ func (r *GCPPrivateServiceConnectReconciler) lookupForwardingRule(ctx context.Co
 	return rule, nil
 }
 
-// isSubnetInUse checks if a subnet is already being used by existing Service Attachments
-func (r *GCPPrivateServiceConnectReconciler) isSubnetInUse(ctx context.Context, subnetName string) (bool, error) {
-	apiCtx, cancel := context.WithTimeout(ctx, gcpAPITimeout)
-	defer cancel()
-
-	serviceAttachments, err := r.GcpClient.ListServiceAttachments(apiCtx, r.ProjectID, r.Region)
-	if err != nil {
-		return false, fmt.Errorf("failed to list service attachments: %w", err)
-	}
-
-	// Check if any Service Attachment is using this subnet
-	for _, sa := range serviceAttachments {
-		for _, natSubnet := range sa.NatSubnets {
-			// NatSubnets contains full URLs like:
-			// "projects/PROJECT_ID/regions/REGION/subnetworks/SUBNET_NAME"
-			// Extract just the subnet name for comparison
-			if strings.HasSuffix(natSubnet, "/"+subnetName) {
-				return true, nil
-			}
-		}
-	}
-
-	return false, nil
-}
-
 // discoverNATSubnet finds an available PRIVATE_SERVICE_CONNECT subnet scoped to the given VPC network.
 // networkURL is the full GCP network URL from the forwarding rule (e.g.
 // "https://www.googleapis.com/compute/v1/projects/…/global/networks/my-vpc").
@@ -310,27 +292,37 @@ func (r *GCPPrivateServiceConnectReconciler) discoverNATSubnet(ctx context.Conte
 		return "", fmt.Errorf("failed to list subnets: %w", err)
 	}
 
-	// Find the first available PSC subnet in the MC's VPC not already in use by another Service Attachment.
-	var checkErrors int
+	// Fetch all service attachments once (now with pagination support) before checking subnet usage.
+	// This replaces N individual API calls with a single paginated fetch.
+	serviceAttachments, err := r.GcpClient.ListServiceAttachments(apiCtx, r.ProjectID, r.Region)
+	if err != nil {
+		return "", fmt.Errorf("failed to list service attachments: %w", err)
+	}
+
+	// Build in-memory map of subnet names currently in use by service attachments.
+	// NatSubnets contains full URLs like "projects/PROJECT_ID/regions/REGION/subnetworks/SUBNET_NAME"
+	usedSubnets := make(map[string]bool)
+	for _, sa := range serviceAttachments {
+		for _, natSubnet := range sa.NatSubnets {
+			// Extract subnet name from URL by taking the suffix after the last "/"
+			if idx := strings.LastIndex(natSubnet, "/"); idx >= 0 {
+				subnetName := natSubnet[idx+1:]
+				usedSubnets[subnetName] = true
+			}
+		}
+	}
+
+	// Find the first available PSC subnet in the MC's VPC not already in use.
 	for _, subnet := range subnets {
-		inUse, err := r.isSubnetInUse(ctx, subnet.Name)
-		if err != nil {
-			log.Error(err, "Failed to check subnet usage", "subnet", subnet.Name)
-			checkErrors++
+		if usedSubnets[subnet.Name] {
+			log.V(1).Info("Subnet already in use, trying next", "subnet", subnet.Name)
 			continue
 		}
 
-		if !inUse {
-			log.Info("Found available PSC subnet", "subnet", subnet.Name)
-			return subnet.Name, nil
-		}
-
-		log.V(1).Info("Subnet already in use, trying next", "subnet", subnet.Name)
+		log.Info("Found available PSC subnet", "subnet", subnet.Name)
+		return subnet.Name, nil
 	}
 
-	if checkErrors > 0 {
-		return "", fmt.Errorf("no available PRIVATE_SERVICE_CONNECT subnet found in region %s (failed to check %d of %d candidates due to API errors)", r.Region, checkErrors, len(subnets))
-	}
 	return "", fmt.Errorf("no available PRIVATE_SERVICE_CONNECT subnet found in region %s", r.Region)
 }
 

--- a/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller.go
+++ b/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
+	"path"
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -30,7 +30,9 @@ import (
 const (
 	finalizer = "hypershift.openshift.io/gcp-private-service-connect"
 
-	// gcpAPITimeout is the timeout for individual GCP API calls to prevent hung reconcilers.
+	// gcpAPITimeout is the timeout for GCP API operations to prevent hung reconcilers.
+	// A single context with this timeout may be shared across multiple API calls
+	// (e.g., ListSubnetworks + paginated ListServiceAttachments in discoverNATSubnet).
 	// GCP SDK has connection-level timeouts (dial: 30s, TLS: 10s) but no overall request timeout.
 	gcpAPITimeout = 30 * time.Second
 )
@@ -65,11 +67,18 @@ func (a *computeServiceAdapter) ListForwardingRules(ctx context.Context, project
 }
 
 func (a *computeServiceAdapter) ListSubnetworks(ctx context.Context, project, region, filter string) ([]*compute.Subnetwork, error) {
-	resp, err := a.svc.Subnetworks.List(project, region).Filter(filter).Context(ctx).Do()
+	var allItems []*compute.Subnetwork
+
+	err := a.svc.Subnetworks.List(project, region).Filter(filter).Context(ctx).Pages(ctx, func(page *compute.SubnetworkList) error {
+		allItems = append(allItems, page.Items...)
+		return nil
+	})
+
 	if err != nil {
 		return nil, err
 	}
-	return resp.Items, nil
+
+	return allItems, nil
 }
 
 func (a *computeServiceAdapter) ListServiceAttachments(ctx context.Context, project, region string) ([]*compute.ServiceAttachment, error) {
@@ -304,9 +313,9 @@ func (r *GCPPrivateServiceConnectReconciler) discoverNATSubnet(ctx context.Conte
 	usedSubnets := make(map[string]bool)
 	for _, sa := range serviceAttachments {
 		for _, natSubnet := range sa.NatSubnets {
-			// Extract subnet name from URL by taking the suffix after the last "/"
-			if idx := strings.LastIndex(natSubnet, "/"); idx >= 0 {
-				subnetName := natSubnet[idx+1:]
+			// Extract subnet name from URL (e.g., "projects/.../subnetworks/NAME" → "NAME")
+			subnetName := path.Base(natSubnet)
+			if subnetName != "" && subnetName != "." && subnetName != "/" {
 				usedSubnets[subnetName] = true
 			}
 		}

--- a/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller_test.go
+++ b/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller_test.go
@@ -608,6 +608,22 @@ func TestDiscoverNATSubnetAllSubnetsInUse(t *testing.T) {
 	}
 }
 
+func TestDiscoverNATSubnetServiceAttachmentsError(t *testing.T) {
+	networkURL := "https://example.com/network"
+	fc := &fakeComputeClient{
+		subnetworks:           []*compute.Subnetwork{{Name: "subnet-1"}},
+		serviceAttachmentsErr: errors.New("GCP API error"),
+	}
+	r := newReconciler(t, fc)
+	_, err := r.discoverNATSubnet(context.Background(), newGCPPSC("", ""), networkURL)
+	if err == nil {
+		t.Error("expected error when ListServiceAttachments fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to list service attachments") {
+		t.Errorf("expected 'failed to list service attachments' error, got: %v", err)
+	}
+}
+
 // TestDiscoverNATSubnetSingleAPICall verifies the GCP-883 optimization:
 // ListServiceAttachments is called only ONCE (not N times, once per subnet).
 func TestDiscoverNATSubnetSingleAPICall(t *testing.T) {
@@ -741,6 +757,111 @@ func TestComputeServiceAdapterListServiceAttachmentsPagination(t *testing.T) {
 	for name, found := range expectedNames {
 		if !found {
 			t.Errorf("missing service attachment: %s", name)
+		}
+	}
+}
+
+// TestComputeServiceAdapterListSubnetworksPagination verifies that
+// computeServiceAdapter.ListSubnetworks correctly handles paginated
+// responses from the GCP API by following next-page tokens and returning
+// items from all pages.
+func TestComputeServiceAdapterListSubnetworksPagination(t *testing.T) {
+	ctx := context.Background()
+
+	// Track which pages were requested to verify pagination logic
+	requestedPages := make(map[string]bool)
+
+	// Create a mock HTTP server that simulates GCP API pagination
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only handle subnetwork list requests
+		if !strings.Contains(r.URL.Path, "/subnetworks") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		pageToken := r.URL.Query().Get("pageToken")
+		requestedPages[pageToken] = true
+
+		var response compute.SubnetworkList
+
+		switch pageToken {
+		case "":
+			// First page: return 2 items + next page token
+			response = compute.SubnetworkList{
+				Items: []*compute.Subnetwork{
+					{Name: "subnet-page1-item1", Purpose: "PRIVATE_SERVICE_CONNECT"},
+					{Name: "subnet-page1-item2", Purpose: "PRIVATE_SERVICE_CONNECT"},
+				},
+				NextPageToken: "page2-token",
+			}
+		case "page2-token":
+			// Second page: return 2 more items, no next page token (end of results)
+			response = compute.SubnetworkList{
+				Items: []*compute.Subnetwork{
+					{Name: "subnet-page2-item1", Purpose: "PRIVATE_SERVICE_CONNECT"},
+					{Name: "subnet-page2-item2", Purpose: "PRIVATE_SERVICE_CONNECT"},
+				},
+				NextPageToken: "", // Last page
+			}
+		default:
+			http.Error(w, "invalid page token", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	// Create a real compute service pointing to our mock server
+	svc, err := compute.NewService(ctx, option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create compute service: %v", err)
+	}
+
+	adapter := &computeServiceAdapter{svc: svc}
+
+	// Call ListSubnetworks - it should automatically handle pagination
+	result, err := adapter.ListSubnetworks(ctx, "test-project", "test-region", `purpose="PRIVATE_SERVICE_CONNECT"`)
+	if err != nil {
+		t.Fatalf("ListSubnetworks failed: %v", err)
+	}
+
+	// Verify that both pages were requested
+	if !requestedPages[""] {
+		t.Error("first page (empty token) was not requested")
+	}
+	if !requestedPages["page2-token"] {
+		t.Error("second page (page2-token) was not requested")
+	}
+	if len(requestedPages) != 2 {
+		t.Errorf("expected exactly 2 page requests, got %d", len(requestedPages))
+	}
+
+	// Verify all items from both pages are returned
+	if len(result) != 4 {
+		t.Errorf("got %d subnetworks, want 4", len(result))
+	}
+
+	expectedNames := map[string]bool{
+		"subnet-page1-item1": false,
+		"subnet-page1-item2": false,
+		"subnet-page2-item1": false,
+		"subnet-page2-item2": false,
+	}
+
+	for _, subnet := range result {
+		if _, ok := expectedNames[subnet.Name]; !ok {
+			t.Errorf("unexpected subnetwork: %s", subnet.Name)
+		}
+		expectedNames[subnet.Name] = true
+	}
+
+	for name, found := range expectedNames {
+		if !found {
+			t.Errorf("missing subnetwork: %s", name)
 		}
 	}
 }

--- a/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller_test.go
+++ b/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller_test.go
@@ -660,9 +660,9 @@ func TestComputeServiceAdapterListServiceAttachmentsPagination(t *testing.T) {
 
 		pageToken := r.URL.Query().Get("pageToken")
 		requestedPages[pageToken] = true
-		
+
 		var response compute.ServiceAttachmentList
-		
+
 		switch pageToken {
 		case "":
 			// First page: return 2 items + next page token

--- a/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller_test.go
+++ b/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller_test.go
@@ -34,7 +34,7 @@ import (
 // capturedSubnetFilter records the filter string passed to ListSubnetworks so
 // tests can assert that the VPC-scoped filter reaches the API call site.
 // listServiceAttachmentsCallCount tracks how many times ListServiceAttachments
-// is called, used to verify the GCP-883 optimization (1 call vs N calls).
+// is called, used to verify subnet availability is checked via a single API call.
 type fakeComputeClient struct {
 	forwardingRules                 []*compute.ForwardingRule
 	forwardingRulesErr              error
@@ -624,8 +624,8 @@ func TestDiscoverNATSubnetServiceAttachmentsError(t *testing.T) {
 	}
 }
 
-// TestDiscoverNATSubnetSingleAPICall verifies the GCP-883 optimization:
-// ListServiceAttachments is called only ONCE (not N times, once per subnet).
+// TestDiscoverNATSubnetSingleAPICall verifies that ListServiceAttachments
+// is called only once regardless of how many subnets exist.
 func TestDiscoverNATSubnetSingleAPICall(t *testing.T) {
 	networkURL := "https://example.com/network"
 	fc := &fakeComputeClient{
@@ -649,8 +649,7 @@ func TestDiscoverNATSubnetSingleAPICall(t *testing.T) {
 		t.Errorf("got %q, want 'subnet-3-available'", result)
 	}
 
-	// Before GCP-883 fix: would be called 3 times (once per subnet check)
-	// After GCP-883 fix: called exactly once upfront
+	// ListServiceAttachments must be called exactly once, not once per subnet.
 	if fc.listServiceAttachmentsCallCount != 1 {
 		t.Errorf("ListServiceAttachments called %d times, want 1", fc.listServiceAttachmentsCallCount)
 	}

--- a/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller_test.go
+++ b/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller_test.go
@@ -2,8 +2,12 @@ package gcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,26 +26,30 @@ import (
 	"github.com/go-logr/logr/testr"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 )
 
 // fakeComputeClient implements ComputeClient for unit tests.
 // Each field holds the canned return values for the corresponding method.
 // capturedSubnetFilter records the filter string passed to ListSubnetworks so
 // tests can assert that the VPC-scoped filter reaches the API call site.
+// listServiceAttachmentsCallCount tracks how many times ListServiceAttachments
+// is called, used to verify the GCP-883 optimization (1 call vs N calls).
 type fakeComputeClient struct {
-	forwardingRules         []*compute.ForwardingRule
-	forwardingRulesErr      error
-	subnetworks             []*compute.Subnetwork
-	subnetworksErr          error
-	capturedSubnetFilter    string
-	serviceAttachments      []*compute.ServiceAttachment
-	serviceAttachmentsErr   error
-	getServiceAttachment    *compute.ServiceAttachment
-	getServiceAttachmentErr error
-	insertOperation         *compute.Operation
-	insertErr               error
-	deleteOperation         *compute.Operation
-	deleteErr               error
+	forwardingRules                 []*compute.ForwardingRule
+	forwardingRulesErr              error
+	subnetworks                     []*compute.Subnetwork
+	subnetworksErr                  error
+	capturedSubnetFilter            string
+	serviceAttachments              []*compute.ServiceAttachment
+	serviceAttachmentsErr           error
+	listServiceAttachmentsCallCount int
+	getServiceAttachment            *compute.ServiceAttachment
+	getServiceAttachmentErr         error
+	insertOperation                 *compute.Operation
+	insertErr                       error
+	deleteOperation                 *compute.Operation
+	deleteErr                       error
 }
 
 func (f *fakeComputeClient) ListForwardingRules(_ context.Context, _, _, _ string) ([]*compute.ForwardingRule, error) {
@@ -54,6 +62,7 @@ func (f *fakeComputeClient) ListSubnetworks(_ context.Context, _, _, filter stri
 }
 
 func (f *fakeComputeClient) ListServiceAttachments(_ context.Context, _, _ string) ([]*compute.ServiceAttachment, error) {
+	f.listServiceAttachmentsCallCount++
 	return f.serviceAttachments, f.serviceAttachmentsErr
 }
 
@@ -596,5 +605,142 @@ func TestDiscoverNATSubnetAllSubnetsInUse(t *testing.T) {
 	wantFilter := buildNATSubnetFilter(networkURL)
 	if fc.capturedSubnetFilter != wantFilter {
 		t.Errorf("ListSubnetworks filter = %q, want %q", fc.capturedSubnetFilter, wantFilter)
+	}
+}
+
+// TestDiscoverNATSubnetSingleAPICall verifies the GCP-883 optimization:
+// ListServiceAttachments is called only ONCE (not N times, once per subnet).
+func TestDiscoverNATSubnetSingleAPICall(t *testing.T) {
+	networkURL := "https://example.com/network"
+	fc := &fakeComputeClient{
+		subnetworks: []*compute.Subnetwork{
+			{Name: "subnet-1"},
+			{Name: "subnet-2"},
+			{Name: "subnet-3-available"},
+		},
+		serviceAttachments: []*compute.ServiceAttachment{
+			{NatSubnets: []string{"projects/p/regions/r/subnetworks/subnet-1"}},
+			{NatSubnets: []string{"projects/p/regions/r/subnetworks/subnet-2"}},
+		},
+	}
+
+	r := newReconciler(t, fc)
+	result, err := r.discoverNATSubnet(context.Background(), newGCPPSC("", ""), networkURL)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if result != "subnet-3-available" {
+		t.Errorf("got %q, want 'subnet-3-available'", result)
+	}
+
+	// Before GCP-883 fix: would be called 3 times (once per subnet check)
+	// After GCP-883 fix: called exactly once upfront
+	if fc.listServiceAttachmentsCallCount != 1 {
+		t.Errorf("ListServiceAttachments called %d times, want 1", fc.listServiceAttachmentsCallCount)
+	}
+}
+
+// TestComputeServiceAdapterListServiceAttachmentsPagination verifies that
+// computeServiceAdapter.ListServiceAttachments correctly handles paginated
+// responses from the GCP API by following next-page tokens and returning
+// items from all pages.
+func TestComputeServiceAdapterListServiceAttachmentsPagination(t *testing.T) {
+	ctx := context.Background()
+
+	// Track which pages were requested to verify pagination logic
+	requestedPages := make(map[string]bool)
+
+	// Create a mock HTTP server that simulates GCP API pagination
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only handle service attachment list requests
+		if !strings.Contains(r.URL.Path, "/serviceAttachments") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		pageToken := r.URL.Query().Get("pageToken")
+		requestedPages[pageToken] = true
+		
+		var response compute.ServiceAttachmentList
+		
+		switch pageToken {
+		case "":
+			// First page: return 2 items + next page token
+			response = compute.ServiceAttachmentList{
+				Items: []*compute.ServiceAttachment{
+					{Name: "sa-page1-item1", NatSubnets: []string{"subnet-1"}},
+					{Name: "sa-page1-item2", NatSubnets: []string{"subnet-2"}},
+				},
+				NextPageToken: "page2-token",
+			}
+		case "page2-token":
+			// Second page: return 2 more items, no next page token (end of results)
+			response = compute.ServiceAttachmentList{
+				Items: []*compute.ServiceAttachment{
+					{Name: "sa-page2-item1", NatSubnets: []string{"subnet-3"}},
+					{Name: "sa-page2-item2", NatSubnets: []string{"subnet-4"}},
+				},
+				NextPageToken: "", // Last page
+			}
+		default:
+			http.Error(w, "invalid page token", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	// Create a real compute service pointing to our mock server
+	svc, err := compute.NewService(ctx, option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create compute service: %v", err)
+	}
+
+	adapter := &computeServiceAdapter{svc: svc}
+
+	// Call ListServiceAttachments - it should automatically handle pagination
+	result, err := adapter.ListServiceAttachments(ctx, "test-project", "test-region")
+	if err != nil {
+		t.Fatalf("ListServiceAttachments failed: %v", err)
+	}
+
+	// Verify that both pages were requested
+	if !requestedPages[""] {
+		t.Error("first page (empty token) was not requested")
+	}
+	if !requestedPages["page2-token"] {
+		t.Error("second page (page2-token) was not requested")
+	}
+	if len(requestedPages) != 2 {
+		t.Errorf("expected exactly 2 page requests, got %d", len(requestedPages))
+	}
+
+	// Verify all items from both pages are returned
+	if len(result) != 4 {
+		t.Errorf("got %d service attachments, want 4", len(result))
+	}
+
+	expectedNames := map[string]bool{
+		"sa-page1-item1": false,
+		"sa-page1-item2": false,
+		"sa-page2-item1": false,
+		"sa-page2-item2": false,
+	}
+
+	for _, sa := range result {
+		if _, ok := expectedNames[sa.Name]; !ok {
+			t.Errorf("unexpected service attachment: %s", sa.Name)
+		}
+		expectedNames[sa.Name] = true
+	}
+
+	for name, found := range expectedNames {
+		if !found {
+			t.Errorf("missing service attachment: %s", name)
+		}
 	}
 }


### PR DESCRIPTION
  ## What this PR does / why we need it:
  
  Optimizes GCP Private Service Connect (PSC) NAT subnet discovery by reducing API calls from O(N) to O(1).

  **Before:** The controller called `ListServiceAttachments` once for each candidate PSC subnet to check if it was in use, resulting in up to N API calls when discovering an available subnet.

  **After:** The controller fetches all service attachments once (with pagination support) and builds an in-memory map of used subnets, then checks candidates against the map. This reduces API overhead from potentially 19+ calls to exactly 1 call per reconciliation.

  **Impact:** In environments with multiple PSC subnets (e.g., 19 subnets configured), this reduces GCP API calls by ~95% during PSC reconciliation, improving performance and reducing rate limit exposure.

  ## Which issue(s) this PR fixes:
  
  Fixes [GCP-883](https://redhat.atlassian.net/browse/GCP-883) (PSC NAT subnet discovery makes excessive API calls)

  ## Special notes for your reviewer:

  - The optimization maintains identical behavior - same subnet selection logic, just more efficient API usage
  - Added pagination support to `ListServiceAttachments` to handle environments with >50 service attachments
  - New unit test `TestDiscoverNATSubnetSingleAPICall` explicitly verifies the API call count went from N to 1
  - All existing tests pass unchanged (behavior is preserved)

  ## Checklist:
  - [x] Subject and description added to both, commit and PR.
  - [x] Relevant issues have been referenced.
  - [ ] This change includes docs. (N/A - internal optimization, no user-facing changes)
  - [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GCP private service connectivity to evaluate all available service attachments across paginated results.
  * GCP subnet discovery now processes all result pages, improving reliability in environments with many subnets.
  * NAT subnet selection now skips subnets already in use and chooses an available option.
  * Reduced unnecessary service-attachment API requests during subnet discovery.
  * Improved error handling when service-attachment discovery fails.

* **Documentation**
  * Clarified timeout guidance for operations involving multiple API calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->