### PR TITLE
AUTOSCALE-998: inject token-minter image to standalone karpenter-operator

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
@@ -22,6 +22,8 @@ const (
 	KarpenterImageAWSEnvVar = "KARPENTER_IMAGE_AWS"
 	// KarpenterImageAzureEnvVar is the environment variable that sets the Karpenter image for Azure.
 	KarpenterImageAzureEnvVar = "KARPENTER_IMAGE_AZURE"
+	// TokenMinterImageEnvVar is the environment variable that sets the Token Minter image.
+	TokenMinterImageEnvVar = "TOKEN_MINTER_IMAGE"
 )
 
 func (karp *KarpenterOperatorOptions) adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
@@ -126,6 +128,9 @@ func adaptStandaloneDeployment(cpContext component.WorkloadContext, deployment *
 	extraEnvVars = append(extraEnvVars, corev1.EnvVar{
 		Name:  ManagementClusterEnvVar,
 		Value: "true",
+	}, corev1.EnvVar{
+		Name:  TokenMinterImageEnvVar,
+		Value: cpContext.ReleaseImageProvider.GetImage("token-minter"),
 	})
 
 	proxy.SetEnvVars(&extraEnvVars)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment_test.go
@@ -277,6 +277,7 @@ func TestAdaptStandaloneDeployment(t *testing.T) {
 			infraID:      "test-infra-123",
 			images: map[string]string{
 				"aws-karpenter-provider-aws": "quay.io/openshift/karpenter-aws:latest",
+				"token-minter":               "quay.io/openshift/token-minter:latest",
 			},
 			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
 				t.Helper()
@@ -298,6 +299,7 @@ func TestAdaptStandaloneDeployment(t *testing.T) {
 					corev1.EnvVar{Name: "AWS_SDK_LOAD_CONFIG", Value: "true"},
 					corev1.EnvVar{Name: KarpenterImageAWSEnvVar, Value: "quay.io/openshift/karpenter-aws:latest"},
 					corev1.EnvVar{Name: ManagementClusterEnvVar, Value: "true"},
+					corev1.EnvVar{Name: TokenMinterImageEnvVar, Value: "quay.io/openshift/token-minter:latest"},
 				))
 
 				g.Expect(container.Args).To(ContainElement(ContainSubstring("--target-kubeconfig=")))
@@ -318,6 +320,7 @@ func TestAdaptStandaloneDeployment(t *testing.T) {
 			infraID:       "test-azure-456",
 			images: map[string]string{
 				"azure-karpenter-provider-azure": "quay.io/openshift/karpenter-azure:latest",
+				"token-minter":                   "quay.io/openshift/token-minter:latest",
 			},
 			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
 				t.Helper()
@@ -336,6 +339,7 @@ func TestAdaptStandaloneDeployment(t *testing.T) {
 					corev1.EnvVar{Name: "REGION", Value: "eastus"},
 					corev1.EnvVar{Name: KarpenterImageAzureEnvVar, Value: "quay.io/openshift/karpenter-azure:latest"},
 					corev1.EnvVar{Name: ManagementClusterEnvVar, Value: "true"},
+					corev1.EnvVar{Name: TokenMinterImageEnvVar, Value: "quay.io/openshift/token-minter:latest"},
 				))
 
 				// Azure should not have AWS-specific env vars
@@ -352,6 +356,7 @@ func TestAdaptStandaloneDeployment(t *testing.T) {
 			rhobsEnabled: true,
 			images: map[string]string{
 				"aws-karpenter-provider-aws": "quay.io/openshift/karpenter-aws:latest",
+				"token-minter":               "quay.io/openshift/token-minter:latest",
 			},
 			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
 				t.Helper()
@@ -376,6 +381,7 @@ func TestAdaptStandaloneDeployment(t *testing.T) {
 			rhobsEnabled: false,
 			images: map[string]string{
 				"aws-karpenter-provider-aws": "quay.io/openshift/karpenter-aws:latest",
+				"token-minter":               "quay.io/openshift/token-minter:latest",
 			},
 			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
 				t.Helper()
@@ -401,6 +407,7 @@ func TestAdaptStandaloneDeployment(t *testing.T) {
 			images: map[string]string{
 				"karpenter-operator":         "quay.io/openshift/karpenter-operator:latest",
 				"aws-karpenter-provider-aws": "quay.io/openshift/karpenter-aws:latest",
+				"token-minter":               "quay.io/openshift/token-minter:latest",
 			},
 			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
 				t.Helper()
@@ -423,6 +430,7 @@ func TestAdaptStandaloneDeployment(t *testing.T) {
 			images: map[string]string{
 				"karpenter-operator":         "quay.io/openshift/karpenter-operator:latest",
 				"aws-karpenter-provider-aws": "quay.io/openshift/karpenter-aws:latest",
+				"token-minter":               "quay.io/openshift/token-minter:latest",
 			},
 			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
 				t.Helper()
@@ -448,6 +456,7 @@ func TestAdaptStandaloneDeployment(t *testing.T) {
 			images: map[string]string{
 				"karpenter-operator":         "quay.io/openshift/karpenter-operator:latest",
 				"aws-karpenter-provider-aws": "quay.io/openshift/karpenter-aws:latest",
+				"token-minter":               "quay.io/openshift/token-minter:latest",
 			},
 			validateFunc: func(t *testing.T, g Gomega, cpContext controlplanecomponent.WorkloadContext) {
 				t.Helper()


### PR DESCRIPTION
## What this PR does / why we need it:

This is part 2 of https://github.com/openshift/karpenter-operator/pull/26. We need to allow the hypershift-operator using CPOv2 architecture to inject a token minter image to KO, so that it can build and deploy the karpenter deployment with a token-minter sidecar container. Otherwise the karpenter-operator fails to come up and blocks hosted cluster creation.

See failures like this: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/84052/rehearse-84052-pull-ci-openshift-hypershift-main-e2e-aws-autonode-standalone-ko/2094892442762350592

This is a migration of the legacy karpenter-operator deployment using CPOv2 architecture: https://github.com/openshift/hypershift/blob/99ac230cd4044ab2c7806b0f0b19a454af308323/control-plane-operator/controllers/hostedcontrolplane/v2/karpenter/deployment.go#L46

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/AUTOSCALE-998

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Standalone Karpenter Operator deployments now automatically receive the appropriate Token Minter image from the release configuration.
  - This ensures the required image is consistently available across supported deployment environments and image override scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->