### PR TITLE
CNTRLPLANE-4369: add prow job id tag to e2e v2 aws resources

### DIFF
--- a/test/e2e/v2/lifecycle/aws.go
+++ b/test/e2e/v2/lifecycle/aws.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	supportawsutil "github.com/openshift/hypershift/support/awsutil"
+
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -21,8 +23,9 @@ type AWSPlatformConfig struct {
 }
 
 type AWSPlatformOptions struct {
-	Region string
-	Zones  string
+	Region    string
+	Zones     string
+	ProwJobId string
 }
 
 func NewAWSPlatformConfig(opts AWSPlatformOptions, sharedDir string) *AWSPlatformConfig {
@@ -32,6 +35,10 @@ func NewAWSPlatformConfig(opts AWSPlatformOptions, sharedDir string) *AWSPlatfor
 	// and should probably be handled another way. That test assumes there is at least one pre-existing
 	// non-kubernetes-namespaced tag on the infra.
 	tags := []string{fmt.Sprintf("expirationDate=%s", time.Now().Add(4*time.Hour).UTC().Format(time.RFC3339))}
+
+	if opts.ProwJobId != "" {
+		tags = append(tags, supportawsutil.HypershiftProwJobIDTagKey+"="+opts.ProwJobId)
+	}
 
 	cfg := &AWSPlatformConfig{
 		region:         opts.Region,

--- a/test/e2e/v2/lifecycle/platform.go
+++ b/test/e2e/v2/lifecycle/platform.go
@@ -212,8 +212,9 @@ func NewPlatformConfig(platform, sharedDir string) (PlatformConfig, error) {
 		return NewAzurePlatformConfig(sharedDir), nil
 	case "aws":
 		return NewAWSPlatformConfig(AWSPlatformOptions{
-			Region: envOrDefault("HYPERSHIFT_AWS_REGION", "us-east-1"),
-			Zones:  envOrDefault("HYPERSHIFT_AWS_ZONES", "us-east-1a"),
+			Region:    envOrDefault("HYPERSHIFT_AWS_REGION", "us-east-1"),
+			Zones:     envOrDefault("HYPERSHIFT_AWS_ZONES", "us-east-1a"),
+			ProwJobId: envOrDefault("PROW_JOB_ID", ""),
 		}, sharedDir), nil
 	default:
 		return nil, fmt.Errorf("unsupported platform %q (supported: azure, aws)", platform)


### PR DESCRIPTION
Before this commit, AWS resources created by e2e v2 AWS tests lacked any metadata about their associated prow job, making leak detection unreliable.

This commit adds the prow job ID via `--additional-tags` passed to the cluster creation CLI command, which propagates to infra, iam, and the hostedcluster.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - AWS end-to-end test resources now include the associated CI job identifier as a tag when available.
  - The job identifier is automatically read from the test environment and applied to AWS platform configuration.
  - AWS resources remain unchanged when no job identifier is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->