### PR TITLE
[WIP] OCPBUGS-54574: fix(networkpolicy): allow Konnectivity, Ignition and OAUTH traffic for Cilium

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -209,7 +209,7 @@ func (r *HostedClusterReconciler) reconcileServiceNetworkPolicies(ctx context.Co
 }
 
 func (r *HostedClusterReconciler) reconcileOAuthNetworkPolicies(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, svc hyperv1.ServicePublishingStrategyMapping, controlPlaneNamespaceName string) error {
-	if svc.ServicePublishingStrategy.Type == hyperv1.NodePort {
+	if svc.ServicePublishingStrategy.Type == hyperv1.NodePort || svc.ServicePublishingStrategy.Type == hyperv1.Route {
 		policy := networkpolicy.NodePortOauthNetworkPolicy(controlPlaneNamespaceName)
 		if _, err := createOrUpdate(ctx, r.Client, policy, func() error {
 			return reconcileNodePortOauthNetworkPolicy(policy, hcluster)

--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -229,7 +229,7 @@ func (r *HostedClusterReconciler) reconcileOAuthNetworkPolicies(ctx context.Cont
 }
 
 func (r *HostedClusterReconciler) reconcileIgnitionNetworkPolicies(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, svc hyperv1.ServicePublishingStrategyMapping, controlPlaneNamespaceName string) error {
-	if svc.ServicePublishingStrategy.Type != hyperv1.NodePort {
+	if svc.ServicePublishingStrategy.Type != hyperv1.NodePort && svc.ServicePublishingStrategy.Type != hyperv1.Route {
 		return nil
 	}
 	policy := networkpolicy.NodePortIgnitionNetworkPolicy(controlPlaneNamespaceName)

--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -248,7 +248,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionNetworkPolicies(ctx context.C
 }
 
 func (r *HostedClusterReconciler) reconcileKonnectivityNetworkPolicies(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, svc hyperv1.ServicePublishingStrategyMapping, controlPlaneNamespaceName string) error {
-	if svc.ServicePublishingStrategy.Type != hyperv1.NodePort {
+	if svc.ServicePublishingStrategy.Type != hyperv1.NodePort && svc.ServicePublishingStrategy.Type != hyperv1.Route {
 		return nil
 	}
 	policy := networkpolicy.NodePortKonnectivityNetworkPolicy(controlPlaneNamespaceName)

--- a/hypershift-operator/controllers/hostedcluster/network_policies_test.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies_test.go
@@ -1117,9 +1117,9 @@ func TestReconcileOAuthNetworkPolicies(t *testing.T) {
 			expectLoadBalancerOauth: true,
 		},
 		{
-			name:                    "When OAuth uses Route, it should create no OAuth policies",
+			name:                    "When OAuth uses Route, it should create nodeport-oauth policy only",
 			serviceType:             hyperv1.Route,
-			expectNodePortOauth:     false,
+			expectNodePortOauth:     true,
 			expectLoadBalancerOauth: false,
 		},
 	}

--- a/hypershift-operator/controllers/hostedcluster/network_policies_test.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies_test.go
@@ -1012,14 +1012,14 @@ func TestReconcileServiceNetworkPolicies(t *testing.T) {
 			expectedPolicies: []string{"nodeport-konnectivity", "nodeport-konnectivity-kas"},
 		},
 		{
-			name: "When Konnectivity uses Route, it should not create konnectivity policies",
+			name: "When Konnectivity uses Route, it should create konnectivity and konnectivity-kas policies",
 			services: []hyperv1.ServicePublishingStrategyMapping{
 				{
 					Service:                   hyperv1.Konnectivity,
 					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route},
 				},
 			},
-			absentPolicies: []string{"nodeport-konnectivity", "nodeport-konnectivity-kas"},
+			expectedPolicies: []string{"nodeport-konnectivity", "nodeport-konnectivity-kas"},
 		},
 		{
 			name: "When multiple services use NodePort, it should create all corresponding policies",
@@ -1265,10 +1265,10 @@ func TestReconcileKonnectivityNetworkPolicies(t *testing.T) {
 			expectKonnectivityKAS: true,
 		},
 		{
-			name:                  "When Konnectivity uses Route, it should create no konnectivity policies",
+			name:                  "When Konnectivity uses Route, it should create both konnectivity and konnectivity-kas policies",
 			serviceType:           hyperv1.Route,
-			expectKonnectivity:    false,
-			expectKonnectivityKAS: false,
+			expectKonnectivity:    true,
+			expectKonnectivityKAS: true,
 		},
 		{
 			name:                  "When Konnectivity uses LoadBalancer, it should create no konnectivity policies",

--- a/hypershift-operator/controllers/hostedcluster/network_policies_test.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies_test.go
@@ -992,14 +992,14 @@ func TestReconcileServiceNetworkPolicies(t *testing.T) {
 			expectedPolicies: []string{"nodeport-ignition", "nodeport-ignition-proxy"},
 		},
 		{
-			name: "When Ignition uses Route, it should not create ignition policies",
+			name: "When Ignition uses Route, it should create ignition and ignition-proxy policies",
 			services: []hyperv1.ServicePublishingStrategyMapping{
 				{
 					Service:                   hyperv1.Ignition,
 					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route},
 				},
 			},
-			absentPolicies: []string{"nodeport-ignition", "nodeport-ignition-proxy"},
+			expectedPolicies: []string{"nodeport-ignition", "nodeport-ignition-proxy"},
 		},
 		{
 			name: "When Konnectivity uses NodePort, it should create konnectivity and konnectivity-kas policies",
@@ -1188,10 +1188,10 @@ func TestReconcileIgnitionNetworkPolicies(t *testing.T) {
 			expectIgnitionProxy: true,
 		},
 		{
-			name:                "When Ignition uses Route, it should create no ignition policies",
+			name:                "When Ignition uses Route, it should create both ignition and ignition-proxy policies",
 			serviceType:         hyperv1.Route,
-			expectIgnition:      false,
-			expectIgnitionProxy: false,
+			expectIgnition:      true,
+			expectIgnitionProxy: true,
 		},
 		{
 			name:                "When Ignition uses LoadBalancer, it should create no ignition policies",


### PR DESCRIPTION
## What this PR does / why we need it:

When Konnectivity uses a Route, traffic follows:
konnectivity agent -> konnectivity route (through management router) -> kube-apiserver:8091

  The management router might be host-networked (e.g. for baremetal management cluster). In this case, Cilium classifies it as host or remote-node traffic rather than as a Pod in the openshift-ingress namespace. The namespace-based ingress policy therefore does not authorize the router's connection to the KAS-hosted Konnectivity server and the traffic from konnectivity-agent in hosted cluster doesn't ready

  Reconcile the existing Konnectivity network policies for both Route and NodePort strategies so TCP/8091 is permitted on the relevant Konnectivity server endpoints.

  For Ignition, traffic from the ingress VIP through a router on another node to ignition-server-proxy is similarly dropped. Local router and proxy placement can hide the problem because same-node traffic remains on the local datapath.

  For oauth, apply the OAuth NodePort-style policy for Route publishing so host-networked ingress routers can reach oauth-openshift on TCP 6443. The Console initializes its OAuth endpoint cache through this route. Cilium classifies host-networked router traffic as host or remote-node, so the namespace-based ingress policy does not allow it.

## Which issue(s) this PR fixes:
Fixes https://redhat.atlassian.net/browse/OCPBUGS-54574 (in addition to specific Cilium settings, see the JIRA if interested)

## Special notes for your reviewer:
The additional NetworkPolicy tested in https://github.com/openshift/release/pull/81307 (though manually applied, not automatically deployed by Hypershift)

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Network policies for OAuth, Ignition, and Konnectivity are now reconciled for hosted clusters using the Route service publishing strategy.
- Route-based publishing now creates the same required policies as NodePort publishing.
- Other service publishing strategies, including LoadBalancer, remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->