### PR TITLE
CNTRLPLANE-2007: KubeVirt default ingress passthrough with HostNetwork endpoint publishing strategy

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
@@ -137,18 +137,62 @@ func ReconcileDefaultIngressControllerCertSecret(certSecret *corev1.Secret, sour
 	return nil
 }
 
-func ReconcileDefaultIngressPassthroughService(service *corev1.Service, defaultNodePort *corev1.Service, hcp *hyperv1.HostedControlPlane) error {
-	detectedHTTPSNodePort := int32(0)
-
-	for _, port := range defaultNodePort.Spec.Ports {
-		if port.Port == 443 {
-			detectedHTTPSNodePort = port.NodePort
-			break
+// EffectiveEndpointPublishingStrategy returns the endpoint publishing strategy
+// in use by the guest default IngressController. It prefers the strategy
+// reported in the IngressController status, then the spec, then the one
+// configured in the HostedControlPlane, and finally falls back to the platform
+// default for KubeVirt (NodePortService).
+func EffectiveEndpointPublishingStrategy(ingressController *operatorv1.IngressController, hcp *hyperv1.HostedControlPlane) *operatorv1.EndpointPublishingStrategy {
+	if ingressController != nil {
+		if ingressController.Status.EndpointPublishingStrategy != nil && ingressController.Status.EndpointPublishingStrategy.Type != "" {
+			return ingressController.Status.EndpointPublishingStrategy
+		}
+		if ingressController.Spec.EndpointPublishingStrategy != nil && ingressController.Spec.EndpointPublishingStrategy.Type != "" {
+			return ingressController.Spec.EndpointPublishingStrategy
 		}
 	}
+	if hcp != nil && hcp.Spec.OperatorConfiguration != nil && hcp.Spec.OperatorConfiguration.IngressOperator != nil &&
+		hcp.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy != nil &&
+		hcp.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy.Type != "" {
+		return hcp.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy
+	}
+	return &operatorv1.EndpointPublishingStrategy{Type: operatorv1.NodePortServiceStrategyType}
+}
 
-	if detectedHTTPSNodePort == 0 {
-		return fmt.Errorf("unable to detect default ingress NodePort https port")
+// passthroughHTTPSTargetPort resolves the port on the guest nodes where the
+// default ingress routers accept HTTPS traffic, according to the endpoint
+// publishing strategy in use.
+func passthroughHTTPSTargetPort(strategy *operatorv1.EndpointPublishingStrategy, defaultNodePort *corev1.Service) (int32, error) {
+	switch strategy.Type {
+	case operatorv1.NodePortServiceStrategyType:
+		if defaultNodePort == nil {
+			return 0, fmt.Errorf("unable to detect default ingress NodePort https port: NodePort service not found")
+		}
+		for _, port := range defaultNodePort.Spec.Ports {
+			if port.Port == 443 && port.NodePort != 0 {
+				return port.NodePort, nil
+			}
+		}
+		return 0, fmt.Errorf("unable to detect default ingress NodePort https port")
+	case operatorv1.HostNetworkStrategyType:
+		// With HostNetwork the routers bind directly on the node network on
+		// the configured HTTPS port (443 by default).
+		if strategy.HostNetwork != nil && strategy.HostNetwork.HTTPSPort != 0 {
+			return strategy.HostNetwork.HTTPSPort, nil
+		}
+		return 443, nil
+	default:
+		return 0, fmt.Errorf("default ingress passthrough is not supported for endpoint publishing strategy %q", strategy.Type)
+	}
+}
+
+func ReconcileDefaultIngressPassthroughService(service *corev1.Service, defaultNodePort *corev1.Service, strategy *operatorv1.EndpointPublishingStrategy, hcp *hyperv1.HostedControlPlane) error {
+	if strategy == nil {
+		strategy = &operatorv1.EndpointPublishingStrategy{Type: operatorv1.NodePortServiceStrategyType}
+	}
+	targetPort, err := passthroughHTTPSTargetPort(strategy, defaultNodePort)
+	if err != nil {
+		return fmt.Errorf("failed to resolve default ingress passthrough https target port: %w", err)
 	}
 
 	if service.Labels == nil {
@@ -159,7 +203,7 @@ func ReconcileDefaultIngressPassthroughService(service *corev1.Service, defaultN
 			Name:       "https-443",
 			Protocol:   corev1.ProtocolTCP,
 			Port:       443,
-			TargetPort: intstr.FromInt(int(detectedHTTPSNodePort)),
+			TargetPort: intstr.FromInt(int(targetPort)),
 		},
 	}
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
@@ -1059,3 +1059,184 @@ func TestReconcileDefaultIngressControllerCertSecret(t *testing.T) {
 		})
 	}
 }
+
+func TestEffectiveEndpointPublishingStrategy(t *testing.T) {
+	hostNetwork := &operatorv1.EndpointPublishingStrategy{Type: operatorv1.HostNetworkStrategyType}
+	nodePort := &operatorv1.EndpointPublishingStrategy{Type: operatorv1.NodePortServiceStrategyType}
+	loadBalancer := &operatorv1.EndpointPublishingStrategy{Type: operatorv1.LoadBalancerServiceStrategyType}
+
+	hcpWith := func(s *operatorv1.EndpointPublishingStrategy) *hyperv1.HostedControlPlane {
+		return &hyperv1.HostedControlPlane{Spec: hyperv1.HostedControlPlaneSpec{
+			OperatorConfiguration: &hyperv1.OperatorConfiguration{
+				IngressOperator: &hyperv1.IngressOperatorSpec{EndpointPublishingStrategy: s},
+			},
+		}}
+	}
+
+	tests := []struct {
+		name              string
+		ingressController *operatorv1.IngressController
+		hcp               *hyperv1.HostedControlPlane
+		expected          operatorv1.EndpointPublishingStrategyType
+	}{
+		{
+			name:     "When ingress controller and hcp are nil, it should default to NodePortService",
+			expected: operatorv1.NodePortServiceStrategyType,
+		},
+		{
+			name:     "When ingress controller is nil and hcp has no configuration, it should default to NodePortService",
+			hcp:      &hyperv1.HostedControlPlane{},
+			expected: operatorv1.NodePortServiceStrategyType,
+		},
+		{
+			name:     "When ingress controller is nil and hcp has a configuration, it should use the hcp strategy",
+			hcp:      hcpWith(hostNetwork),
+			expected: operatorv1.HostNetworkStrategyType,
+		},
+		{
+			name: "When ingress controller spec and hcp have a strategy, it should prefer the ingress controller spec",
+			ingressController: &operatorv1.IngressController{Spec: operatorv1.IngressControllerSpec{
+				EndpointPublishingStrategy: loadBalancer,
+			}},
+			hcp:      hcpWith(hostNetwork),
+			expected: operatorv1.LoadBalancerServiceStrategyType,
+		},
+		{
+			name: "When ingress controller status and spec have a strategy, it should prefer the status",
+			ingressController: &operatorv1.IngressController{
+				Spec:   operatorv1.IngressControllerSpec{EndpointPublishingStrategy: nodePort},
+				Status: operatorv1.IngressControllerStatus{EndpointPublishingStrategy: hostNetwork},
+			},
+			hcp:      hcpWith(loadBalancer),
+			expected: operatorv1.HostNetworkStrategyType,
+		},
+		{
+			name: "When ingress controller status has a strategy with empty type, it should fall through to the spec",
+			ingressController: &operatorv1.IngressController{
+				Spec:   operatorv1.IngressControllerSpec{EndpointPublishingStrategy: hostNetwork},
+				Status: operatorv1.IngressControllerStatus{EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{}},
+			},
+			hcp:      hcpWith(loadBalancer),
+			expected: operatorv1.HostNetworkStrategyType,
+		},
+		{
+			name: "When ingress controller status and spec have strategies with empty type, it should fall through to the hcp",
+			ingressController: &operatorv1.IngressController{
+				Spec:   operatorv1.IngressControllerSpec{EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{}},
+				Status: operatorv1.IngressControllerStatus{EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{}},
+			},
+			hcp:      hcpWith(hostNetwork),
+			expected: operatorv1.HostNetworkStrategyType,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			got := EffectiveEndpointPublishingStrategy(tt.ingressController, tt.hcp)
+			g.Expect(got).ToNot(BeNil())
+			g.Expect(got.Type).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestReconcileDefaultIngressPassthroughService(t *testing.T) {
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "hc", Namespace: "clusters-hc"},
+		Spec:       hyperv1.HostedControlPlaneSpec{InfraID: "hc-infra"},
+	}
+	nodePortService := &corev1.Service{Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{
+		{Name: "http", Port: 80, NodePort: 30080},
+		{Name: "https", Port: 443, NodePort: 30443},
+	}}}
+
+	tests := []struct {
+		name               string
+		strategy           *operatorv1.EndpointPublishingStrategy
+		nodePortService    *corev1.Service
+		expectedTargetPort int32
+		expectedErr        string
+	}{
+		{
+			name:               "When strategy is NodePortService, it should target the https nodePort",
+			strategy:           &operatorv1.EndpointPublishingStrategy{Type: operatorv1.NodePortServiceStrategyType},
+			nodePortService:    nodePortService,
+			expectedTargetPort: 30443,
+		},
+		{
+			name:               "When strategy is nil, it should default to NodePortService and target the https nodePort",
+			nodePortService:    nodePortService,
+			expectedTargetPort: 30443,
+		},
+		{
+			name:            "When strategy is NodePortService and the nodeport service is missing, it should fail",
+			strategy:        &operatorv1.EndpointPublishingStrategy{Type: operatorv1.NodePortServiceStrategyType},
+			nodePortService: nil,
+			expectedErr:     "unable to detect default ingress NodePort https port",
+		},
+		{
+			name:     "When strategy is NodePortService and the https port is missing, it should fail",
+			strategy: &operatorv1.EndpointPublishingStrategy{Type: operatorv1.NodePortServiceStrategyType},
+			nodePortService: &corev1.Service{Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{
+				{Name: "http", Port: 80, NodePort: 30080},
+			}}},
+			expectedErr: "unable to detect default ingress NodePort https port",
+		},
+		{
+			name:     "When strategy is NodePortService and the https port has no nodePort allocated, it should fail",
+			strategy: &operatorv1.EndpointPublishingStrategy{Type: operatorv1.NodePortServiceStrategyType},
+			nodePortService: &corev1.Service{Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{
+				{Name: "https", Port: 443, NodePort: 0},
+			}}},
+			expectedErr: "unable to detect default ingress NodePort https port",
+		},
+		{
+			name:               "When strategy is HostNetwork without ports, it should target port 443",
+			strategy:           &operatorv1.EndpointPublishingStrategy{Type: operatorv1.HostNetworkStrategyType},
+			expectedTargetPort: 443,
+		},
+		{
+			name: "When strategy is HostNetwork with empty ports, it should target port 443",
+			strategy: &operatorv1.EndpointPublishingStrategy{
+				Type:        operatorv1.HostNetworkStrategyType,
+				HostNetwork: &operatorv1.HostNetworkStrategy{},
+			},
+			expectedTargetPort: 443,
+		},
+		{
+			name: "When strategy is HostNetwork with httpsPort, it should target the configured httpsPort",
+			strategy: &operatorv1.EndpointPublishingStrategy{
+				Type:        operatorv1.HostNetworkStrategyType,
+				HostNetwork: &operatorv1.HostNetworkStrategy{HTTPPort: 80, HTTPSPort: 8443, StatsPort: 1936},
+			},
+			// The nodeport service must be ignored for HostNetwork.
+			nodePortService:    nodePortService,
+			expectedTargetPort: 8443,
+		},
+		{
+			name:        "When strategy is unsupported, it should fail",
+			strategy:    &operatorv1.EndpointPublishingStrategy{Type: operatorv1.LoadBalancerServiceStrategyType},
+			expectedErr: "not supported for endpoint publishing strategy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			service := manifests.IngressDefaultIngressPassthroughService("clusters-hc")
+			err := ReconcileDefaultIngressPassthroughService(service, tt.nodePortService, tt.strategy, hcp)
+			if tt.expectedErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectedErr))
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			g.Expect(service.Spec.Selector).To(BeEmpty())
+			g.Expect(service.Labels).To(HaveKeyWithValue(hyperv1.InfraIDLabel, "hc-infra"))
+			g.Expect(service.Spec.Ports).To(HaveLen(1))
+			g.Expect(service.Spec.Ports[0].Name).To(Equal("https-443"))
+			g.Expect(service.Spec.Ports[0].Port).To(Equal(int32(443)))
+			g.Expect(service.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+			g.Expect(service.Spec.Ports[0].TargetPort.IntValue()).To(Equal(int(tt.expectedTargetPort)))
+		})
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1448,17 +1448,23 @@ func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv
 		// Here we are creating a route and service in the hosted control plane namespace
 		// while in the HCCO (which typically only works on the guest client, not the mgmt client).
 		//
-		// This is being done in the HCCO because we have to get the NodePort's port used by the
-		// default ingress services in the guest cluster in order to create the service in the
+		// This is being done in the HCCO because we have to know the port on the guest nodes
+		// where the default ingress routers listen in order to create the service in the
 		// mgmt/infra cluster. basically, the mgmt cluster service has to point the backend
-		// "somewhere", and that somewhere is the nodeport's port of the routers in the guest cluster.
-		// The component that can get that information about the nodeport's port is the HCCO, so
-		// that's why we're reconciling a service and route within hosted control plane in the HCCO
+		// "somewhere", and that somewhere is either the nodeport's port of the routers in the
+		// guest cluster (NodePortService strategy) or the routers' host network https port
+		// (HostNetwork strategy). The component that can get that information is the HCCO,
+		// so that's why we're reconciling a service and route within hosted control plane in the HCCO
 
-		defaultIngressNodePortService := manifests.IngressDefaultIngressNodePortService()
-		err := r.client.Get(ctx, client.ObjectKeyFromObject(defaultIngressNodePortService), defaultIngressNodePortService)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to retrieve guest cluster ingress NodePort: %w", err))
+		strategy := ingress.EffectiveEndpointPublishingStrategy(ingressController, hcp)
+
+		var defaultIngressNodePortService *corev1.Service
+		if strategy.Type == operatorv1.NodePortServiceStrategyType {
+			defaultIngressNodePortService = manifests.IngressDefaultIngressNodePortService()
+			if err := r.client.Get(ctx, client.ObjectKeyFromObject(defaultIngressNodePortService), defaultIngressNodePortService); err != nil {
+				errs = append(errs, fmt.Errorf("failed to retrieve guest cluster ingress NodePort: %w", err))
+				return utilerrors.NewAggregate(errs)
+			}
 		}
 
 		var namespace string
@@ -1483,7 +1489,7 @@ func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv
 			hcp.Spec.Platform.Kubevirt.GenerateID)
 
 		if _, err := r.CreateOrUpdate(ctx, r.kubevirtInfraClient, cpService, func() error {
-			return ingress.ReconcileDefaultIngressPassthroughService(cpService, defaultIngressNodePortService, hcp)
+			return ingress.ReconcileDefaultIngressPassthroughService(cpService, defaultIngressNodePortService, strategy, hcp)
 		}); err != nil {
 			errs = append(errs, fmt.Errorf("failed to reconcile kubevirt ingress passthrough service: %w", err))
 		}

--- a/docs/content/how-to/kubevirt/ingress-and-dns.md
+++ b/docs/content/how-to/kubevirt/ingress-and-dns.md
@@ -32,6 +32,51 @@ be `*.apps.guest.apps.mgmt-cluster.example.com`.
     limitation only applies to the default ingress behavior and not the custom ingress
     behavior where manual creation of an ingress LoadBalancer and DNS is performed.
 
+### How the default ingress passthrough works
+
+The default ingress passthrough is implemented in the infra cluster namespace
+where the KubeVirt VMs run with:
+
+- A selector-less `ClusterIP` Service (`default-ingress-passthrough-service-<id>`)
+  exposing port `443`.
+- `EndpointSlice`s for that Service, one per worker VM, pointing at the VM
+  internal IPs and the port where the guest routers listen.
+- A wildcard passthrough `Route` (`default-ingress-passthrough-route-<id>`) for
+  `*.apps.<guest>.<infra base domain>` targeting that Service.
+
+The port targeted on the VMs depends on the guest default `IngressController`
+`endpointPublishingStrategy`:
+
+- `NodePortService` (default for KubeVirt): the HTTPS `nodePort` of the
+  `openshift-ingress/router-nodeport-default` Service in the guest cluster.
+- `HostNetwork`: the `hostNetwork.httpsPort` (defaults to `443`). This strategy
+  can be selected at creation time through
+  `spec.operatorConfiguration.ingressOperator.endpointPublishingStrategy` in the
+  `HostedCluster`, for example:
+
+    ```yaml
+    spec:
+      operatorConfiguration:
+        ingressOperator:
+          endpointPublishingStrategy:
+            type: HostNetwork
+            hostNetwork:
+              httpPort: 80
+              httpsPort: 443
+              statsPort: 1936
+              protocol: TCP
+    ```
+
+!!! note
+
+    With `HostNetwork`, every running worker VM is added as an endpoint. Only the
+    nodes where a router pod is scheduled accept connections; the infra cluster
+    router health checks exclude the other endpoints.
+
+Other endpoint publishing strategies (e.g. `LoadBalancerService`) are not
+supported by the default ingress passthrough; use the customized ingress
+behavior described below instead.
+
 ## Customized Ingress and DNS Behavior
 
 In lieu of the default ingress and DNS behavior, it is also possible to

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -28158,6 +28158,51 @@ be `*.apps.guest.apps.mgmt-cluster.example.com`.
     limitation only applies to the default ingress behavior and not the custom ingress
     behavior where manual creation of an ingress LoadBalancer and DNS is performed.
 
+### How the default ingress passthrough works
+
+The default ingress passthrough is implemented in the infra cluster namespace
+where the KubeVirt VMs run with:
+
+- A selector-less `ClusterIP` Service (`default-ingress-passthrough-service-<id>`)
+  exposing port `443`.
+- `EndpointSlice`s for that Service, one per worker VM, pointing at the VM
+  internal IPs and the port where the guest routers listen.
+- A wildcard passthrough `Route` (`default-ingress-passthrough-route-<id>`) for
+  `*.apps.<guest>.<infra base domain>` targeting that Service.
+
+The port targeted on the VMs depends on the guest default `IngressController`
+`endpointPublishingStrategy`:
+
+- `NodePortService` (default for KubeVirt): the HTTPS `nodePort` of the
+  `openshift-ingress/router-nodeport-default` Service in the guest cluster.
+- `HostNetwork`: the `hostNetwork.httpsPort` (defaults to `443`). This strategy
+  can be selected at creation time through
+  `spec.operatorConfiguration.ingressOperator.endpointPublishingStrategy` in the
+  `HostedCluster`, for example:
+
+    ```yaml
+    spec:
+      operatorConfiguration:
+        ingressOperator:
+          endpointPublishingStrategy:
+            type: HostNetwork
+            hostNetwork:
+              httpPort: 80
+              httpsPort: 443
+              statsPort: 1936
+              protocol: TCP
+    ```
+
+!!! note
+
+    With `HostNetwork`, every running worker VM is added as an endpoint. Only the
+    nodes where a router pod is scheduled accept connections; the infra cluster
+    router health checks exclude the other endpoints.
+
+Other endpoint publishing strategies (e.g. `LoadBalancerService`) are not
+supported by the default ingress passthrough; use the customized ingress
+behavior described below instead.
+
 ## Customized Ingress and DNS Behavior
 
 In lieu of the default ingress and DNS behavior, it is also possible to

--- a/test/e2e/nodepool_kv_hostnetwork_ingress_test.go
+++ b/test/e2e/nodepool_kv_hostnetwork_ingress_test.go
@@ -1,0 +1,171 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hcpmanifests "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// kubevirtHostNetworkIngressHTTPSPort is the host network https port
+	// configured at the default ingress controller for the HostNetwork
+	// passthrough e2e test. A non default value is used so the test can tell
+	// it apart from the passthrough service port.
+	kubevirtHostNetworkIngressHTTPSPort int32 = 8443
+)
+
+// kubevirtHostNetworkIngressBeforeApply returns a BeforeApply hook that
+// configures the HostedCluster default ingress controller to use the
+// HostNetwork endpoint publishing strategy.
+func kubevirtHostNetworkIngressBeforeApply(original func(crclient.Object)) func(crclient.Object) {
+	return func(o crclient.Object) {
+		if original != nil {
+			original(o)
+		}
+		hc, ok := o.(*hyperv1.HostedCluster)
+		if !ok {
+			return
+		}
+		if hc.Spec.OperatorConfiguration == nil {
+			hc.Spec.OperatorConfiguration = &hyperv1.OperatorConfiguration{}
+		}
+		if hc.Spec.OperatorConfiguration.IngressOperator == nil {
+			hc.Spec.OperatorConfiguration.IngressOperator = &hyperv1.IngressOperatorSpec{}
+		}
+		hc.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+			Type: operatorv1.HostNetworkStrategyType,
+			HostNetwork: &operatorv1.HostNetworkStrategy{
+				Protocol:  operatorv1.TCPProtocol,
+				HTTPPort:  80,
+				HTTPSPort: kubevirtHostNetworkIngressHTTPSPort,
+				StatsPort: 1936,
+			},
+		}
+	}
+}
+
+// KubeVirtHostNetworkIngressPassthroughTest validates that the default
+// ingress passthrough (Service, EndpointSlices and Route at the infra cluster)
+// is properly reconciled when the guest default ingress controller uses the
+// HostNetwork endpoint publishing strategy.
+type KubeVirtHostNetworkIngressPassthroughTest struct {
+	DummyInfraSetup
+	infra        e2eutil.KubeVirtInfra
+	guestClient  crclient.Client
+	nodePoolName string
+}
+
+func NewKubeVirtHostNetworkIngressPassthroughTest(ctx context.Context, mgmtClient crclient.Client, hc *hyperv1.HostedCluster, guestClient crclient.Client) NodePoolTest {
+	return &KubeVirtHostNetworkIngressPassthroughTest{
+		infra:        e2eutil.NewKubeVirtInfra(ctx, mgmtClient, hc),
+		guestClient:  guestClient,
+		nodePoolName: hc.Name + "-" + "test-kv-hostnetwork-ingress",
+	}
+}
+
+func (k KubeVirtHostNetworkIngressPassthroughTest) Setup(t *testing.T) {
+	if globalOpts.Platform != hyperv1.KubevirtPlatform {
+		t.Skip("test only supported on KubeVirt platform")
+	}
+	hc := k.infra.HostedCluster()
+	if hc.Spec.Platform.Kubevirt == nil || !ptr.Deref(hc.Spec.Platform.Kubevirt.BaseDomainPassthrough, false) {
+		t.Skip("test only supported with kubevirt base domain passthrough")
+	}
+	t.Log("Starting test KubeVirtHostNetworkIngressPassthroughTest")
+}
+
+func (k KubeVirtHostNetworkIngressPassthroughTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {
+	nodePool := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k.nodePoolName,
+			Namespace: k.infra.HostedCluster().Namespace,
+		},
+	}
+	defaultNodepool.Spec.DeepCopyInto(&nodePool.Spec)
+	nodePool.Spec.Replicas = ptr.To[int32](1)
+	return nodePool, nil
+}
+
+func (k KubeVirtHostNetworkIngressPassthroughTest) Run(t *testing.T, nodePool hyperv1.NodePool, _ []corev1.Node) {
+	g := NewWithT(t)
+	ctx := k.infra.Ctx()
+	hc := k.infra.HostedCluster()
+
+	// The guest default ingress controller should report the HostNetwork strategy.
+	ingressController := hcpmanifests.IngressDefaultIngressController()
+	e2eutil.EventuallyObject(t, ctx, "default ingress controller to use HostNetwork strategy",
+		func(ctx context.Context) (*operatorv1.IngressController, error) {
+			err := k.guestClient.Get(ctx, crclient.ObjectKeyFromObject(ingressController), ingressController)
+			return ingressController, err
+		},
+		[]e2eutil.Predicate[*operatorv1.IngressController]{
+			func(ic *operatorv1.IngressController) (bool, string, error) {
+				strategy := ic.Status.EndpointPublishingStrategy
+				if strategy == nil {
+					return false, "status.endpointPublishingStrategy not set yet", nil
+				}
+				if strategy.Type != operatorv1.HostNetworkStrategyType {
+					return false, fmt.Sprintf("status.endpointPublishingStrategy.type is %q", strategy.Type), nil
+				}
+				return true, "status.endpointPublishingStrategy.type is HostNetwork", nil
+			},
+		},
+	)
+
+	infraClient, err := k.infra.DiscoverClient()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Every machine of the nodepool should have a ready EndpointSlice
+	// with the machine internal IP and the host network https port.
+	machines := &capiv1.MachineList{}
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name)
+	g.Expect(k.infra.MGMTClient().List(ctx, machines, crclient.InNamespace(hcpNamespace),
+		crclient.MatchingLabels{capiv1.MachineDeploymentNameLabel: nodePool.Name})).To(Succeed())
+	g.Expect(machines.Items).To(HaveLen(1))
+
+	g.Eventually(func() error {
+		return e2eutil.ValidateKubeVirtIngressPassthrough(ctx, infraClient, k.infra.Namespace(), hc, machines.Items, kubevirtHostNetworkIngressHTTPSPort)
+	}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Succeed())
+
+	// Finally verify traffic flows end to end through the infra router,
+	// the passthrough Route/Service and the guest router bound on the host
+	// network by completing a TLS handshake against the guest console.
+	consoleHost := fmt.Sprintf("console-openshift-console.apps.%s.%s", hc.Name, hc.Spec.DNS.BaseDomain)
+	t.Logf("Checking TLS handshake with %s through the default ingress passthrough", consoleHost)
+	g.Eventually(func(ctx context.Context) error {
+		dialer := &tls.Dialer{
+			NetDialer: &net.Dialer{Timeout: 10 * time.Second},
+			Config: &tls.Config{
+				ServerName:         consoleHost,
+				InsecureSkipVerify: true, //nolint:gosec // we only care about reaching the guest router
+			},
+		}
+		conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(consoleHost, "443"))
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	}).WithTimeout(10*time.Minute).WithPolling(15*time.Second).WithContext(ctx).Should(Succeed(),
+		"should complete a TLS handshake with the guest console through the default ingress passthrough")
+}

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -32,6 +32,9 @@ var (
 type HostedClusterNodePoolTestCases struct {
 	build HostedClusterNodePoolTestCasesBuilderFn
 	setup func(t *testing.T)
+	// mutateClusterOpts allows customizing the HostedCluster creation
+	// options before the HostedCluster for these test cases is created.
+	mutateClusterOpts func(clusterOpts *e2eutil.PlatformAgnosticOptions)
 }
 
 type HostedClusterNodePoolTestCasesBuilderFn func(ctx context.Context, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts e2eutil.PlatformAgnosticOptions) []NodePoolTestCase
@@ -155,18 +158,36 @@ func TestNodePool(t *testing.T) {
 				}
 			},
 		},
-		// This kubevirt test need to run at different hosted cluster
+		// This kubevirt test need to run at different hosted cluster.
+		// The hosted cluster is created with the default ingress controller
+		// using the HostNetwork endpoint publishing strategy so the default
+		// ingress passthrough is exercised with it too.
+		//
+		// KubeVirtNodeAdvancedMultinetTest is compatible with HostNetwork: it
+		// builds its custom EndpointSlice from the passthrough Service
+		// targetPort read at runtime (whatever the strategy resolves it to)
+		// and its DNAT rule at the dnsmasq proxy pod is port-agnostic, so
+		// traffic still reaches the guest router bound on the host network.
 		{
 			setup: func(t *testing.T) {
 				if globalOpts.Platform != hyperv1.KubevirtPlatform {
 					t.Skip("tests only supported on platform KubeVirt")
 				}
 			},
+			mutateClusterOpts: func(clusterOpts *e2eutil.PlatformAgnosticOptions) {
+				clusterOpts.BeforeApply = kubevirtHostNetworkIngressBeforeApply(clusterOpts.BeforeApply)
+			},
 			build: func(ctx context.Context, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts e2eutil.PlatformAgnosticOptions) []NodePoolTestCase {
-				return []NodePoolTestCase{{
-					name: "KubeVirtNodeAdvancedMultinetTest",
-					test: NewKubeVirtAdvancedMultinetTest(ctx, mgtClient, hostedCluster),
-				}}
+				return []NodePoolTestCase{
+					{
+						name: "KubeVirtNodeAdvancedMultinetTest",
+						test: NewKubeVirtAdvancedMultinetTest(ctx, mgtClient, hostedCluster),
+					},
+					{
+						name: "KubeVirtHostNetworkIngressPassthroughTest",
+						test: NewKubeVirtHostNetworkIngressPassthroughTest(ctx, mgtClient, hostedCluster, hostedClusterClient),
+					},
+				}
 			},
 		},
 		{
@@ -232,6 +253,10 @@ func executeNodePoolTests(t *testing.T, nodePoolTestCasesPerHostedCluster []Host
 			// will be marked as degraded.
 			if globalOpts.Platform == hyperv1.OpenStackPlatform {
 				clusterOpts.NodePoolReplicas = 1
+			}
+
+			if nodePoolTestCases.mutateClusterOpts != nil {
+				nodePoolTestCases.mutateClusterOpts(&clusterOpts)
 			}
 
 			ctx, cancel := context.WithCancel(testContext)

--- a/test/e2e/util/kubevirt_ingress.go
+++ b/test/e2e/util/kubevirt_ingress.go
@@ -1,0 +1,106 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hcpmanifests "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+
+	routev1 "github.com/openshift/api/route/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ValidateKubeVirtIngressPassthrough checks the Service, managed EndpointSlices
+// for the supplied machines, and Route without polling or mutating resources.
+// Callers supply the expected HTTPS port independently of the observed Service.
+func ValidateKubeVirtIngressPassthrough(ctx context.Context, infraClient crclient.Reader, namespace string, hc *hyperv1.HostedCluster, machines []capiv1.Machine, httpsPort int32) error {
+	if hc == nil || hc.Spec.Platform.Type != hyperv1.KubevirtPlatform || hc.Spec.Platform.Kubevirt == nil || hc.Spec.Platform.Kubevirt.GenerateID == "" {
+		return fmt.Errorf("expected a KubeVirt HostedCluster with a GenerateID")
+	}
+	if len(machines) == 0 {
+		return fmt.Errorf("expected at least one machine to validate passthrough endpoints")
+	}
+	svc := hcpmanifests.IngressDefaultIngressPassthroughService(namespace)
+	svc.Name = hcpmanifests.IngressDefaultIngressPassthroughServiceName + "-" + hc.Spec.Platform.Kubevirt.GenerateID
+	if err := infraClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc); err != nil {
+		return fmt.Errorf("getting passthrough Service: %w", err)
+	}
+	if svc.Spec.Type != corev1.ServiceTypeClusterIP || len(svc.Spec.Selector) != 0 {
+		return fmt.Errorf("service %s/%s must be a selector-less ClusterIP", namespace, svc.Name)
+	}
+	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 443 || svc.Spec.Ports[0].Protocol != corev1.ProtocolTCP || svc.Spec.Ports[0].TargetPort != intstr.FromInt32(httpsPort) {
+		return fmt.Errorf("service %s/%s must expose TCP 443 targeting %d, got %v", namespace, svc.Name, httpsPort, svc.Spec.Ports)
+	}
+	if len(svc.Spec.IPFamilies) == 0 {
+		return fmt.Errorf("service %s/%s has no IP families", namespace, svc.Name)
+	}
+	for _, machine := range machines {
+		if err := validateKubeVirtIngressMachineEndpoints(ctx, infraClient, svc, machine, httpsPort); err != nil {
+			return err
+		}
+	}
+	route := hcpmanifests.IngressDefaultIngressPassthroughRoute(namespace)
+	route.Name = hcpmanifests.IngressDefaultIngressPassthroughRouteName + "-" + hc.Spec.Platform.Kubevirt.GenerateID
+	if err := infraClient.Get(ctx, crclient.ObjectKeyFromObject(route), route); err != nil {
+		return fmt.Errorf("getting passthrough Route: %w", err)
+	}
+	if route.Spec.To.Kind != "Service" || route.Spec.To.Name != svc.Name || route.Spec.Host != fmt.Sprintf("https.apps.%s.%s", hc.Name, hc.Spec.DNS.BaseDomain) || route.Spec.WildcardPolicy != routev1.WildcardPolicySubdomain || route.Spec.TLS == nil || route.Spec.TLS.Termination != routev1.TLSTerminationPassthrough {
+		return fmt.Errorf("route %s/%s must be a wildcard TLS passthrough to Service %s", namespace, route.Name, svc.Name)
+	}
+	return nil
+}
+
+func validateKubeVirtIngressMachineEndpoints(ctx context.Context, infraClient crclient.Reader, svc *corev1.Service, machine capiv1.Machine, httpsPort int32) error {
+	readyEndpoint := false
+	for _, family := range svc.Spec.IPFamilies {
+		// CAPK may report multiple addresses per family; HCCO uses the first
+		// non-link-local internal address, not every interface on the VM.
+		expectedAddress := ""
+		for _, address := range machine.Status.Addresses {
+			ip, err := netip.ParseAddr(address.Address)
+			if address.Type != capiv1.MachineInternalIP || err != nil || ip.IsLinkLocalUnicast() {
+				continue
+			}
+			if (family == corev1.IPv4Protocol && ip.Is4()) || (family == corev1.IPv6Protocol && ip.Is6()) {
+				expectedAddress = address.Address
+				break
+			}
+		}
+		slice := &discoveryv1.EndpointSlice{}
+		key := crclient.ObjectKey{Namespace: svc.Namespace, Name: svc.Name + "-" + machine.Name + "-" + strings.ToLower(string(family))}
+		if err := infraClient.Get(ctx, key, slice); err != nil {
+			return fmt.Errorf("getting EndpointSlice %s: %w", key, err)
+		}
+		if slice.Labels[discoveryv1.LabelServiceName] != svc.Name || slice.Labels[discoveryv1.LabelManagedBy] != "control-plane-operator.hypershift.openshift.io" || slice.AddressType != discoveryv1.AddressType(family) {
+			return fmt.Errorf("EndpointSlice %s has incorrect labels or address type", key)
+		}
+		if len(slice.Ports) != 1 || ptr.Deref(slice.Ports[0].Port, 0) != httpsPort || ptr.Deref(slice.Ports[0].Name, "") != svc.Spec.Ports[0].Name || ptr.Deref(slice.Ports[0].Protocol, "") != corev1.ProtocolTCP {
+			return fmt.Errorf("EndpointSlice %s ports do not match the passthrough Service", key)
+		}
+		if expectedAddress == "" && len(slice.Endpoints) == 0 {
+			continue
+		}
+		if expectedAddress == "" || len(slice.Endpoints) != 1 || len(slice.Endpoints[0].Addresses) != 1 || slice.Endpoints[0].Addresses[0] != expectedAddress {
+			return fmt.Errorf("EndpointSlice %s must contain machine internal address %q", key, expectedAddress)
+		}
+		endpoint := slice.Endpoints[0]
+		if !ptr.Deref(endpoint.Conditions.Ready, false) || !ptr.Deref(endpoint.Conditions.Serving, false) {
+			return fmt.Errorf("EndpointSlice %s is not ready/serving", key)
+		}
+		readyEndpoint = true
+	}
+	if !readyEndpoint {
+		return fmt.Errorf("machine %s has no ready passthrough endpoint", machine.Name)
+	}
+	return nil
+}

--- a/test/e2e/util/kubevirt_ingress_test.go
+++ b/test/e2e/util/kubevirt_ingress_test.go
@@ -1,0 +1,112 @@
+package util
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	routev1 "github.com/openshift/api/route/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestValidateKubeVirtIngressPassthrough(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		mutate        func(*corev1.Service, *discoveryv1.EndpointSlice, *routev1.Route)
+		noMachines    bool
+		missingRoute  bool
+		ipv6          bool
+		defaultPort   bool
+		expectedError string
+	}{
+		{name: "When resources target the configured port, it should pass"},
+		{name: "When resources use IPv6, it should validate IPv6 endpoints", ipv6: true},
+		{name: "When resources target the default HTTPS port, it should pass", defaultPort: true},
+		{name: "When no machines are supplied, it should fail", noMachines: true, expectedError: "at least one machine"},
+		{name: "When the service targets the wrong port, it should fail", mutate: func(s *corev1.Service, _ *discoveryv1.EndpointSlice, _ *routev1.Route) {
+			s.Spec.Ports[0].TargetPort = intstr.FromInt32(443)
+		}, expectedError: "targeting 8443"},
+		{name: "When the service has a selector, it should fail", mutate: func(s *corev1.Service, _ *discoveryv1.EndpointSlice, _ *routev1.Route) {
+			s.Spec.Selector = map[string]string{"app": "router"}
+		}, expectedError: "selector-less"},
+		{name: "When the endpoints have the wrong port, it should fail", mutate: func(_ *corev1.Service, e *discoveryv1.EndpointSlice, _ *routev1.Route) {
+			e.Ports[0].Port = ptr.To[int32](443)
+		}, expectedError: "ports do not match"},
+		{name: "When the slice has no endpoints, it should fail", mutate: func(_ *corev1.Service, e *discoveryv1.EndpointSlice, _ *routev1.Route) { e.Endpoints = nil }, expectedError: "machine internal address"},
+		{name: "When the endpoint address is wrong, it should fail", mutate: func(_ *corev1.Service, e *discoveryv1.EndpointSlice, _ *routev1.Route) {
+			e.Endpoints[0].Addresses = []string{"192.0.2.20"}
+		}, expectedError: "machine internal address"},
+		{name: "When the endpoint is not ready, it should fail", mutate: func(_ *corev1.Service, e *discoveryv1.EndpointSlice, _ *routev1.Route) {
+			e.Endpoints[0].Conditions.Ready = ptr.To(false)
+		}, expectedError: "not ready/serving"},
+		{name: "When the route lacks TLS, it should fail", mutate: func(_ *corev1.Service, _ *discoveryv1.EndpointSlice, r *routev1.Route) { r.Spec.TLS = nil }, expectedError: "wildcard TLS passthrough"},
+		{name: "When the route is missing, it should return the lookup error", missingRoute: true, expectedError: "getting passthrough Route"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			scheme := runtime.NewScheme()
+			g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			g.Expect(discoveryv1.AddToScheme(scheme)).To(Succeed())
+			g.Expect(routev1.AddToScheme(scheme)).To(Succeed())
+			hc := &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Name: "hc"}, Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{Type: hyperv1.KubevirtPlatform, Kubevirt: &hyperv1.KubevirtPlatformSpec{GenerateID: "test"}},
+				DNS:      hyperv1.DNSSpec{BaseDomain: "example.com"},
+			}}
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "default-ingress-passthrough-service-test"}, Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP, IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
+				Ports: []corev1.ServicePort{{Name: "https-443", Port: 443, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt32(8443)}},
+			}}
+			slice := &discoveryv1.EndpointSlice{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: svc.Name + "-machine-ipv4", Labels: map[string]string{
+				discoveryv1.LabelServiceName: svc.Name, discoveryv1.LabelManagedBy: "control-plane-operator.hypershift.openshift.io",
+			}}, AddressType: discoveryv1.AddressTypeIPv4,
+				Ports:     []discoveryv1.EndpointPort{{Name: ptr.To("https-443"), Port: ptr.To[int32](8443), Protocol: ptr.To(corev1.ProtocolTCP)}},
+				Endpoints: []discoveryv1.Endpoint{{Addresses: []string{"192.0.2.10"}, Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(true), Serving: ptr.To(true)}}},
+			}
+			route := &routev1.Route{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "default-ingress-passthrough-route-test"}, Spec: routev1.RouteSpec{
+				Host: "https.apps.hc.example.com", To: routev1.RouteTargetReference{Kind: "Service", Name: svc.Name},
+				WildcardPolicy: routev1.WildcardPolicySubdomain, TLS: &routev1.TLSConfig{Termination: routev1.TLSTerminationPassthrough},
+			}}
+			machines := []capiv1.Machine{{ObjectMeta: metav1.ObjectMeta{Name: "machine"}, Status: capiv1.MachineStatus{Addresses: []capiv1.MachineAddress{{Type: capiv1.MachineInternalIP, Address: "192.0.2.10"}}}}}
+			if tc.ipv6 {
+				svc.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol}
+				slice.Name = svc.Name + "-machine-ipv6"
+				slice.AddressType = discoveryv1.AddressTypeIPv6
+				slice.Endpoints[0].Addresses = []string{"2001:db8::10"}
+				machines[0].Status.Addresses[0].Address = "2001:db8::10"
+			}
+			expectedPort := int32(8443)
+			if tc.defaultPort {
+				expectedPort = 443
+				svc.Spec.Ports[0].TargetPort = intstr.FromInt32(expectedPort)
+				slice.Ports[0].Port = ptr.To(expectedPort)
+			}
+			if tc.noMachines {
+				machines = nil
+			}
+			if tc.mutate != nil {
+				tc.mutate(svc, slice, route)
+			}
+			builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(svc, slice)
+			if !tc.missingRoute {
+				builder.WithObjects(route)
+			}
+			err := ValidateKubeVirtIngressPassthrough(t.Context(), builder.Build(), "infra", hc, machines, expectedPort)
+			if tc.expectedError != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tc.expectedError)))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

The KubeVirt default ingress passthrough (Service + EndpointSlices + wildcard Route created by the HCCO in the infra namespace) hardcoded the Service `targetPort` to the https `nodePort` of the guest `openshift-ingress/router-nodeport-default` Service. When the default IngressController is configured with `endpointPublishingStrategy.type: HostNetwork` (via `spec.operatorConfiguration.ingressOperator`) that Service does not exist, the reconcile failed on every loop, and users had to manually create the Service/EndpointSlice/Route (see the workaround in [OCPSTRAT-2519](https://redhat.atlassian.net/browse/OCPSTRAT-2519)).

This PR makes the passthrough strategy-aware:
- Resolve the effective strategy from the guest IngressController (status → spec → HCP config → default `NodePortService`).
- `NodePortService`: keep using the https nodePort (unchanged behaviour).
- `HostNetwork`: target `hostNetwork.httpsPort` (443 by default) and skip fetching the NodePort Service.
- Other strategies: explicit error.

The `machine` controller EndpointSlices already take the port from the Service `targetPort` and cover every Running machine, so no change is required there.

E2E: instead of adding a new HostedCluster to the KubeVirt job, the existing KubeVirt-only HostedCluster in `TestNodePool` is now created with `HostNetwork` and a new `KubeVirtHostNetworkIngressPassthroughTest` validates the passthrough Service targetPort, the managed EndpointSlices, and a TLS handshake to the guest console through the infra router.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-2007

## Special notes for your reviewer:

- Out of scope: day-2 changes to `endpointPublishingStrategy` still do not propagate to an existing IngressController (`ReconcileDefaultIngressController` skips existing objects), so switching strategy on a running cluster still requires deleting the guest IngressController.
- With `HostNetwork` all Running machines are endpoints; nodes without a router pod are excluded by the infra router health checks rather than by filtering endpoints.
- The e2e TLS handshake assumes the runner can reach the management cluster public ingress (true for the AWS-hosted KubeVirt job). If it proves flaky it can be dropped, keeping the object-level assertions.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [x] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for KubeVirt ingress passthrough with the `HostNetwork` endpoint publishing strategy.
  * Improved endpoint strategy selection across supported configurations, with appropriate HTTPS port handling.
  * Added validation and clearer errors for missing services or ports and unsupported strategies.

* **Documentation**
  * Documented KubeVirt ingress passthrough architecture, endpoint strategies, health checks, and customization options.

* **Tests**
  * Added end-to-end coverage for HostNetwork ingress passthrough, endpoint readiness, and TLS connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->