### PR TITLE
OCPBUGS-120685: fix(e2e): select a live NodePool for osImageStream node OS verification

### DIFF
--- a/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
@@ -61,13 +61,13 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 			Expect(err).NotTo(HaveOccurred())
 
 			np := getDefaultNodePool(tc.Context, tc.MgmtClient, hc)
-			if np == nil ||
-				np.Spec.Management.UpgradeType == hyperv1.UpgradeTypeInPlace ||
-				np.Spec.Replicas == nil ||
-				*np.Spec.Replicas == 0 {
-				Skip("no suitable NodePool found (need non-InPlace upgrade type with replicas > 0)")
+			// getDefaultNodePool already guarantees a non-deleting NodePool with at
+			// least one ready replica, so nodeCount comes from status.replicas rather
+			// than spec.replicas; only the InPlace upgrade type remains unsupported here.
+			if np == nil || np.Spec.Management.UpgradeType == hyperv1.UpgradeTypeInPlace {
+				Skip("no suitable NodePool found (need non-InPlace upgrade type with a ready replica)")
 			}
-			nodeCount := *np.Spec.Replicas
+			nodeCount := np.Status.Replicas
 
 			var dummyPullSecretData = []byte(`{"auths": {"quay.io": {"auth": "YWRtaW46cGFzc3dvcmQ="}}}`)
 			var updatedPullSecretData = []byte(`{"auths": {"registry.example.com": {"auth": "dXNlcjpwYXNzd29yZA=="}}}`)

--- a/test/e2e/v2/tests/nodepool_autoscaling_test.go
+++ b/test/e2e/v2/tests/nodepool_autoscaling_test.go
@@ -244,20 +244,33 @@ func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 
 // Helper functions
 
-// getDefaultNodePool finds an existing NodePool for the hosted cluster to copy platform config
+// getDefaultNodePool finds a NodePool for the hosted cluster that is not being
+// deleted and has at least one ready replica (status.replicas). It is used both
+// as a template for platform config and for inspecting a backing node, so it
+// skips NodePools with a deletion timestamp (e.g. test NodePools mid-teardown)
+// and those without a ready node. Returns nil if none qualifies.
 func getDefaultNodePool(ctx context.Context, client crclient.Client, hc *hyperv1.HostedCluster) *hyperv1.NodePool {
 	GinkgoHelper()
 
 	npList := &hyperv1.NodePoolList{}
-	err := client.List(ctx, npList, crclient.InNamespace(hc.Namespace))
-	Expect(err).NotTo(HaveOccurred(), "failed to list NodePools")
+	Expect(client.List(ctx, npList, crclient.InNamespace(hc.Namespace))).To(Succeed(),
+		"failed to list NodePools for HostedCluster %s/%s", hc.Namespace, hc.Name)
 	Expect(npList.Items).NotTo(BeEmpty(), "should have at least one NodePool")
 
-	// Find a NodePool for this HostedCluster
+	// Find a live NodePool for this HostedCluster, skipping any that are
+	// terminating or have no ready replica.
 	for i := range npList.Items {
-		if npList.Items[i].Spec.ClusterName == hc.Name {
-			return &npList.Items[i]
+		np := &npList.Items[i]
+		if np.Spec.ClusterName != hc.Name {
+			continue
 		}
+		if np.DeletionTimestamp != nil {
+			continue
+		}
+		if np.Status.Replicas < 1 {
+			continue
+		}
+		return np
 	}
 
 	return nil

--- a/test/e2e/v2/tests/nodepool_osimagestream_test.go
+++ b/test/e2e/v2/tests/nodepool_osimagestream_test.go
@@ -326,10 +326,46 @@ func verifyNodeOSMatchesStream(testCtx *internal.TestContext, np *hyperv1.NodePo
 	ensureNodesRuntimeV2(nodeList.Items, expectedStream)
 }
 
+// getNodePoolWithReadyNode returns a NodePool for the hosted cluster that is not
+// being deleted and has at least one observed replica (status.replicas), so its
+// backing node object can be inspected. Unlike getDefaultNodePool, it skips
+// NodePools that carry a deletion timestamp (e.g. test NodePools mid-teardown).
+// It returns nil if no such NodePool exists; callers should assert the result is
+// non-nil.
+//
+// NOTE: this helper is NOT Eventually-compatible. It uses Gomega assertions (via
+// GinkgoHelper), so a list failure is reported at the caller's line and aborts
+// the spec immediately rather than retrying. Do not call it inside an
+// Eventually/Consistently polling loop.
+func getNodePoolWithReadyNode(ctx context.Context, client crclient.Client, hc *hyperv1.HostedCluster) *hyperv1.NodePool {
+	GinkgoHelper()
+
+	npList := &hyperv1.NodePoolList{}
+	Expect(client.List(ctx, npList, crclient.InNamespace(hc.Namespace))).To(Succeed(),
+		"failed to list NodePools for HostedCluster %s/%s", hc.Namespace, hc.Name)
+
+	for i := range npList.Items {
+		np := &npList.Items[i]
+		if np.Spec.ClusterName != hc.Name {
+			continue
+		}
+		if np.DeletionTimestamp != nil {
+			continue
+		}
+		if np.Status.Replicas < 1 {
+			continue
+		}
+		return np
+	}
+
+	return nil
+}
+
 // NodePoolOSImageStreamNodeOSVerificationTest verifies that actual node OS versions
-// match the expected osImageStream across three scenarios: the default NodePool
-// (no osImageStream set), an explicit rhel-9 NodePool, and an explicit rhel-10
-// NodePool. This is a lifecycle test because it creates additional NodePools.
+// match the expected osImageStream across two scenarios: an existing NodePool
+// running its version-derived (or explicitly configured) stream, and an explicit
+// NodePool created with the alternate stream. This is a lifecycle test because it
+// creates additional NodePools.
 func NodePoolOSImageStreamNodeOSVerificationTest(getTestCtx internal.TestContextGetter) {
 	It("When NodePools have different osImageStream values, nodes should run the matching OS version", Label("Informing"), func() {
 		testCtx := getTestCtx()
@@ -342,12 +378,11 @@ func NodePoolOSImageStreamNodeOSVerificationTest(getTestCtx internal.TestContext
 
 		ctx := testCtx.Context
 
-		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
-		Expect(defaultNP).NotTo(BeNil(), "default NodePool should exist")
-		Expect(defaultNP.Spec.OSImageStream.Name).To(BeEmpty(),
-			"default NodePool %s should not have an explicit spec.osImageStream set", defaultNP.Name)
+		defaultNP := getNodePoolWithReadyNode(ctx, testCtx.MgmtClient, hc)
+		Expect(defaultNP).NotTo(BeNil(),
+			"a non-deleting NodePool with at least one replica should exist for HostedCluster %s/%s", hc.Namespace, hc.Name)
 
-		By("waiting for the default NodePool to have status.osImageStream resolved")
+		By("waiting for the NodePool to have status.osImageStream resolved")
 		e2eutil.EventuallyObject[*hyperv1.NodePool](
 			GinkgoTB(), ctx,
 			fmt.Sprintf("NodePool %s/%s status.osImageStream to be set", defaultNP.Namespace, defaultNP.Name),
@@ -363,11 +398,12 @@ func NodePoolOSImageStreamNodeOSVerificationTest(getTestCtx internal.TestContext
 			e2eutil.WithInterval(15*time.Second),
 		)
 
-		Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), defaultNP)).To(Succeed())
+		Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), defaultNP)).To(Succeed(),
+			"failed to get NodePool %s/%s", defaultNP.Namespace, defaultNP.Name)
 		defaultStream := defaultNP.Status.OSImageStream.Name
-		Expect(defaultStream).NotTo(BeEmpty(), "default NodePool %s should have status.osImageStream.name set", defaultNP.Name)
+		Expect(defaultStream).NotTo(BeEmpty(), "NodePool %s/%s should have status.osImageStream.name set", defaultNP.Namespace, defaultNP.Name)
 
-		By(fmt.Sprintf("verifying the default NodePool (spec.osImageStream=%q, status.osImageStream=%s) runs the expected OS",
+		By(fmt.Sprintf("verifying the NodePool (spec.osImageStream=%q, status.osImageStream=%s) runs the expected OS",
 			defaultNP.Spec.OSImageStream.Name, defaultStream))
 		verifyNodeOSMatchesStream(testCtx, defaultNP, defaultStream)
 
@@ -378,7 +414,7 @@ func NodePoolOSImageStreamNodeOSVerificationTest(getTestCtx internal.TestContext
 		case hyperv1.OSImageStreamRHEL9:
 			alternateStream = hyperv1.OSImageStreamRHEL10
 		default:
-			Fail(fmt.Sprintf("unexpected default stream %q", defaultStream))
+			Fail(fmt.Sprintf("unexpected stream %q on NodePool %s/%s", defaultStream, defaultNP.Namespace, defaultNP.Name))
 		}
 
 		By(fmt.Sprintf("creating a NodePool with osImageStream=%s", alternateStream))

--- a/test/e2e/v2/tests/nodepool_osimagestream_test.go
+++ b/test/e2e/v2/tests/nodepool_osimagestream_test.go
@@ -326,41 +326,6 @@ func verifyNodeOSMatchesStream(testCtx *internal.TestContext, np *hyperv1.NodePo
 	ensureNodesRuntimeV2(nodeList.Items, expectedStream)
 }
 
-// getNodePoolWithReadyNode returns a NodePool for the hosted cluster that is not
-// being deleted and has at least one observed replica (status.replicas), so its
-// backing node object can be inspected. Unlike getDefaultNodePool, it skips
-// NodePools that carry a deletion timestamp (e.g. test NodePools mid-teardown).
-// It returns nil if no such NodePool exists; callers should assert the result is
-// non-nil.
-//
-// NOTE: this helper is NOT Eventually-compatible. It uses Gomega assertions (via
-// GinkgoHelper), so a list failure is reported at the caller's line and aborts
-// the spec immediately rather than retrying. Do not call it inside an
-// Eventually/Consistently polling loop.
-func getNodePoolWithReadyNode(ctx context.Context, client crclient.Client, hc *hyperv1.HostedCluster) *hyperv1.NodePool {
-	GinkgoHelper()
-
-	npList := &hyperv1.NodePoolList{}
-	Expect(client.List(ctx, npList, crclient.InNamespace(hc.Namespace))).To(Succeed(),
-		"failed to list NodePools for HostedCluster %s/%s", hc.Namespace, hc.Name)
-
-	for i := range npList.Items {
-		np := &npList.Items[i]
-		if np.Spec.ClusterName != hc.Name {
-			continue
-		}
-		if np.DeletionTimestamp != nil {
-			continue
-		}
-		if np.Status.Replicas < 1 {
-			continue
-		}
-		return np
-	}
-
-	return nil
-}
-
 // NodePoolOSImageStreamNodeOSVerificationTest verifies that actual node OS versions
 // match the expected osImageStream across two scenarios: an existing NodePool
 // running its version-derived (or explicitly configured) stream, and an explicit
@@ -378,7 +343,7 @@ func NodePoolOSImageStreamNodeOSVerificationTest(getTestCtx internal.TestContext
 
 		ctx := testCtx.Context
 
-		defaultNP := getNodePoolWithReadyNode(ctx, testCtx.MgmtClient, hc)
+		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
 		Expect(defaultNP).NotTo(BeNil(),
 			"a non-deleting NodePool with at least one replica should exist for HostedCluster %s/%s", hc.Namespace, hc.Name)
 


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

NodePoolOSImageStreamNodeOSVerificationTest used `getDefaultNodePool`, which returns the first NodePool matching the cluster name. When a prior test's NodePool (e.g. the rhel-10 runc-rejection pool) is still terminating, that pool is returned instead of the provisioned default, and the assertion that spec.osImageStream is empty fails with 'rhel-10'.

Add `getNodePoolWithReadyNode`, which skips NodePools carrying a deletion timestamp and requires at least one observed replica (status.replicas) so a backing node object exists to inspect. Drop the assertion that spec.osImageStream is empty; the test now reads status.osImageStream from whichever live NodePool it selects and verifies the node OS matches.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes OCPBUGS-120685

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated OS image stream lifecycle validation to support existing NodePools with resolved or explicitly configured streams.
  * Added verification for alternate image streams and the `Informing` label.
  * Improved NodePool selection by excluding terminating, in-place, or not-yet-ready pools.
  * Validation now uses observed ready replica counts and safely handles cases where no eligible NodePool is available.
  * Improved error reporting and retained verification of image stream resolution and available nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->