### PR TITLE
NO-JIRA: feat(chaibot): add per-platform Slack handle pings to CI health report

### DIFF
--- a/.chai-bot/hypershift_ci_daily_health_report.md
+++ b/.chai-bot/hypershift_ci_daily_health_report.md
@@ -20,6 +20,8 @@ https://raw.githubusercontent.com/openshift/hypershift/refs/heads/main/.chai-bot
 
 Use `fetch_web_content` to retrieve this file. Parse the YAML to extract each category's `name`, `description`, `platform`, `ocp_versions`, `test_framework`, and job list. The `platform`, `ocp_versions`, and `test_framework` fields are the authoritative grouping keys; do not infer them from display names.
 
+Also parse the optional `slack_handle` field when present. Most categories will not have one; only those whose owning team has registered a handle will include it.
+
 This registry is auto-generated nightly by `hack/ci/update-job-registry.py` from the periodic job configs in `openshift/release`.
 
 ### Step 2 — Collect Build History
@@ -209,6 +211,12 @@ Use the `---THREAD_DETAILS---` delimiter to start threaded content. Use `---THRE
    - Classify the failure (infrastructure, test flake, product regression, configuration)
    - Link to the failing build: `https://prow.ci.openshift.org/view/gs/test-platform-results/logs/{JOB_NAME}/{BUILD_ID}`
 4. **Common patterns**: If multiple jobs share the same failure mode, call it out
+
+**Team ping**: If the category has a `slack_handle` in the registry **and** its pass rate is below 50% or its trend is 📉, end the thread with:
+```text
+cc {slack_handle} — please investigate ({pass_rate}% pass rate)
+```
+Do not ping when the pass rate is ≥ 50% and the trend is not 📉, even if a handle is configured.
 
 **Thread constraints:**
 - Keep each thread under 4000 characters

--- a/hack/ci/update-job-registry.py
+++ b/hack/ci/update-job-registry.py
@@ -66,6 +66,16 @@ PLATFORM_RULES: list[PlatformRule] = [
 # per-version categories. Others are combined across versions.
 VERSION_SPLIT_PLATFORMS: set[str] = {"aws", "aro", "kubevirt", "azure"}
 
+# Slack handles to mention in ChaiBot failure threads when a platform's pass
+# rate drops below 50% or shows a 📉 degrading trend. Sparse — only platforms
+# with a designated triage handle need an entry here.
+SLACK_HANDLES: dict[str, str] = {
+    "openstack": "@team-hcp-openstack",
+    "kubevirt":  "@team-hcp-kubevirt",
+    "gke":       "@gcp-hcp-e2e-watcher",
+    "mce":       "@hypershift-agent-engineering",
+}
+
 # Descriptions per platform key — {version} is substituted for split platforms.
 DESCRIPTIONS: dict[str, str] = {
     "aws":       "AWS hosted control planes — OCP {version}",
@@ -80,13 +90,18 @@ DESCRIPTIONS: dict[str, str] = {
 }
 
 
-class Category(TypedDict):
+class _CategoryBase(TypedDict):
     name: str
     description: str
     platform: str
     ocp_versions: list[str]
     test_framework: str
     jobs: list[str]
+
+
+class Category(_CategoryBase, total=False):
+    # Present only for platforms listed in SLACK_HANDLES.
+    slack_handle: str
 
 
 def sparse_checkout(dest: str) -> str:
@@ -186,20 +201,25 @@ def build_categories(all_jobs: list[str], selected_versions: set[str]) -> list[C
         versions = sorted(grouped[key].keys(), key=version_sort_key, reverse=True)
         desc_template = DESCRIPTIONS.get(key, "")
 
+        slack_handle = SLACK_HANDLES.get(key)
+
         if key in VERSION_SPLIT_PLATFORMS:
             for v in versions:
                 for framework in (FRAMEWORK_V1, FRAMEWORK_V2):
                     jobs = grouped[key][v].get(framework, [])
                     if not jobs:
                         continue
-                    categories.append(Category(
+                    category = Category(
                         name=f"{display_name} ({v}) ({framework})",
                         description=f"{desc_template.format(version=v)} — {framework}",
                         platform=display_name,
                         ocp_versions=[v],
                         test_framework=framework,
                         jobs=sorted(jobs),
-                    ))
+                    )
+                    if slack_handle:
+                        category["slack_handle"] = slack_handle
+                    categories.append(category)
         else:
             for framework in (FRAMEWORK_V1, FRAMEWORK_V2):
                 all_platform_jobs: list[str] = []
@@ -218,14 +238,17 @@ def build_categories(all_jobs: list[str], selected_versions: set[str]) -> list[C
                 elif version_strs:
                     desc += f" — OCP {' + '.join(version_strs)}"
                 desc += f" — {framework}"
-                categories.append(Category(
+                category = Category(
                     name=f"{display_name} ({framework})",
                     description=desc,
                     platform=display_name,
                     ocp_versions=version_strs,
                     test_framework=framework,
                     jobs=sorted(all_platform_jobs),
-                ))
+                )
+                if slack_handle:
+                    category["slack_handle"] = slack_handle
+                categories.append(category)
 
     # Keep the generated registry in the same order the report uses.
     categories.sort(key=lambda c: (
@@ -266,6 +289,8 @@ def render_yaml(categories: list[Category]) -> str:
         for version in cat["ocp_versions"]:
             lines.append(f'      - "{version}"')
         lines.append(f'    test_framework: "{cat["test_framework"]}"')
+        if cat.get("slack_handle"):
+            lines.append(f'    slack_handle: "{cat["slack_handle"]}"')
         lines.append("    jobs:")
         for job in cat["jobs"]:
             lines.append(f"      - {job}")


### PR DESCRIPTION
## Summary

Enables ChaiBot's daily CI health report to ping the team that owns a platform
when that platform's periodic jobs are meaningfully unhealthy, so degradations
land in front of the right people without manual triage.

## What changed

**`hack/ci/update-job-registry.py`**
- Adds a sparse `SLACK_HANDLES` dict keyed by the same `platform_key` used in
  `PLATFORM_RULES`/`DESCRIPTIONS`. Initial entries:
  - `openstack` → `@team-hcp-openstack`
  - `kubevirt`  → `@team-hcp-kubevirt`
  - `gke`       → `@gcp-hcp-e2e-watcher`
- Carries the handle through `build_categories()` (both the version-split and
  the version-combined branches) and adds `slack_handle: str | None` to the
  `Category` TypedDict.
- `render_yaml()` emits a `slack_handle` field only when it is set, so
  platforms without a handle produce no new field in `ci-status-jobs.yaml`.

**`.chai-bot/hypershift_ci_daily_health_report.md`**
- Step 1 now parses the optional `slack_handle` field.
- Step 6 (threaded failure analysis) appends a `cc @handle — please investigate`
  line when the category has a handle **and** its pass rate is `< 50%` **or**
  its trend is 📉.

## No false pings within the gate

The ping lives entirely inside Step 6, which only runs for categories **below
80%**. Within that set, the prompt explicitly suppresses the ping when the pass
rate is `≥ 50%` **and** the trend is not 📉. Concretely:

- 60–79%, stable trend, has handle → thread posted, **no ping**.
- 60–79%, 📉 trend, has handle → ping.
- `< 50%`, any trend, has handle → ping.
- Any pass rate, **no** handle → never pinged.

Each handle is written only into its own platform's category entries, so a ping
can only ever appear in that platform's own thread — no cross-platform pings.
The `< 50%` threshold matches the rest of the report (Step 3's 🔴 band and
Step 7's incident escalation both use strictly-less-than 50%).

## Behavior notes from `VERSION_SPLIT_PLATFORMS`

`kubevirt` is in `VERSION_SPLIT_PLATFORMS`, so it is emitted as separate
per-version categories (e.g. KubeVirt 5.1 / 5.0 / 4.23 / 4.22). If more than one
KubeVirt version is unhealthy, `@team-hcp-kubevirt` is mentioned once **per
failing version thread** — each mention is a distinct, genuinely failing
category, not a duplicate. By contrast, `openstack` and `gke` are *not*
version-split; they are combined across versions into a single category per
framework, so each pings at most once per report.

A category that is degrading (📉) but still **≥ 80%** produces no thread and
therefore no ping; this is intentional and keeps still-healthy platforms quiet.

## Adding a new platform handle

Add an entry to `SLACK_HANDLES` in `hack/ci/update-job-registry.py` using the
platform's existing key from `PLATFORM_RULES`. The nightly registry-update job
regenerates `ci-status-jobs.yaml` and the handle is picked up automatically.

## Checklist:
- [x] Subject and description added to both, commit and PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Slack triage handles for supported CI job categories.
  * Failure-analysis threads now mention the registered team when a category’s pass rate falls below 50% or its performance trend is degrading.
  * Team mentions are omitted when category performance is stable and meets the defined threshold.
  * Categories without a configured Slack handle continue to be supported without a team mention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->