### PR TITLE
test(e2e): avoid missing fast NodePool config updates

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -503,37 +503,34 @@ func WaitForNodePoolConfigUpdateCompleteWithPlatform(t testing.TB, ctx context.C
 		// KubeVirt also tends to be slower for config updates
 		configUpdateTimeout = 45 * time.Minute
 	}
-	EventuallyObject(t, ctx, fmt.Sprintf("NodePool %s/%s to start config update", np.Namespace, np.Name),
-		func(ctx context.Context) (*hyperv1.NodePool, error) {
-			nodePool := &hyperv1.NodePool{}
-			err := client.Get(ctx, crclient.ObjectKeyFromObject(np), nodePool)
-			return nodePool, err
-		},
-		[]Predicate[*hyperv1.NodePool]{
-			ConditionPredicate[*hyperv1.NodePool](Condition{
-				Type:   hyperv1.NodePoolUpdatingConfigConditionType,
-				Status: metav1.ConditionTrue,
-			}),
-		},
-		// TODO:https://issues.redhat.com/browse/OCPBUGS-43824
-		WithTimeout(5*time.Minute),   // Increased from 1 minute
-		WithInterval(15*time.Second), // Increased from 10 seconds to reduce API calls and prevent rate limiting
-	)
 	EventuallyObject(t, ctx, fmt.Sprintf("NodePool %s/%s to finish config update", np.Namespace, np.Name),
 		func(ctx context.Context) (*hyperv1.NodePool, error) {
 			nodePool := &hyperv1.NodePool{}
 			err := client.Get(ctx, crclient.ObjectKeyFromObject(np), nodePool)
 			return nodePool, err
 		},
-		[]Predicate[*hyperv1.NodePool]{
-			ConditionPredicate[*hyperv1.NodePool](Condition{
-				Type:   hyperv1.NodePoolUpdatingConfigConditionType,
-				Status: metav1.ConditionFalse,
-			}),
-		},
+		[]Predicate[*hyperv1.NodePool]{nodePoolConfigUpdateCompletePredicate(np.Generation)},
 		WithTimeout(configUpdateTimeout),
 		WithInterval(20*time.Second), // Increased from 15 seconds to reduce API calls and prevent rate limiting
 	)
+}
+
+func nodePoolConfigUpdateCompletePredicate(expectedGeneration int64) Predicate[*hyperv1.NodePool] {
+	return func(nodePool *hyperv1.NodePool) (bool, string, error) {
+		for _, condition := range nodePool.Status.Conditions {
+			if condition.Type != hyperv1.NodePoolUpdatingConfigConditionType {
+				continue
+			}
+			if condition.ObservedGeneration < expectedGeneration {
+				return false, fmt.Sprintf("condition %s observed generation %d, want at least %d", condition.Type, condition.ObservedGeneration, expectedGeneration), nil
+			}
+			if condition.Status != corev1.ConditionFalse {
+				return false, fmt.Sprintf("condition %s is %s, want %s", condition.Type, condition.Status, corev1.ConditionFalse), nil
+			}
+			return true, fmt.Sprintf("condition %s is %s for generation %d", condition.Type, condition.Status, condition.ObservedGeneration), nil
+		}
+		return false, fmt.Sprintf("condition %s is missing", hyperv1.NodePoolUpdatingConfigConditionType), nil
+	}
 }
 
 type NodePoolPollOptions struct {

--- a/test/e2e/util/util_test.go
+++ b/test/e2e/util/util_test.go
@@ -11,8 +11,81 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/certs"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
+
+func TestNodePoolConfigUpdateCompletePredicate(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []hyperv1.NodePoolCondition
+		generation int64
+		wantDone   bool
+	}{
+		{
+			name:       "When the UpdatingConfig condition is missing, it should report incomplete",
+			generation: 2,
+			wantDone:   false,
+		},
+		{
+			name: "When the UpdatingConfig condition has not observed the expected generation, it should report incomplete",
+			conditions: []hyperv1.NodePoolCondition{{
+				Type:               hyperv1.NodePoolUpdatingConfigConditionType,
+				Status:             corev1.ConditionFalse,
+				ObservedGeneration: 1,
+			}},
+			generation: 2,
+			wantDone:   false,
+		},
+		{
+			name: "When the current generation is still updating, it should report incomplete",
+			conditions: []hyperv1.NodePoolCondition{{
+				Type:               hyperv1.NodePoolUpdatingConfigConditionType,
+				Status:             corev1.ConditionTrue,
+				ObservedGeneration: 2,
+			}},
+			generation: 2,
+			wantDone:   false,
+		},
+		{
+			name: "When the current generation is no longer updating, it should report complete",
+			conditions: []hyperv1.NodePoolCondition{{
+				Type:               hyperv1.NodePoolUpdatingConfigConditionType,
+				Status:             corev1.ConditionFalse,
+				ObservedGeneration: 2,
+			}},
+			generation: 2,
+			wantDone:   true,
+		},
+		{
+			name: "When a newer generation is no longer updating, it should report complete",
+			conditions: []hyperv1.NodePoolCondition{{
+				Type:               hyperv1.NodePoolUpdatingConfigConditionType,
+				Status:             corev1.ConditionFalse,
+				ObservedGeneration: 3,
+			}},
+			generation: 2,
+			wantDone:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			nodePool := &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{Generation: tc.generation},
+				Status:     hyperv1.NodePoolStatus{Conditions: tc.conditions},
+			}
+
+			done, reason, err := nodePoolConfigUpdateCompletePredicate(tc.generation)(nodePool)
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(done).To(Equal(tc.wantDone), reason)
+			g.Expect(reason).NotTo(BeEmpty())
+		})
+	}
+}
 
 func TestAllowedCIDRsTargetService(t *testing.T) {
 	const ns = "test-hcp"


### PR DESCRIPTION
## What this PR does

Avoids a race in `WaitForNodePoolConfigUpdateCompleteWithPlatform` when a NodePool config update completes between polling intervals.

The helper previously required observing `UpdatingConfig=True` before waiting for completion. In the [failing AKS job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/9437/pull-ci-openshift-hypershift-release-4.22-e2e-aks-4-21/2094867366927142912), the condition returned to `False` within 14 seconds while the helper polled every 15 seconds. The rollout proceeded successfully, but the test missed the transient state and timed out.

The helper now waits for the durable completion state:

- `UpdatingConfig=False`
- `ObservedGeneration` is at least the generation submitted by the test

Checking the observed generation prevents a stale `False` condition from satisfying the wait without requiring the test to witness the short-lived intermediate state.

## Test plan

- `go test ./test/e2e/util -count=1`
- Added unit coverage for missing, stale, updating, current-generation, and newer-generation conditions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NodePool configuration update detection by waiting for completion against the latest observed generation.
  * Prevented premature completion checks when updates are still in progress or conditions are outdated.

* **Tests**
  * Added coverage for missing, outdated, active, completed, and newer-generation update conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->