### PR TITLE
HYPERFLEET-1557: scope monitoring resources behind --platform-monitoring flag

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -535,6 +535,7 @@ type HyperShiftOperatorDeployment struct {
 	ServiceAccount                          *corev1.ServiceAccount
 	Replicas                                int32
 	EnableOCPClusterMonitoring              bool
+	EnablePlatformMonitoring                bool
 	EnableCIDebugOutput                     bool
 	EnableWebhook                           bool
 	EnableValidatingWebhook                 bool
@@ -856,6 +857,7 @@ func (o HyperShiftOperatorDeployment) buildEnvVars() []corev1.EnvVar {
 		trimmedValue := strings.TrimSpace(value)
 		if trimmedKey != "" &&
 			trimmedValue != "" &&
+			trimmedKey != config.EnablePlatformMonitoringEnvVar &&
 			!slices.ContainsFunc(envVars, func(e corev1.EnvVar) bool {
 				return e.Name == trimmedKey
 			}) {
@@ -874,6 +876,9 @@ func (o HyperShiftOperatorDeployment) buildEnvVars() []corev1.EnvVar {
 	}
 	if o.EnableCVOManagementClusterMetricsAccess {
 		envVars = append(envVars, corev1.EnvVar{Name: config.EnableCVOManagementClusterMetricsAccessEnvVar, Value: "1"})
+	}
+	if o.EnablePlatformMonitoring {
+		envVars = append(envVars, corev1.EnvVar{Name: config.EnablePlatformMonitoringEnvVar, Value: "1"})
 	}
 	if len(o.ManagedService) > 0 {
 		envVars = append(envVars, corev1.EnvVar{Name: "MANAGED_SERVICE", Value: o.ManagedService})

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -914,10 +914,11 @@ func TestBuildArgs(t *testing.T) {
 
 func TestBuildEnvVars(t *testing.T) {
 	tests := []struct {
-		name           string
-		deployment     HyperShiftOperatorDeployment
-		expectContains []corev1.EnvVar
-		expectAbsent   []string
+		name             string
+		deployment       HyperShiftOperatorDeployment
+		expectContains   []corev1.EnvVar
+		expectAbsent     []string
+		expectExactCount map[string]int
 	}{
 		{
 			name: "When TechPreviewNoUpgrade is enabled, it should include HYPERSHIFT_FEATURESET env var",
@@ -1041,6 +1042,51 @@ func TestBuildEnvVars(t *testing.T) {
 				"CAPI_STORAGE_VERSION",
 			},
 		},
+		{
+			name: "When EnablePlatformMonitoring is enabled, it should include the env var",
+			deployment: HyperShiftOperatorDeployment{
+				EnablePlatformMonitoring: true,
+			},
+			expectContains: []corev1.EnvVar{
+				{Name: config.EnablePlatformMonitoringEnvVar, Value: "1"},
+			},
+		},
+		{
+			name: "When EnablePlatformMonitoring is disabled, it should not include the env var",
+			deployment: HyperShiftOperatorDeployment{
+				EnablePlatformMonitoring: false,
+			},
+			expectAbsent: []string{
+				config.EnablePlatformMonitoringEnvVar,
+			},
+		},
+		{
+			name: "When AdditionalOperatorEnvVars tries to set the reserved platform monitoring env var while disabled, it should be rejected",
+			deployment: HyperShiftOperatorDeployment{
+				EnablePlatformMonitoring: false,
+				AdditionalOperatorEnvVars: map[string]string{
+					config.EnablePlatformMonitoringEnvVar: "1",
+				},
+			},
+			expectAbsent: []string{
+				config.EnablePlatformMonitoringEnvVar,
+			},
+		},
+		{
+			name: "When AdditionalOperatorEnvVars tries to override the reserved platform monitoring env var while enabled, the managed value wins",
+			deployment: HyperShiftOperatorDeployment{
+				EnablePlatformMonitoring: true,
+				AdditionalOperatorEnvVars: map[string]string{
+					config.EnablePlatformMonitoringEnvVar: "0",
+				},
+			},
+			expectContains: []corev1.EnvVar{
+				{Name: config.EnablePlatformMonitoringEnvVar, Value: "1"},
+			},
+			expectExactCount: map[string]int{
+				config.EnablePlatformMonitoringEnvVar: 1,
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -1049,6 +1095,15 @@ func TestBuildEnvVars(t *testing.T) {
 			envVars := tc.deployment.buildEnvVars()
 			for _, expected := range tc.expectContains {
 				g.Expect(envVars).To(ContainElement(expected))
+			}
+			for name, count := range tc.expectExactCount {
+				actual := 0
+				for _, env := range envVars {
+					if env.Name == name {
+						actual++
+					}
+				}
+				g.Expect(actual).To(Equal(count), "expected %d env var(s) named %q, got %d", count, name, actual)
 			}
 			for _, absent := range tc.expectAbsent {
 				for _, env := range envVars {

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -1292,21 +1292,25 @@ func setupMonitoring(opts Options, operatorNamespace *corev1.Namespace) []crclie
 	}.Build()
 	objects = append(objects, prometheusRoleBinding)
 
-	serviceMonitor := assets.HyperShiftServiceMonitor{
-		Namespace: operatorNamespace,
-	}.Build()
-	objects = append(objects, serviceMonitor)
-
-	recordingRule := assets.HypershiftRecordingRule{
-		Namespace: operatorNamespace,
-	}.Build()
-	objects = append(objects, recordingRule)
-
-	if opts.SLOsAlerts {
-		alertingRule := assets.HypershiftAlertingRule{
-			Namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-monitoring"}},
+	// ServiceMonitor/PrometheusRule require the monitoring.coreos.com CRDs,
+	// absent when platform monitoring is disabled
+	if opts.PlatformMonitoring.IsEnabled() {
+		serviceMonitor := assets.HyperShiftServiceMonitor{
+			Namespace: operatorNamespace,
 		}.Build()
-		objects = append(objects, alertingRule)
+		objects = append(objects, serviceMonitor)
+
+		recordingRule := assets.HypershiftRecordingRule{
+			Namespace: operatorNamespace,
+		}.Build()
+		objects = append(objects, recordingRule)
+
+		if opts.SLOsAlerts {
+			alertingRule := assets.HypershiftAlertingRule{
+				Namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-monitoring"}},
+			}.Build()
+			objects = append(objects, alertingRule)
+		}
 	}
 
 	if opts.MonitoringDashboards {
@@ -1379,6 +1383,7 @@ func setupOperatorResources(opts Options, userCABundleCM *corev1.ConfigMap, trus
 		ServiceAccount:                          operatorServiceAccount,
 		Replicas:                                opts.HyperShiftOperatorReplicas,
 		EnableOCPClusterMonitoring:              opts.PlatformMonitoring == metrics.PlatformMonitoringAll,
+		EnablePlatformMonitoring:                opts.PlatformMonitoring.IsEnabled(),
 		EnableCIDebugOutput:                     opts.EnableCIDebugOutput,
 		EnableWebhook:                           opts.EnableDefaultingWebhook || opts.EnableConversionWebhook || !opts.DisableCAPIConversionWebhook || opts.EnableValidatingWebhook || opts.EnableAuditLogPersistence,
 		EnableValidatingWebhook:                 opts.EnableValidatingWebhook,
@@ -1531,10 +1536,12 @@ func setupExternalDNS(ctx context.Context, opts Options, operatorNamespace *core
 	}.Build()
 	objects = append(objects, externalDNSDeployment)
 
-	podMonitor := assets.ExternalDNSPodMonitor{
-		Namespace: operatorNamespace,
-	}.Build()
-	objects = append(objects, podMonitor)
+	if opts.PlatformMonitoring.IsEnabled() {
+		podMonitor := assets.ExternalDNSPodMonitor{
+			Namespace: operatorNamespace,
+		}.Build()
+		objects = append(objects, podMonitor)
+	}
 
 	return objects, nil
 }

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -1931,6 +1931,22 @@ func TestSetupMonitoring(t *testing.T) {
 			expectDashboards: true,
 			minResourceCount: 5,
 		},
+		{
+			name: "When platform monitoring is None, it should not include ServiceMonitor or PrometheusRule resources",
+			opts: Options{
+				PlatformMonitoring: metrics.PlatformMonitoringNone,
+			},
+			minResourceCount: 2,
+		},
+		{
+			name: "When platform monitoring is None and SLOs alerts are enabled, it should not include the alerting rule",
+			opts: Options{
+				PlatformMonitoring: metrics.PlatformMonitoringNone,
+				SLOsAlerts:         true,
+			},
+			expectSLOAlerts:  false,
+			minResourceCount: 2,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1941,13 +1957,28 @@ func TestSetupMonitoring(t *testing.T) {
 
 			g.Expect(len(objects)).To(BeNumerically(">=", tc.minResourceCount))
 
-			// Check SLO alerts
+			// Check ServiceMonitor and recording/alerting PrometheusRule resources are only
+			// rendered when platform monitoring is enabled
+			foundServiceMonitor := false
+			foundPrometheusRule := false
 			foundAlertingRule := false
 			for _, obj := range objects {
-				if rule, ok := obj.(*prometheusoperatorv1.PrometheusRule); ok && rule.Namespace == "openshift-monitoring" {
-					foundAlertingRule = true
-					break
+				if _, ok := obj.(*prometheusoperatorv1.ServiceMonitor); ok {
+					foundServiceMonitor = true
 				}
+				if rule, ok := obj.(*prometheusoperatorv1.PrometheusRule); ok {
+					foundPrometheusRule = true
+					if rule.Namespace == "openshift-monitoring" {
+						foundAlertingRule = true
+					}
+				}
+			}
+			if tc.opts.PlatformMonitoring == metrics.PlatformMonitoringNone {
+				g.Expect(foundServiceMonitor).To(BeFalse(), "expected no ServiceMonitor when platform monitoring is None")
+				g.Expect(foundPrometheusRule).To(BeFalse(), "expected no PrometheusRule when platform monitoring is None")
+			} else {
+				g.Expect(foundServiceMonitor).To(BeTrue(), "expected ServiceMonitor when platform monitoring is enabled")
+				g.Expect(foundPrometheusRule).To(BeTrue(), "expected recording rule PrometheusRule when platform monitoring is enabled")
 			}
 			if tc.expectSLOAlerts {
 				g.Expect(foundAlertingRule).To(BeTrue(), "expected SLO alerting rule to be present when SLOsAlerts is enabled")
@@ -2081,6 +2112,16 @@ func TestSetupExternalDNS(t *testing.T) {
 			},
 			minResourceCount: 5,
 		},
+		{
+			name: "When platform monitoring is None, it should not include a PodMonitor",
+			opts: Options{
+				ExternalDNSProvider:          "aws",
+				ExternalDNSDomainFilter:      "example.com",
+				ExternalDNSCredentialsSecret: "my-dns-secret",
+				PlatformMonitoring:           metrics.PlatformMonitoringNone,
+			},
+			minResourceCount: 4,
+		},
 	}
 
 	for _, tc := range tests {
@@ -2105,6 +2146,18 @@ func TestSetupExternalDNS(t *testing.T) {
 						g.Expect(foundDNSEndpoints).To(BeTrue(), "expected dnsendpoints rule for google provider")
 					}
 				}
+			}
+
+			foundPodMonitor := false
+			for _, obj := range objects {
+				if _, ok := obj.(*prometheusoperatorv1.PodMonitor); ok {
+					foundPodMonitor = true
+				}
+			}
+			if tc.opts.PlatformMonitoring == metrics.PlatformMonitoringNone {
+				g.Expect(foundPodMonitor).To(BeFalse(), "expected no PodMonitor when platform monitoring is None")
+			} else {
+				g.Expect(foundPodMonitor).To(BeTrue(), "expected a PodMonitor when platform monitoring is enabled")
 			}
 		})
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -190,6 +190,7 @@ type HostedControlPlaneReconciler struct {
 	awsSession                              *aws.Config
 	reconcileInfrastructureStatus           func(ctx context.Context, hcp *hyperv1.HostedControlPlane) (infra.InfrastructureStatus, error)
 	EnableCVOManagementClusterMetricsAccess bool
+	EnablePlatformMonitoring                bool
 	ImageMetadataProvider                   util.ImageMetadataProvider
 	cpoAzureCredentialsLoaded               sync.Map
 	kmsAzureCredentialsLoaded               sync.Map
@@ -368,9 +369,6 @@ func (r *HostedControlPlaneReconciler) eventHandlers(scheme *runtime.Scheme, res
 		{obj: &corev1.Secret{}, handler: handler.EnqueueRequestForOwner(scheme, restMapper, &hyperv1.HostedControlPlane{})},
 		{obj: &corev1.ServiceAccount{}, handler: handler.EnqueueRequestForOwner(scheme, restMapper, &hyperv1.HostedControlPlane{})},
 		{obj: &policyv1.PodDisruptionBudget{}, handler: handler.EnqueueRequestForOwner(scheme, restMapper, &hyperv1.HostedControlPlane{})},
-		{obj: &prometheusoperatorv1.PodMonitor{}, handler: handler.EnqueueRequestForOwner(scheme, restMapper, &hyperv1.HostedControlPlane{})},
-		{obj: &prometheusoperatorv1.ServiceMonitor{}, handler: handler.EnqueueRequestForOwner(scheme, restMapper, &hyperv1.HostedControlPlane{})},
-		{obj: &prometheusoperatorv1.PrometheusRule{}, handler: handler.EnqueueRequestForOwner(scheme, restMapper, &hyperv1.HostedControlPlane{})},
 		{obj: &rbacv1.Role{}, handler: handler.EnqueueRequestForOwner(scheme, restMapper, &hyperv1.HostedControlPlane{})},
 		{obj: &rbacv1.RoleBinding{}, handler: handler.EnqueueRequestForOwner(scheme, restMapper, &hyperv1.HostedControlPlane{})},
 		{obj: &batchv1.CronJob{}, handler: handler.EnqueueRequestForOwner(scheme, restMapper, &hyperv1.HostedControlPlane{})},
@@ -378,6 +376,13 @@ func (r *HostedControlPlaneReconciler) eventHandlers(scheme *runtime.Scheme, res
 	}
 	if r.ManagementClusterCapabilities.Has(capabilities.CapabilityRoute) {
 		handlers = append(handlers, eventHandler{obj: &routev1.Route{}, handler: handler.EnqueueRequestForOwner(scheme, restMapper, &hyperv1.HostedControlPlane{})})
+	}
+	if r.EnablePlatformMonitoring {
+		handlers = append(handlers,
+			eventHandler{obj: &prometheusoperatorv1.PodMonitor{}, handler: handler.EnqueueRequestForOwner(scheme, restMapper, &hyperv1.HostedControlPlane{})},
+			eventHandler{obj: &prometheusoperatorv1.ServiceMonitor{}, handler: handler.EnqueueRequestForOwner(scheme, restMapper, &hyperv1.HostedControlPlane{})},
+			eventHandler{obj: &prometheusoperatorv1.PrometheusRule{}, handler: handler.EnqueueRequestForOwner(scheme, restMapper, &hyperv1.HostedControlPlane{})},
+		)
 	}
 
 	return handlers

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -82,6 +82,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/go-logr/zapr"
 	"github.com/opencontainers/go-digest"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap/zaptest"
 )
@@ -748,6 +749,7 @@ func TestEventHandling(t *testing.T) {
 		},
 		SetDefaultSecurityContext: false,
 		ec2Client:                 mockEC2,
+		EnablePlatformMonitoring:  true,
 	}
 	r.setup(controllerutil.CreateOrUpdate)
 
@@ -783,6 +785,38 @@ func TestEventHandling(t *testing.T) {
 
 			if len(fakeQueue.items) != 1 || fakeQueue.items[0].Namespace != hcp.Namespace || fakeQueue.items[0].Name != hcp.Name {
 				t.Errorf("object %+v didn't correctly create event", createdObject)
+			}
+		})
+	}
+}
+
+func TestEventHandlersPlatformMonitoring(t *testing.T) {
+	tests := []struct {
+		name                     string
+		enablePlatformMonitoring bool
+	}{
+		{name: "When platform monitoring is disabled, Prometheus Operator resources are not watched", enablePlatformMonitoring: false},
+		{name: "When platform monitoring is enabled, Prometheus Operator resources are watched", enablePlatformMonitoring: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			r := &HostedControlPlaneReconciler{
+				ManagementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
+				EnablePlatformMonitoring:      tc.enablePlatformMonitoring,
+			}
+
+			prometheusCount := 0
+			for _, eh := range r.eventHandlers(api.Scheme, meta.NewDefaultRESTMapper(nil)) {
+				switch eh.obj.(type) {
+				case *prometheusoperatorv1.PodMonitor, *prometheusoperatorv1.ServiceMonitor, *prometheusoperatorv1.PrometheusRule:
+					prometheusCount++
+				}
+			}
+			if tc.enablePlatformMonitoring {
+				g.Expect(prometheusCount).To(Equal(3))
+			} else {
+				g.Expect(prometheusCount).To(Equal(0))
 			}
 		})
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/component.go
@@ -28,6 +28,8 @@ type ControlPlaneOperatorOptions struct {
 	DefaultIngressDomain        string
 
 	FeatureSet configv1.FeatureSet
+
+	EnablePlatformMonitoring bool
 }
 
 // IsRequestServing implements controlplanecomponent.ComponentOptions.
@@ -55,6 +57,9 @@ func NewComponent(options *ControlPlaneOperatorOptions) component.ControlPlaneCo
 		WithManifestAdapter(
 			"podmonitor.yaml",
 			component.WithAdaptFunction(options.adaptPodMonitor),
+			component.WithPredicate(func(_ component.WorkloadContext) bool {
+				return options.EnablePlatformMonitoring
+			}),
 		).
 		WithManifestAdapter(
 			"rolebinding.yaml",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/deployment.go
@@ -149,6 +149,17 @@ func (cpo *ControlPlaneOperatorOptions) adaptDeployment(cpContext component.Work
 			)
 		}
 
+		platformMonitoringValue := "0"
+		if cpo.EnablePlatformMonitoring {
+			platformMonitoringValue = "1"
+		}
+		c.Env = append(c.Env,
+			corev1.EnvVar{
+				Name:  config.EnablePlatformMonitoringEnvVar,
+				Value: platformMonitoringValue,
+			},
+		)
+
 		if watchListClient := os.Getenv("KUBE_FEATURE_WatchListClient"); watchListClient != "" {
 			c.Env = append(c.Env,
 				corev1.EnvVar{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/deployment_test.go
@@ -7,6 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
+	"github.com/openshift/hypershift/support/config"
 	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
 
 	corev1 "k8s.io/api/core/v1"
@@ -157,6 +158,75 @@ func TestAdaptDeploymentWatchListClientEnv(t *testing.T) {
 			} else {
 				g.Expect(envVars).ToNot(ContainElement(HaveField("Name", "KUBE_FEATURE_WatchListClient")))
 			}
+		})
+	}
+}
+
+func TestAdaptDeploymentPlatformMonitoringEnv(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		enablePlatformMonitoring bool
+		expectedValue            string
+	}{
+		{
+			name:                     "When EnablePlatformMonitoring is true it should set the env var to 1",
+			enablePlatformMonitoring: true,
+			expectedValue:            "1",
+		},
+		{
+			name:                     "When EnablePlatformMonitoring is false it should explicitly set the env var to 0",
+			enablePlatformMonitoring: false,
+			expectedValue:            "0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			hc := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "clusters",
+				},
+			}
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "clusters-test-cluster",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					InfraID: "test-infra-id",
+				},
+			}
+
+			cpo := &ControlPlaneOperatorOptions{
+				HostedCluster:            hc,
+				Image:                    "test-image:latest",
+				UtilitiesImage:           "utilities:latest",
+				HasUtilities:             true,
+				EnablePlatformMonitoring: tc.enablePlatformMonitoring,
+			}
+
+			cpContext := controlplanecomponent.WorkloadContext{
+				Context: t.Context(),
+				HCP:     hcp,
+			}
+
+			deployment, err := assets.LoadDeploymentManifest(ComponentName)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			err = cpo.adaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			envVars := deployment.Spec.Template.Spec.Containers[0].Env
+			expectedEnvVar := corev1.EnvVar{
+				Name:  config.EnablePlatformMonitoringEnvVar,
+				Value: tc.expectedValue,
+			}
+
+			g.Expect(envVars).To(ContainElement(expectedEnvVar))
 		})
 	}
 }

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -520,6 +520,9 @@ func NewStartCommand() *cobra.Command {
 
 		enableCVOManagementClusterMetricsAccess := (os.Getenv(config.EnableCVOManagementClusterMetricsAccessEnvVar) == "1")
 
+		// Default enabled for compatibility with an older hypershift-operator that never sets this var
+		enablePlatformMonitoring := (os.Getenv(config.EnablePlatformMonitoringEnvVar) != "0")
+
 		if err := (&hostedcontrolplane.HostedControlPlaneReconciler{
 			Client:                                  mgr.GetClient(),
 			GVKAccessChecker:                        component.NewGVKAccessCache(mgr.GetAPIReader()),
@@ -532,6 +535,7 @@ func NewStartCommand() *cobra.Command {
 			MetricsSet:                              metricsSet,
 			CertRotationScale:                       certRotationScale,
 			EnableCVOManagementClusterMetricsAccess: enableCVOManagementClusterMetricsAccess,
+			EnablePlatformMonitoring:                enablePlatformMonitoring,
 			ImageMetadataProvider:                   imageMetaDataProvider,
 		}).SetupWithManager(mgr, upsert.New(enableCIDebugOutput).CreateOrUpdate, hcp); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "hosted-control-plane")

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -180,6 +180,8 @@ type HostedClusterReconciler struct {
 
 	EnableOCPClusterMonitoring bool
 
+	EnablePlatformMonitoring bool
+
 	createOrUpdate func(reconcile.Request) upsert.CreateOrUpdateFN
 
 	EnableCIDebugOutput bool
@@ -268,7 +270,6 @@ func (r *HostedClusterReconciler) managedResources() []client.Object {
 	managedResources := []client.Object{
 		&hyperv1.HostedControlPlane{},
 		&appsv1.Deployment{},
-		&prometheusoperatorv1.PodMonitor{},
 		&networkingv1.NetworkPolicy{},
 		&rbacv1.ClusterRole{},
 		&rbacv1.ClusterRoleBinding{},
@@ -301,6 +302,11 @@ func (r *HostedClusterReconciler) managedResources() []client.Object {
 	// reconcile HostedClusters since some CRs are only installed in the managed Azure use case.
 	if azureutil.IsAroHCP() {
 		managedResources = append(managedResources, k8sutil.ManagedAzure...)
+	}
+
+	// Only watch PodMonitor if platform monitoring is enabled
+	if r.EnablePlatformMonitoring {
+		managedResources = append(managedResources, &prometheusoperatorv1.PodMonitor{})
 	}
 
 	// Watch if etcd recovery is enabled
@@ -2999,6 +3005,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(cpContext contro
 		OpenShiftRegistryOverrides:  hyperutil.ConvertOpenShiftImageRegistryOverridesToCommandLineFlag(releaseProvider.GetOpenShiftImageRegistryOverrides()),
 		DefaultIngressDomain:        defaultIngressDomain,
 		FeatureSet:                  r.FeatureSet,
+		EnablePlatformMonitoring:    r.EnablePlatformMonitoring,
 	})
 
 	if err := cpo.Reconcile(cpContext); err != nil {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -86,6 +86,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap/zapcore"
 )
@@ -1752,6 +1753,41 @@ func TestReconcileAWSResourceTags(t *testing.T) {
 	}
 }
 
+func TestManagedResourcesPlatformMonitoring(t *testing.T) {
+	tests := []struct {
+		name                     string
+		enablePlatformMonitoring bool
+	}{
+		{
+			name:                     "When platform monitoring is disabled, PodMonitor is not watched",
+			enablePlatformMonitoring: false,
+		},
+		{
+			name:                     "When platform monitoring is enabled, PodMonitor is watched",
+			enablePlatformMonitoring: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			r := &HostedClusterReconciler{
+				ManagementClusterCapabilities: fakecapabilities.NewSupportAllExcept(),
+				EnablePlatformMonitoring:      tc.enablePlatformMonitoring,
+			}
+
+			foundPodMonitor := false
+			for _, resource := range r.managedResources() {
+				if _, ok := resource.(*prometheusoperatorv1.PodMonitor); ok {
+					foundPodMonitor = true
+					break
+				}
+			}
+			g.Expect(foundPodMonitor).To(Equal(tc.enablePlatformMonitoring))
+		})
+	}
+}
+
 func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockedProviderWithOpenShiftImageRegistryOverrides := releaseinfo.NewMockProviderWithOpenShiftImageRegistryOverrides(mockCtrl)
@@ -2193,6 +2229,7 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 					},
 				},
 				EnableEtcdRecovery:         true,
+				EnablePlatformMonitoring:   true,
 				now:                        metav1.Now,
 				OpenShiftTrustedCAFilePath: tmpCABundleFile.Name(),
 				HypershiftOperatorImage:    "test-image",
@@ -2243,6 +2280,156 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 				t.Errorf("the set of resources that are being created differs from the one that is being watched: %s", diff)
 			}
 		})
+	}
+}
+
+// TestReconcileSkipsPodMonitorWhenPlatformMonitoringDisabled verifies that reconciling a
+// HostedCluster does not create PodMonitor for the control-plane-operator component when
+// platform monitoring is disabled
+func TestReconcileSkipsPodMonitorWhenPlatformMonitoringDisabled(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	mockedProviderWithOpenShiftImageRegistryOverrides := releaseinfo.NewMockProviderWithOpenShiftImageRegistryOverrides(mockCtrl)
+	mockedProviderWithOpenShiftImageRegistryOverrides.EXPECT().
+		Lookup(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(testutils.InitReleaseImageOrDie("4.15.0"), nil).AnyTimes()
+	mockedProviderWithOpenShiftImageRegistryOverrides.EXPECT().
+		GetOpenShiftImageRegistryOverrides().
+		Return(nil).AnyTimes()
+	mockedProviderWithOpenShiftImageRegistryOverrides.EXPECT().
+		GetRegistryOverrides().
+		Return(nil).AnyTimes()
+
+	releaseImage := "quay.io/openshift-release-dev/ocp-release:4.15.0"
+	manifests := []manifestlist.ManifestDescriptor{
+		{
+			Descriptor: distribution.Descriptor{
+				MediaType: ManifestListMediaType,
+				Digest:    "sha256:70fb4524d21e1b6c08477eb5d1ca2cf282b3270b1d008f70dd7e1cf13d8ba4ce",
+			},
+			Platform: manifestlist.PlatformSpec{
+				Architecture: ArchitectureAMD64,
+				OS:           LinuxOS,
+			},
+		},
+	}
+	deserializeFunc := func(payload []byte) (*manifestlist.DeserializedManifestList, error) {
+		return &manifestlist.DeserializedManifestList{
+			ManifestList: manifestlist.ManifestList{
+				Manifests: manifests,
+			},
+		}, nil
+	}
+
+	hostedCluster := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "none",
+			Namespace: "test",
+		},
+		Spec: hyperv1.HostedClusterSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.NonePlatform,
+			},
+			Release: hyperv1.Release{
+				Image: releaseImage,
+			},
+			Services: []hyperv1.ServicePublishingStrategyMapping{
+				{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
+				{Service: hyperv1.Konnectivity, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route}},
+				{Service: hyperv1.OAuthServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route}},
+				{Service: hyperv1.Ignition, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route}},
+			},
+			PullSecret: corev1.LocalObjectReference{Name: "secret"},
+			InfraID:    "infra-id",
+			Networking: hyperv1.ClusterNetworking{
+				ClusterNetwork: []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}},
+				MachineNetwork: []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
+				ServiceNetwork: []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/24")}},
+			},
+		},
+	}
+
+	objects := []crclient.Object{
+		hostedCluster,
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret",
+				Namespace: "test",
+			},
+			Data: map[string][]byte{
+				"credentials":       []byte("creds"),
+				".dockerconfigjson": []byte("{}"),
+			},
+		},
+		&configv1.Network{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Spec:       configv1.NetworkSpec{NetworkType: "OVNKubernetes"},
+		},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "none"}},
+		//nolint:staticcheck // SA1019: corev1.Endpoints is intentionally used for backward compatibility
+		&corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "kubernetes", Namespace: "default"}},
+		&configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "supported-versions",
+				Namespace: "hypershift",
+				Labels: map[string]string{
+					"hypershift.openshift.io/supported-versions": "true",
+				},
+			},
+			Data: map[string]string{
+				"supported-versions": "{\"versions\":[\"4.22\",\"4.21\",\"4.20\",\"4.19\",\"4.18\",\"4.17\",\"4.16\",\"4.15\",\"4.14\"]}",
+				"server-version":     "some-fake-server-version",
+			},
+		},
+	}
+
+	tmpCABundleFile, err := os.CreateTemp("/tmp", "tls-ca-bundle.pem")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpCABundleFile.Name())
+
+	client := &createTypeTrackingClient{Client: fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).WithStatusSubresource(&hyperv1.HostedCluster{}).Build()}
+	r := &HostedClusterReconciler{
+		Client:            client,
+		Clock:             clock.RealClock{},
+		CertRotationScale: 24 * time.Hour,
+		ManagementClusterCapabilities: fakecapabilities.NewSupportAllExcept(
+			capabilities.CapabilityInfrastructure,
+			capabilities.CapabilityIngress,
+			capabilities.CapabilityProxy,
+		),
+		createOrUpdate: func(reconcile.Request) upsert.CreateOrUpdateFN { return ctrl.CreateOrUpdate },
+		RegistryProvider: fakeReleaseProvider{
+			releaseProvider: mockedProviderWithOpenShiftImageRegistryOverrides,
+			metadataProvider: fakeimagemetadataprovider.FakeRegistryClientImageMetadataProvider{
+				Result:    &dockerv1client.DockerImageConfig{},
+				Manifest:  fakeimagemetadataprovider.FakeManifest{},
+				MediaType: ManifestListMediaType,
+			},
+		},
+		EnablePlatformMonitoring:   false,
+		now:                        metav1.Now,
+		OpenShiftTrustedCAFilePath: tmpCABundleFile.Name(),
+		HypershiftOperatorImage:    "test-image",
+	}
+	r.KubevirtInfraClients = kvinfra.NewMockKubevirtInfraClientMap(&createTypeTrackingClient{Client: fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).Build()},
+		"v1.2.0",
+		"1.28.0")
+
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+		o.EncodeTime = zapcore.RFC3339TimeEncoder
+	})))
+
+	ctx := context.WithValue(t.Context(), registryclient.DeserializeFuncName, deserializeFunc)
+	if _, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: hostedCluster.Namespace, Name: hostedCluster.Name}}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	for _, resourceType := range sets.List(client.createdTypes) {
+		if resourceType == "*v1.PodMonitor" {
+			t.Errorf("expected no PodMonitor to be created when platform monitoring is disabled, but found one")
+		}
 	}
 }
 

--- a/hypershift-operator/controllers/hostedcluster/testdata/control-plane-operator/zz_fixture_TestReconcileComponents.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/control-plane-operator/zz_fixture_TestReconcileComponents.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     hypershift.openshift.io/cluster: ""
-    hypershift.openshift.io/desired-state-hash: 844c6d9543448ed692ef0d3fc38f47e052accf6a174e7ea196c269be7eb6b8f5
+    hypershift.openshift.io/desired-state-hash: a9b5fb9b4137b0db31646651c29ed9880ec6ff5cae36dd22a7be103b53aea02e
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: control-plane-operator
@@ -104,6 +104,8 @@ spec:
         - name: DEFAULT_SECURITY_CONTEXT_UID
           value: "0"
         - name: METRICS_SET
+        - name: ENABLE_PLATFORM_MONITORING
+          value: "0"
         - name: AWS_SHARED_CREDENTIALS_FILE
           value: /etc/provider/credentials
         - name: AWS_REGION

--- a/hypershift-operator/controllers/hostedcluster/testdata/control-plane-operator/zz_fixture_TestReconcileComponents_component.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/control-plane-operator/zz_fixture_TestReconcileComponents_component.yaml
@@ -19,9 +19,6 @@ status:
     status: "False"
     type: RolloutComplete
   resources:
-  - group: monitoring.coreos.com
-    kind: PodMonitor
-    name: controlplane-operator
   - group: rbac.authorization.k8s.io
     kind: Role
     name: control-plane-operator

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -557,6 +557,7 @@ func setupMetricsSet(mgr ctrl.Manager, opts *StartOptions, log logr.Logger) (met
 func setupHostedClusterController(ctx context.Context, mgr ctrl.Manager, opts *StartOptions, mgmtClusterCaps *capabilities.ManagementClusterCapabilities, operatorImage string, createOrUpdate upsert.CreateOrUpdateProvider, metricsSet metrics.MetricsSet, sreConfigHash string, registryProvider globalconfig.CommonRegistryProvider, log logr.Logger) error {
 	monitoringDashboards := (os.Getenv("MONITORING_DASHBOARDS") == "1")
 	enableCVOManagementClusterMetricsAccess := (os.Getenv(config.EnableCVOManagementClusterMetricsAccessEnvVar) == "1")
+	enablePlatformMonitoring := os.Getenv(config.EnablePlatformMonitoringEnvVar) == "1"
 	enableEtcdRecovery := os.Getenv(config.EnableEtcdRecoveryEnvVar) == "1"
 	reconcileLegacy := os.Getenv(config.ReconcileLegacyEnvVar) == "1"
 
@@ -572,6 +573,7 @@ func setupHostedClusterController(ctx context.Context, mgr ctrl.Manager, opts *S
 		RegistryOverrides:                       opts.RegistryOverrides,
 		RegistryProvider:                        registryProvider,
 		EnableOCPClusterMonitoring:              opts.EnableOCPClusterMonitoring,
+		EnablePlatformMonitoring:                enablePlatformMonitoring,
 		EnableCIDebugOutput:                     opts.EnableCIDebugOutput,
 		MetricsSet:                              metricsSet,
 		OperatorNamespace:                       opts.Namespace,

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -48,8 +48,9 @@ const (
 	EnableCVOManagementClusterMetricsAccessEnvVar = "ENABLE_CVO_MANAGEMENT_CLUSTER_METRICS_ACCESS"
 	CVOPrometheusURLEnvVar                        = "CVO_PROMETHEUS_URL"
 
-	EnableEtcdRecoveryEnvVar = "ENABLE_ETCD_RECOVERY"
-	ReconcileLegacyEnvVar    = "HYPERSHIFT_RECONCILE_LEGACY"
+	EnableEtcdRecoveryEnvVar       = "ENABLE_ETCD_RECOVERY"
+	ReconcileLegacyEnvVar          = "HYPERSHIFT_RECONCILE_LEGACY"
+	EnablePlatformMonitoringEnvVar = "ENABLE_PLATFORM_MONITORING"
 
 	AuditWebhookService = "audit-webhook"
 


### PR DESCRIPTION
## What this PR does / why we need it:

With `--platform-monitoring None`, `hypershift install` still rendered a `ServiceMonitor` and `PrometheusRule`, and the `hypershift-operator` still watched `PodMonitor`. On a management cluster without the `monitoring.coreos.com` CRDs (e.g. a non-OpenShift/vanilla Kubernetes cluster), this made `install` exit non-zero and caused the operator to log missing-kind errors on startup.

This scopes every Prometheus Operator resource (rendering and watching) behind the `--platform-monitoring` flag:
- `cmd/install/install.go` / `cmd/install/assets`: `setupMonitoring()` and `setupExternalDNS()` only render
  `ServiceMonitor`/`PrometheusRule`/`PodMonitor` when platform monitoring is enabled.
- `hypershift-operator`: gate the `PodMonitor` watch.
- `control-plane-operator`: gate the CPO-bootstrap `PodMonitor` and the CPO's own watch for all three kinds, so a HostedCluster on a None-mode install doesn't hit the same failure in the per-cluster CPO pod.

Existing behavior with monitoring enabled (`OperatorOnly`/`All`) is unchanged. Out of scope: per-component CPOv2 metrics.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes: https://redhat.atlassian.net/browse/HYPERFLEET-1557

## Special notes for your reviewer:
- Verified on a `kind` cluster (no `monitoring.coreos.com` CRDs installed): `install --platform-monitoring None` exits `0`, operator pods stay healthy, no `no matches for kind` errors. Reproduced the original failure and re-running the same test (non-zero exit, `no matches for kind` in operator logs). Also verified the `All`-mode regression path with the CRDs installed.
- No docs change,`--platform-monitoring` already existed and is documented.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable platform monitoring for HyperShift components.
  * When enabled, monitoring resources are created, tracked, and updated.
  * Added support for configuring platform monitoring through the `ENABLE_PLATFORM_MONITORING` environment variable.

* **Bug Fixes**
  * Monitoring resources are no longer created or watched when platform monitoring is disabled.
  * Reserved monitoring configuration cannot be overridden by additional environment variables.

* **Tests**
  * Expanded coverage for enabled and disabled platform monitoring scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->