### PR TITLE
OCPBUGS-120840: remove TechPreviewNoUpgrade from AWS cluster creation args

### DIFF
--- a/test/e2e/v2/lifecycle/aws.go
+++ b/test/e2e/v2/lifecycle/aws.go
@@ -61,6 +61,7 @@ func (a *AWSPlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Cluster
 			Variant: "public",
 			ExtraArgs: append(extraArgs, []string{
 				"--public-only",
+				"--feature-set=TechPreviewNoUpgrade",
 			}...),
 		},
 		{
@@ -87,6 +88,7 @@ func (a *AWSPlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Cluster
 				"--auto-node",
 				// Required for karpenter to reach the hosted cluster API server from the mgmt cluster
 				"--endpoint-access=PublicAndPrivate",
+				"--feature-set=TechPreviewNoUpgrade",
 			}...),
 		},
 		{

--- a/test/e2e/v2/lifecycle/aws.go
+++ b/test/e2e/v2/lifecycle/aws.go
@@ -113,7 +113,6 @@ func (a *AWSPlatformConfig) CreateArgs() []string {
 		"--toleration=key=hypershift-e2e-test-toleration,operator=Equal,value=true,effect=NoSchedule",
 		"--annotations=hypershift.openshift.io/cleanup-cloud-resources=true",
 		"--annotations=hypershift.openshift.io/skip-release-image-validation=true",
-		"--feature-set=TechPreviewNoUpgrade",
 	}
 	for _, tag := range a.additionalTags {
 		args = append(args, "--additional-tags="+tag)


### PR DESCRIPTION
## Summary

Fixes OCPBUGS-120840: control-plane-upgrade test was failing due to TechPreviewNoUpgrade being applied globally to all test clusters.

## Root Cause

`--feature-set=TechPreviewNoUpgrade` was in the global `CreateArgs()`, affecting ALL clusters including upgrade variants. When upgrade tests run on TechPreview clusters, they expose a CSI snapshot controller CRD storage-version conflict: v1beta2 was removed from spec.versions but still present in status.storedVersions.

## Fix

- Remove `TechPreviewNoUpgrade` from global `CreateArgs()`
- Add it only to variants that need TechPreview features: **public** and **karpenter**
- Keep it off **upgrade** and **karpenter-upgrade** variants

Upgrade tests should use stable GA APIs, not preview features.

## Testing

- Control-plane-upgrade test runs with stable APIs
- Public/karpenter tests still get TechPreview features for development testing
- No impact on other tests

Fixes: OCPBUGS-120840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Changes**
  - AWS-hosted clusters no longer default to the `TechPreviewNoUpgrade` feature set.
  - Clusters created through the `public` and `karpenter` variants now use the `TechPreviewNoUpgrade` feature set.
  - Cluster lifecycle behavior is now aligned with the selected cluster specification variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->