### PR TITLE
NO-JIRA: remove unsafe v1 framework usage from karpenter upgrade test

### DIFF
--- a/test/e2e/v2/tests/karpenter_control_plane_upgrade_test.go
+++ b/test/e2e/v2/tests/karpenter_control_plane_upgrade_test.go
@@ -130,21 +130,36 @@ func KarpenterUpgradeTest(getTestCtx internal.TestContextGetter) {
 			Expect(err).NotTo(HaveOccurred(), "failed to update hosted cluster release image")
 
 			By("Waiting for NodeClaims to be drifted")
-			driftChan := make(chan struct{})
-			go func() {
-				defer close(driftChan)
-				defer GinkgoRecover()
-				for _, nodeClaim := range nodeClaims.Items {
-					waitForNodeClaimDrifted(ctx, hcClient, &nodeClaim)
-				}
-			}()
+			for i := range nodeClaims.Items {
+				nodeClaim := &nodeClaims.Items[i]
+				Eventually(func(g Gomega, pollCtx context.Context) {
+					current := &karpenterv1.NodeClaim{}
+					err := hcClient.Get(pollCtx, crclient.ObjectKeyFromObject(nodeClaim), current)
+					g.Expect(err).NotTo(HaveOccurred())
+					if err != nil {
+						return
+					}
+
+					found := false
+					for _, condition := range current.Status.Conditions {
+						if condition.Type == karpenterv1.ConditionTypeDrifted {
+							found = true
+							g.Expect(condition.Status).To(Equal(metav1.ConditionTrue),
+								"condition %s is not True in NodeClaim %s", karpenterv1.ConditionTypeDrifted, nodeClaim.Name)
+						}
+					}
+					g.Expect(found).To(BeTrue(), "condition %s not found in NodeClaim %s", karpenterv1.ConditionTypeDrifted, nodeClaim.Name)
+				}).
+					WithContext(ctx).
+					WithTimeout(5 * time.Minute).
+					WithPolling(3 * time.Second).
+					Should(Succeed())
+			}
+			GinkgoWriter.Println("Karpenter Nodes drifted")
 
 			By("Waiting for control plane components to complete rollout")
 			ExpectHostedClusterUpgradeToComplete(ctx, tc.MgmtClient, hc, latestImage)
-
-			GinkgoWriter.Printf("Control plane upgraded, awaiting drift\n")
-			<-driftChan
-			GinkgoWriter.Println("Karpenter Nodes drifted")
+			GinkgoWriter.Println("Control plane upgraded")
 
 			preUpgradeRHCOSVersion := extractRHCOSVersion(preUpgradeOSImage)
 			GinkgoWriter.Printf("Pre-upgrade RHCOS version: %s\n", preUpgradeRHCOSVersion)
@@ -178,29 +193,30 @@ func KarpenterUpgradeTest(getTestCtx internal.TestContextGetter) {
 			nodeClaims = waitForReadyNodeClaims(ctx, hcClient, len(nodes))
 
 			By("Validating AutoNode status counts are populated after upgrade")
-			e2eutil.EventuallyObject(t, ctx, fmt.Sprintf("HostedCluster %s/%s to have AutoNode status counts", hc.Namespace, hc.Name),
-				func(ctx context.Context) (*hyperv1.HostedCluster, error) {
-					updated := &hyperv1.HostedCluster{}
-					err := tc.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), updated)
-					return updated, err
-				},
-				[]e2eutil.Predicate[*hyperv1.HostedCluster]{
-					func(hc *hyperv1.HostedCluster) (done bool, reasons string, err error) {
-						if hc.Status.AutoNode.NodeCount == nil {
-							return false, "Status.AutoNode.NodeCount is nil", nil
-						}
-						if *hc.Status.AutoNode.NodeCount < int32(len(nodes)) {
-							return false, fmt.Sprintf("expected NodeCount >= %d, got %v", len(nodes), hc.Status.AutoNode.NodeCount), nil
-						}
-						if hc.Status.AutoNode.NodeClaimCount == nil || *hc.Status.AutoNode.NodeClaimCount < int32(len(nodeClaims.Items)) {
-							return false, fmt.Sprintf("expected NodeClaimCount >= %d, got %v", len(nodeClaims.Items), hc.Status.AutoNode.NodeClaimCount), nil
-						}
-						return true, fmt.Sprintf("AutoNode status: NodeCount=%d, NodeClaimCount=%d",
-							*hc.Status.AutoNode.NodeCount, *hc.Status.AutoNode.NodeClaimCount), nil
-					},
-				},
-				e2eutil.WithTimeout(5*time.Minute),
-			)
+			Eventually(func(g Gomega, pollCtx context.Context) {
+				updated := &hyperv1.HostedCluster{}
+				err := tc.MgmtClient.Get(pollCtx, crclient.ObjectKeyFromObject(hc), updated)
+				g.Expect(err).NotTo(HaveOccurred())
+				if err != nil {
+					return
+				}
+
+				g.Expect(updated.Status.AutoNode.NodeCount).NotTo(BeNil())
+				if updated.Status.AutoNode.NodeCount == nil {
+					return
+				}
+				g.Expect(*updated.Status.AutoNode.NodeCount).To(BeNumerically(">=", len(nodes)))
+
+				g.Expect(updated.Status.AutoNode.NodeClaimCount).NotTo(BeNil())
+				if updated.Status.AutoNode.NodeClaimCount == nil {
+					return
+				}
+				g.Expect(*updated.Status.AutoNode.NodeClaimCount).To(BeNumerically(">=", len(nodeClaims.Items)))
+			}).
+				WithContext(ctx).
+				WithTimeout(5 * time.Minute).
+				WithPolling(3 * time.Second).
+				Should(Succeed())
 		})
 	})
 }
@@ -267,39 +283,4 @@ func waitForReadyNodeClaims(ctx context.Context, client crclient.Client, n int) 
 	)
 
 	return nodeClaims
-}
-
-// waitForNodeClaimDrifted polls until the given NodeClaim has the Drifted
-// condition set to True.
-func waitForNodeClaimDrifted(ctx context.Context, client crclient.Client, nc *karpenterv1.NodeClaim) {
-	t := GinkgoTB()
-	e2eutil.EventuallyObject(t, ctx, fmt.Sprintf("NodeClaim %s to be drifted", nc.Name),
-		func(ctx context.Context) (*karpenterv1.NodeClaim, error) {
-			nodeClaim := &karpenterv1.NodeClaim{}
-			err := client.Get(ctx, crclient.ObjectKeyFromObject(nc), nodeClaim)
-			if err == nil {
-				haystack, err := e2eutil.Conditions(nodeClaim)
-				if err != nil {
-					return nil, err
-				}
-				for _, condition := range haystack {
-					if karpenterv1.ConditionTypeDrifted == condition.Type {
-						if condition.Status == metav1.ConditionTrue {
-							return nodeClaim, nil
-						}
-						return nil, fmt.Errorf("condition %s is not True in NodeClaim %s", karpenterv1.ConditionTypeDrifted, nc.Name)
-					}
-				}
-				return nil, fmt.Errorf("condition %s not found in NodeClaim %s", karpenterv1.ConditionTypeDrifted, nc.Name)
-			}
-			return nil, err
-		},
-		[]e2eutil.Predicate[*karpenterv1.NodeClaim]{
-			e2eutil.ConditionPredicate[*karpenterv1.NodeClaim](e2eutil.Condition{
-				Type:   karpenterv1.ConditionTypeDrifted,
-				Status: metav1.ConditionTrue,
-			}),
-		},
-		e2eutil.WithTimeout(5*time.Minute),
-	)
 }


### PR DESCRIPTION
Before this commit, the karpenter upgrade e2e v2 test was using the v1 `EventuallyObject()` function which is now understood to be unsafe in v2 test code[1] and causes failures in this test not to be marked informing when they should be.

This commit replaces usage of `EventuallyObject()` with simple Ginkgo assertions which have cover the same assertions but which lack the diagnostic features of `EventuallyObject()`. If those diagnostics are desirable going forward, we should consider a followup to port that utility to a v2 compatible package.

The use of a goroutine for drift detection has been removed because the same assertion can be expressed without a goroutine by simply making sequential observations about the nodes.

[1] https://redhat.atlassian.net/browse/OCPBUGS-120799

To verify this we'd need to see the test fail and be marked informing (example of the problem: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/9485/pull-ci-openshift-hypershift-release-5.0-e2e-v2-aws/2095465801162166272)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end validation for node lifecycle drift and AutoNode status counts.
  - Added clearer control-plane upgrade completion logging.
  - Increased test reliability by using direct, explicit status checks and sequential validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->