### PR TITLE
GCP-958: fix(gcp): exclude GCP PD CSI driver operator/controller from CVO management

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -32,6 +32,8 @@ func ResourcesToRemove(platformType hyperv1.PlatformType) []client.Object {
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-controller-operator", Namespace: "openshift-cluster-storage-operator"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "aws-ebs-csi-driver-operator", Namespace: "openshift-cluster-csi-drivers"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "aws-ebs-csi-driver-controller", Namespace: "openshift-cluster-csi-drivers"}},
+			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gcp-pd-csi-driver-operator", Namespace: "openshift-cluster-csi-drivers"}},
+			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gcp-pd-csi-driver-controller", Namespace: "openshift-cluster-csi-drivers"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-controller", Namespace: "openshift-cluster-storage-operator"}},
 		}
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile_test.go
@@ -107,10 +107,10 @@ func TestResourcesToRemove(t *testing.T) {
 			},
 		},
 		{
-			name:     "When platform is default (e.g., AWS), it should return 11 resources",
+			name:     "When platform is default (e.g., AWS), it should return the expected resources",
 			platform: hyperv1.AWSPlatform,
 			validate: func(g Gomega, resources []client.Object) {
-				g.Expect(resources).To(HaveLen(11))
+				g.Expect(resources).To(HaveLen(13))
 			},
 		},
 		{

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 5288104983c017ca7b1036d882c154427a0976aa69cfdf2052c2eb1ed50e0156
+    hypershift.openshift.io/desired-state-hash: 8f6e63fbe7ba66535bf94d15b65ec2bde7d0cdcb74808872919e65bd94a155de
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: cluster-version-operator
@@ -286,6 +286,24 @@ spec:
           kind: Deployment
           metadata:
             name: aws-ebs-csi-driver-controller
+            namespace: openshift-cluster-csi-drivers
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: gcp-pd-csi-driver-operator
+            namespace: openshift-cluster-csi-drivers
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: gcp-pd-csi-driver-controller
             namespace: openshift-cluster-csi-drivers
             annotations:
               include.release.openshift.io/ibm-cloud-managed: "true"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 29dc2c52b418bf8830ffcd6445b83e5fa91c74888158ab1e9231f6ccd0817a9d
+    hypershift.openshift.io/desired-state-hash: 3d64f364d30391b2fb3a322a2c060b1650abb8f33d9d429800f924c4639bed9e
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: cluster-version-operator
@@ -297,6 +297,24 @@ spec:
           kind: Deployment
           metadata:
             name: aws-ebs-csi-driver-controller
+            namespace: openshift-cluster-csi-drivers
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: gcp-pd-csi-driver-operator
+            namespace: openshift-cluster-csi-drivers
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: gcp-pd-csi-driver-controller
             namespace: openshift-cluster-csi-drivers
             annotations:
               include.release.openshift.io/ibm-cloud-managed: "true"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/ModernTLS/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/ModernTLS/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: a2f4050d62c9625ee2bca92a331ba4405d9a12d9718971ffc9506b2723b768d7
+    hypershift.openshift.io/desired-state-hash: c81b372f98e2b1cd6fc3942fb3ccdf8688abec87daa1b39e68f4ef534e3dbc3a
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: cluster-version-operator
@@ -285,6 +285,24 @@ spec:
           kind: Deployment
           metadata:
             name: aws-ebs-csi-driver-controller
+            namespace: openshift-cluster-csi-drivers
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: gcp-pd-csi-driver-operator
+            namespace: openshift-cluster-csi-drivers
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: gcp-pd-csi-driver-controller
             namespace: openshift-cluster-csi-drivers
             annotations:
               include.release.openshift.io/ibm-cloud-managed: "true"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 6391557b86ce683aaf87f297967cb27e9f7f8de4ff793aeaf4bd642a453453f1
+    hypershift.openshift.io/desired-state-hash: dd779bf1dc805b00622984db220847843cbc8094c508e92e4826b4fccf602308
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: cluster-version-operator
@@ -286,6 +286,24 @@ spec:
           kind: Deployment
           metadata:
             name: aws-ebs-csi-driver-controller
+            namespace: openshift-cluster-csi-drivers
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: gcp-pd-csi-driver-operator
+            namespace: openshift-cluster-csi-drivers
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: gcp-pd-csi-driver-controller
             namespace: openshift-cluster-csi-drivers
             annotations:
               include.release.openshift.io/ibm-cloud-managed: "true"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 5288104983c017ca7b1036d882c154427a0976aa69cfdf2052c2eb1ed50e0156
+    hypershift.openshift.io/desired-state-hash: 8f6e63fbe7ba66535bf94d15b65ec2bde7d0cdcb74808872919e65bd94a155de
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: cluster-version-operator
@@ -286,6 +286,24 @@ spec:
           kind: Deployment
           metadata:
             name: aws-ebs-csi-driver-controller
+            namespace: openshift-cluster-csi-drivers
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: gcp-pd-csi-driver-operator
+            namespace: openshift-cluster-csi-drivers
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: gcp-pd-csi-driver-controller
             namespace: openshift-cluster-csi-drivers
             annotations:
               include.release.openshift.io/ibm-cloud-managed: "true"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
@@ -297,6 +297,8 @@ func resourcesToRemove(platformType hyperv1.PlatformType) []client.Object {
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-controller-operator", Namespace: "openshift-cluster-storage-operator"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "aws-ebs-csi-driver-operator", Namespace: "openshift-cluster-csi-drivers"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "aws-ebs-csi-driver-controller", Namespace: "openshift-cluster-csi-drivers"}},
+			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gcp-pd-csi-driver-operator", Namespace: "openshift-cluster-csi-drivers"}},
+			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gcp-pd-csi-driver-controller", Namespace: "openshift-cluster-csi-drivers"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-controller", Namespace: "openshift-cluster-storage-operator"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "kube-storage-version-migrator-operator", Namespace: "openshift-kube-storage-version-migrator-operator"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "migrator", Namespace: "openshift-kube-storage-version-migrator"}},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment_test.go
@@ -191,6 +191,17 @@ func TestResourcesToRemove(t *testing.T) {
 			},
 		},
 		{
+			name:         "When platform is GCP, it should return the full list including GCP PD CSI driver operator and controller",
+			platformType: hyperv1.GCPPlatform,
+			assertions: func(g Gomega, resources []string) {
+				g.Expect(resources).To(ContainElement("cluster-storage-operator"))
+				g.Expect(resources).To(ContainElement("csi-snapshot-controller-operator"))
+				g.Expect(resources).To(ContainElement("gcp-pd-csi-driver-operator"))
+				g.Expect(resources).To(ContainElement("gcp-pd-csi-driver-controller"))
+				g.Expect(resources).To(ContainElement("csi-snapshot-controller"))
+			},
+		},
+		{
 			name:         "When platform is IBMCloud, it should return fewer resources than the default platform",
 			platformType: hyperv1.IBMCloudPlatform,
 			assertions: func(g Gomega, resources []string) {


### PR DESCRIPTION
## Summary

openshift/cluster-storage-operator#728 (merged 2026-09-01) taught `cluster-storage-operator`'s `HyperShiftStarter` to recognize GCP as a platform and activate HyperShift support for the GCP PD CSI driver. That change is now in the `main` release payload.

As a result, on GCP `HostedCluster`s, the guest cluster's CVO now attempts to reconcile the `gcp-pd-csi-driver-operator` and `gcp-pd-csi-driver-controller` `Deployment`s directly from the release payload, racing with HyperShift's own management-cluster-side wiring for these components (landing separately in #9450). This blocks `ClusterVersion` from reaching `Completed` on GCP e2e clusters, currently breaking `e2e-v2-gke` broadly on `main` (independent of PR content).

This PR mirrors the existing `aws-ebs-csi-driver-operator`/`aws-ebs-csi-driver-controller` exclusion pattern by adding the GCP PD equivalents to CVO's resource removal list, so CVO no longer tries to manage them for HyperShift guest clusters. This is a minimal, isolated cherry-pick of the CVO-exclusion piece of #9450, split out so it can merge quickly and unblock CI.

## Test plan

- [x] Unit tests updated and passing: `go test ./control-plane-operator/controllers/hostedcontrolplane/cvo/... ./control-plane-operator/controllers/hostedcontrolplane/v2/cvo/...`
- [x] `gofmt` clean
- [ ] CI: verify `e2e-v2-gke` no longer hangs waiting on `ClusterVersion` for GCP clusters

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default-platform cleanup behavior to remove GCP persistent-disk CSI driver components.
  * Preserved required GCP storage, CSI snapshot, operator, and controller resources when running on GCP.

* **Tests**
  * Updated resource-count expectations and added coverage for GCP resource retention during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->