### PR TITLE
OCPBUGS-112638: Enable DeviceTaintRule API for hosted clusters

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
 	"github.com/openshift/hypershift/support/certs"
 	hcpconfig "github.com/openshift/hypershift/support/config"
@@ -28,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	podsecurityadmissionv1 "k8s.io/pod-security-admission/admission/api/v1"
+
+	"github.com/blang/semver"
 )
 
 const (
@@ -45,6 +48,10 @@ func adaptKubeAPIServerConfig(cpContext component.WorkloadContext, config *corev
 		return err
 	}
 	configParams := NewConfigParams(cpContext.HCP, featureGates)
+	configParams.KubernetesVersion, err = kubernetesVersionForFeatureGates(featureGates, cpContext.ReleaseImageProvider)
+	if err != nil {
+		return err
+	}
 	kasConfig, err := generateConfig(configParams)
 	if err != nil {
 		return err
@@ -59,6 +66,21 @@ func adaptKubeAPIServerConfig(cpContext component.WorkloadContext, config *corev
 	}
 	config.Data[KubeAPIServerConfigKey] = string(serializedConfig)
 	return nil
+}
+
+func kubernetesVersionForFeatureGates(featureGates []string, releaseImageProvider imageprovider.ReleaseImageProvider) (string, error) {
+	if !slices.Contains(featureGates, "DRADeviceTaintRules=true") {
+		return "", nil
+	}
+	componentVersions, err := releaseImageProvider.ComponentVersions()
+	if err != nil {
+		return "", fmt.Errorf("failed to get control plane component versions: %w", err)
+	}
+	kubernetesVersion := componentVersions["kubernetes"]
+	if kubernetesVersion == "" {
+		return "", fmt.Errorf("control plane Kubernetes component version is missing")
+	}
+	return kubernetesVersion, nil
 }
 
 type kubeAPIServerArgs map[string]kcpv1.Arguments
@@ -247,6 +269,15 @@ func generateConfig(p KubeAPIServerConfigParams) (*kcpv1.KubeAPIServerConfig, er
 		}
 		if gate == "DynamicResourceAllocation=true" {
 			runtimeConfig = append(runtimeConfig, "resource.k8s.io/v1beta1=true")
+		}
+		if gate == "DRADeviceTaintRules=true" {
+			kubeVersion, err := semver.ParseTolerant(p.KubernetesVersion)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse Kubernetes version %q for DRADeviceTaintRules: %w", p.KubernetesVersion, err)
+			}
+			if kubeVersion.Major == 1 && kubeVersion.Minor == 36 {
+				runtimeConfig = append(runtimeConfig, "resource.k8s.io/v1beta2=true")
+			}
 		}
 		if gate == "VolumeAttributesClass=true" {
 			runtimeConfig = append(runtimeConfig, "storage.k8s.io/v1beta1=true")

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config_test.go
@@ -1,7 +1,11 @@
 package kas
 
 import (
+	"errors"
 	"testing"
+
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
+	"github.com/openshift/hypershift/support/testutil"
 
 	configv1 "github.com/openshift/api/config/v1"
 	kcpv1 "github.com/openshift/api/kubecontrolplane/v1"
@@ -18,9 +22,10 @@ import (
 
 func TestGenerateConfig(t *testing.T) {
 	type testcase struct {
-		name     string
-		params   KubeAPIServerConfigParams
-		expected *kcpv1.KubeAPIServerConfig
+		name          string
+		params        KubeAPIServerConfigParams
+		expected      *kcpv1.KubeAPIServerConfig
+		expectedError string
 	}
 
 	testcases := []testcase{
@@ -516,6 +521,71 @@ func TestGenerateConfig(t *testing.T) {
 			),
 		},
 		{
+			name: "When DRADeviceTaintRules is enabled on Kubernetes 1.36, it should enable the v1beta2 API",
+			params: KubeAPIServerConfigParams{
+				FeatureGates: []string{
+					"DRADeviceTaintRules=true",
+				},
+				KubernetesVersion: "1.36.3",
+			},
+			expected: modifyKasConfig(defaultKASConfig(),
+				func(kasc *kcpv1.KubeAPIServerConfig) {
+					kasc.APIServerArguments["runtime-config"] = append(kcpv1.Arguments{"resource.k8s.io/v1beta2=true"}, kasc.APIServerArguments["runtime-config"]...)
+					kasc.APIServerArguments["feature-gates"] = append(kcpv1.Arguments{"DRADeviceTaintRules=true"}, kasc.APIServerArguments["feature-gates"]...)
+				},
+			),
+		},
+		{
+			name: "When DRADeviceTaintRules is enabled on Kubernetes 1.35, it should not enable the v1beta2 API",
+			params: KubeAPIServerConfigParams{
+				FeatureGates: []string{
+					"DRADeviceTaintRules=true",
+				},
+				KubernetesVersion: "1.35.0",
+			},
+			expected: modifyKasConfig(defaultKASConfig(),
+				func(kasc *kcpv1.KubeAPIServerConfig) {
+					kasc.APIServerArguments["feature-gates"] = append(kcpv1.Arguments{"DRADeviceTaintRules=true"}, kasc.APIServerArguments["feature-gates"]...)
+				},
+			),
+		},
+		{
+			name: "When DRADeviceTaintRules is enabled on Kubernetes 1.37, it should not enable the v1beta2 API",
+			params: KubeAPIServerConfigParams{
+				FeatureGates: []string{
+					"DRADeviceTaintRules=true",
+				},
+				KubernetesVersion: "1.37.0",
+			},
+			expected: modifyKasConfig(defaultKASConfig(),
+				func(kasc *kcpv1.KubeAPIServerConfig) {
+					kasc.APIServerArguments["feature-gates"] = append(kcpv1.Arguments{"DRADeviceTaintRules=true"}, kasc.APIServerArguments["feature-gates"]...)
+				},
+			),
+		},
+		{
+			name: "When DRADeviceTaintRules is disabled, it should not enable the v1beta2 API",
+			params: KubeAPIServerConfigParams{
+				FeatureGates: []string{
+					"DRADeviceTaintRules=false",
+				},
+			},
+			expected: modifyKasConfig(defaultKASConfig(),
+				func(kasc *kcpv1.KubeAPIServerConfig) {
+					kasc.APIServerArguments["feature-gates"] = append(kcpv1.Arguments{"DRADeviceTaintRules=false"}, kasc.APIServerArguments["feature-gates"]...)
+				},
+			),
+		},
+		{
+			name: "When DRADeviceTaintRules is enabled without a Kubernetes version, it should return an error",
+			params: KubeAPIServerConfigParams{
+				FeatureGates: []string{
+					"DRADeviceTaintRules=true",
+				},
+			},
+			expectedError: `failed to parse Kubernetes version "" for DRADeviceTaintRules`,
+		},
+		{
 			name: "When ValidatingAdmissionPolicy feature gate is explicitly enabled, it should return default config",
 			params: KubeAPIServerConfigParams{
 				FeatureGates: []string{
@@ -584,12 +654,80 @@ func TestGenerateConfig(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			kasConfig, _ := generateConfig(tc.params)
+			kasConfig, err := generateConfig(tc.params)
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+			require.NoError(t, err)
 
 			diff := cmp.Diff(tc.expected, kasConfig)
 			require.Empty(t, diff, "expected KAS config does not match actual")
 		})
 	}
+}
+
+func TestKubernetesVersionForFeatureGates(t *testing.T) {
+	testCases := []struct {
+		name             string
+		featureGates     []string
+		componentVersion map[string]string
+		componentError   error
+		expectedVersion  string
+		expectedError    string
+	}{
+		{
+			name:           "When DRADeviceTaintRules is not enabled, it should not request component versions",
+			componentError: errors.New("component versions should not be requested"),
+		},
+		{
+			name:         "When DRADeviceTaintRules is enabled, it should return the Kubernetes component version",
+			featureGates: []string{"DRADeviceTaintRules=true"},
+			componentVersion: map[string]string{
+				"kubernetes": "1.36.3",
+			},
+			expectedVersion: "1.36.3",
+		},
+		{
+			name:           "When component version lookup fails, it should return an error",
+			featureGates:   []string{"DRADeviceTaintRules=true"},
+			componentError: errors.New("lookup failed"),
+			expectedError:  "failed to get control plane component versions: lookup failed",
+		},
+		{
+			name:             "When the Kubernetes component version is missing, it should return an error",
+			featureGates:     []string{"DRADeviceTaintRules=true"},
+			componentVersion: map[string]string{},
+			expectedError:    "control plane Kubernetes component version is missing",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			releaseImageProvider := &componentVersionReleaseImageProvider{
+				ReleaseImageProvider: testutil.FakeImageProvider(),
+				componentVersions:    tc.componentVersion,
+				componentError:       tc.componentError,
+			}
+			version, err := kubernetesVersionForFeatureGates(tc.featureGates, releaseImageProvider)
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedVersion, version)
+		})
+	}
+}
+
+type componentVersionReleaseImageProvider struct {
+	imageprovider.ReleaseImageProvider
+	componentVersions map[string]string
+	componentError    error
+}
+
+func (p *componentVersionReleaseImageProvider) ComponentVersions() (map[string]string, error) {
+	return p.componentVersions, p.componentError
 }
 
 func defaultKASConfig() *kcpv1.KubeAPIServerConfig {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/params.go
@@ -45,6 +45,7 @@ type KubeAPIServerConfigParams struct {
 	EtcdURL                          string
 	EtcdServersOverrides             []string
 	FeatureGates                     []string
+	KubernetesVersion                string
 	NodePortRange                    string
 	AuditWebhookEnabled              bool
 	ConsolePublicURL                 string


### PR DESCRIPTION
## What this PR does / why we need it:

Enables the `resource.k8s.io/v1beta2` API in hosted kube-apiservers when the `DRADeviceTaintRules` feature gate is enabled on Kubernetes 1.36.

Without the runtime API, kube-scheduler enables its `DeviceTaintRule` informer but cannot list the resource. The informer never synchronizes, preventing the production scheduler from starting and leaving hosted-cluster workloads unscheduled after bootstrap.

The mapping is limited to Kubernetes 1.36. `DeviceTaintRule` is unavailable before 1.36 and graduates to `resource.k8s.io/v1` in Kubernetes 1.37. The Kubernetes version is read from the control-plane release component metadata, and is only requested when the feature gate is enabled.

Related changes:

- openshift/api#3004 registers and enables `DRADeviceTaintRules` in TechPreviewNoUpgrade.
- openshift/cluster-kube-apiserver-operator#2275 adds the equivalent mapping for self-managed clusters.
- openshift/origin#31566 updates the DRA API availability test expectation.

Failure analysis: https://github.com/openshift/api/pull/3004#issuecomment-5539818984

## Which issue(s) this PR fixes:

Related to OCPBUGS-112638

## Special notes for your reviewer:

The mapping is dormant when `DRADeviceTaintRules` is absent or disabled, allowing this change to merge before openshift/api#3004 activates the gate.

Unit coverage includes Kubernetes 1.35, 1.36, and 1.37; a disabled gate; missing Kubernetes component metadata; and component-version lookup errors.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. Not applicable; this is an internal kube-apiserver runtime configuration fix.
- [x] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Kubernetes API server support for `resource.k8s.io/v1beta2` runtime configuration on Kubernetes 1.36 when `DRADeviceTaintRules` is enabled.

* **Bug Fixes**
  * Added validation and clear errors when the Kubernetes version is unavailable or cannot be determined for this configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->