### PR TITLE
[release-4.22] OCPBUGS-119698: Add proxy env vars to cluster-storage-operator deployment"

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -14,6 +15,7 @@ import (
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		proxy.SetEnvVars(&c.Env)
 		envReplacer := newEnvironmentReplacer(cpContext.ReleaseImageProvider, cpContext.UserReleaseImageProvider)
 		envReplacer.replaceEnvVars(c.Env)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment_test.go
@@ -1,0 +1,130 @@
+package storage
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/util"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAdaptDeployment(t *testing.T) {
+	testCases := []struct {
+		name       string
+		httpProxy  string
+		httpsProxy string
+		noProxy    string
+		validate   func(*WithT, *corev1.Container)
+	}{
+		{
+			name:       "When proxy environment variables are set, it should add proxy env vars to container",
+			httpProxy:  "http://proxy.example.com:8080",
+			httpsProxy: "https://proxy.example.com:8443",
+			noProxy:    "localhost,127.0.0.1",
+			validate: func(g *WithT, container *corev1.Container) {
+				httpProxy := util.FindEnvVar("HTTP_PROXY", container.Env)
+				g.Expect(httpProxy).ToNot(BeNil())
+				g.Expect(httpProxy.Value).To(Equal("http://proxy.example.com:8080"))
+
+				httpsProxy := util.FindEnvVar("HTTPS_PROXY", container.Env)
+				g.Expect(httpsProxy).ToNot(BeNil())
+				g.Expect(httpsProxy.Value).To(Equal("https://proxy.example.com:8443"))
+
+				noProxy := util.FindEnvVar("NO_PROXY", container.Env)
+				g.Expect(noProxy).ToNot(BeNil())
+				g.Expect(noProxy.Value).To(ContainSubstring("localhost"))
+				g.Expect(noProxy.Value).To(ContainSubstring("127.0.0.1"))
+				g.Expect(noProxy.Value).To(ContainSubstring("kube-apiserver"))
+
+				g.Expect(util.FindEnvVar("OPERATOR_IMAGE_VERSION", container.Env)).ToNot(BeNil())
+				g.Expect(util.FindEnvVar("AWS_EBS_DRIVER_OPERATOR_IMAGE", container.Env)).ToNot(BeNil())
+				g.Expect(util.FindEnvVar("HYPERSHIFT_IMAGE", container.Env)).ToNot(BeNil())
+			},
+		},
+		{
+			name:      "When only HTTP_PROXY is set, it should add HTTP_PROXY and NO_PROXY but not HTTPS_PROXY",
+			httpProxy: "http://proxy.example.com:8080",
+			noProxy:   "localhost,127.0.0.1",
+			validate: func(g *WithT, container *corev1.Container) {
+				httpProxy := util.FindEnvVar("HTTP_PROXY", container.Env)
+				g.Expect(httpProxy).ToNot(BeNil())
+				g.Expect(httpProxy.Value).To(Equal("http://proxy.example.com:8080"))
+
+				g.Expect(util.FindEnvVar("HTTPS_PROXY", container.Env)).To(BeNil())
+
+				noProxy := util.FindEnvVar("NO_PROXY", container.Env)
+				g.Expect(noProxy).ToNot(BeNil())
+				g.Expect(noProxy.Value).To(ContainSubstring("localhost"))
+				g.Expect(noProxy.Value).To(ContainSubstring("127.0.0.1"))
+				g.Expect(noProxy.Value).To(ContainSubstring("kube-apiserver"))
+			},
+		},
+		{
+			name:       "When only HTTPS_PROXY is set, it should add HTTPS_PROXY and NO_PROXY but not HTTP_PROXY",
+			httpsProxy: "https://proxy.example.com:8443",
+			noProxy:    "localhost,127.0.0.1",
+			validate: func(g *WithT, container *corev1.Container) {
+				g.Expect(util.FindEnvVar("HTTP_PROXY", container.Env)).To(BeNil())
+
+				httpsProxy := util.FindEnvVar("HTTPS_PROXY", container.Env)
+				g.Expect(httpsProxy).ToNot(BeNil())
+				g.Expect(httpsProxy.Value).To(Equal("https://proxy.example.com:8443"))
+
+				noProxy := util.FindEnvVar("NO_PROXY", container.Env)
+				g.Expect(noProxy).ToNot(BeNil())
+				g.Expect(noProxy.Value).To(ContainSubstring("localhost"))
+				g.Expect(noProxy.Value).To(ContainSubstring("127.0.0.1"))
+				g.Expect(noProxy.Value).To(ContainSubstring("kube-apiserver"))
+			},
+		},
+		{
+			name: "When no proxy is set, it should not add proxy env vars",
+			validate: func(g *WithT, container *corev1.Container) {
+				g.Expect(util.FindEnvVar("HTTP_PROXY", container.Env)).To(BeNil())
+				g.Expect(util.FindEnvVar("HTTPS_PROXY", container.Env)).To(BeNil())
+				g.Expect(util.FindEnvVar("NO_PROXY", container.Env)).To(BeNil())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			t.Setenv("HTTP_PROXY", tc.httpProxy)
+			t.Setenv("HTTPS_PROXY", tc.httpsProxy)
+			t.Setenv("NO_PROXY", tc.noProxy)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-namespace",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{},
+			}
+
+			cpContext := component.WorkloadContext{
+				HCP:                      hcp,
+				ReleaseImageProvider:     &fakeReleaseImageProvider{images: map[string]string{}, version: "4.18.0"},
+				UserReleaseImageProvider: &fakeReleaseImageProvider{images: map[string]string{}, version: "4.18.0"},
+			}
+
+			deployment, err := assets.LoadDeploymentManifest(ComponentName)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			err = adaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+			g.Expect(container).ToNot(BeNil(), "cluster-storage-operator container should exist")
+
+			tc.validate(g, container)
+		})
+	}
+}


### PR DESCRIPTION
**Original PR (5.0):** #9332
**JIRA:** https://issues.redhat.com/browse/OCPBUGS-105282

**Manual backport required:** Automatic backport failed due to conflicts

**Changes:**
- CPO reads HTTP_PROXY/HTTPS_PROXY/NO_PROXY from os.Getenv()
- Injects proxy env vars into cluster-storage-operator deployment via proxy.SetEnvVars()
- Adds comprehensive test coverage for proxy env var propagation

**4.22 Adaptation:**
- Uses \`support/util\` instead of \`support/podspec\` (the refactor to podspec happened in 4.23+, commit 6acdc2b0b2)
- All functionality identical to 5.0 version

**Files changed:**
- control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment.go
- control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment_test.go (new)

**Note on linting:**
Pre-existing kubeapilinter errors in aws.go and endporelated to this backport (verified to exist on cleanrelease-4.22 branch).

**Related PRs:**
- cluster-storage-operator: (will add after creating)
- csi-operator: #619 (already merged to 4.22)

**Testing:**
- Builds successfully on release-4.22
- Logic identical to 5.0 version (#9332)"


## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.