### PR TITLE
CNTRLPLANE-3646: increase e2e v2 control plane upgrade coverage for v1 parity

### DIFF
--- a/test/e2e/v2/lifecycle/aws.go
+++ b/test/e2e/v2/lifecycle/aws.go
@@ -158,6 +158,11 @@ func (a *AWSPlatformConfig) TestMatrix() TestMatrix {
 				Variant:     "karpenter",
 				LabelFilter: "karpenter",
 			},
+			// TODO: It might be possible to decompose the karpenter upgrade test
+			// into pre and post upgrade specs which communicate with a well defined
+			// IPC protocol, like the pre step serializing observations which the
+			// post step can use. Then we can compose the regular upgrade test here
+			// instead of duplicating upgrade logic inside the karpenter test.
 			{
 				Name:        "karpenter-upgrade",
 				Variant:     "karpenter-upgrade",
@@ -172,6 +177,11 @@ func (a *AWSPlatformConfig) TestMatrix() TestMatrix {
 						Name:        "upgrade",
 						Variant:     "upgrade",
 						LabelFilter: "control-plane-upgrade",
+					},
+					{
+						Name:        "post-upgrade-health",
+						Variant:     "upgrade",
+						LabelFilter: "hosted-cluster-health || control-plane-workloads",
 					},
 					{
 						Name:        "control-plane-tls",

--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -390,6 +390,11 @@ func (a *AzurePlatformConfig) TestMatrix() TestMatrix {
 						LabelFilter: "control-plane-upgrade",
 					},
 					{
+						Name:        "post-upgrade-health",
+						Variant:     "upgrade",
+						LabelFilter: "hosted-cluster-health || control-plane-workloads",
+					},
+					{
 						Name:        "control-plane-tls",
 						Variant:     "upgrade",
 						LabelFilter: "control-plane-pki-operator",

--- a/test/e2e/v2/tests/control_plane_upgrade_test.go
+++ b/test/e2e/v2/tests/control_plane_upgrade_test.go
@@ -17,38 +17,135 @@ limitations under the License.
 package tests
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 
+	corev1 "k8s.io/api/core/v1"
+
+	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// ensureNodeCountMatchesNodePoolReplicas verifies that every NodePool belonging
+// to the HostedCluster has the number of Ready hosted cluster Nodes specified
+// by its replicas. It fails the current Ginkgo assertion if a NodePool has no
+// replicas set or any of its nodes are not Ready.
+func ensureNodeCountMatchesNodePoolReplicas(
+	ctx context.Context,
+	managementClient crclient.Client,
+	hostedClusterClient crclient.Client,
+	hostedCluster *hyperv1.HostedCluster,
+) {
+	GinkgoHelper()
+	Expect(hostedCluster).NotTo(BeNil(), "hosted cluster should not be nil")
+	if hostedCluster == nil {
+		return
+	}
+
+	nodePoolList := &hyperv1.NodePoolList{}
+	if err := managementClient.List(ctx, nodePoolList, crclient.InNamespace(hostedCluster.Namespace)); err != nil {
+		Expect(err).NotTo(HaveOccurred(), "failed to list NodePools in namespace %s", hostedCluster.Namespace)
+		return
+	}
+	Expect(nodePoolList.Items).NotTo(BeEmpty())
+
+	foundNodePool := false
+	for _, nodePool := range nodePoolList.Items {
+		if nodePool.Spec.ClusterName != hostedCluster.Name {
+			continue
+		}
+		foundNodePool = true
+		if nodePool.Spec.AutoScaling != nil {
+			// TODO: Implement post-upgrade assertions for autoscaled NodePools.
+			Skip(fmt.Sprintf("post-upgrade assertions are not implemented for autoscaled NodePool %s/%s", nodePool.Namespace, nodePool.Name))
+		}
+
+		Expect(nodePool.Spec.Replicas).NotTo(BeNil(), "NodePool %s/%s replicas are not set", nodePool.Namespace, nodePool.Name)
+		if nodePool.Spec.Replicas == nil {
+			continue
+		}
+
+		nodeList := &corev1.NodeList{}
+		Expect(hostedClusterClient.List(ctx, nodeList, crclient.MatchingLabels{
+			hyperv1.NodePoolLabel: nodePool.Name,
+		})).To(Succeed(), "failed to list Nodes for NodePool %s/%s", nodePool.Namespace, nodePool.Name)
+
+		Expect(nodeList.Items).To(HaveLen(int(*nodePool.Spec.Replicas)),
+			"expected %d Nodes for NodePool %s/%s, got %d",
+			*nodePool.Spec.Replicas, nodePool.Namespace, nodePool.Name, len(nodeList.Items))
+
+		for _, node := range nodeList.Items {
+			ready := false
+			for _, condition := range node.Status.Conditions {
+				if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+					ready = true
+					break
+				}
+			}
+			Expect(ready).To(BeTrue(), "Node %s for NodePool %s/%s is not Ready", node.Name, nodePool.Namespace, nodePool.Name)
+		}
+	}
+	Expect(foundNodePool).To(BeTrue(), "expected at least one NodePool for HostedCluster %s/%s", hostedCluster.Namespace, hostedCluster.Name)
+}
+
+// ensureMachineDeploymentGeneration verifies that every MachineDeployment in
+// the hosted control-plane namespace has the expected generation.
+func ensureMachineDeploymentGeneration(
+	ctx context.Context,
+	managementClient crclient.Client,
+	hostedCluster *hyperv1.HostedCluster,
+	expectedGeneration int64,
+) {
+	GinkgoHelper()
+	Expect(hostedCluster).NotTo(BeNil(), "hosted cluster should not be nil")
+	if hostedCluster == nil {
+		return
+	}
+
+	namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+	machineDeploymentList := &capiv1.MachineDeploymentList{}
+	Expect(managementClient.List(ctx, machineDeploymentList, crclient.InNamespace(namespace))).To(Succeed(),
+		"failed to list MachineDeployments in namespace %s", namespace)
+	Expect(machineDeploymentList.Items).NotTo(BeEmpty(),
+		"expected at least one MachineDeployment in namespace %s", namespace)
+
+	for i := range machineDeploymentList.Items {
+		machineDeployment := &machineDeploymentList.Items[i]
+		Expect(machineDeployment.Generation).To(Equal(expectedGeneration),
+			"MachineDeployment %s does not have expected generation %d, got %d",
+			crclient.ObjectKeyFromObject(machineDeployment), expectedGeneration, machineDeployment.Generation)
+	}
+}
 
 // ControlPlaneUpgradeTest upgrades the hosted cluster from N-1 to the latest release image.
 func ControlPlaneUpgradeTest(getTestCtx internal.TestContextGetter) {
 	It("should upgrade the control plane from N-1 to latest", func() {
 		testCtx := getTestCtx()
+		testCtx.SkipIfVersionBelow(e2eutil.Version422)
+
 		ctx := testCtx.Context
+		By("Fetching the HostedCluster before upgrade")
 		hc, err := testCtx.GetHostedCluster()
 		Expect(err).NotTo(HaveOccurred())
 
+		By("Preparing the latest release image for upgrade")
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")
 		Expect(latestImage).NotTo(BeEmpty(), "E2E_LATEST_RELEASE_IMAGE must be set for upgrade tests")
-
-		testCtx.SkipIfVersionBelow(e2eutil.Version422)
 
 		var startingVersion string
 		if hc.Status.Version != nil && len(hc.Status.Version.History) > 0 {
 			startingVersion = hc.Status.Version.History[0].Version
 		}
 
-		GinkgoWriter.Printf("Starting upgrade from version %s to image %s\n", startingVersion, latestImage)
-
+		By(fmt.Sprintf("Requesting control plane upgrade from version %s to image %s", startingVersion, latestImage))
 		err = e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 			obj.Spec.Release.Image = latestImage
 			if obj.Annotations == nil {
@@ -61,15 +158,16 @@ func ControlPlaneUpgradeTest(getTestCtx internal.TestContextGetter) {
 		By(fmt.Sprintf("Waiting for the control plane and data plane to reach image %s", latestImage))
 		ExpectHostedClusterUpgradeToComplete(ctx, testCtx.MgmtClient, hc, latestImage)
 
-		// Re-fetch HC after upgrade
+		By("Re-fetching HostedCluster after upgrade")
 		Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), hc)).To(Succeed())
+		By("Creating a hosted cluster client after upgrade")
+		hcClient, err := testCtx.GetHostedClusterClient(hc)
+		Expect(err).NotTo(HaveOccurred())
 
-		// TODO: Add post-upgrade validation checks once the Ensure* functions
-		// in e2eutil are refactored from *testing.T to testing.TB:
-		//   - EnsureFeatureGateStatus
-		//   - EnsureNodeCountMatchesNodePoolReplicas
-		//   - EnsureNoCrashingPods
-		//   - EnsureMachineDeploymentGeneration
+		By("Validating node count after upgrade")
+		ensureNodeCountMatchesNodePoolReplicas(ctx, testCtx.MgmtClient, hcClient, hc)
+		By("Validating MachineDeployment generation after upgrade")
+		ensureMachineDeploymentGeneration(ctx, testCtx.MgmtClient, hc, 1)
 	})
 }
 

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -51,6 +51,142 @@ var (
 	desiredStateHashHexRE = regexp.MustCompile(`^[0-9a-f]{64}$`)
 )
 
+// podCrashTolerations defines the tolerated amount of restarts a pod is allowed
+// to suffer until it is considered to be crashing. Pods whose component
+// matches a key are evaluated with the associated toleration. If a pod is not
+// listed, the default toleration is used.
+var podCrashTolerations = map[string]int32{
+	// TODO: Figure out why Route kind does not exist when ingress-operator first starts
+	"ingress-operator": 20,
+	// Seeing flakes due to https://issues.redhat.com/browse/OCPBUGS-30068
+	"cloud-credential-operator": 20,
+	// Restart built into OLM by design by https://github.com/openshift/operator-framework-olm/commit/1cf358424a0cbe353428eab9a16051c6cabbd002
+	"olm-operator":                20,
+	"catalog-operator":            20,
+	"certified-operators-catalog": 20,
+	"community-operators-catalog": 20,
+	"redhat-operators-catalog":    20,
+	"redhat-marketplace-catalog":  20,
+	// Temporary workaround for https://issues.redhat.com/browse/OCPBUGS-45182
+	"openstack-manila-csi-controllerplugin": 20,
+	// Temporary workaround for https://issues.redhat.com/browse/CNV-40820
+	"kubevirt-csi":                  20,
+	"aws-ebs-csi-driver-controller": 1,
+	// Allow 1 restart for network-node-identity webhook startup timing
+	"network-node-identity": 1,
+	// Temporary workaround for https://issues.redhat.com/browse/CNV-76520
+	"kubevirt-cloud-controller-manager": 2,
+	// Allow 1 restart for token-minter sidecar race condition: https://issues.redhat.com/browse/GCP-441
+	// TODO(GCP-447): Remove this toleration once token-minter is injected as a native sidecar init container.
+	"gcp-cloud-controller-manager": 1,
+	// During minor version upgrades the controlplane-manager rolls out the new
+	// dns-operator before CVO applies the updated ClusterRole on the hosted
+	// cluster. The 4.22 dns-operator requires NetworkPolicy and APIServer RBAC
+	// that does not exist in 4.21, so it crash-loops until CVO catches up. This
+	// is a deterministic ordering issue, not a race.
+	// See https://issues.redhat.com/browse/OCPBUGS-78539
+	"dns-operator": 5,
+	// CVO and CNO may restart once during hosted cluster initialization due to
+	// dependency ordering and hosted kube-apiserver availability timing.
+	// See https://issues.redhat.com/browse/OCPBUGS-109581
+	// See https://issues.redhat.com/browse/OCPBUGS-77042
+	// See https://issues.redhat.com/browse/OCPBUGS-18569
+	"cluster-version-operator": 1,
+	"cluster-network-operator": 1,
+}
+
+func defaultCrashTolerationForCluster(hostedCluster *hyperv1.HostedCluster) int32 {
+	defaultCrashToleration := int32(0)
+	if hostedCluster.Spec.Platform.Type == hyperv1.KubevirtPlatform {
+		kvPlatform := hostedCluster.Spec.Platform.Kubevirt
+		// External infra can be slow at times due to the nested nature of how
+		// external infra is tested within a kubevirt HCP running within baremetal
+		// OCP. Occasionally pods will fail with "Error: context deadline exceeded"
+		// reported by the kubelet. This seems to be an infra issue with etcd
+		// latency within the external infra test environment. Tolerating a single
+		// restart for random components helps.
+		//
+		// This toleration is not used for the default local HCP KubeVirt, only
+		// external infra.
+		if kvPlatform != nil && kvPlatform.Credentials != nil {
+			defaultCrashToleration = 1
+		}
+		// In Azure infra, the CAPK pod might crash on startup because it cannot
+		// get a leader election lock lease during the early stages due to a
+		// "context deadline exceeded" error.
+		if kvPlatform != nil && hostedCluster.Annotations != nil {
+			if hostedCluster.Annotations[hyperv1.ManagementPlatformAnnotation] == string(hyperv1.AzurePlatform) {
+				defaultCrashToleration = 1
+			}
+		}
+	}
+	return defaultCrashToleration
+}
+
+func crashTolerationForComponent(componentName string, defaultCrashToleration int32) int32 {
+	crashToleration := defaultCrashToleration
+	if toleration, ok := podCrashTolerations[componentName]; ok {
+		crashToleration = toleration
+	}
+	return crashToleration
+}
+
+// isCertificateTriggeredRestart checks if a kube-controller-manager restart
+// was triggered by certificate rotation.
+func isCertificateTriggeredRestart(ctx context.Context, client crclient.Client, pod *corev1.Pod) bool {
+	hcpList := &hyperv1.HostedControlPlaneList{}
+	if err := client.List(ctx, hcpList, crclient.InNamespace(pod.Namespace)); err != nil {
+		fmt.Fprintf(GinkgoWriter, "couldn't list HostedControlPlanes; pod namespace: %s, pod name: %s, error: %v\n", pod.Namespace, pod.Name, err)
+		return false
+	}
+	for _, hcp := range hcpList.Items {
+		if restartAnnotation, ok := hcp.Annotations[hyperv1.RestartDateAnnotation]; ok && strings.HasPrefix(restartAnnotation, "CertHash:") {
+			return true
+		}
+	}
+	return false
+}
+
+var leaderElectionFailurePatterns = []string{
+	"election lost",
+	"failed to renew lease",
+	"stopped leading",
+}
+
+func isLeaderElectionFailure(ctx context.Context, client kubernetes.Interface, pod *corev1.Pod, containerName string) bool {
+	req := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+		Container: containerName,
+		Previous:  true,
+		TailLines: ptr.To[int64](100),
+	})
+	podLogs, err := req.Stream(ctx)
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "couldn't stream pod log; pod namespace: %s, pod name: %s, error: %v\n", pod.Namespace, pod.Name, err)
+		return false
+	}
+	defer podLogs.Close()
+
+	scanner := bufio.NewScanner(podLogs)
+	const (
+		bufSize          = 256 * 1024
+		maxScanTokenSize = 512 * 1024
+	)
+	scanner.Buffer(make([]byte, bufSize), maxScanTokenSize)
+	for scanner.Scan() {
+		line := strings.ToLower(scanner.Text())
+		for _, pattern := range leaderElectionFailurePatterns {
+			if strings.Contains(line, pattern) {
+				return true
+			}
+		}
+	}
+	_, _ = io.Copy(io.Discard, podLogs)
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(GinkgoWriter, "failed to read pod log; pod namespace: %s, pod name: %s, error: %v\n", pod.Namespace, pod.Name, err)
+	}
+	return false
+}
+
 func getWorkloadPods(testCtx *internal.TestContext, workload internal.WorkloadSpec) []corev1.Pod {
 	GinkgoHelper()
 	pods, err := internal.GetWorkloadPodsBySelector(testCtx.Context, testCtx.MgmtClient, testCtx.ControlPlaneNamespace, workload)
@@ -850,69 +986,8 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 	})
 }
 
-func isCertificateTriggeredRestart(ctx context.Context, client crclient.Client, pod *corev1.Pod) bool {
-	hcpList := &hyperv1.HostedControlPlaneList{}
-	if err := client.List(ctx, hcpList, crclient.InNamespace(pod.Namespace)); err != nil {
-		fmt.Fprintf(GinkgoWriter, "couldn't list HostedControlPlanes; pod namespace: %s, pod name: %s, error: %v\n", pod.Namespace, pod.Name, err)
-		return false
-	}
-	for _, hcp := range hcpList.Items {
-		if restartAnnotation, ok := hcp.Annotations[hyperv1.RestartDateAnnotation]; ok {
-			if strings.HasPrefix(restartAnnotation, "CertHash:") {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func isLeaderElectionFailure(ctx context.Context, client kubernetes.Interface, pod *corev1.Pod, containerName string) bool {
-	req := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
-		Container: containerName,
-		Previous:  true,
-		TailLines: ptr.To[int64](100),
-	})
-	podLogs, err := req.Stream(ctx)
-	if err != nil {
-		fmt.Fprintf(GinkgoWriter, "couldn't stream pod log; pod namespace: %s, pod name: %s, error: %v\n", pod.Namespace, pod.Name, err)
-		return false
-	}
-	defer podLogs.Close()
-
-	scanner := bufio.NewScanner(podLogs)
-	scanner.Buffer(make([]byte, 256*1024), 512*1024)
-	for scanner.Scan() {
-		if e2eutil.MatchesLeaderElectionFailure(scanner.Text()) {
-			return true
-		}
-	}
-	_, _ = io.Copy(io.Discard, podLogs)
-	if err := scanner.Err(); err != nil {
-		fmt.Fprintf(GinkgoWriter, "failed to read pod log; pod namespace: %s, pod name: %s, error: %v\n", pod.Namespace, pod.Name, err)
-	}
-	return false
-}
-
 func NoCrashingPodsTest(getTestCtx internal.TestContextGetter) {
 	Context("No crashing pods", func() {
-		crashTolerations := map[string]int32{
-			"ingress-operator":                      20,
-			"cloud-credential-operator":             20,
-			"olm-operator":                          20,
-			"catalog-operator":                      20,
-			"certified-operators-catalog":           20,
-			"community-operators-catalog":           20,
-			"redhat-operators-catalog":              20,
-			"redhat-marketplace-catalog":            20,
-			"openstack-manila-csi-controllerplugin": 20,
-			"kubevirt-csi":                          20,
-			"aws-ebs-csi-driver-controller":         1,
-			"network-node-identity":                 1,
-			"kubevirt-cloud-controller-manager":     2,
-			"gcp-cloud-controller-manager":          1,
-			"dns-operator":                          5,
-		}
-
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
 				It("should have no crashing pods", func() {
@@ -929,27 +1004,12 @@ func NoCrashingPodsTest(getTestCtx internal.TestContextGetter) {
 						Skip(fmt.Sprintf("no pods found for workload %s", workload.Name))
 					}
 
-					var defaultCrashToleration int32
-					if hostedCluster.Spec.Platform.Type == hyperv1.KubevirtPlatform {
-						kvPlatform := hostedCluster.Spec.Platform.Kubevirt
-						if kvPlatform != nil && kvPlatform.Credentials != nil {
-							defaultCrashToleration = 1
-						}
-						if kvPlatform != nil && hostedCluster.Annotations != nil {
-							mgmtPlatform, annotationExists := hostedCluster.Annotations[hyperv1.ManagementPlatformAnnotation]
-							if annotationExists && mgmtPlatform == string(hyperv1.AzurePlatform) {
-								defaultCrashToleration = 1
-							}
-						}
-					}
-
-					toleration := defaultCrashToleration
-					if t, ok := crashTolerations[workload.Name]; ok {
-						toleration = t
-					}
+					defaultCrashToleration := defaultCrashTolerationForCluster(hostedCluster)
+					var toleration int32
 
 					var k8sClient kubernetes.Interface
 					for _, pod := range pods {
+						toleration = crashTolerationForComponent(workload.Name, defaultCrashToleration)
 						for _, containerStatus := range pod.Status.ContainerStatuses {
 							if containerStatus.RestartCount <= toleration {
 								continue

--- a/test/e2e/v2/tests/upgrade_assertions.go
+++ b/test/e2e/v2/tests/upgrade_assertions.go
@@ -1,3 +1,5 @@
+//go:build e2ev2
+
 package tests
 
 import (
@@ -41,6 +43,10 @@ func ExpectHostedClusterUpgradeToComplete(
 // for assertions so this function can be called from Eventually.
 func ExpectHostedClusterUpgradeComplete(ctx context.Context, g Gomega, mgmtClient crclient.Client, hc *hyperv1.HostedCluster, image string) {
 	GinkgoHelper()
+
+	if !g.Expect(hc).NotTo(BeNil(), "HostedCluster input cannot be nil") {
+		return
+	}
 
 	currentHC := &hyperv1.HostedCluster{}
 	if err := mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), currentHC); err != nil {


### PR DESCRIPTION
Before this commit, the e2e v2 control plane upgrade test was missing several
post-upgrade assertions against the upgraded hosted cluster compared to e2e v1.

This commit implements the missing assertions, bringing the upgrade logic up
to parity with the v1 coverage for this scenario.

This commit further improves on the v1 coverage by taking advantage of the v2
framework to re-use the basic cluster health and conformance tests following
the upgrade, so we get greatly enhanced coverage of the upgraded cluster state
very cheaply (slightly increased runtime for read-only assertions).

We should consider a future refactor to decompose the karpenter upgrade tests
in a way that they can reuse the same strategy and benefit from the same
coverage.

Assertion and utility code from v1 is intentionally left alone and rewritten
with v2 / Ginkgo semantics to further decrease coupling between the frameworks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded AWS and Azure lifecycle coverage for cluster upgrades.
  - Added post-upgrade health checks, control-plane TLS validation, and etcd resilience testing.
  - Strengthened verification of upgrade completion, control-plane versions, node readiness, node counts, and deployment generations.
  - Improved workload resilience coverage across infrastructure and platform components, including additional crash-tolerance scenarios.
  - Refined leader-election failure detection to improve reliability of workload disruption tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->