### PR TITLE
OCPBUGS-114936: add PodDisruptionBudget for the HyperShift Operator

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -30,6 +30,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1128,6 +1129,38 @@ func (o HyperShiftOperatorService) Build() *corev1.Service {
 					TargetPort: intstr.FromString("manager"),
 				},
 			},
+		},
+	}
+}
+
+type HyperShiftOperatorPodDisruptionBudget struct {
+	Namespace *corev1.Namespace
+}
+
+func (o HyperShiftOperatorPodDisruptionBudget) Build() *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PodDisruptionBudget",
+			APIVersion: policyv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: o.Namespace.Name,
+			Name:      HypershiftOperatorName,
+			Labels: map[string]string{
+				"name": HypershiftOperatorName,
+			},
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": HypershiftOperatorName,
+				},
+			},
+			// Require at least one operator pod to remain available during
+			// voluntary disruptions (e.g. node drains). With the default 2
+			// replicas this still permits one pod to be evicted at a time.
+			MinAvailable:               ptr.To(intstr.FromInt32(1)),
+			UnhealthyPodEvictionPolicy: ptr.To(policyv1.AlwaysAllow),
 		},
 	}
 }

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -15,6 +15,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -833,6 +834,25 @@ func TestHyperShiftOperatorClusterRole_WebhookRBAC(t *testing.T) {
 			ResourceNames: []string{hyperv1.GroupVersion.Group},
 		})))
 	})
+}
+
+func TestHyperShiftOperatorPodDisruptionBudget_Build(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	namespace := HyperShiftNamespace{Name: "hypershift"}.Build()
+	pdb := HyperShiftOperatorPodDisruptionBudget{Namespace: namespace}.Build()
+
+	g.Expect(pdb.Namespace).To(Equal(namespace.Name))
+	g.Expect(pdb.Name).To(Equal(HypershiftOperatorName))
+	g.Expect(pdb.Labels).To(HaveKeyWithValue("name", HypershiftOperatorName))
+	g.Expect(pdb.Spec.Selector).ToNot(BeNil())
+	g.Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue("name", HypershiftOperatorName))
+	g.Expect(pdb.Spec.MaxUnavailable).To(BeNil(), "should use minAvailable, not maxUnavailable")
+	g.Expect(pdb.Spec.MinAvailable).ToNot(BeNil())
+	g.Expect(pdb.Spec.MinAvailable.IntValue()).To(Equal(1))
+	g.Expect(pdb.Spec.UnhealthyPodEvictionPolicy).ToNot(BeNil())
+	g.Expect(*pdb.Spec.UnhealthyPodEvictionPolicy).To(Equal(policyv1.AlwaysAllow))
 }
 
 func TestBuildArgs(t *testing.T) {

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -1428,8 +1428,11 @@ func setupOperatorResources(opts Options, userCABundleCM *corev1.ConfigMap, trus
 	operatorService := assets.HyperShiftOperatorService{
 		Namespace: operatorNamespace,
 	}.Build()
+	operatorPodDisruptionBudget := assets.HyperShiftOperatorPodDisruptionBudget{
+		Namespace: operatorNamespace,
+	}.Build()
 
-	return operatorService, []crclient.Object{operatorDeployment, operatorService}
+	return operatorService, []crclient.Object{operatorDeployment, operatorService, operatorPodDisruptionBudget}
 }
 
 // setupExternalDNS creates the resources for external-dns

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -26,6 +26,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1058,6 +1059,52 @@ func TestHyperShiftOperatorManifests_SharedIngress(t *testing.T) {
 				g.Expect(hasSharedIngressClusterRole).To(BeFalse(), "expected shared ingress ClusterRole to not be present")
 				g.Expect(hasSharedIngressClusterRoleBinding).To(BeFalse(), "expected shared ingress ClusterRoleBinding to not be present")
 			}
+		})
+	}
+}
+
+func TestHyperShiftOperatorPodDisruptionBudget(t *testing.T) {
+	// The PDB must be emitted for every install regardless of the effective
+	// operator replica count, and must use maxUnavailable:1 so it never
+	// deadlocks drains of a single-replica deployment.
+	tests := []struct {
+		name string
+		opts Options
+	}{
+		{
+			name: "default (webhooks enabled, 2 replicas)",
+			opts: Options{PrivatePlatform: string(hyperv1.NonePlatform)},
+		},
+		{
+			name: "single replica (webhooks disabled)",
+			opts: Options{
+				PrivatePlatform:              string(hyperv1.NonePlatform),
+				DisableCAPIConversionWebhook: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			_, objects, err := hyperShiftOperatorManifests(t.Context(), nil, tc.opts)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			var pdb *policyv1.PodDisruptionBudget
+			for _, obj := range objects {
+				if p, ok := obj.(*policyv1.PodDisruptionBudget); ok {
+					pdb = p
+					break
+				}
+			}
+			g.Expect(pdb).ToNot(BeNil(), "expected a PodDisruptionBudget for the operator")
+			g.Expect(pdb.Name).To(Equal(assets.HypershiftOperatorName))
+			g.Expect(pdb.Spec.MaxUnavailable).To(BeNil(), "should use minAvailable, not maxUnavailable")
+			g.Expect(pdb.Spec.MinAvailable).ToNot(BeNil())
+			g.Expect(pdb.Spec.MinAvailable.IntValue()).To(Equal(1))
+			g.Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue("name", assets.HypershiftOperatorName))
+			g.Expect(pdb.Spec.UnhealthyPodEvictionPolicy).ToNot(BeNil())
+			g.Expect(*pdb.Spec.UnhealthyPodEvictionPolicy).To(Equal(policyv1.AlwaysAllow))
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:

The HyperShift Operator (HO) runs highly available (2 replicas by default when webhooks are enabled) but has no `PodDisruptionBudget`. Nothing prevents a routine voluntary maintenance operation — for example draining two nodes back-to-back during a node upgrade or cordon/drain cycle — from evicting both HO replicas in immediate succession and taking the operator fully offline, which halts reconciliation for every HostedCluster it manages. Each individual drain looks legitimate to Kubernetes; without a PDB there is no floor stopping the second eviction while the first replica is still rescheduling.

This PR adds a `PodDisruptionBudget` to the operator install manifest set:

- `minAvailable: 1`
- `unhealthyPodEvictionPolicy: AlwaysAllow`
- selector `name: operator`

The budget is always emitted so the protection is present regardless of the effective replica count. This governs only the voluntary, eviction-API path (`oc adm drain`, cluster autoscaler consolidation, etc.); it does not change HO behavior otherwise.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-114936

## Depends on:

- https://github.com/stolostron/hypershift-addon-operator/pull/804
- https://github.com/openshift/managed-cluster-config/pull/2872

## Special notes for your reviewer:

> [!IMPORTANT]
> **Cross-repo RBAC dependency — must land before this reaches MCE/ROSA.**

On MCE/ROSA the HO is not installed by an admin running `hypershift install`; it is installed by the **hypershift-addon install Job**, running as ServiceAccount `hypershift-addon-agent-sa`. That SA's ClusterRole does **not** currently permit managing `poddisruptionbudgets`, so adding a PDB to the install manifest set causes the apply to be **rejected** and the whole install Job to fail.

Verified live (MCE 2.17.2, hub OCP 4.20.x):

- Install job log: `applied Deployment/Service ...` then
  `poddisruptionbudgets.policy "operator" is forbidden: User "system:serviceaccount:open-cluster-management-agent-addon:hypershift-addon-agent-sa" cannot patch resource "poddisruptionbudgets" in API group "policy"`
- `oc auth can-i create poddisruptionbudgets.policy -n hypershift --as=...hypershift-addon-agent-sa` → **no** (while `deployments.apps` → yes)
- Result: `hypershift-install-job-*` pods repeatedly `Failed`; the Deployment applies (pods run) but the PDB is never created.

**This feature therefore spans three coordinated PRs:**

1. **openshift/hypershift** (this PR) — add the PDB.
2. **stolostron/hypershift-addon-operator** — add `policy/poddisruptionbudgets` (get/list/watch/create/update/patch/delete) to the agent ClusterRole (the `*-hypershift-addon-agent` role shipped via the `addon-hypershift-addon-deploy` ManifestWork). **Load-bearing for all MCE.**
3. **openshift/managed-cluster-config** — add the same rule to the supplementary `hypershift-addon-agent` ClusterRole (`deploy/hypershift-addon-agent-rbac/`) for the **SRE-P/ROSA** management-cluster fleet.

**Sequencing:** land #2 (and #3 for ROSA) **before** this PR reaches MCE, or the addon install Job breaks fleet-wide on the forbidden PDB apply. Details tracked on OCPBUGS-114936.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PodDisruptionBudget for the HyperShift operator.
  * Configures voluntary disruption handling for operator pods and allows unhealthy pods to be evicted.
  * Applies consistently to both multi-replica and single-replica configurations.
  * Helps maintain operator availability during routine maintenance, node drains, and other planned cluster disruptions.

* **Tests**
  * Added coverage validating the generated PodDisruptionBudget across supported operator configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->