### PR TITLE
[release-5.0] OCPBUGS-115188: fix operator health probes

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -120,6 +120,7 @@ const (
 	externaDNSCredsSecretName     = "external-dns-credentials"
 
 	HypershiftOperatorName                = "operator"
+	HypershiftOperatorHealthProbePort     = 8081
 	ExternalDNSDeploymentName             = "external-dns"
 	HyperShiftInstallCLIVersionAnnotation = "hypershift.openshift.io/install-cli-version"
 )
@@ -672,8 +673,8 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Path:   "/metrics",
-										Port:   intstr.FromInt(9000),
+										Path:   "/healthz",
+										Port:   intstr.FromInt(HypershiftOperatorHealthProbePort),
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
@@ -686,8 +687,8 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Path:   "/metrics",
-										Port:   intstr.FromInt(9000),
+										Path:   "/readyz",
+										Port:   intstr.FromInt(HypershiftOperatorHealthProbePort),
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
@@ -706,6 +707,11 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 								{
 									Name:          "manager",
 									ContainerPort: 9443,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "health",
+									ContainerPort: HypershiftOperatorHealthProbePort,
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
@@ -593,8 +594,24 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 			deployment := test.inputBuildParameters.Build()
 			g.Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(BeEquivalentTo(test.expectedArgs))
 			g.Expect(deployment.Spec.Template.Spec.Volumes).To(BeEquivalentTo(test.expectedVolumes))
-			g.Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts).To(BeEquivalentTo(test.expectedVolumeMounts))
-			g.Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(ContainElements(test.expectedEnvVars))
+			container := deployment.Spec.Template.Spec.Containers[0]
+			g.Expect(container.VolumeMounts).To(BeEquivalentTo(test.expectedVolumeMounts))
+			g.Expect(container.Env).To(ContainElements(test.expectedEnvVars))
+			g.Expect(container.LivenessProbe.HTTPGet).To(Equal(&corev1.HTTPGetAction{
+				Path:   "/healthz",
+				Port:   intstr.FromInt(HypershiftOperatorHealthProbePort),
+				Scheme: corev1.URISchemeHTTP,
+			}))
+			g.Expect(container.ReadinessProbe.HTTPGet).To(Equal(&corev1.HTTPGetAction{
+				Path:   "/readyz",
+				Port:   intstr.FromInt(HypershiftOperatorHealthProbePort),
+				Scheme: corev1.URISchemeHTTP,
+			}))
+			g.Expect(container.Ports).To(ContainElement(corev1.ContainerPort{
+				Name:          "health",
+				ContainerPort: HypershiftOperatorHealthProbePort,
+				Protocol:      corev1.ProtocolTCP,
+			}))
 		})
 	}
 }

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -94,6 +94,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -274,6 +275,9 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	if err != nil {
 		return err
 	}
+	if err := setupHealthChecks(mgr, opts.CertDir != ""); err != nil {
+		return err
+	}
 
 	operatorImage, err := resolveOperatorImage(ctx, mgr, opts, log)
 	if err != nil {
@@ -447,11 +451,34 @@ func createManager(restConfig *rest.Config, webhookOptions webhook.Options, opts
 		LeaseDuration:                 &leaseDuration,
 		RenewDeadline:                 &renewDeadline,
 		RetryPeriod:                   &retryPeriod,
+		HealthProbeBindAddress:        fmt.Sprintf(":%d", assets.HypershiftOperatorHealthProbePort),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to start manager: %w", err)
 	}
 	return mgr, nil
+}
+
+type healthCheckManager interface {
+	AddHealthzCheck(string, healthz.Checker) error
+	AddReadyzCheck(string, healthz.Checker) error
+	GetWebhookServer() webhook.Server
+}
+
+func setupHealthChecks(mgr healthCheckManager, webhookEnabled bool) error {
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return fmt.Errorf("unable to set up health check: %w", err)
+	}
+	readyCheck := healthz.Ping
+	if webhookEnabled {
+		// Conversion webhooks must be reachable before caches can sync resources
+		// requested in a version different from their storage version.
+		readyCheck = mgr.GetWebhookServer().StartedChecker()
+	}
+	if err := mgr.AddReadyzCheck("readyz", readyCheck); err != nil {
+		return fmt.Errorf("unable to set up ready check: %w", err)
+	}
+	return nil
 }
 
 func resolveOperatorImage(ctx context.Context, mgr ctrl.Manager, opts *StartOptions, log logr.Logger) (string, error) {

--- a/hypershift-operator/main_test.go
+++ b/hypershift-operator/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+type fakeHealthCheckManager struct {
+	webhookServer webhook.Server
+	healthChecks  map[string]healthz.Checker
+	readyChecks   map[string]healthz.Checker
+}
+
+func (m *fakeHealthCheckManager) AddHealthzCheck(name string, check healthz.Checker) error {
+	m.healthChecks[name] = check
+	return nil
+}
+
+func (m *fakeHealthCheckManager) AddReadyzCheck(name string, check healthz.Checker) error {
+	m.readyChecks[name] = check
+	return nil
+}
+
+func (m *fakeHealthCheckManager) GetWebhookServer() webhook.Server {
+	return m.webhookServer
+}
+
+func TestSetupHealthChecks(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		webhookEnabled     bool
+		expectReadyToError bool
+	}{
+		{
+			name:               "When webhooks are enabled it should wait for the webhook server",
+			webhookEnabled:     true,
+			expectReadyToError: true,
+		},
+		{
+			name:           "When webhooks are disabled it should report ready",
+			webhookEnabled: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			mgr := &fakeHealthCheckManager{
+				webhookServer: webhook.NewServer(webhook.Options{}),
+				healthChecks:  map[string]healthz.Checker{},
+				readyChecks:   map[string]healthz.Checker{},
+			}
+
+			g.Expect(setupHealthChecks(mgr, tc.webhookEnabled)).To(Succeed())
+			g.Expect(mgr.healthChecks).To(HaveKey("healthz"))
+			g.Expect(mgr.readyChecks).To(HaveKey("readyz"))
+
+			request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+			g.Expect(mgr.healthChecks["healthz"](request)).To(Succeed())
+			if tc.expectReadyToError {
+				g.Expect(mgr.readyChecks["readyz"](request)).To(MatchError("webhook server has not been started yet"))
+			} else {
+				g.Expect(mgr.readyChecks["readyz"](request)).To(Succeed())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it

Fixes the HyperShift operator rollout deadlock in the release-5.0 upgrade job. The job runs the shared `hypershift-tests:latest` image, which generates `/readyz:8081` probes after upstream #9387, while the release-5.0 operator image did not bind a health server on that port. The new pod stayed Running but never became Ready, so the old leader could not be replaced.

This backports the complete health-probe fix from #9387:
- bind controller-runtime health endpoints on port 8081;
- use `healthz.Ping` for liveness;
- use webhook-server startup readiness when webhooks are enabled;
- generate matching `/healthz` and `/readyz` probes and test coverage.

## Which issue(s) this PR fixes

https://redhat.atlassian.net/browse/OCPBUGS-115188

Backport of https://github.com/openshift/hypershift/pull/9387

## Testing

- `GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor go test -race ./hypershift-operator ./cmd/install/assets`
- `git diff --check`

The release-5.0 `e2e-aws-upgrade-hypershift-operator` job should be rerun as the acceptance test.