### PR TITLE
OCPBUGS-121208: filter AWS-reserved tag keys before calling DeleteTags

### DIFF
--- a/support/awsutil/sg.go
+++ b/support/awsutil/sg.go
@@ -3,6 +3,7 @@ package awsutil
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/openshift/hypershift/support/awsapi"
 
@@ -245,6 +246,13 @@ func UpdateResourceTags(ctx context.Context, ec2Client awsapi.EC2API, resourceID
 		// Create/Update tags in AWS.
 		if _, err := ec2Client.CreateTags(ctx, input); err != nil {
 			return errors.Wrapf(err, "failed to create tags for resource %q: %+v", resourceID, create)
+		}
+	}
+
+	// Filter out AWS-reserved tag keys (aws:* prefix) that cannot be deleted.
+	for key := range remove {
+		if strings.HasPrefix(key, "aws:") {
+			delete(remove, key)
 		}
 	}
 

--- a/support/awsutil/sg_test.go
+++ b/support/awsutil/sg_test.go
@@ -1,0 +1,114 @@
+package awsutil
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/openshift/hypershift/support/awsapi"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+type fakeEC2TagClient struct {
+	awsapi.EC2API
+	createdTags []ec2types.Tag
+	deletedTags []ec2types.Tag
+	deleteCalls int
+}
+
+func (f *fakeEC2TagClient) CreateTags(_ context.Context, input *ec2.CreateTagsInput, _ ...func(*ec2.Options)) (*ec2.CreateTagsOutput, error) {
+	f.createdTags = append(f.createdTags, input.Tags...)
+	return &ec2.CreateTagsOutput{}, nil
+}
+
+func (f *fakeEC2TagClient) DeleteTags(_ context.Context, input *ec2.DeleteTagsInput, _ ...func(*ec2.Options)) (*ec2.DeleteTagsOutput, error) {
+	f.deleteCalls++
+	f.deletedTags = append(f.deletedTags, input.Tags...)
+	return &ec2.DeleteTagsOutput{}, nil
+}
+
+func TestUpdateResourceTags_FiltersAWSReservedKeys(t *testing.T) {
+	tests := []struct {
+		name               string
+		remove             map[string]string
+		expectDeleteCalled bool
+		expectDeletedKeys  []string
+	}{
+		{
+			name: "only aws: prefixed keys are filtered, no DeleteTags call",
+			remove: map[string]string{
+				"aws:cloudformation:stack-name": "my-stack",
+				"aws:cloudformation:stack-id":   "arn:aws:cloudformation:us-east-1:123456:stack/my-stack/guid",
+				"aws:cloudformation:logical-id": "DefaultSg",
+				"aws:":                          "reserved",
+			},
+			expectDeleteCalled: false,
+		},
+		{
+			name: "mixed keys, only non-aws keys passed to DeleteTags",
+			remove: map[string]string{
+				"aws:cloudformation:stack-name": "my-stack",
+				"custom-tag":                    "value1",
+				"another-tag":                   "value2",
+			},
+			expectDeleteCalled: true,
+			expectDeletedKeys:  []string{"custom-tag", "another-tag"},
+		},
+		{
+			name: "no aws: keys, all passed to DeleteTags",
+			remove: map[string]string{
+				"red-hat-managed": "true",
+				"Name":            "my-sg",
+			},
+			expectDeleteCalled: true,
+			expectDeletedKeys:  []string{"red-hat-managed", "Name"},
+		},
+		{
+			name:               "empty remove map",
+			remove:             map[string]string{},
+			expectDeleteCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeEC2TagClient{}
+			err := UpdateResourceTags(context.Background(), fake, "sg-test123", nil, tt.remove)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !tt.expectDeleteCalled {
+				if fake.deleteCalls != 0 {
+					t.Errorf("expected no DeleteTags call, but got %d call(s)", fake.deleteCalls)
+				}
+				return
+			}
+
+			deletedKeys := make(map[string]bool)
+			for _, tag := range fake.deletedTags {
+				deletedKeys[aws.ToString(tag.Key)] = true
+			}
+
+			for _, key := range tt.expectDeletedKeys {
+				if !deletedKeys[key] {
+					t.Errorf("expected key %q to be deleted, but it wasn't", key)
+				}
+			}
+
+			if len(deletedKeys) != len(tt.expectDeletedKeys) {
+				t.Errorf("expected %d deleted keys, got %d: %v", len(tt.expectDeletedKeys), len(deletedKeys), deletedKeys)
+			}
+
+			// Verify no aws: prefixed keys leaked through
+			for key := range deletedKeys {
+				if strings.HasPrefix(key, "aws:") {
+					t.Errorf("aws: prefixed key %q should have been filtered", key)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

When a Security Group carries AWS-injected reserved tags (e.g. `aws:cloudformation:*`), the CPO
`reconcileDefaultSecurityGroup` falls back to reading all tags from AWS, diffs them against desired
tags, and passes `aws:*` keys to `DeleteTags`. AWS rejects these with `InvalidParameterValue` because
`aws:*` prefixed tags are reserved and cannot be deleted by users. This causes an infinite reconcile
retry loop that blocks cluster upgrades.

This PR filters out any tag keys with the `aws:` prefix from the remove map in `UpdateResourceTags`
before calling `ec2.DeleteTags`. This is the most defensive fix location as it protects all callers
of `UpdateResourceTags`.

## Which issue(s) this PR fixes:

Fixes [OCPBUGS-121208](https://issues.redhat.com/browse/OCPBUGS-121208)

## Special notes for your reviewer:

- Bug affects `release-4.19` through `release-5.2` — backports needed after merge to `main`
- Releases 4.14–4.18 are **not affected** (`reconcileDefaultSecurityGroup` early-returns without tag diffing)
- The annotation workaround from the Slack thread (manually setting `hypershift.openshift.io/last-applied-security-group-tags`) remains valid for clusters on older versions until backports ship

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevents attempts to remove AWS-reserved resource tags, avoiding invalid deletion requests.
  - Continues removing eligible non-reserved tags as expected.
  - Skips deletion requests when no eligible tags remain.
  - Ensures reserved tags are never included in tag-deletion operations, including when only reserved tags are selected.

- **Tests**
  - Added coverage confirming reserved tags are excluded, eligible tags are removed, and unnecessary deletion requests are avoided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->