### PR TITLE
HYPERFLEET-1556 - docs: document CPO/payload alignment rule  

### DIFF
--- a/contrib/konflux/README.md
+++ b/contrib/konflux/README.md
@@ -59,6 +59,8 @@ connect to the cluster:
 
 ## Creating a new CPO release
 
+Standard OCP minor CPO streams must use `hypershift-cpo-template`, whose Component git `revision` is `release-{{.version}}`. Leave that pin unchanged so the stream builds from the minor's release branch. Hotfix CPO streams use `hypershift-cpo-hotfix-template` instead. For the alignment rule this enforces and the payload mapping, see [Versioning and support: CPO](../../docs/content/reference/versioning-support.md#cpo).
+
 For each managed deliverable, after branching happens, we should:
 
 1. Create a ProjectDevelopmentStream that references the appropriate

--- a/docs/content/contribute/custom-images.md
+++ b/docs/content/contribute/custom-images.md
@@ -84,6 +84,21 @@ oc annotate hostedcluster my-hosted-cluster -n clusters \
   --overwrite
 ```
 
+!!! warning "The CPO must match the payload's release line"
+
+    A custom CPO owns the control-plane manifests it renders, but the binaries those manifests launch come from the payload. When the CPO is from a newer git line than the payload, it can render a command line the older payload binary does not understand, and that component crash-loops.
+
+    This is a real failure, not a hypothetical. A CPO built from a `main`-based fork branch was annotated onto a HostedCluster with a `4.20.2` payload. The CPO renders the `cluster-image-registry-operator` Deployment, and its `main` base included flags (`--config`/`--files`) added after `release-4.20` was cut. The `4.20.2` payload's image-registry-operator binary did not recognize those flags and exited with an unknown-flag error.
+
+    Being an *ancestor* of `release-X.Y` is not sufficient either: a descendant on the same branch can still render a flag the payload binary predates. The only reliable rule is same release line.
+
+    Prefer, in this order:
+
+    1. The payload `hypershift` image (`oc adm release info <release-image> --image-for=hypershift`). This is the aligned, safest CPO.
+    2. A CPO from the same `release-X.Y` line as the payload.
+
+    See [Versioning and support: CPO](../reference/versioning-support.md#cpo) for the full selection order and the CPO-to-payload alignment rule.
+
 This triggers a rollout of the control plane with your custom CPO image. You can verify the new image is running:
 
 ```shell

--- a/docs/content/contribute/release-process.md
+++ b/docs/content/contribute/release-process.md
@@ -15,7 +15,7 @@ title: Release process
 
 The [hypershift repo]( https://github.com/openshift/hypershift) produces two different artifacts: Hypershift Operator (HO) and Control Plane Operator (CPO).
 
-The CPO release lifecycle is dictated by the [OCP release payload](https://access.redhat.com/support/policy/updates/openshift).
+The CPO release lifecycle is dictated by the [OCP release payload](https://access.redhat.com/support/policy/updates/openshift). Each OCP minor's CPO must stay aligned with its payload; see [Versioning and support: CPO](../reference/versioning-support.md#cpo) for the alignment rule and the in-tree stream mapping.
 
 The HO has an independent release cadence. For consumer products:
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -763,6 +763,21 @@ oc annotate hostedcluster my-hosted-cluster -n clusters \
   --overwrite
 ```
 
+!!! warning "The CPO must match the payload's release line"
+
+    A custom CPO owns the control-plane manifests it renders, but the binaries those manifests launch come from the payload. When the CPO is from a newer git line than the payload, it can render a command line the older payload binary does not understand, and that component crash-loops.
+
+    This is a real failure, not a hypothetical. A CPO built from a `main`-based fork branch was annotated onto a HostedCluster with a `4.20.2` payload. The CPO renders the `cluster-image-registry-operator` Deployment, and its `main` base included flags (`--config`/`--files`) added after `release-4.20` was cut. The `4.20.2` payload's image-registry-operator binary did not recognize those flags and exited with an unknown-flag error.
+
+    Being an *ancestor* of `release-X.Y` is not sufficient either: a descendant on the same branch can still render a flag the payload binary predates. The only reliable rule is same release line.
+
+    Prefer, in this order:
+
+    1. The payload `hypershift` image (`oc adm release info <release-image> --image-for=hypershift`). This is the aligned, safest CPO.
+    2. A CPO from the same `release-X.Y` line as the payload.
+
+    See Versioning and support: CPO for the full selection order and the CPO-to-payload alignment rule.
+
 This triggers a rollout of the control plane with your custom CPO image. You can verify the new image is running:
 
 ```shell
@@ -1406,7 +1421,7 @@ title: Release process
 
 The hypershift repo produces two different artifacts: Hypershift Operator (HO) and Control Plane Operator (CPO).
 
-The CPO release lifecycle is dictated by the OCP release payload.
+The CPO release lifecycle is dictated by the OCP release payload. Each OCP minor's CPO must stay aligned with its payload; see Versioning and support: CPO for the alignment rule and the in-tree stream mapping.
 
 The HO has an independent release cadence. For consumer products:
 
@@ -67700,11 +67715,29 @@ metadata:
         4.17 cannot be created.
 
 ### CPO
-The CPO is released as part of each OCP payload release image. You can find those release images here:
+The Control Plane Operator (CPO) is the `hypershift` image inside the HostedCluster control-plane release payload. It is released as part of each OCP payload release image, with one CPO lineage per OCP minor (`release-X.Y`).
+
+Look up the payload CPO for a given release image:
+
+```shell
+oc adm release info <release-image> --image-for=hypershift
+```
+
+You can find those release images here:
 
 - amd64
 - arm64
 - multi-arch
+
+When a HostedCluster is created, the HyperShift Operator selects the CPO image in this order:
+
+1. The HostedCluster annotation `hypershift.openshift.io/control-plane-operator-image`, if set.
+2. An optional exact version and platform match from `ENABLE_CPO_OVERRIDES` (AWS and Azure only). This is a per-z-stream hotfix exception, not the alignment rule. See CPO Overrides.
+3. The `hypershift` image from the HostedCluster control-plane release payload.
+
+The payload `hypershift` image is the aligned default. Pairing a CPO from a different git line than the payload (for example `main` against a GA `4.Y` payload) can render control-plane manifests that payload binaries do not accept. See Use custom operator images.
+
+The in-tree Konflux CPO streams live in `contrib/konflux/cpo_*_stream.yaml`; each `cpo_X_Y_stream.yaml` uses `hypershift-cpo-template` pinned to git revision `release-X.Y`. Hotfix streams (for example the 4.17 hotfix) use `hypershift-cpo-hotfix-template` instead. The `control-plane-operator-main` component (`.tekton/control-plane-operator-main-push.yaml`) builds from `main` for development and must not be paired with a GA payload.
 
 ### HyperShift CLI
 The HyperShift CLI is a helper utility used only for development and testing purposes. No compatibility policies are

--- a/docs/content/reference/versioning-support.md
+++ b/docs/content/reference/versioning-support.md
@@ -103,11 +103,29 @@ metadata:
         4.17 cannot be created.
 
 ### CPO
-The CPO is released as part of each OCP payload release image. You can find those release images here:
+The Control Plane Operator (CPO) is the `hypershift` image inside the HostedCluster control-plane release payload. It is released as part of each OCP payload release image, with one CPO lineage per OCP minor (`release-X.Y`).
+
+Look up the payload CPO for a given release image:
+
+```shell
+oc adm release info <release-image> --image-for=hypershift
+```
+
+You can find those release images here:
 
 - [amd64](https://amd64.ocp.releases.ci.openshift.org/)
 - [arm64](https://arm64.ocp.releases.ci.openshift.org/)
 - [multi-arch](https://multi.ocp.releases.ci.openshift.org/)
+
+When a HostedCluster is created, the HyperShift Operator selects the CPO image in this order:
+
+1. The HostedCluster annotation `hypershift.openshift.io/control-plane-operator-image`, if set.
+2. An optional exact version and platform match from `ENABLE_CPO_OVERRIDES` (AWS and Azure only). This is a per-z-stream hotfix exception, not the alignment rule. See [CPO Overrides](../contribute/cpo-overrides.md).
+3. The `hypershift` image from the HostedCluster control-plane release payload.
+
+The payload `hypershift` image is the aligned default. Pairing a CPO from a different git line than the payload (for example `main` against a GA `4.Y` payload) can render control-plane manifests that payload binaries do not accept. See [Use custom operator images](../contribute/custom-images.md).
+
+The in-tree Konflux CPO streams live in `contrib/konflux/cpo_*_stream.yaml`; each `cpo_X_Y_stream.yaml` uses `hypershift-cpo-template` pinned to git revision `release-X.Y`. Hotfix streams (for example the 4.17 hotfix) use `hypershift-cpo-hotfix-template` instead. The `control-plane-operator-main` component (`.tekton/control-plane-operator-main-push.yaml`) builds from `main` for development and must not be paired with a GA payload.
 
 ### HyperShift CLI
 The HyperShift CLI is a helper utility used only for development and testing purposes. No compatibility policies are 


### PR DESCRIPTION
Define the control plane operator to release payload alignment rule in one canonical place and add a Konflux stream drift check without gating every PR on it.

  - versioning-support.md: make the "### CPO" section the single source of
    truth (selection order, alignment rule, main-vs-GA warning). Drop the
    hand-maintained OCP-minor/stream/revision table and its caveats, which
    duplicated contrib/konflux/cpo_*_stream.yaml and would rot; point to
    those files instead.
  - custom-images.md: remove the internal-only [HYPERFLEET-1592](https://redhat.atlassian.net/browse/HYPERFLEET-1592) reference
    from public docs and make the warning self-contained; link to the
    canonical CPO section.
  - release-process.md, contrib/konflux/README.md: trim repeated alignment
    prose to a pointer; keep only the actionable stream-pinning instruction.
  - Makefile: move cpo-stream-alignment out of verify-ci (which gates all
    PRs) into verify-parallel, matching the sibling cpo-container-sync.
  - .pre-commit-config.yaml: add cpo-stream-alignment hook scoped to
    contrib/konflux/cpo_*.yaml so it runs only when those files change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how Control Plane Operator (CPO) images map to release payloads and supported version lines.
  * Documented image-selection precedence, payload lookup, and development or hotfix exceptions.
  * Added guidance for configuring standard and hotfix CPO release streams.
  * Warned that custom CPO images may be incompatible with older payloads and recommended compatible image sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->