### PR TITLE
[release-4.22] CNTRLPLANE-4321: Cherry-pick kube-scheduler metrics support

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1686,6 +1686,13 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		return fmt.Errorf("failed to reconcile olm operator serving cert: %w", err)
 	}
 
+	schedulerServerSecret := manifests.SchedulerServerCertSecret(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, schedulerServerSecret, func() error {
+		return pki.ReconcileSchedulerServerSecret(schedulerServerSecret, rootCASecret, p.OwnerRef)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile scheduler serving cert: %w", err)
+	}
+
 	cvoServerCert := manifests.ClusterVersionOperatorServerCertSecret(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, cvoServerCert, func() error {
 		return pki.ReconcileCVOServerSecret(cvoServerCert, rootCASecret, p.OwnerRef)

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -272,6 +272,8 @@ func KASMachineBootstrapClientCertSecret(ns string) *corev1.Secret {
 
 func KCMServerCertSecret(ns string) *corev1.Secret { return secretFor(ns, "kcm-server") }
 
+func SchedulerServerCertSecret(ns string) *corev1.Secret { return secretFor(ns, "scheduler-server") }
+
 func ServiceAccountSigningKeySecret(ns string) *corev1.Secret { return secretFor(ns, "sa-signing-key") }
 
 func OpenShiftAPIServerCertSecret(ns string) *corev1.Secret {

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/scheduler.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/scheduler.go
@@ -1,0 +1,19 @@
+package pki
+
+import (
+	"fmt"
+
+	"github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func ReconcileSchedulerServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	dnsNames := []string{
+		fmt.Sprintf("kube-scheduler.%s.svc", secret.Namespace),
+		fmt.Sprintf("kube-scheduler.%s.svc.cluster.local", secret.Namespace),
+		"kube-scheduler",
+		"localhost",
+	}
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "kube-scheduler", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/scheduler_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/scheduler_test.go
@@ -1,0 +1,76 @@
+package pki
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReconcileSchedulerServerSecret(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When secret is empty it should generate a valid cert", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ca := createTestCA(t)
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scheduler-server",
+				Namespace: "test-namespace",
+			},
+		}
+
+		err := ReconcileSchedulerServerSecret(secret, ca, config.OwnerRef{})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(secret.Data[corev1.TLSCertKey]).ToNot(BeEmpty())
+		g.Expect(secret.Data[corev1.TLSPrivateKeyKey]).ToNot(BeEmpty())
+	})
+
+	t.Run("When secret already has a valid cert it should not regenerate", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ca := createTestCA(t)
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scheduler-server",
+				Namespace: "test-namespace",
+			},
+		}
+
+		err := ReconcileSchedulerServerSecret(secret, ca, config.OwnerRef{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		initialCert := make([]byte, len(secret.Data[corev1.TLSCertKey]))
+		copy(initialCert, secret.Data[corev1.TLSCertKey])
+
+		err = ReconcileSchedulerServerSecret(secret, ca, config.OwnerRef{})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(secret.Data[corev1.TLSCertKey]).To(Equal(initialCert))
+	})
+}
+
+func createTestCA(t *testing.T) *corev1.Secret {
+	t.Helper()
+	g := NewWithT(t)
+
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "root-ca",
+			Namespace: "test-namespace",
+		},
+	}
+	err := ReconcileRootCA(caSecret, config.OwnerRef{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(caSecret.Data[certs.CASignerCertMapKey]).ToNot(BeEmpty())
+	g.Expect(caSecret.Data[certs.CASignerKeyMapKey]).ToNot(BeEmpty())
+
+	return caSecret
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
@@ -25,3 +25,9 @@ status:
   - group: ""
     kind: Secret
     name: kube-scheduler-kubeconfig
+  - group: ""
+    kind: Service
+    name: kube-scheduler
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 98b990eeb924b9d1a7d63ca29c0e49ef560eb741028f4689111170bf757eae59
+    hypershift.openshift.io/desired-state-hash: 8484b582e67fa04954af2f0d6d8d12c0453664a1f4995872243d165a4a5e9dd2
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -29,7 +29,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work,tmp-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 022a8a3ab4d55cfe
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
@@ -80,7 +80,8 @@ spec:
       containers:
       - args:
         - --config=/etc/kubernetes/config/config.json
-        - --cert-dir=/var/run/kubernetes
+        - --tls-cert-file=/etc/kubernetes/certs/tls.crt
+        - --tls-private-key-file=/etc/kubernetes/certs/tls.key
         - --secure-port=10259
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
@@ -201,6 +202,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: kube-scheduler
+        ports:
+        - containerPort: 10259
+          name: client
+          protocol: TCP
         resources:
           requests:
             cpu: 25m
@@ -209,8 +214,8 @@ spec:
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/kubernetes
-          name: cert-work
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
@@ -243,8 +248,10 @@ spec:
           defaultMode: 420
           name: kube-scheduler
         name: scheduler-config
-      - emptyDir: {}
-        name: cert-work
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: scheduler-server
       - name: kubeconfig
         secret:
           defaultMode: 416

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - name: client
+    port: 10259
+    protocol: TCP
+    targetPort: client
+  selector:
+    app: kube-scheduler
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: c0aa8d94b7d45d0c5a7059fc484fc091301fb6208fa587c8ad066977daac3c7b
   labels:
     app: kube-scheduler
   name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -41,6 +41,30 @@ spec:
         key: tls.key
         name: metrics-client
       serverName: kube-scheduler
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    path: /metrics/resources
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
   namespaceSelector:
     matchNames:
     - hcp-namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   annotations:
+    hypershift.openshift.io/desired-state-hash: 4ab258dfcc00528f24147c718a86b42c3f31b23c608a4899faab5b01af0ec9e9
     hypershift.openshift.io/metrics-endpoint: https
     hypershift.openshift.io/metrics-job: kube-scheduler
     hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    hypershift.openshift.io/metrics-endpoint: https
+    hypershift.openshift.io/metrics-job: kube-scheduler
+    hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler
+    hypershift.openshift.io/metrics-service: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  endpoints:
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  selector:
+    matchLabels:
+      app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
@@ -25,3 +25,9 @@ status:
   - group: ""
     kind: Secret
     name: kube-scheduler-kubeconfig
+  - group: ""
+    kind: Service
+    name: kube-scheduler
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -29,7 +29,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work,tmp-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 022a8a3ab4d55cfe
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
@@ -80,7 +80,8 @@ spec:
       containers:
       - args:
         - --config=/etc/kubernetes/config/config.json
-        - --cert-dir=/var/run/kubernetes
+        - --tls-cert-file=/etc/kubernetes/certs/tls.crt
+        - --tls-private-key-file=/etc/kubernetes/certs/tls.key
         - --secure-port=10259
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
@@ -200,6 +201,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: kube-scheduler
+        ports:
+        - containerPort: 10259
+          name: client
+          protocol: TCP
         resources:
           requests:
             cpu: 25m
@@ -213,8 +218,8 @@ spec:
           runAsNonRoot: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/kubernetes
-          name: cert-work
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
@@ -253,8 +258,10 @@ spec:
           defaultMode: 420
           name: kube-scheduler
         name: scheduler-config
-      - emptyDir: {}
-        name: cert-work
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: scheduler-server
       - name: kubeconfig
         secret:
           defaultMode: 416

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 690e93f1be605c1fea1338d7ad580135005961de9b94fbeb92f37a4fe8c49af2
+    hypershift.openshift.io/desired-state-hash: 419ad99c8d2bab2dfce727b666e60961838b6d23b64eca923046a470b7a02c18
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - name: client
+    port: 10259
+    protocol: TCP
+    targetPort: client
+  selector:
+    app: kube-scheduler
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: c0aa8d94b7d45d0c5a7059fc484fc091301fb6208fa587c8ad066977daac3c7b
   labels:
     app: kube-scheduler
   name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -41,6 +41,30 @@ spec:
         key: tls.key
         name: metrics-client
       serverName: kube-scheduler
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    path: /metrics/resources
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
   namespaceSelector:
     matchNames:
     - hcp-namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   annotations:
+    hypershift.openshift.io/desired-state-hash: 4ab258dfcc00528f24147c718a86b42c3f31b23c608a4899faab5b01af0ec9e9
     hypershift.openshift.io/metrics-endpoint: https
     hypershift.openshift.io/metrics-job: kube-scheduler
     hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    hypershift.openshift.io/metrics-endpoint: https
+    hypershift.openshift.io/metrics-job: kube-scheduler
+    hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler
+    hypershift.openshift.io/metrics-service: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  endpoints:
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  selector:
+    matchLabels:
+      app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
@@ -25,3 +25,9 @@ status:
   - group: ""
     kind: Secret
     name: kube-scheduler-kubeconfig
+  - group: ""
+    kind: Service
+    name: kube-scheduler
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -29,7 +29,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work,tmp-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 022a8a3a40ea5fe1
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
@@ -80,7 +80,8 @@ spec:
       containers:
       - args:
         - --config=/etc/kubernetes/config/config.json
-        - --cert-dir=/var/run/kubernetes
+        - --tls-cert-file=/etc/kubernetes/certs/tls.crt
+        - --tls-private-key-file=/etc/kubernetes/certs/tls.key
         - --secure-port=10259
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
@@ -201,6 +202,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: kube-scheduler
+        ports:
+        - containerPort: 10259
+          name: client
+          protocol: TCP
         resources:
           requests:
             cpu: 25m
@@ -209,8 +214,8 @@ spec:
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/kubernetes
-          name: cert-work
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
@@ -243,8 +248,10 @@ spec:
           defaultMode: 420
           name: kube-scheduler
         name: scheduler-config
-      - emptyDir: {}
-        name: cert-work
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: scheduler-server
       - name: kubeconfig
         secret:
           defaultMode: 416

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: d5bb991e6d19aaa9eaf009cfda95ab90b28b47daf3c7ebdf8de69b79cd883a74
+    hypershift.openshift.io/desired-state-hash: 141e8559d837b853f1a4203a6b68e1e1d65263612a65fc18cb017a74558f9d88
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - name: client
+    port: 10259
+    protocol: TCP
+    targetPort: client
+  selector:
+    app: kube-scheduler
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: c0aa8d94b7d45d0c5a7059fc484fc091301fb6208fa587c8ad066977daac3c7b
   labels:
     app: kube-scheduler
   name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -41,6 +41,30 @@ spec:
         key: tls.key
         name: metrics-client
       serverName: kube-scheduler
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    path: /metrics/resources
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
   namespaceSelector:
     matchNames:
     - hcp-namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   annotations:
+    hypershift.openshift.io/desired-state-hash: 4ab258dfcc00528f24147c718a86b42c3f31b23c608a4899faab5b01af0ec9e9
     hypershift.openshift.io/metrics-endpoint: https
     hypershift.openshift.io/metrics-job: kube-scheduler
     hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    hypershift.openshift.io/metrics-endpoint: https
+    hypershift.openshift.io/metrics-job: kube-scheduler
+    hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler
+    hypershift.openshift.io/metrics-service: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  endpoints:
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  selector:
+    matchLabels:
+      app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
@@ -25,3 +25,9 @@ status:
   - group: ""
     kind: Secret
     name: kube-scheduler-kubeconfig
+  - group: ""
+    kind: Service
+    name: kube-scheduler
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -29,7 +29,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work,tmp-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 022a8a3ab4d55cfe
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
@@ -80,7 +80,8 @@ spec:
       containers:
       - args:
         - --config=/etc/kubernetes/config/config.json
-        - --cert-dir=/var/run/kubernetes
+        - --tls-cert-file=/etc/kubernetes/certs/tls.crt
+        - --tls-private-key-file=/etc/kubernetes/certs/tls.key
         - --secure-port=10259
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
@@ -200,6 +201,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: kube-scheduler
+        ports:
+        - containerPort: 10259
+          name: client
+          protocol: TCP
         resources:
           requests:
             cpu: 25m
@@ -208,8 +213,8 @@ spec:
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/kubernetes
-          name: cert-work
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
@@ -242,8 +247,10 @@ spec:
           defaultMode: 420
           name: kube-scheduler
         name: scheduler-config
-      - emptyDir: {}
-        name: cert-work
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: scheduler-server
       - name: kubeconfig
         secret:
           defaultMode: 416

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 80fc7b6e9490063806424ff851ab6fef230b4982777ce61298f533605fd08a78
+    hypershift.openshift.io/desired-state-hash: d04f06a8d922118cb22a9edcfad4502feff2a053fbd791ef031f6cc85af9a2c6
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - name: client
+    port: 10259
+    protocol: TCP
+    targetPort: client
+  selector:
+    app: kube-scheduler
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: c0aa8d94b7d45d0c5a7059fc484fc091301fb6208fa587c8ad066977daac3c7b
   labels:
     app: kube-scheduler
   name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -41,6 +41,30 @@ spec:
         key: tls.key
         name: metrics-client
       serverName: kube-scheduler
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    path: /metrics/resources
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
   namespaceSelector:
     matchNames:
     - hcp-namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   annotations:
+    hypershift.openshift.io/desired-state-hash: 4ab258dfcc00528f24147c718a86b42c3f31b23c608a4899faab5b01af0ec9e9
     hypershift.openshift.io/metrics-endpoint: https
     hypershift.openshift.io/metrics-job: kube-scheduler
     hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    hypershift.openshift.io/metrics-endpoint: https
+    hypershift.openshift.io/metrics-job: kube-scheduler
+    hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler
+    hypershift.openshift.io/metrics-service: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  endpoints:
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  selector:
+    matchLabels:
+      app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
@@ -25,3 +25,9 @@ status:
   - group: ""
     kind: Secret
     name: kube-scheduler-kubeconfig
+  - group: ""
+    kind: Service
+    name: kube-scheduler
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 98b990eeb924b9d1a7d63ca29c0e49ef560eb741028f4689111170bf757eae59
+    hypershift.openshift.io/desired-state-hash: 8484b582e67fa04954af2f0d6d8d12c0453664a1f4995872243d165a4a5e9dd2
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -29,7 +29,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work,tmp-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 022a8a3ab4d55cfe
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
@@ -80,7 +80,8 @@ spec:
       containers:
       - args:
         - --config=/etc/kubernetes/config/config.json
-        - --cert-dir=/var/run/kubernetes
+        - --tls-cert-file=/etc/kubernetes/certs/tls.crt
+        - --tls-private-key-file=/etc/kubernetes/certs/tls.key
         - --secure-port=10259
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
@@ -201,6 +202,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: kube-scheduler
+        ports:
+        - containerPort: 10259
+          name: client
+          protocol: TCP
         resources:
           requests:
             cpu: 25m
@@ -209,8 +214,8 @@ spec:
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/kubernetes
-          name: cert-work
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
@@ -243,8 +248,10 @@ spec:
           defaultMode: 420
           name: kube-scheduler
         name: scheduler-config
-      - emptyDir: {}
-        name: cert-work
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: scheduler-server
       - name: kubeconfig
         secret:
           defaultMode: 416

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - name: client
+    port: 10259
+    protocol: TCP
+    targetPort: client
+  selector:
+    app: kube-scheduler
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: c0aa8d94b7d45d0c5a7059fc484fc091301fb6208fa587c8ad066977daac3c7b
   labels:
     app: kube-scheduler
   name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -41,6 +41,30 @@ spec:
         key: tls.key
         name: metrics-client
       serverName: kube-scheduler
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    path: /metrics/resources
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
   namespaceSelector:
     matchNames:
     - hcp-namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   annotations:
+    hypershift.openshift.io/desired-state-hash: 4ab258dfcc00528f24147c718a86b42c3f31b23c608a4899faab5b01af0ec9e9
     hypershift.openshift.io/metrics-endpoint: https
     hypershift.openshift.io/metrics-job: kube-scheduler
     hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    hypershift.openshift.io/metrics-endpoint: https
+    hypershift.openshift.io/metrics-job: kube-scheduler
+    hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler
+    hypershift.openshift.io/metrics-service: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  endpoints:
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  selector:
+    matchLabels:
+      app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/deployment.yaml
@@ -20,7 +20,8 @@ spec:
       containers:
       - args:
         - --config=/etc/kubernetes/config/config.json
-        - --cert-dir=/var/run/kubernetes
+        - --tls-cert-file=/etc/kubernetes/certs/tls.crt
+        - --tls-private-key-file=/etc/kubernetes/certs/tls.key
         - --secure-port=10259
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
@@ -41,13 +42,17 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: kube-scheduler
+        ports:
+        - containerPort: 10259
+          name: client
+          protocol: TCP
         resources:
           requests:
             cpu: 25m
             memory: 150Mi
         volumeMounts:
-        - mountPath: /var/run/kubernetes
-          name: cert-work
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
@@ -57,8 +62,10 @@ spec:
           defaultMode: 420
           name: kube-scheduler
         name: scheduler-config
-      - emptyDir: {}
-        name: cert-work
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: scheduler-server
       - name: kubeconfig
         secret:
           defaultMode: 416

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-scheduler
+  name: kube-scheduler
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - name: client
+    port: 10259
+    protocol: TCP
+    targetPort: client
+  selector:
+    app: kube-scheduler
+  sessionAffinity: None
+  type: ClusterIP

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/servicemonitor.yaml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kube-scheduler
+  annotations:
+    hypershift.openshift.io/metrics-job: kube-scheduler
+    hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler
+    hypershift.openshift.io/metrics-service: kube-scheduler
+    hypershift.openshift.io/metrics-endpoint: https
+spec:
+  endpoints:
+  - scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
+  selector:
+    matchLabels:
+      app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/servicemonitor.yaml
@@ -24,6 +24,22 @@ spec:
         key: tls.key
         name: metrics-client
       serverName: kube-scheduler
+  - scheme: https
+    path: /metrics/resources
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
   selector:
     matchLabels:
       app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/component.go
@@ -40,6 +40,10 @@ func NewComponent() component.ControlPlaneComponent {
 			"kubeconfig.yaml",
 			component.WithAdaptFunction(adaptKubeconfig),
 		).
+		WithManifestAdapter(
+			"servicemonitor.yaml",
+			component.WithAdaptFunction(adaptServiceMonitor),
+		).
 		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/component_test.go
@@ -1,0 +1,35 @@
+package scheduler
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestKubeSchedulerOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When IsRequestServing is called it should return false", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ks := &kubeScheduler{}
+		g.Expect(ks.IsRequestServing()).To(BeFalse())
+	})
+
+	t.Run("When MultiZoneSpread is called it should return true", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ks := &kubeScheduler{}
+		g.Expect(ks.MultiZoneSpread()).To(BeTrue())
+	})
+
+	t.Run("When NeedsManagementKASAccess is called it should return false", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ks := &kubeScheduler{}
+		g.Expect(ks.NeedsManagementKASAccess()).To(BeFalse())
+	})
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/servicemonitor.go
@@ -1,0 +1,19 @@
+package scheduler
+
+import (
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/util"
+
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+func adaptServiceMonitor(cpContext component.WorkloadContext, sm *prometheusoperatorv1.ServiceMonitor) error {
+	sm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
+		MatchNames: []string{sm.Namespace},
+	}
+	sm.Spec.Endpoints[0].MetricRelabelConfigs = metrics.SchedulerRelabelConfigs(cpContext.MetricsSet)
+	util.ApplyClusterIDLabel(&sm.Spec.Endpoints[0], cpContext.HCP.Spec.ClusterID)
+
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/servicemonitor.go
@@ -12,8 +12,12 @@ func adaptServiceMonitor(cpContext component.WorkloadContext, sm *prometheusoper
 	sm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
 		MatchNames: []string{sm.Namespace},
 	}
+
 	sm.Spec.Endpoints[0].MetricRelabelConfigs = metrics.SchedulerRelabelConfigs(cpContext.MetricsSet)
 	util.ApplyClusterIDLabel(&sm.Spec.Endpoints[0], cpContext.HCP.Spec.ClusterID)
+
+	sm.Spec.Endpoints[1].MetricRelabelConfigs = metrics.SchedulerResourceRelabelConfigs(cpContext.MetricsSet)
+	util.ApplyClusterIDLabel(&sm.Spec.Endpoints[1], cpContext.HCP.Spec.ClusterID)
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/servicemonitor_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/servicemonitor_test.go
@@ -1,0 +1,110 @@
+package scheduler
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/metrics"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+func TestAdaptServiceMonitor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		metricsSet metrics.MetricsSet
+		clusterID  string
+		validate   func(*testing.T, *prometheusoperatorv1.ServiceMonitor, error)
+	}{
+		{
+			name:       "When service monitor is adapted it should set namespace selector",
+			metricsSet: metrics.MetricsSetTelemetry,
+			clusterID:  "test-cluster-id",
+			validate: func(t *testing.T, sm *prometheusoperatorv1.ServiceMonitor, err error) {
+				g := NewWithT(t)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(sm.Spec.NamespaceSelector.MatchNames).To(Equal([]string{"test-namespace"}))
+			},
+		},
+		{
+			name:       "When service monitor is adapted it should apply cluster ID label",
+			metricsSet: metrics.MetricsSetAll,
+			clusterID:  "cluster-abc-123",
+			validate: func(t *testing.T, sm *prometheusoperatorv1.ServiceMonitor, err error) {
+				g := NewWithT(t)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(sm.Spec.Endpoints).To(HaveLen(1))
+
+				relabelConfigs := sm.Spec.Endpoints[0].RelabelConfigs
+				foundClusterIDLabel := false
+				for _, config := range relabelConfigs {
+					if config.TargetLabel == "_id" && config.Replacement != nil && *config.Replacement == "cluster-abc-123" {
+						foundClusterIDLabel = true
+						break
+					}
+				}
+				g.Expect(foundClusterIDLabel).To(BeTrue(), "cluster ID label should be applied")
+			},
+		},
+		{
+			name:       "When metrics set is Telemetry it should drop all metrics",
+			metricsSet: metrics.MetricsSetTelemetry,
+			clusterID:  "test-cluster",
+			validate: func(t *testing.T, sm *prometheusoperatorv1.ServiceMonitor, err error) {
+				g := NewWithT(t)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(sm.Spec.Endpoints).To(HaveLen(1))
+
+				g.Expect(sm.Spec.Endpoints[0].MetricRelabelConfigs).To(HaveLen(2))
+				g.Expect(sm.Spec.Endpoints[0].MetricRelabelConfigs[0].Action).To(Equal("drop"))
+				g.Expect(sm.Spec.Endpoints[0].MetricRelabelConfigs[0].Regex).To(Equal(".*"))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-namespace",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					ClusterID: tc.clusterID,
+				},
+			}
+
+			cpContext := component.WorkloadContext{
+				Context:    t.Context(),
+				HCP:        hcp,
+				MetricsSet: tc.metricsSet,
+			}
+
+			sm := &prometheusoperatorv1.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-scheduler",
+					Namespace: "test-namespace",
+				},
+				Spec: prometheusoperatorv1.ServiceMonitorSpec{
+					Endpoints: []prometheusoperatorv1.Endpoint{
+						{
+							Port: "metrics",
+						},
+					},
+				},
+			}
+
+			err := adaptServiceMonitor(cpContext, sm)
+			tc.validate(t, sm, err)
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/servicemonitor_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/servicemonitor_test.go
@@ -34,37 +34,55 @@ func TestAdaptServiceMonitor(t *testing.T) {
 			},
 		},
 		{
-			name:       "When service monitor is adapted it should apply cluster ID label",
+			name:       "When service monitor is adapted it should apply cluster ID label to both endpoints",
 			metricsSet: metrics.MetricsSetAll,
 			clusterID:  "cluster-abc-123",
 			validate: func(t *testing.T, sm *prometheusoperatorv1.ServiceMonitor, err error) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(sm.Spec.Endpoints).To(HaveLen(1))
+				g.Expect(sm.Spec.Endpoints).To(HaveLen(2))
 
-				relabelConfigs := sm.Spec.Endpoints[0].RelabelConfigs
-				foundClusterIDLabel := false
-				for _, config := range relabelConfigs {
-					if config.TargetLabel == "_id" && config.Replacement != nil && *config.Replacement == "cluster-abc-123" {
-						foundClusterIDLabel = true
-						break
+				for i, ep := range sm.Spec.Endpoints {
+					foundClusterIDLabel := false
+					for _, config := range ep.RelabelConfigs {
+						if config.TargetLabel == "_id" && config.Replacement != nil && *config.Replacement == "cluster-abc-123" {
+							foundClusterIDLabel = true
+							break
+						}
 					}
+					g.Expect(foundClusterIDLabel).To(BeTrue(), "cluster ID label should be applied to endpoint %d", i)
 				}
-				g.Expect(foundClusterIDLabel).To(BeTrue(), "cluster ID label should be applied")
 			},
 		},
 		{
-			name:       "When metrics set is Telemetry it should drop all metrics",
+			name:       "When metrics set is Telemetry it should drop all metrics on both endpoints",
 			metricsSet: metrics.MetricsSetTelemetry,
 			clusterID:  "test-cluster",
 			validate: func(t *testing.T, sm *prometheusoperatorv1.ServiceMonitor, err error) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(sm.Spec.Endpoints).To(HaveLen(1))
+				g.Expect(sm.Spec.Endpoints).To(HaveLen(2))
 
 				g.Expect(sm.Spec.Endpoints[0].MetricRelabelConfigs).To(HaveLen(2))
 				g.Expect(sm.Spec.Endpoints[0].MetricRelabelConfigs[0].Action).To(Equal("drop"))
 				g.Expect(sm.Spec.Endpoints[0].MetricRelabelConfigs[0].Regex).To(Equal(".*"))
+
+				g.Expect(sm.Spec.Endpoints[1].MetricRelabelConfigs).To(HaveLen(2))
+				g.Expect(sm.Spec.Endpoints[1].MetricRelabelConfigs[0].Action).To(Equal("drop"))
+				g.Expect(sm.Spec.Endpoints[1].MetricRelabelConfigs[0].Regex).To(Equal(".*"))
+			},
+		},
+		{
+			name:       "When metrics set is All it should not add metric relabel configs on the resources endpoint",
+			metricsSet: metrics.MetricsSetAll,
+			clusterID:  "test-cluster",
+			validate: func(t *testing.T, sm *prometheusoperatorv1.ServiceMonitor, err error) {
+				g := NewWithT(t)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(sm.Spec.Endpoints).To(HaveLen(2))
+
+				g.Expect(sm.Spec.Endpoints[1].MetricRelabelConfigs).To(HaveLen(1))
+				g.Expect(sm.Spec.Endpoints[1].MetricRelabelConfigs[0].TargetLabel).To(Equal("_id"))
 			},
 		},
 	}
@@ -98,6 +116,10 @@ func TestAdaptServiceMonitor(t *testing.T) {
 					Endpoints: []prometheusoperatorv1.Endpoint{
 						{
 							Port: "metrics",
+						},
+						{
+							Port: "metrics",
+							Path: "/metrics/resources",
 						},
 					},
 				},

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
@@ -137,6 +137,22 @@ func MetricsClientClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	}
 }
 
+func MetricsResourcesClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hypershift-metrics-resources-reader",
+		},
+	}
+}
+
+func MetricsResourcesClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hypershift-metrics-resources-reader",
+		},
+	}
+}
+
 func AuthenticatedReaderForAuthenticatedUserRolebinding() *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
@@ -280,6 +280,32 @@ func ReconcileGenericMetricsClusterRoleBinding(cn string) func(*rbacv1.ClusterRo
 	}
 }
 
+func ReconcileMetricsResourcesClusterRole(r *rbacv1.ClusterRole) error {
+	r.Rules = []rbacv1.PolicyRule{
+		{
+			NonResourceURLs: []string{"/metrics/resources"},
+			Verbs:           []string{"get"},
+		},
+	}
+	return nil
+}
+
+func ReconcileMetricsResourcesClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
+	r.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "ClusterRole",
+		Name:     "hypershift-metrics-resources-reader",
+	}
+	r.Subjects = []rbacv1.Subject{
+		{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "User",
+			Name:     "system:serviceaccount:hypershift:prometheus",
+		},
+	}
+	return nil
+}
+
 func ReconcileAuthenticatedReaderForAuthenticatedUserRolebinding(r *rbacv1.RoleBinding) error {
 	r.RoleRef = rbacv1.RoleRef{
 		APIGroup: rbacv1.SchemeGroupVersion.Group,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile_test.go
@@ -1,0 +1,51 @@
+package rbac
+
+import (
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestReconcileMetricsResourcesClusterRole(t *testing.T) {
+	t.Run("When reconciling it should set the correct policy rules", func(t *testing.T) {
+		role := &rbacv1.ClusterRole{}
+		if err := ReconcileMetricsResourcesClusterRole(role); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(role.Rules) != 1 {
+			t.Fatalf("expected 1 rule, got %d", len(role.Rules))
+		}
+		rule := role.Rules[0]
+		if len(rule.NonResourceURLs) != 1 || rule.NonResourceURLs[0] != "/metrics/resources" {
+			t.Errorf("expected NonResourceURLs [\"/metrics/resources\"], got %v", rule.NonResourceURLs)
+		}
+		if len(rule.Verbs) != 1 || rule.Verbs[0] != "get" {
+			t.Errorf("expected Verbs [\"get\"], got %v", rule.Verbs)
+		}
+	})
+}
+
+func TestReconcileMetricsResourcesClusterRoleBinding(t *testing.T) {
+	t.Run("When reconciling it should set the correct role ref and subjects", func(t *testing.T) {
+		binding := &rbacv1.ClusterRoleBinding{}
+		if err := ReconcileMetricsResourcesClusterRoleBinding(binding); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if binding.RoleRef.Kind != "ClusterRole" {
+			t.Errorf("expected RoleRef.Kind ClusterRole, got %s", binding.RoleRef.Kind)
+		}
+		if binding.RoleRef.Name != "hypershift-metrics-resources-reader" {
+			t.Errorf("expected RoleRef.Name hypershift-metrics-resources-reader, got %s", binding.RoleRef.Name)
+		}
+		if len(binding.Subjects) != 1 {
+			t.Fatalf("expected 1 subject, got %d", len(binding.Subjects))
+		}
+		subject := binding.Subjects[0]
+		if subject.Kind != "User" {
+			t.Errorf("expected subject Kind User, got %s", subject.Kind)
+		}
+		if subject.Name != "system:serviceaccount:hypershift:prometheus" {
+			t.Errorf("expected subject Name system:serviceaccount:hypershift:prometheus, got %s", subject.Name)
+		}
+	})
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1278,6 +1278,8 @@ func (r *reconciler) reconcileRBAC(ctx context.Context, hcp *hyperv1.HostedContr
 		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.NodeBootstrapperClusterRoleBinding, reconcile: rbac.ReconcileNodeBootstrapperClusterRoleBinding},
 		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.CSRRenewalClusterRoleBinding, reconcile: rbac.ReconcileCSRRenewalClusterRoleBinding},
 		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.MetricsClientClusterRoleBinding, reconcile: rbac.ReconcileGenericMetricsClusterRoleBinding("system:serviceaccount:hypershift:prometheus")},
+		manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.MetricsResourcesClusterRole, reconcile: rbac.ReconcileMetricsResourcesClusterRole},
+		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.MetricsResourcesClusterRoleBinding, reconcile: rbac.ReconcileMetricsResourcesClusterRoleBinding},
 
 		manifestAndReconcile[*rbacv1.RoleBinding]{manifest: manifests.IngressToRouteControllerRoleBinding, reconcile: rbac.ReconcileIngressToRouteControllerRoleBinding},
 

--- a/support/metrics/sets.go
+++ b/support/metrics/sets.go
@@ -52,6 +52,7 @@ type MetricsSetConfig struct {
 	OLM                             []prometheusoperatorv1.RelabelConfig `json:"olm,omitempty"`
 	CatalogOperator                 []prometheusoperatorv1.RelabelConfig `json:"catalogOperator,omitempty"`
 	RegistryOperator                []prometheusoperatorv1.RelabelConfig `json:"registryOperator,omitempty"`
+	KubeScheduler                   []prometheusoperatorv1.RelabelConfig `json:"kubeScheduler,omitempty"`
 	NodeTuningOperator              []prometheusoperatorv1.RelabelConfig `json:"nodeTuningOperator,omitempty"`
 
 	// HyperShift components
@@ -222,6 +223,23 @@ func KASRelabelConfigs(set MetricsSet) []prometheusoperatorv1.RelabelConfig {
 				SourceLabels: []prometheusoperatorv1.LabelName{"__name__", "le"},
 			},
 		}
+	}
+}
+
+func SchedulerRelabelConfigs(set MetricsSet) []prometheusoperatorv1.RelabelConfig {
+	switch set {
+	case MetricsSetTelemetry:
+		return []prometheusoperatorv1.RelabelConfig{
+			{
+				Action:       "drop",
+				Regex:        ".*",
+				SourceLabels: []prometheusoperatorv1.LabelName{"__name__"},
+			},
+		}
+	case MetricsSetSRE:
+		return sreMetricsSetConfig.KubeScheduler
+	default:
+		return nil
 	}
 }
 

--- a/support/metrics/sets.go
+++ b/support/metrics/sets.go
@@ -53,6 +53,7 @@ type MetricsSetConfig struct {
 	CatalogOperator                 []prometheusoperatorv1.RelabelConfig `json:"catalogOperator,omitempty"`
 	RegistryOperator                []prometheusoperatorv1.RelabelConfig `json:"registryOperator,omitempty"`
 	KubeScheduler                   []prometheusoperatorv1.RelabelConfig `json:"kubeScheduler,omitempty"`
+	KubeSchedulerResourceMetrics    []prometheusoperatorv1.RelabelConfig `json:"kubeSchedulerResourceMetrics,omitempty"`
 	NodeTuningOperator              []prometheusoperatorv1.RelabelConfig `json:"nodeTuningOperator,omitempty"`
 
 	// HyperShift components
@@ -238,6 +239,23 @@ func SchedulerRelabelConfigs(set MetricsSet) []prometheusoperatorv1.RelabelConfi
 		}
 	case MetricsSetSRE:
 		return sreMetricsSetConfig.KubeScheduler
+	default:
+		return nil
+	}
+}
+
+func SchedulerResourceRelabelConfigs(set MetricsSet) []prometheusoperatorv1.RelabelConfig {
+	switch set {
+	case MetricsSetTelemetry:
+		return []prometheusoperatorv1.RelabelConfig{
+			{
+				Action:       "drop",
+				Regex:        ".*",
+				SourceLabels: []prometheusoperatorv1.LabelName{"__name__"},
+			},
+		}
+	case MetricsSetSRE:
+		return sreMetricsSetConfig.KubeSchedulerResourceMetrics
 	default:
 		return nil
 	}

--- a/support/metrics/sets_test.go
+++ b/support/metrics/sets_test.go
@@ -8,6 +8,43 @@ import (
 //go:embed testdata/sreconfig.yaml
 var sampleSREConfigYAML string
 
+func TestSchedulerResourceRelabelConfigs(t *testing.T) {
+	tests := []struct {
+		name string
+		set  MetricsSet
+		want int
+	}{
+		{
+			name: "When using Telemetry metrics set it should return a drop-all relabel config",
+			set:  MetricsSetTelemetry,
+			want: 1,
+		},
+		{
+			name: "When using SRE metrics set it should return SRE config",
+			set:  MetricsSetSRE,
+			want: 0,
+		},
+		{
+			name: "When using All metrics set it should return nil",
+			set:  MetricsSetAll,
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SchedulerResourceRelabelConfigs(tt.set)
+			if len(got) != tt.want {
+				t.Errorf("SchedulerResourceRelabelConfigs(%s) returned %d configs, want %d", tt.set, len(got), tt.want)
+			}
+			if tt.set == MetricsSetTelemetry {
+				if got[0].Action != "drop" {
+					t.Errorf("expected drop action for Telemetry set, got %s", got[0].Action)
+				}
+			}
+		})
+	}
+}
+
 func TestLoadMetricsConfig(t *testing.T) {
 	config := MetricsSetConfig{}
 	err := config.LoadFromString(sampleSREConfigYAML)


### PR DESCRIPTION
## What this PR does / why we need it:

Cherry-picks PRs [#8489](https://github.com/openshift/hypershift/pull/8489) and [#8680](https://github.com/openshift/hypershift/pull/8680) to `release-4.22` to enable Prometheus metrics scraping for the kube-scheduler control plane component.

**PR #8489** adds a CA-signed serving certificate, Service, and ServiceMonitor for the kube-scheduler, replacing the previously auto-generated self-signed certificates. This enables proper mTLS authentication for Prometheus metrics scraping of `/metrics` and `/metrics/resources` endpoints.

**PR #8680** adds the necessary RBAC (ClusterRole and ClusterRoleBinding) in the hosted cluster for the `system:kube-scheduler` service account to access the `/metrics/resources` endpoint.

### Conflict resolution notes:
- `hostedcontrolplane_controller.go`: The v1 `reconcileOLMAndMiscCerts` function was refactored out in release-4.22. The scheduler cert reconciliation was added directly to the existing `reconcilePKI` function instead.
- `kube_scheduler/component.go`: Kept `util.AvailabilityProberOpts{}` (release-4.22) instead of `podspec.AvailabilityProberOpts{}` (main), while adding the ServiceMonitor manifest adapter.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-4314](https://redhat.atlassian.net/browse/CNTRLPLANE-4314)

## Special notes for your reviewer:

- The conflict resolution in `hostedcontrolplane_controller.go` is the key area to review — the scheduler cert was placed between KCM and CVO certs in `reconcilePKI`, matching the logical placement from the original PR.
- PR #9159 (e2e tests) was intentionally **not** backported because it gates on `Version423` (would be skipped on 4.22) and depends on `test/e2e/v2/util` which doesn't exist on this branch.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.