### PR TITLE
OCPBUGS-115542: fix(e2e): poll for etcd-init completion before reading restore logs

### DIFF
--- a/test/e2e/v2/backuprestore/etcd_snapshot.go
+++ b/test/e2e/v2/backuprestore/etcd_snapshot.go
@@ -78,15 +78,62 @@ func WaitForHCPEtcdBackupCondition(testCtx *internal.TestContext, backupName str
 	})
 }
 
-// VerifyEtcdInitLogs retrieves the etcd-init container logs from the etcd-0 pod in the
-// control plane namespace and verifies that they contain expected snapshot restore traces.
-// The expected log lines from etcdutl/etcdctl indicate a successful snapshot restore:
-//   - "restoring snapshot" (restore started)
-//   - "restored snapshot" (restore completed)
+// WaitForEtcdInitAndVerifyLogs polls until the etcd-init container in etcd-0 has
+// terminated successfully, then reads and verifies its logs contain snapshot restore
+// traces. This must run before the post-restore health check: after restore, CPO
+// clears restoreSnapshotURL which triggers a second StatefulSet rollout that replaces
+// the pod without the etcd-init container.
 //
-// It also checks that the restore was not skipped due to existing data:
-//   - "not empty, not restoring snapshot" must NOT be present
-func VerifyEtcdInitLogs(ctx context.Context, logger logr.Logger, kubeClient kubernetes.Interface, controlPlaneNamespace string) error {
+// Behavior:
+//   - Retries when the pod is not found, the init container has not terminated yet,
+//     or the log stream cannot be opened (transient errors from pod replacement).
+//   - Returns immediately with an error if the init container exits with a nonzero
+//     code, or if the logs indicate the restore was skipped or incomplete (terminal).
+//   - Returns a timeout error if RestoreTimeout expires before the init container
+//     terminates and logs are verified.
+//
+// TODO: In a follow-up PR, move log interpretation into the etcd controller (CPOv2)
+// so the restore result is reported via a declared ConfigMap resource, decoupling the
+// test from pod lifecycle timing entirely.
+func WaitForEtcdInitAndVerifyLogs(ctx context.Context, logger logr.Logger, kubeClient kubernetes.Interface, controlPlaneNamespace string) error {
+	return wait.PollUntilContextTimeout(ctx, PollInterval, RestoreTimeout, true, func(ctx context.Context) (bool, error) {
+		pod, err := kubeClient.CoreV1().Pods(controlPlaneNamespace).Get(ctx, EtcdPodName, metav1.GetOptions{})
+		if err != nil {
+			logger.V(1).Info("waiting for etcd pod", "error", err)
+			return false, nil
+		}
+
+		for _, cs := range pod.Status.InitContainerStatuses {
+			if cs.Name != EtcdInitContainerName {
+				continue
+			}
+			if cs.State.Terminated == nil {
+				logger.V(1).Info("etcd-init container not yet terminated, waiting")
+				return false, nil
+			}
+			if cs.State.Terminated.ExitCode != 0 {
+				return false, fmt.Errorf("etcd-init container in pod %s/%s exited with code %d: %s",
+					controlPlaneNamespace, EtcdPodName, cs.State.Terminated.ExitCode, cs.State.Terminated.Reason)
+			}
+			result, readErr := readEtcdInitLogs(ctx, kubeClient, controlPlaneNamespace)
+			if readErr != nil {
+				logger.V(1).Info("failed to read etcd-init logs, retrying", "error", readErr)
+				return false, nil
+			}
+			if validationErr := validateEtcdInitResult(logger, result); validationErr != nil {
+				return false, validationErr
+			}
+			return true, nil
+		}
+
+		logger.V(1).Info("etcd-init container not found in pod status, waiting")
+		return false, nil
+	})
+}
+
+// readEtcdInitLogs retrieves and parses the etcd-init container logs from etcd-0.
+// Errors are transient (pod replaced between status check and log read).
+func readEtcdInitLogs(ctx context.Context, kubeClient kubernetes.Interface, controlPlaneNamespace string) (*etcdInitLogResult, error) {
 	podLogOpts := &corev1.PodLogOptions{
 		Container: EtcdInitContainerName,
 	}
@@ -94,15 +141,16 @@ func VerifyEtcdInitLogs(ctx context.Context, logger logr.Logger, kubeClient kube
 	req := kubeClient.CoreV1().Pods(controlPlaneNamespace).GetLogs(EtcdPodName, podLogOpts)
 	logStream, err := req.Stream(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to stream %s container logs from %s: %w", EtcdInitContainerName, EtcdPodName, err)
+		return nil, fmt.Errorf("failed to stream %s container logs from %s: %w", EtcdInitContainerName, EtcdPodName, err)
 	}
 	defer logStream.Close()
 
-	result, err := parseEtcdInitLogs(logStream)
-	if err != nil {
-		return err
-	}
+	return parseEtcdInitLogs(logStream)
+}
 
+// validateEtcdInitResult checks the parsed log result for expected restore markers.
+// Errors are terminal (the logs won't change on retry).
+func validateEtcdInitResult(logger logr.Logger, result *etcdInitLogResult) error {
 	logger.Info("etcd-init container logs scanned", "lines", result.lineCount)
 
 	if result.restoreSkipped {

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -583,6 +583,21 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 	})
 
 	Context(ContextPostRestoreControlPlane, func() {
+		// etcd-init log verification must run before the health check. After restore,
+		// CPO clears restoreSnapshotURL which triggers a second StatefulSet rollout
+		// that replaces the pod without the etcd-init container. The poll-based
+		// function captures logs before that window closes.
+		It("should have etcd-init container logs showing successful snapshot restore", func() {
+			By("Polling for etcd-init container completion and verifying restore logs")
+			restConfig, err := util.GetConfig()
+			Expect(err).NotTo(HaveOccurred(), "failed to get REST config for pod log access")
+			kubeClient, err := kubernetes.NewForConfig(restConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to create kubernetes clientset")
+
+			err = backuprestore.WaitForEtcdInitAndVerifyLogs(testCtx.Context, GinkgoLogr.WithName("etcd-init"), kubeClient, testCtx.ControlPlaneNamespace)
+			Expect(err).NotTo(HaveOccurred(), "etcd-init container logs should confirm snapshot restore")
+		})
+
 		It("should have control plane healthy after restore", func() {
 			validatePostRestoreControlPlane(testCtx, platformCfg.excludeWorkloads, expectedConditions, false)
 		})
@@ -605,17 +620,6 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 					"expected restoreSnapshotURL to be a non-empty presigned URL")
 			}).WithPolling(backuprestore.PollInterval).WithTimeout(backuprestore.RestoreTimeout).Should(Succeed())
 			GinkgoWriter.Printf("RestoreSnapshotURL is set on HostedCluster\n")
-		})
-
-		It("should have etcd-init container logs showing successful snapshot restore", func() {
-			By("Verifying etcd-0 init container logs for snapshot restore traces")
-			restConfig, err := util.GetConfig()
-			Expect(err).NotTo(HaveOccurred(), "failed to get REST config for pod log access")
-			kubeClient, err := kubernetes.NewForConfig(restConfig)
-			Expect(err).NotTo(HaveOccurred(), "failed to create kubernetes clientset")
-
-			err = backuprestore.VerifyEtcdInitLogs(testCtx.Context, GinkgoLogr.WithName("etcd-init"), kubeClient, testCtx.ControlPlaneNamespace)
-			Expect(err).NotTo(HaveOccurred(), "etcd-init container logs should confirm snapshot restore")
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- **OCPBUGS-115542**: Fix flake in `TestBackupRestoreEtcdSnapshot` where the etcd-init log verification fails with "container etcd-init is not valid for pod etcd-0"
- Replace one-shot `VerifyEtcdInitLogs` with `WaitForEtcdInitAndVerifyLogs` that polls for the init container to terminate before reading logs
- Move the log verification `It` block before the health check to capture logs during the window between init container completion and post-restore rollout

## Fixes
- [OCPBUGS-115542](https://redhat.atlassian.net/browse/OCPBUGS-115542)

## Root Cause
After a restore, the CPO clears `restoreSnapshotURL`, triggering a second StatefulSet rollout that replaces `etcd-0` with a pod that no longer has the `etcd-init` init container. The original test ran log verification after the full control plane health check, by which time the pod had already been replaced.

## Changes
- `etcd_snapshot.go`: New `WaitForEtcdInitAndVerifyLogs` function that polls `etcd-0` init container status until `etcd-init` terminates successfully, then reads and verifies logs immediately. Renamed `VerifyEtcdInitLogs` to unexported `verifyEtcdInitLogs` (called internally by the poll). If the pod is replaced between Get and GetLogs, the poll retries transparently.
- `backup_restore_test.go`: Move log verification `It` block to first position in `PostRestoreControlPlane` context, use `WaitForEtcdInitAndVerifyLogs`.

## Follow-up
The proper long-term solution is to move log interpretation into the etcd controller (CPOv2), where the init container writes output to a shared volume mount and a status reporter init container parses and writes the result to a declared ConfigMap resource. This decouples the test from pod lifecycle timing entirely. See TODO in `WaitForEtcdInitAndVerifyLogs`.

## Test plan
- [ ] `pull-ci-openshift-hypershift-main-e2e-v2-aws-backuprestore` passes without flake
- [ ] Log verification captures restore traces before second rollout replaces the pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup and restore validation by confirming restoration initialization before checking control-plane health.
  * Enhanced restoration log verification with clearer handling of unsuccessful initialization and terminal failures.
  * Improved resilience when initialization status or logs are temporarily unavailable by retrying transient issues.
  * Added more informative error details for restoration failures and preserved relevant status information for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->