### PR TITLE
OCPBUGS-74960: fix orphaned security group during VPC endpoint deletion

### DIFF
--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -1236,11 +1236,22 @@ func (r *AWSEndpointServiceReconciler) delete(ctx context.Context, awsEndpointSe
 		}
 
 		if output != nil && len(output.VpcEndpoints) != 0 {
-			// Once the VPC Endpoint is deleted, we need to return an error to reexecute the reconciliation
-			return false, fmt.Errorf("resource requested for deletion but still present")
+			// Check if all returned endpoints are in terminal/transitional deletion states.
+			// AWS continues to return endpoints in "Deleting" and "Deleted" states for a period
+			// after DeleteVpcEndpoints is called. Treating these states as "still present" causes
+			// error-driven exponential backoff, which can delay security group cleanup long enough
+			// for the hypershift-operator's 10-minute grace period to expire — orphaning the SG.
+			// Instead, proceed to SG cleanup when the endpoint is being deleted; the existing
+			// DependencyViolation retry (fixed 5s interval) handles the ENI detachment race.
+			for _, ep := range output.VpcEndpoints {
+				if ep.State != ec2types.StateDeleting && ep.State != ec2types.StateDeleted {
+					return false, fmt.Errorf("resource requested for deletion but still present in state %s", ep.State)
+				}
+			}
+			log.Info("endpoint deletion in progress, proceeding to security group cleanup", "endpointID", endpointID, "state", output.VpcEndpoints[0].State)
+		} else {
+			log.Info("endpoint deleted", "endpointID", endpointID)
 		}
-
-		log.Info("endpoint deleted", "endpointID", endpointID)
 	}
 
 	if awsEndpointService.Status.SecurityGroupID != "" {

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
@@ -569,6 +569,180 @@ func TestReconcileDeletion(t *testing.T) {
 			expectFinalizer: true,
 		},
 		{
+			name: "When VPC endpoint is in deleting state, it should proceed to SG cleanup and requeue",
+			awsEndpointSvc: &hyperv1.AWSEndpointService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "private-router",
+					Namespace:         "clusters-test",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{finalizer},
+				},
+				Status: hyperv1.AWSEndpointServiceStatus{
+					EndpointID:      "vpce-12345",
+					SecurityGroupID: "sg-12345",
+				},
+			},
+			setupMocks: func(mockCtrl *gomock.Controller) *MockawsClientProvider {
+				mockBuilder := NewMockawsClientProvider(mockCtrl)
+				mockEC2 := awsapi.NewMockEC2API(mockCtrl)
+				mockRoute53 := awsapi.NewMockROUTE53API(mockCtrl)
+				vpceInput := &ec2v2.DeleteVpcEndpointsInput{VpcEndpointIds: []string{"vpce-12345"}}
+				describeVpceInput := &ec2v2.DescribeVpcEndpointsInput{VpcEndpointIds: []string{"vpce-12345"}}
+				describeSGInput := &ec2v2.DescribeSecurityGroupsInput{GroupIds: []string{"sg-12345"}}
+				// VPC endpoint delete succeeds but describe shows it still in "Deleting" state
+				mockEC2.EXPECT().DeleteVpcEndpoints(gomock.Any(), gomock.Eq(vpceInput)).Return(&ec2v2.DeleteVpcEndpointsOutput{}, nil)
+				mockEC2.EXPECT().DescribeVpcEndpoints(gomock.Any(), gomock.Eq(describeVpceInput)).Return(&ec2v2.DescribeVpcEndpointsOutput{
+					VpcEndpoints: []ec2types.VpcEndpoint{{
+						VpcEndpointId: aws.String("vpce-12345"),
+						State:         ec2types.StateDeleting,
+					}},
+				}, nil)
+				// The controller should proceed to SG cleanup despite the endpoint still being in "Deleting" state.
+				// The SG deletion will fail with DependencyViolation because the endpoint ENI is still attached.
+				mockEC2.EXPECT().DescribeSecurityGroups(gomock.Any(), gomock.Eq(describeSGInput)).Return(&ec2v2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []ec2types.SecurityGroup{{
+						GroupId:             aws.String("sg-12345"),
+						IpPermissions:       []ec2types.IpPermission{ingressPermission},
+						IpPermissionsEgress: []ec2types.IpPermission{egressPermission},
+					}},
+				}, nil)
+				mockEC2.EXPECT().RevokeSecurityGroupIngress(gomock.Any(), gomock.Eq(&ec2v2.RevokeSecurityGroupIngressInput{
+					GroupId:       aws.String("sg-12345"),
+					IpPermissions: []ec2types.IpPermission{ingressPermission},
+				})).Return(&ec2v2.RevokeSecurityGroupIngressOutput{}, nil)
+				mockEC2.EXPECT().RevokeSecurityGroupEgress(gomock.Any(), gomock.Eq(&ec2v2.RevokeSecurityGroupEgressInput{
+					GroupId:       aws.String("sg-12345"),
+					IpPermissions: []ec2types.IpPermission{egressPermission},
+				})).Return(&ec2v2.RevokeSecurityGroupEgressOutput{}, nil)
+				mockEC2.EXPECT().DeleteSecurityGroup(gomock.Any(), gomock.Eq(&ec2v2.DeleteSecurityGroupInput{
+					GroupId: aws.String("sg-12345"),
+				})).Return(nil, &smithy.GenericAPIError{Code: "DependencyViolation", Message: "resource has a dependent object"})
+				mockBuilder.EXPECT().getClients(gomock.Any()).Return(mockEC2, mockRoute53, nil)
+				return mockBuilder
+			},
+			expectError:     false,
+			expectRequeue:   true,
+			expectFinalizer: true,
+		},
+		{
+			name: "When VPC endpoint is in deleted state, it should proceed to SG cleanup and complete deletion",
+			awsEndpointSvc: &hyperv1.AWSEndpointService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "private-router",
+					Namespace:         "clusters-test",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{finalizer},
+				},
+				Status: hyperv1.AWSEndpointServiceStatus{
+					EndpointID:      "vpce-12345",
+					SecurityGroupID: "sg-12345",
+					DNSNames:        []string{"api.example.com"},
+					DNSZoneID:       "Z1234567890",
+				},
+			},
+			setupMocks: func(mockCtrl *gomock.Controller) *MockawsClientProvider {
+				mockBuilder := NewMockawsClientProvider(mockCtrl)
+				mockEC2 := awsapi.NewMockEC2API(mockCtrl)
+				mockRoute53 := awsapi.NewMockROUTE53API(mockCtrl)
+				vpceInput := &ec2v2.DeleteVpcEndpointsInput{VpcEndpointIds: []string{"vpce-12345"}}
+				describeVpceInput := &ec2v2.DescribeVpcEndpointsInput{VpcEndpointIds: []string{"vpce-12345"}}
+				describeSGInput := &ec2v2.DescribeSecurityGroupsInput{GroupIds: []string{"sg-12345"}}
+				// VPC endpoint delete succeeds but describe shows it in "Deleted" state (AWS can return
+				// endpoints in this state for minutes after deletion)
+				mockEC2.EXPECT().DeleteVpcEndpoints(gomock.Any(), gomock.Eq(vpceInput)).Return(&ec2v2.DeleteVpcEndpointsOutput{}, nil)
+				mockEC2.EXPECT().DescribeVpcEndpoints(gomock.Any(), gomock.Eq(describeVpceInput)).Return(&ec2v2.DescribeVpcEndpointsOutput{
+					VpcEndpoints: []ec2types.VpcEndpoint{{
+						VpcEndpointId: aws.String("vpce-12345"),
+						State:         ec2types.StateDeleted,
+					}},
+				}, nil)
+				// The controller should proceed to SG cleanup since the endpoint is in terminal "Deleted" state.
+				// The ENI should already be detached, so SG deletion succeeds.
+				mockEC2.EXPECT().DescribeSecurityGroups(gomock.Any(), gomock.Eq(describeSGInput)).Return(&ec2v2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []ec2types.SecurityGroup{{
+						GroupId:             aws.String("sg-12345"),
+						IpPermissions:       []ec2types.IpPermission{ingressPermission},
+						IpPermissionsEgress: []ec2types.IpPermission{egressPermission},
+					}},
+				}, nil)
+				mockEC2.EXPECT().RevokeSecurityGroupIngress(gomock.Any(), gomock.Eq(&ec2v2.RevokeSecurityGroupIngressInput{
+					GroupId:       aws.String("sg-12345"),
+					IpPermissions: []ec2types.IpPermission{ingressPermission},
+				})).Return(&ec2v2.RevokeSecurityGroupIngressOutput{}, nil)
+				mockEC2.EXPECT().RevokeSecurityGroupEgress(gomock.Any(), gomock.Eq(&ec2v2.RevokeSecurityGroupEgressInput{
+					GroupId:       aws.String("sg-12345"),
+					IpPermissions: []ec2types.IpPermission{egressPermission},
+				})).Return(&ec2v2.RevokeSecurityGroupEgressOutput{}, nil)
+				mockEC2.EXPECT().DeleteSecurityGroup(gomock.Any(), gomock.Eq(&ec2v2.DeleteSecurityGroupInput{
+					GroupId: aws.String("sg-12345"),
+				})).Return(&ec2v2.DeleteSecurityGroupOutput{}, nil)
+				mockBuilder.EXPECT().getClients(gomock.Any()).Return(mockEC2, mockRoute53, nil)
+				// DNS cleanup: FindRecord constructs a targeted query with StartRecordName/Type/MaxItems
+				dnsRecord := route53types.ResourceRecordSet{
+					Name: aws.String("api.example.com."),
+					Type: route53types.RRTypeCname,
+					TTL:  aws.Int64(300),
+					ResourceRecords: []route53types.ResourceRecord{
+						{Value: aws.String("vpce-12345.vpce-svc.us-east-1.vpce.amazonaws.com")},
+					},
+				}
+				mockRoute53.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Eq(&route53sdk.ListResourceRecordSetsInput{
+					HostedZoneId:    aws.String("Z1234567890"),
+					StartRecordName: aws.String("api.example.com."),
+					StartRecordType: route53types.RRTypeCname,
+					MaxItems:        aws.Int32(1),
+				})).Return(
+					&route53sdk.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []route53types.ResourceRecordSet{dnsRecord},
+					}, nil)
+				mockRoute53.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Eq(&route53sdk.ChangeResourceRecordSetsInput{
+					HostedZoneId: aws.String("Z1234567890"),
+					ChangeBatch: &route53types.ChangeBatch{
+						Changes: []route53types.Change{{
+							Action:            route53types.ChangeActionDelete,
+							ResourceRecordSet: &dnsRecord,
+						}},
+					},
+				})).Return(&route53sdk.ChangeResourceRecordSetsOutput{}, nil)
+				return mockBuilder
+			},
+			expectError:     false,
+			expectFinalizer: false,
+		},
+		{
+			name: "When VPC endpoint is in available state after delete call, it should return error to requeue",
+			awsEndpointSvc: &hyperv1.AWSEndpointService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "private-router",
+					Namespace:         "clusters-test",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{finalizer},
+				},
+				Status: hyperv1.AWSEndpointServiceStatus{
+					EndpointID: "vpce-12345",
+				},
+			},
+			setupMocks: func(mockCtrl *gomock.Controller) *MockawsClientProvider {
+				mockBuilder := NewMockawsClientProvider(mockCtrl)
+				mockEC2 := awsapi.NewMockEC2API(mockCtrl)
+				mockRoute53 := awsapi.NewMockROUTE53API(mockCtrl)
+				vpceInput := &ec2v2.DeleteVpcEndpointsInput{VpcEndpointIds: []string{"vpce-12345"}}
+				describeVpceInput := &ec2v2.DescribeVpcEndpointsInput{VpcEndpointIds: []string{"vpce-12345"}}
+				// VPC endpoint delete was called but it's still in "Available" state (unusual but possible)
+				mockEC2.EXPECT().DeleteVpcEndpoints(gomock.Any(), gomock.Eq(vpceInput)).Return(&ec2v2.DeleteVpcEndpointsOutput{}, nil)
+				mockEC2.EXPECT().DescribeVpcEndpoints(gomock.Any(), gomock.Eq(describeVpceInput)).Return(&ec2v2.DescribeVpcEndpointsOutput{
+					VpcEndpoints: []ec2types.VpcEndpoint{{
+						VpcEndpointId: aws.String("vpce-12345"),
+						State:         ec2types.StateAvailable,
+					}},
+				}, nil)
+				mockBuilder.EXPECT().getClients(gomock.Any()).Return(mockEC2, mockRoute53, nil)
+				return mockBuilder
+			},
+			expectError:     true,
+			expectFinalizer: true,
+		},
+		{
 			name: "When Route53 hosted zone is already deleted externally, it should treat deletion as successful",
 			awsEndpointSvc: &hyperv1.AWSEndpointService{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

- Fix orphaned `${infraID}-vpce-private-router` security groups that block VPC deletion after HCP cluster teardown
- After `DeleteVpcEndpoints`, AWS can return the endpoint in `Deleting`/`Deleted` state for minutes; the prior code treated any non-empty `DescribeVpcEndpoints` response as "still present" and returned an error, triggering controller-runtime's exponential backoff
- The exponential backoff could delay security group cleanup past the hypershift-operator's 10-minute grace period, causing it to force-remove the CPO finalizer and orphan the security group
- Fix: check VPC endpoint `State` — treat `Deleting`/`Deleted` as effectively gone and proceed immediately to security group cleanup; the existing `DependencyViolation` retry (fixed 5s requeue) handles the ENI detachment race

## Test plan

- [x] New unit tests added covering VPC endpoint in `Deleting`, `Deleted`, and `Available` states
- [x] All existing `TestReconcileDeletion` subtests pass
- [x] Full `awsprivatelink` package test suite passes
- [ ] Verify fix with ROSA HCP cluster deletion (create cluster in BYO-VPC, delete, confirm VPC can be deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS VPC endpoint deletion handling.
  * Endpoints in `Deleting` or `Deleted` states now proceed with security-group cleanup.
  * Completed endpoints can continue through Route 53 cleanup and finalization.
  * Endpoints in unexpected states continue to retry instead of being cleaned up prematurely.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->