### PR TITLE
OCPBUGS-115403: ensure informing junit files are unique across test groups

### DIFF
--- a/test/e2e/v2/tests/suite_test.go
+++ b/test/e2e/v2/tests/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -61,7 +62,6 @@ func TestE2EV2(t *testing.T) {
 // TODO(CNTRLPLANE-3863): Replace this with OTE's built-in lifecycle JUnit
 // emission once the test framework is ported to OTE.
 var _ = ReportAfterSuite("Write lifecycle-aware JUnit", func(report Report) {
-	artifactDir := internal.GetEnvVarValue("ARTIFACT_DIR")
 	suites := internal.BuildInformingTestsLifecycleReport(report.SuiteDescription, report.SpecReports)
 	if len(suites.Suites) == 0 || len(suites.Suites[0].TestCases) == 0 {
 		return
@@ -70,13 +70,18 @@ var _ = ReportAfterSuite("Write lifecycle-aware JUnit", func(report Report) {
 	// The filename here is arbitrary; the CI system ingests all JUnit files written
 	// to the artifact location, so the only constraint to satisfy is that this name
 	// shouldn't conflict with the reports the main Ginkgo report writer produces.
-	const junitFilename = "junit_lifecycle_informing.xml"
+	// Auto-detect the configured JUnit file path (assumed to be unique) and add
+	// a suffix to indicate it's for the informing output.
+	_, reporterConfig := GinkgoConfiguration()
+	if reporterConfig.JUnitReport == "" {
+		return
+	}
+	path := strings.TrimSuffix(reporterConfig.JUnitReport, filepath.Ext(reporterConfig.JUnitReport)) + "_informing.xml"
 
 	data, err := xml.MarshalIndent(suites, "", "    ")
 	if err != nil {
 		Fail(fmt.Sprintf("failed to marshal lifecycle JUnit: %v", err))
 	}
-	path := filepath.Join(artifactDir, junitFilename)
 	if err := os.WriteFile(path, append([]byte(xml.Header), data...), 0644); err != nil {
 		Fail(fmt.Sprintf("failed to write lifecycle JUnit to %s: %v", path, err))
 	}


### PR DESCRIPTION
Before this change, the informing junit file used a static filename, which means the last test group to write to a shared directory would overwrite any existing file.

This change updates the handler to auto-detect the current test's junit report filename (already guaranteed to be unique) and appends an "_informing.xml" suffix to ensure the informing file is unique.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generation of informing-test JUnit reports by deriving the output location from the configured JUnit report path.
  * Avoided creating an informing-test report when no JUnit report is configured.
  * Ensured generated report filenames consistently match the configured report name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->