### PR TITLE
OCPBUGS-120685: fix(e2e): label flaking nodepool osImageStream test informing

### DIFF
--- a/test/e2e/v2/tests/nodepool_osimagestream_test.go
+++ b/test/e2e/v2/tests/nodepool_osimagestream_test.go
@@ -331,7 +331,7 @@ func verifyNodeOSMatchesStream(testCtx *internal.TestContext, np *hyperv1.NodePo
 // (no osImageStream set), an explicit rhel-9 NodePool, and an explicit rhel-10
 // NodePool. This is a lifecycle test because it creates additional NodePools.
 func NodePoolOSImageStreamNodeOSVerificationTest(getTestCtx internal.TestContextGetter) {
-	It("When NodePools have different osImageStream values, nodes should run the matching OS version", func() {
+	It("When NodePools have different osImageStream values, nodes should run the matching OS version", Label("Informing"), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()


### PR DESCRIPTION
This test was recently introduced and is now flaking, it probably should be been marked informing until it was proven stable. This commit marks the test as informing for now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the node pool OS image stream verification test to be informational rather than blocking.
  - Test logic and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->