### PR TITLE
[release-5.0] OCPBUGS-121650, OCPBUGS-115188: backport safe-to-evict annotation and operator health probes fixes

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -120,6 +120,7 @@ const (
 	externaDNSCredsSecretName     = "external-dns-credentials"
 
 	HypershiftOperatorName                = "operator"
+	HypershiftOperatorHealthProbePort     = 8081
 	ExternalDNSDeploymentName             = "external-dns"
 	HyperShiftInstallCLIVersionAnnotation = "hypershift.openshift.io/install-cli-version"
 )
@@ -672,8 +673,8 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Path:   "/metrics",
-										Port:   intstr.FromInt(9000),
+										Path:   "/healthz",
+										Port:   intstr.FromInt(HypershiftOperatorHealthProbePort),
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
@@ -686,8 +687,8 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Path:   "/metrics",
-										Port:   intstr.FromInt(9000),
+										Path:   "/readyz",
+										Port:   intstr.FromInt(HypershiftOperatorHealthProbePort),
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
@@ -706,6 +707,11 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 								{
 									Name:          "manager",
 									ContainerPort: 9443,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "health",
+									ContainerPort: HypershiftOperatorHealthProbePort,
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
@@ -593,8 +594,24 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 			deployment := test.inputBuildParameters.Build()
 			g.Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(BeEquivalentTo(test.expectedArgs))
 			g.Expect(deployment.Spec.Template.Spec.Volumes).To(BeEquivalentTo(test.expectedVolumes))
-			g.Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts).To(BeEquivalentTo(test.expectedVolumeMounts))
-			g.Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(ContainElements(test.expectedEnvVars))
+			container := deployment.Spec.Template.Spec.Containers[0]
+			g.Expect(container.VolumeMounts).To(BeEquivalentTo(test.expectedVolumeMounts))
+			g.Expect(container.Env).To(ContainElements(test.expectedEnvVars))
+			g.Expect(container.LivenessProbe.HTTPGet).To(Equal(&corev1.HTTPGetAction{
+				Path:   "/healthz",
+				Port:   intstr.FromInt(HypershiftOperatorHealthProbePort),
+				Scheme: corev1.URISchemeHTTP,
+			}))
+			g.Expect(container.ReadinessProbe.HTTPGet).To(Equal(&corev1.HTTPGetAction{
+				Path:   "/readyz",
+				Port:   intstr.FromInt(HypershiftOperatorHealthProbePort),
+				Scheme: corev1.URISchemeHTTP,
+			}))
+			g.Expect(container.Ports).To(ContainElement(corev1.ContainerPort{
+				Name:          "health",
+				ContainerPort: HypershiftOperatorHealthProbePort,
+				Protocol:      corev1.ProtocolTCP,
+			}))
 		})
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -757,13 +757,13 @@ func (r *reconciler) reconcileAPIServicesAndOAuth(ctx context.Context, hcp *hype
 		errs = append(errs, fmt.Errorf("failed to reconcile konnectivity agent: %w", err))
 	}
 
-	log.Info("reconciling KAS connection checker deployment")
+	log.Info("reconciling KAS connection checker resources")
 	cliImage, ok := releaseImage.ComponentImages()["cli"]
 	if !ok {
 		errs = append(errs, fmt.Errorf("failed to find cli image in release"))
 	} else {
-		if err := r.reconcileKASConnectionCheckerDeployment(ctx, hcp, cliImage); err != nil {
-			errs = append(errs, fmt.Errorf("failed to reconcile KAS connection checker deployment: %w", err))
+		if err := r.reconcileKASConnectionChecker(ctx, hcp, cliImage); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile KAS connection checker: %w", err))
 		}
 	}
 
@@ -1740,7 +1740,7 @@ func (r *reconciler) patchHCPStatusCondition(ctx context.Context, hcp *hyperv1.H
 	return nil
 }
 
-func (r *reconciler) reconcileKASConnectionCheckerDeployment(ctx context.Context, hcp *hyperv1.HostedControlPlane, cliImage string) error {
+func (r *reconciler) reconcileKASConnectionChecker(ctx context.Context, hcp *hyperv1.HostedControlPlane, cliImage string) error {
 	endpoint := getKASHealthCheckEndpoint(hcp.Spec.Platform.Type)
 
 	serviceAccount := manifests.KASConnectionCheckerServiceAccount()
@@ -1791,12 +1791,20 @@ done`, endpoint, manifests.KASConnectionCheckerConfigMapName, manifests.KASConne
 			},
 		}
 
-		deployment.Spec.Template.ObjectMeta.Labels = map[string]string{
-			"app": manifests.KASConnectionCheckerName,
+		if deployment.Spec.Template.ObjectMeta.Labels == nil {
+			deployment.Spec.Template.ObjectMeta.Labels = map[string]string{}
 		}
-		deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{
-			"openshift.io/required-scc": "restricted-v2",
+		deployment.Spec.Template.ObjectMeta.Labels["app"] = manifests.KASConnectionCheckerName
+
+		if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+			deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{}
 		}
+		// Remove stale annotation left by older HCCO versions.
+		delete(deployment.Spec.Template.ObjectMeta.Annotations, "openshift.io/required-scc")
+		// Allow the cluster autoscaler to evict this pod during scale-down.
+		// Without this annotation, kube-system pods without a PDB are treated
+		// as unmovable system pods that block node scale-down.
+		deployment.Spec.Template.ObjectMeta.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] = "true"
 
 		deployment.Spec.Template.Spec.ServiceAccountName = manifests.KASConnectionCheckerName
 		deployment.Spec.Template.Spec.PriorityClassName = "system-node-critical"
@@ -1817,30 +1825,24 @@ done`, endpoint, manifests.KASConnectionCheckerConfigMapName, manifests.KASConne
 			},
 		}
 
-		// Tolerate NoSchedule taints so it can be scheduled on tainted nodes,
-		// and specific NoExecute taints so it is not evicted from unhealthy nodes.
-		// A catch-all {Operator: Exists} toleration is NOT used because it also
-		// bypasses the NodeUnschedulable filter, causing replacement pods to be
-		// scheduled back onto cordoned nodes during drain — creating an infinite
-		// eviction loop that blocks node rollouts.
-		deployment.Spec.Template.Spec.Tolerations = []corev1.Toleration{
+		// Spread pods across nodes.
+		deployment.Spec.Template.Spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
 			{
-				Operator: corev1.TolerationOpExists,
-				Effect:   corev1.TaintEffectNoSchedule,
-			},
-			{
-				Key:               "node.kubernetes.io/unreachable",
-				Operator:          corev1.TolerationOpExists,
-				Effect:            corev1.TaintEffectNoExecute,
-				TolerationSeconds: ptr.To[int64](120),
-			},
-			{
-				Key:               "node.kubernetes.io/not-ready",
-				Operator:          corev1.TolerationOpExists,
-				Effect:            corev1.TaintEffectNoExecute,
-				TolerationSeconds: ptr.To[int64](120),
+				MaxSkew:           1,
+				TopologyKey:       "kubernetes.io/hostname",
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": manifests.KASConnectionCheckerName,
+					},
+				},
 			},
 		}
+
+		// No custom tolerations — the previous blanket NoSchedule toleration
+		// matched the cordon taint, causing a drain loop. Kubernetes provides
+		// default NoExecute tolerations via DefaultTolerationSeconds.
+		deployment.Spec.Template.Spec.Tolerations = nil
 
 		return nil
 	}); err != nil {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -3122,42 +3121,43 @@ func verifyKASCheckerPodSpec(t *testing.T, dep *appsv1.Deployment) {
 	}
 }
 
-func verifyKASCheckerTolerations(t *testing.T, dep *appsv1.Deployment) {
+func verifyKASCheckerNoTolerations(t *testing.T, dep *appsv1.Deployment) {
 	t.Helper()
-	expectedTolerations := []corev1.Toleration{
-		{
-			Operator: corev1.TolerationOpExists,
-			Effect:   corev1.TaintEffectNoSchedule,
-		},
-		{
-			Key:               "node.kubernetes.io/unreachable",
-			Operator:          corev1.TolerationOpExists,
-			Effect:            corev1.TaintEffectNoExecute,
-			TolerationSeconds: ptr.To[int64](120),
-		},
-		{
-			Key:               "node.kubernetes.io/not-ready",
-			Operator:          corev1.TolerationOpExists,
-			Effect:            corev1.TaintEffectNoExecute,
-			TolerationSeconds: ptr.To[int64](120),
-		},
+	// No custom tolerations — the previous blanket NoSchedule toleration
+	// matched the cordon taint, causing pods to be scheduled back onto
+	// cordoned nodes during drain.
+	if len(dep.Spec.Template.Spec.Tolerations) != 0 {
+		t.Errorf("Expected no tolerations, got %d", len(dep.Spec.Template.Spec.Tolerations))
 	}
-	if len(dep.Spec.Template.Spec.Tolerations) != len(expectedTolerations) {
-		t.Fatalf("Expected %d tolerations, got %d", len(expectedTolerations), len(dep.Spec.Template.Spec.Tolerations))
+}
+
+func verifyKASCheckerTopologySpread(t *testing.T, dep *appsv1.Deployment) {
+	t.Helper()
+	if len(dep.Spec.Template.Spec.TopologySpreadConstraints) != 1 {
+		t.Fatalf("Expected 1 topology spread constraint, got %d", len(dep.Spec.Template.Spec.TopologySpreadConstraints))
 	}
-	for i, expected := range expectedTolerations {
-		actual := dep.Spec.Template.Spec.Tolerations[i]
-		if actual.Operator != expected.Operator || actual.Effect != expected.Effect || actual.Key != expected.Key || !reflect.DeepEqual(actual.TolerationSeconds, expected.TolerationSeconds) {
-			t.Errorf("Toleration[%d] mismatch: got {Key:%q, Operator:%q, Effect:%q, TolerationSeconds:%v}, want {Key:%q, Operator:%q, Effect:%q, TolerationSeconds:%v}",
-				i, actual.Key, actual.Operator, actual.Effect, actual.TolerationSeconds, expected.Key, expected.Operator, expected.Effect, expected.TolerationSeconds)
-		}
+	tsc := dep.Spec.Template.Spec.TopologySpreadConstraints[0]
+	if tsc.MaxSkew != 1 {
+		t.Errorf("Expected MaxSkew 1, got %d", tsc.MaxSkew)
+	}
+	if tsc.TopologyKey != "kubernetes.io/hostname" {
+		t.Errorf("Expected TopologyKey kubernetes.io/hostname, got %s", tsc.TopologyKey)
+	}
+	if tsc.WhenUnsatisfiable != corev1.ScheduleAnyway {
+		t.Errorf("Expected WhenUnsatisfiable ScheduleAnyway, got %s", tsc.WhenUnsatisfiable)
+	}
+	if tsc.LabelSelector == nil || tsc.LabelSelector.MatchLabels["app"] != manifests.KASConnectionCheckerName {
+		t.Error("Expected LabelSelector to match app=kas-connection-checker")
 	}
 }
 
 func verifyKASCheckerAnnotations(t *testing.T, dep *appsv1.Deployment) {
 	t.Helper()
-	if dep.Spec.Template.ObjectMeta.Annotations["openshift.io/required-scc"] != "restricted-v2" {
-		t.Errorf("Expected openshift.io/required-scc annotation 'restricted-v2', got %s", dep.Spec.Template.ObjectMeta.Annotations["openshift.io/required-scc"])
+	if got, ok := dep.Spec.Template.ObjectMeta.Annotations["openshift.io/required-scc"]; ok {
+		t.Errorf("openshift.io/required-scc annotation should not be set, got %s", got)
+	}
+	if dep.Spec.Template.ObjectMeta.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] != "true" {
+		t.Error("Expected safe-to-evict annotation to be set to 'true'")
 	}
 }
 
@@ -3177,7 +3177,7 @@ func getKASCheckerDeployment(t *testing.T, c client.Client) *appsv1.Deployment {
 	return dep
 }
 
-func Test_reconciler_reconcileKASConnectionCheckerDeployment(t *testing.T) {
+func TestReconcileKASConnectionChecker(t *testing.T) {
 	t.Parallel()
 	const testCLIImage = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cli-test"
 
@@ -3204,8 +3204,9 @@ func Test_reconciler_reconcileKASConnectionCheckerDeployment(t *testing.T) {
 				}
 				verifyKASCheckerPodSpec(t, dep)
 				verifyKASCheckerResources(t, container)
-				verifyKASCheckerTolerations(t, dep)
+				verifyKASCheckerNoTolerations(t, dep)
 				verifyKASCheckerAnnotations(t, dep)
+				verifyKASCheckerTopologySpread(t, dep)
 
 				cm := &corev1.ConfigMap{}
 				if err := c.Get(context.Background(), client.ObjectKey{Name: manifests.KASConnectionCheckerConfigMapName, Namespace: manifests.KASConnectionCheckerNamespace}, cm); err != nil {
@@ -3282,7 +3283,9 @@ func Test_reconciler_reconcileKASConnectionCheckerDeployment(t *testing.T) {
 				if dep.Spec.Template.Spec.ServiceAccountName != manifests.KASConnectionCheckerName {
 					t.Errorf("Expected ServiceAccountName %s, got %s", manifests.KASConnectionCheckerName, dep.Spec.Template.Spec.ServiceAccountName)
 				}
+				verifyKASCheckerNoTolerations(t, dep)
 				verifyKASCheckerAnnotations(t, dep)
+				verifyKASCheckerTopologySpread(t, dep)
 			},
 		},
 	}
@@ -3291,7 +3294,7 @@ func Test_reconciler_reconcileKASConnectionCheckerDeployment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var r reconciler
 
-			// Setup fake client with existing Deployment if provided
+			// Setup fake client with existing objects if provided
 			var objects []client.Object
 			if tt.existingDeployment != nil {
 				objects = append(objects, tt.existingDeployment)
@@ -3300,10 +3303,10 @@ func Test_reconciler_reconcileKASConnectionCheckerDeployment(t *testing.T) {
 			r.CreateOrUpdateProvider = &simpleCreateOrUpdater{}
 
 			ctx := context.Background()
-			err := r.reconcileKASConnectionCheckerDeployment(ctx, tt.hcp, testCLIImage)
+			err := r.reconcileKASConnectionChecker(ctx, tt.hcp, testCLIImage)
 
 			if (err != nil) != tt.wantErr {
-				t.Errorf("reconcileKASConnectionCheckerDeployment() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("reconcileKASConnectionChecker() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -94,6 +94,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -274,6 +275,9 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	if err != nil {
 		return err
 	}
+	if err := setupHealthChecks(mgr, opts.CertDir != ""); err != nil {
+		return err
+	}
 
 	operatorImage, err := resolveOperatorImage(ctx, mgr, opts, log)
 	if err != nil {
@@ -447,11 +451,34 @@ func createManager(restConfig *rest.Config, webhookOptions webhook.Options, opts
 		LeaseDuration:                 &leaseDuration,
 		RenewDeadline:                 &renewDeadline,
 		RetryPeriod:                   &retryPeriod,
+		HealthProbeBindAddress:        fmt.Sprintf(":%d", assets.HypershiftOperatorHealthProbePort),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to start manager: %w", err)
 	}
 	return mgr, nil
+}
+
+type healthCheckManager interface {
+	AddHealthzCheck(string, healthz.Checker) error
+	AddReadyzCheck(string, healthz.Checker) error
+	GetWebhookServer() webhook.Server
+}
+
+func setupHealthChecks(mgr healthCheckManager, webhookEnabled bool) error {
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return fmt.Errorf("unable to set up health check: %w", err)
+	}
+	readyCheck := healthz.Ping
+	if webhookEnabled {
+		// Conversion webhooks must be reachable before caches can sync resources
+		// requested in a version different from their storage version.
+		readyCheck = mgr.GetWebhookServer().StartedChecker()
+	}
+	if err := mgr.AddReadyzCheck("readyz", readyCheck); err != nil {
+		return fmt.Errorf("unable to set up ready check: %w", err)
+	}
+	return nil
 }
 
 func resolveOperatorImage(ctx context.Context, mgr ctrl.Manager, opts *StartOptions, log logr.Logger) (string, error) {

--- a/hypershift-operator/main_test.go
+++ b/hypershift-operator/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+type fakeHealthCheckManager struct {
+	webhookServer webhook.Server
+	healthChecks  map[string]healthz.Checker
+	readyChecks   map[string]healthz.Checker
+}
+
+func (m *fakeHealthCheckManager) AddHealthzCheck(name string, check healthz.Checker) error {
+	m.healthChecks[name] = check
+	return nil
+}
+
+func (m *fakeHealthCheckManager) AddReadyzCheck(name string, check healthz.Checker) error {
+	m.readyChecks[name] = check
+	return nil
+}
+
+func (m *fakeHealthCheckManager) GetWebhookServer() webhook.Server {
+	return m.webhookServer
+}
+
+func TestSetupHealthChecks(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		webhookEnabled     bool
+		expectReadyToError bool
+	}{
+		{
+			name:               "When webhooks are enabled it should wait for the webhook server",
+			webhookEnabled:     true,
+			expectReadyToError: true,
+		},
+		{
+			name:           "When webhooks are disabled it should report ready",
+			webhookEnabled: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			mgr := &fakeHealthCheckManager{
+				webhookServer: webhook.NewServer(webhook.Options{}),
+				healthChecks:  map[string]healthz.Checker{},
+				readyChecks:   map[string]healthz.Checker{},
+			}
+
+			g.Expect(setupHealthChecks(mgr, tc.webhookEnabled)).To(Succeed())
+			g.Expect(mgr.healthChecks).To(HaveKey("healthz"))
+			g.Expect(mgr.readyChecks).To(HaveKey("readyz"))
+
+			request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+			g.Expect(mgr.healthChecks["healthz"](request)).To(Succeed())
+			if tc.expectReadyToError {
+				g.Expect(mgr.readyChecks["readyz"](request)).To(MatchError("webhook server has not been started yet"))
+			} else {
+				g.Expect(mgr.readyChecks["readyz"](request)).To(Succeed())
+			}
+		})
+	}
+}

--- a/test/e2e/v2/tests/control_plane_tls_operator_test.go
+++ b/test/e2e/v2/tests/control_plane_tls_operator_test.go
@@ -227,7 +227,7 @@ func waitForAppPodRestart(
 		newPodUID = string(readyPod.UID)
 		g.Expect(newPodUID).NotTo(Equal(previousUID),
 			"%s pod UID should have changed after TLS config mutation (still %s)", appLabel, previousUID)
-	}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+	}, 5*time.Minute, 5*time.Second).Should(Succeed(),
 		"%s pod should restart and become ready after TLS config mutation", appLabel)
 	return newPodUID
 }


### PR DESCRIPTION
## Summary

This PR combines three backport fixes that are blocking all release-5.0 merges:

### 1. kas-connection-checker safe-to-evict annotation (backport of #8338)
- Add `cluster-autoscaler.kubernetes.io/safe-to-evict: "true"` annotation to kas-connection-checker deployment so cluster autoscaler can evict pods during scale-down
- Add TopologySpreadConstraints to distribute replicas across nodes
- Remove all custom tolerations to break drain loop caused by blanket NoSchedule toleration matching cordon taints
- Remove stale `openshift.io/required-scc` annotation (kube-system is exempt from SCC admission)
- Preserve existing annotations/labels instead of replacing entire maps

### 2. Operator health probes (backport of #9387, originally PR #9485)
- Bind controller-runtime health endpoints on port 8081
- Use `healthz.Ping` for liveness
- Use webhook-server startup readiness when webhooks are enabled
- Generate matching `/healthz` and `/readyz` probes and test coverage

### 3. TLS test timeout fix (backport of #9422)
- Increase `waitForAppPodRestart` timeout from 2 minutes to 5 minutes
- Pod restarts after TLS config mutation can take longer than 2 minutes in CI, causing flaky failures in `ControlPlaneTLS` tests

## Which issue(s) this PR fixes

- https://redhat.atlassian.net/browse/OCPBUGS-121650
- https://redhat.atlassian.net/browse/OCPBUGS-115188

## Why

These three fixes are **mutually dependent for CI**:
- Without the health probes fix, `e2e-aws-upgrade-hypershift-operator` deadlocks (new pod can't pass readiness without leader lease, old pod holds lease)
- Without the safe-to-evict fix, `e2e-v2-aws` compliance test fails deterministically
- Without the TLS timeout fix, `e2e-v2-aws` ControlPlaneTLS test times out waiting for pod restart

All three are required to unblock the release-5.0 merge queue.

## Test plan

- [x] Unit tests pass (`TestReconcileKASConnectionChecker` — 3 subtests)
- [x] Unit tests pass (`TestHyperShiftOperatorHealthProbes`)
- [ ] CI `e2e-aws-upgrade-hypershift-operator` should pass (health probes fix)
- [ ] CI `e2e-v2-aws` should pass (safe-to-evict + TLS timeout fixes)
- [ ] Verify no regression in other e2e suites

/assign jparrill

🤖 Generated with [Claude Code](https://claude.com/claude-code)