### PR TITLE
CNTRLPLANE-3646: enable e2e v2 aws control plane upgrade tests

### DIFF
--- a/test/e2e/v2/lifecycle/aws.go
+++ b/test/e2e/v2/lifecycle/aws.go
@@ -63,6 +63,13 @@ func (a *AWSPlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Cluster
 				"--public-only",
 			}...),
 		},
+		{
+			Variant:      "upgrade",
+			ReleaseImage: n1Image,
+			ExtraArgs: append(extraArgs, []string{
+				"--control-plane-availability-policy=HighlyAvailable",
+			}...),
+		},
 		// The KarpenterBillingConsolidationTest actually tests hostedcluster teardown
 		// behavior and so needs its own dedicated cluster. This seems somewhat leaky
 		// in terms of test isolation because a downstream teardown of a cluster the
@@ -155,6 +162,28 @@ func (a *AWSPlatformConfig) TestMatrix() TestMatrix {
 				Name:        "karpenter-upgrade",
 				Variant:     "karpenter-upgrade",
 				LabelFilter: "karpenter-upgrade",
+			},
+		},
+		Sequential: []SequentialGroup{
+			{
+				Name: "upgrade-and-chaos",
+				Steps: []TestGroup{
+					{
+						Name:        "upgrade",
+						Variant:     "upgrade",
+						LabelFilter: "control-plane-upgrade",
+					},
+					{
+						Name:        "control-plane-tls",
+						Variant:     "upgrade",
+						LabelFilter: "control-plane-pki-operator",
+					},
+					{
+						Name:        "etcd-chaos",
+						Variant:     "upgrade",
+						LabelFilter: "etcd-chaos",
+					},
+				},
 			},
 		},
 	}

--- a/test/e2e/v2/tests/control_plane_upgrade_test.go
+++ b/test/e2e/v2/tests/control_plane_upgrade_test.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -26,8 +25,6 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
-
-	configv1 "github.com/openshift/api/config/v1"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -62,32 +59,7 @@ func ControlPlaneUpgradeTest(getTestCtx internal.TestContextGetter) {
 		Expect(err).NotTo(HaveOccurred(), "failed to update hosted cluster release image")
 
 		By(fmt.Sprintf("Waiting for the control plane and data plane to reach image %s", latestImage))
-		Eventually(func(g Gomega) {
-			currentHC := &hyperv1.HostedCluster{}
-			hcErr := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), currentHC)
-			if hcErr != nil {
-				g.Expect(hcErr).NotTo(HaveOccurred(), "failed to get HostedCluster %s/%s", hc.Namespace, hc.Name)
-				return
-			}
-
-			g.Expect(currentHC.Status.ControlPlaneVersion.Desired.Image).To(Equal(latestImage))
-			if len(currentHC.Status.ControlPlaneVersion.History) == 0 {
-				g.Expect(currentHC.Status.ControlPlaneVersion.History).NotTo(BeEmpty())
-				return
-			}
-			g.Expect(currentHC.Status.ControlPlaneVersion.History[0].State).To(Equal(configv1.CompletedUpdate))
-
-			if currentHC.Status.Version == nil {
-				g.Expect(currentHC.Status.Version).NotTo(BeNil())
-				return
-			}
-			g.Expect(currentHC.Status.Version.Desired.Image).To(Equal(latestImage))
-			if len(currentHC.Status.Version.History) == 0 {
-				g.Expect(currentHC.Status.Version.History).NotTo(BeEmpty())
-				return
-			}
-			g.Expect(currentHC.Status.Version.History[0].State).To(Equal(configv1.CompletedUpdate))
-		}).WithContext(ctx).WithTimeout(30 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+		ExpectHostedClusterUpgradeToComplete(ctx, testCtx.MgmtClient, hc, latestImage)
 
 		// Re-fetch HC after upgrade
 		Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), hc)).To(Succeed())

--- a/test/e2e/v2/tests/karpenter_control_plane_upgrade_test.go
+++ b/test/e2e/v2/tests/karpenter_control_plane_upgrade_test.go
@@ -17,8 +17,6 @@ import (
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 
-	configv1 "github.com/openshift/api/config/v1"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -142,32 +140,7 @@ func KarpenterUpgradeTest(getTestCtx internal.TestContextGetter) {
 			}()
 
 			By("Waiting for control plane components to complete rollout")
-			Eventually(func(g Gomega) {
-				currentHC := &hyperv1.HostedCluster{}
-				hcErr := tc.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), currentHC)
-				if hcErr != nil {
-					g.Expect(hcErr).NotTo(HaveOccurred(), "failed to get HostedCluster %s/%s", hc.Namespace, hc.Name)
-					return
-				}
-
-				g.Expect(currentHC.Status.ControlPlaneVersion.Desired.Image).To(Equal(latestImage))
-				if len(currentHC.Status.ControlPlaneVersion.History) == 0 {
-					g.Expect(currentHC.Status.ControlPlaneVersion.History).NotTo(BeEmpty())
-					return
-				}
-				g.Expect(currentHC.Status.ControlPlaneVersion.History[0].State).To(Equal(configv1.CompletedUpdate))
-
-				if currentHC.Status.Version == nil {
-					g.Expect(currentHC.Status.Version).NotTo(BeNil())
-					return
-				}
-				g.Expect(currentHC.Status.Version.Desired.Image).To(Equal(latestImage))
-				if len(currentHC.Status.Version.History) == 0 {
-					g.Expect(currentHC.Status.Version.History).NotTo(BeEmpty())
-					return
-				}
-				g.Expect(currentHC.Status.Version.History[0].State).To(Equal(configv1.CompletedUpdate))
-			}).WithContext(ctx).WithTimeout(30 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+			ExpectHostedClusterUpgradeToComplete(ctx, tc.MgmtClient, hc, latestImage)
 
 			GinkgoWriter.Printf("Control plane upgraded, awaiting drift\n")
 			<-driftChan

--- a/test/e2e/v2/tests/upgrade_assertions.go
+++ b/test/e2e/v2/tests/upgrade_assertions.go
@@ -1,0 +1,68 @@
+package tests
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ExpectHostedClusterUpgradeToComplete waits for the HostedCluster's control
+// plane and overall version status to report the expected release image and a
+// completed update. It polls every 10 seconds for up to 30 minutes and fails
+// the current Ginkgo assertion if the upgrade does not complete.
+func ExpectHostedClusterUpgradeToComplete(
+	ctx context.Context,
+	client crclient.Client,
+	hc *hyperv1.HostedCluster,
+	image string,
+) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		ExpectHostedClusterUpgradeComplete(ctx, g, client, hc, image)
+	}).
+		WithContext(ctx).
+		WithTimeout(30 * time.Minute).
+		WithPolling(10 * time.Second).
+		Should(Succeed())
+}
+
+// ExpectHostedClusterUpgradeComplete performs one check that the HostedCluster
+// reports the expected release image and completed update in both its control
+// plane and overall version status. The supplied Gomega instance must be used
+// for assertions so this function can be called from Eventually.
+func ExpectHostedClusterUpgradeComplete(ctx context.Context, g Gomega, mgmtClient crclient.Client, hc *hyperv1.HostedCluster, image string) {
+	GinkgoHelper()
+
+	currentHC := &hyperv1.HostedCluster{}
+	if err := mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), currentHC); err != nil {
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster %s/%s", hc.Namespace, hc.Name)
+		return
+	}
+
+	g.Expect(currentHC.Status.ControlPlaneVersion.Desired.Image).To(Equal(image))
+	if len(currentHC.Status.ControlPlaneVersion.History) == 0 {
+		g.Expect(currentHC.Status.ControlPlaneVersion.History).NotTo(BeEmpty())
+		return
+	}
+	g.Expect(currentHC.Status.ControlPlaneVersion.History[0].State).To(Equal(configv1.CompletedUpdate))
+
+	if currentHC.Status.Version == nil {
+		g.Expect(currentHC.Status.Version).NotTo(BeNil())
+		return
+	}
+	g.Expect(currentHC.Status.Version.Desired.Image).To(Equal(image))
+	if len(currentHC.Status.Version.History) == 0 {
+		g.Expect(currentHC.Status.Version.History).NotTo(BeEmpty())
+		return
+	}
+	g.Expect(currentHC.Status.Version.History[0].State).To(Equal(configv1.CompletedUpdate))
+}


### PR DESCRIPTION
Update the aws e2e v2 test matrix to include all the same upgrade tests currently exercised on Azure. Refactor the control plane upgrade assertions shared by different suites into a shared assertions file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded upgrade validation to cover highly available control-plane upgrades.
  - Added sequential testing for control-plane upgrades, control-plane TLS, and etcd disruption scenarios.
  - Improved consistency and reliability of upgrade completion checks across supported test scenarios.
  - Added validation that upgrades reach the expected release image and complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->