### PR TITLE
CNTRLPLANE-4370: enforce explicit blocking/informing labels on all v2 e2e tests

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -12,3 +12,4 @@ AfterAll
 SME
 uptodate
 enbale
+XDescribe

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,7 @@ linters:
             enable:
               - testcasename
               - testfuncname
+              - e2eteststate
               - sippyannotation
               - guestcluster
               - contextbackground

--- a/hack/tools/hypershiftlinter/README.md
+++ b/hack/tools/hypershiftlinter/README.md
@@ -30,7 +30,7 @@ relying on reviewer memory. That matters for several reasons:
 
 ## Analyzers
 
-The plugin ships 9 analyzers, scoped so each rule only fires where it applies.
+The plugin ships 10 analyzers, scoped so each rule only fires where it applies.
 
 ### Unit test conventions (`TESTING.md`, unit tests only)
 
@@ -43,6 +43,7 @@ The plugin ships 9 analyzers, scoped so each rule only fires where it applies.
 
 | Analyzer            | Enforces                                                                                          |
 | ------------------- | ------------------------------------------------------------------------------------------------ |
+| `e2eteststate`      | Requires each v2 Ginkgo subject node to be explicitly labeled `Informing` or `Blocking`.         |
 | `guestcluster`      | Bans "guest cluster" terminology; use "hosted cluster" instead.                                  |
 | `contextbackground` | Bans `context.Background()` / `context.TODO()` in tests; use `tc.Context` instead.               |
 | `vacuouspass`       | Flags vacuously-passing tests that iterate a collection without asserting it is non-empty.        |

--- a/hack/tools/hypershiftlinter/analyzers/e2eteststate/e2eteststate.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eteststate/e2eteststate.go
@@ -1,0 +1,140 @@
+package e2eteststate
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+	"strings"
+
+	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/pathutil"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "e2eteststate",
+	Doc:  "requires every v2 e2e Ginkgo subject node to be explicitly labeled Informing or Blocking",
+	Run:  run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	for _, file := range pass.Files {
+		filename := pass.Fset.File(file.Pos()).Name()
+		if !pathutil.IsV2E2ETest(filename) || !strings.HasSuffix(filename, "_test.go") {
+			continue
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			name := callName(call)
+			informing, blocking := testStates(call)
+			if isContainer(name) {
+				if informing || blocking || hasLiteralState(call) {
+					pass.Reportf(call.Pos(), "internal.InformingLabel and internal.BlockingLabel may only be applied directly to Ginkgo subject nodes")
+				}
+				return true
+			}
+			if !isSubjectNode(name) {
+				return true
+			}
+			if hasLiteralState(call) {
+				pass.Reportf(call.Pos(), `Ginkgo subject state labels must use internal.InformingLabel or internal.BlockingLabel instead of string literals`)
+				return true
+			}
+
+			switch {
+			case informing && blocking:
+				pass.Reportf(call.Pos(), "Ginkgo subject must not have both internal.InformingLabel and internal.BlockingLabel")
+			case !informing && !blocking:
+				pass.Reportf(call.Pos(), "Ginkgo subject must have Label(internal.InformingLabel) or Label(internal.BlockingLabel); new tests must be informing")
+			}
+			return true
+		})
+	}
+	return nil, nil
+}
+
+func isSubjectNode(name string) bool {
+	switch name {
+	case "It", "FIt", "PIt", "XIt", "Specify", "FSpecify", "PSpecify", "XSpecify":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasLiteralState(call *ast.CallExpr) bool {
+	for _, arg := range call.Args {
+		labelCall, ok := arg.(*ast.CallExpr)
+		if !ok || callName(labelCall) != "Label" {
+			continue
+		}
+		for _, label := range labelCall.Args {
+			literal, ok := label.(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				continue
+			}
+			value, err := strconv.Unquote(literal.Value)
+			if err == nil && (value == "Informing" || value == "Blocking") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isContainer(name string) bool {
+	switch name {
+	case "Describe", "FDescribe", "PDescribe", "XDescribe",
+		"Context", "FContext", "PContext", "XContext",
+		"When", "FWhen", "PWhen", "XWhen":
+		return true
+	default:
+		return false
+	}
+}
+
+func testStates(it *ast.CallExpr) (informing, blocking bool) {
+	for _, arg := range it.Args {
+		labelCall, ok := arg.(*ast.CallExpr)
+		if !ok || callName(labelCall) != "Label" {
+			continue
+		}
+		for _, label := range labelCall.Args {
+			switch stateLabelName(label) {
+			case "InformingLabel":
+				informing = true
+			case "BlockingLabel":
+				blocking = true
+			}
+		}
+	}
+	return informing, blocking
+}
+
+func callName(call *ast.CallExpr) string {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name
+	case *ast.SelectorExpr:
+		return fn.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func stateLabelName(expr ast.Expr) string {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	packageName, ok := selector.X.(*ast.Ident)
+	if !ok || packageName.Name != "internal" {
+		return ""
+	}
+	return selector.Sel.Name
+}

--- a/hack/tools/hypershiftlinter/analyzers/e2eteststate/e2eteststate_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eteststate/e2eteststate_test.go
@@ -1,0 +1,12 @@
+package e2eteststate
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, Analyzer, "test/e2e/v2/good", "test/e2e/v2/bad")
+}

--- a/hack/tools/hypershiftlinter/analyzers/e2eteststate/testdata/src/test/e2e/v2/bad/bad_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eteststate/testdata/src/test/e2e/v2/bad/bad_test.go
@@ -1,0 +1,40 @@
+package bad
+
+func tests() {
+	It("has no state", func() {})                                                                   // want `Ginkgo subject must have Label\(internal.InformingLabel\) or Label\(internal.BlockingLabel\); new tests must be informing`
+	It("has only an unrelated label", Label("AWS"), func() {})                                      // want `Ginkgo subject must have Label\(internal.InformingLabel\) or Label\(internal.BlockingLabel\); new tests must be informing`
+	It("uses a raw state string", Label("Informing"), func() {})                                    // want `Ginkgo subject state labels must use internal.InformingLabel or internal.BlockingLabel instead of string literals`
+	It("mixes constant and literal states", Label(internal.InformingLabel, "Blocking"), func() {})  // want `Ginkgo subject state labels must use internal.InformingLabel or internal.BlockingLabel instead of string literals`
+	It("has conflicting states", Label(internal.InformingLabel, internal.BlockingLabel), func() {}) // want `Ginkgo subject must not have both internal.InformingLabel and internal.BlockingLabel`
+	Specify("has no state", func() {})                                                              // want `Ginkgo subject must have Label\(internal.InformingLabel\) or Label\(internal.BlockingLabel\); new tests must be informing`
+	FIt("has no state", func() {})                                                                  // want `Ginkgo subject must have Label\(internal.InformingLabel\) or Label\(internal.BlockingLabel\); new tests must be informing`
+	FSpecify("has no state", func() {})                                                             // want `Ginkgo subject must have Label\(internal.InformingLabel\) or Label\(internal.BlockingLabel\); new tests must be informing`
+	PIt("has no state", func() {})                                                                  // want `Ginkgo subject must have Label\(internal.InformingLabel\) or Label\(internal.BlockingLabel\); new tests must be informing`
+	PSpecify("has no state", func() {})                                                             // want `Ginkgo subject must have Label\(internal.InformingLabel\) or Label\(internal.BlockingLabel\); new tests must be informing`
+	XIt("has no state", func() {})                                                                  // want `Ginkgo subject must have Label\(internal.InformingLabel\) or Label\(internal.BlockingLabel\); new tests must be informing`
+	XSpecify("has no state", func() {})                                                             // want `Ginkgo subject must have Label\(internal.InformingLabel\) or Label\(internal.BlockingLabel\); new tests must be informing`
+	Describe("inherits informing", Label(internal.InformingLabel), func() {})                       // want `internal.InformingLabel and internal.BlockingLabel may only be applied directly to Ginkgo subject nodes`
+	Context("inherits blocking", Label(internal.BlockingLabel), func() {})                          // want `internal.InformingLabel and internal.BlockingLabel may only be applied directly to Ginkgo subject nodes`
+	PWhen("inherits informing", Label(internal.InformingLabel), func() {})                          // want `internal.InformingLabel and internal.BlockingLabel may only be applied directly to Ginkgo subject nodes`
+	Describe("inherits a raw state", Label("Blocking"), func() {})                                  // want `internal.InformingLabel and internal.BlockingLabel may only be applied directly to Ginkgo subject nodes`
+}
+
+var internal labels
+
+type labels struct {
+	InformingLabel string
+	BlockingLabel  string
+}
+
+func It(string, ...any)       {}
+func Specify(string, ...any)  {}
+func FIt(string, ...any)      {}
+func FSpecify(string, ...any) {}
+func PIt(string, ...any)      {}
+func PSpecify(string, ...any) {}
+func XIt(string, ...any)      {}
+func XSpecify(string, ...any) {}
+func Describe(string, ...any) {}
+func Context(string, ...any)  {}
+func PWhen(string, ...any)    {}
+func Label(...string) any     { return nil }

--- a/hack/tools/hypershiftlinter/analyzers/e2eteststate/testdata/src/test/e2e/v2/good/good_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eteststate/testdata/src/test/e2e/v2/good/good_test.go
@@ -1,0 +1,36 @@
+package good
+
+func tests() {
+	It("starts informing", Label(internal.InformingLabel), func() {})
+	ginkgo.It("is explicitly blocking", ginkgo.Label(internal.BlockingLabel), func() {})
+	It("may have other labels", Label("AWS", internal.BlockingLabel), func() {})
+	Specify("specifies behavior", Label(internal.InformingLabel), func() {})
+	FIt("focuses a test", Label(internal.InformingLabel), func() {})
+	FSpecify("focuses specified behavior", Label(internal.BlockingLabel), func() {})
+	PIt("pends a test", Label(internal.InformingLabel), func() {})
+	PSpecify("pends specified behavior", Label(internal.BlockingLabel), func() {})
+	XIt("disables a test", Label(internal.InformingLabel), func() {})
+	XSpecify("disables specified behavior", Label(internal.BlockingLabel), func() {})
+}
+
+var internal labels
+var ginkgo dsl
+
+type labels struct {
+	InformingLabel string
+	BlockingLabel  string
+}
+
+type dsl struct{}
+
+func (dsl) It(string, ...any)   {}
+func (dsl) Label(...string) any { return nil }
+func It(string, ...any)         {}
+func Specify(string, ...any)    {}
+func FIt(string, ...any)        {}
+func FSpecify(string, ...any)   {}
+func PIt(string, ...any)        {}
+func PSpecify(string, ...any)   {}
+func XIt(string, ...any)        {}
+func XSpecify(string, ...any)   {}
+func Label(...string) any       { return nil }

--- a/hack/tools/hypershiftlinter/plugin.go
+++ b/hack/tools/hypershiftlinter/plugin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/contextbackground"
+	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/e2eteststate"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/guestcluster"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch"
@@ -62,6 +63,7 @@ func allAnalyzers() []*analysis.Analyzer {
 	return []*analysis.Analyzer{
 		testcasename.Analyzer,
 		testfuncname.Analyzer,
+		e2eteststate.Analyzer,
 		sippyannotation.Analyzer,
 		guestcluster.Analyzer,
 		contextbackground.Analyzer,

--- a/test/e2e/v2/AGENTS.md
+++ b/test/e2e/v2/AGENTS.md
@@ -92,7 +92,16 @@ DeferCleanup(func() {
 
 ### 10. Labels
 
-Apply labels to `Describe` and `It` blocks for test filtering. Only apply labels to `Context` blocks when you have explicit filtering intent (e.g., `Label("Informing")` to mark non-blocking tests). The `Informing` label causes the custom fail handler to skip rather than fail.
+Apply labels to `Describe` and `It` blocks for test filtering. Only apply labels to `Context` blocks when you have explicit filtering intent (e.g., a platform label). The `Informing` label causes the custom fail handler to skip rather than fail.
+
+Every Ginkgo subject node (`It`, `Specify`, and their focused or pending
+variants) must also declare exactly one test state directly on the leaf:
+
+- New tests use `Label(internal.InformingLabel)` and remain non-blocking during
+  their externally defined observational period.
+- After promotion, replace it with `Label(internal.BlockingLabel)` so failures
+  block the suite.
+- To demote a test, replace `BlockingLabel` with `InformingLabel`.
 
 ### 11. Pointer Safety
 

--- a/test/e2e/v2/internal/fail_handler.go
+++ b/test/e2e/v2/internal/fail_handler.go
@@ -10,8 +10,14 @@ import (
 	"github.com/onsi/ginkgo/v2/types"
 )
 
-// InformingLabel is the Ginkgo label that marks a test as informing.
-const InformingLabel = "Informing"
+const (
+	// InformingLabel marks a test as non-blocking while it completes its
+	// observational period.
+	InformingLabel = "Informing"
+	// BlockingLabel marks a test that has completed its observational period and
+	// whose failures block the suite.
+	BlockingLabel = "Blocking"
+)
 
 const informingSkipPrefix = "informing test failure: "
 

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -150,14 +150,14 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 	})
 
 	Context(ContextPreBackupControlPlane, func() {
-		It("should have control plane healthy before backup", func() {
+		It("should have control plane healthy before backup", Label(internal.BlockingLabel), func() {
 			expectedConditions = validatePreBackupControlPlane(testCtx, platformCfg.excludeWorkloads)
 		})
 	})
 
 	// Setup the continual operations
 	Context(ContextSetupContinual, func() {
-		It("should setup continual operations successfully", func() {
+		It("should setup continual operations successfully", Label(internal.BlockingLabel), func() {
 			verifyReconciliationActiveFunction := func() error {
 				hostedCluster := &hyperv1.HostedCluster{}
 				err := testCtx.MgmtClient.Get(testCtx.Context, crclient.ObjectKey{
@@ -182,7 +182,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 	})
 
 	Context(ContextBackup, func() {
-		It("should create backup and schedule successfully", func() {
+		It("should create backup and schedule successfully", Label(internal.BlockingLabel), func() {
 			hc, err := testCtx.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			if hc.Spec.Platform.Type == hyperv1.AgentPlatform {
@@ -253,7 +253,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 
 	// Verify the continual operations
 	Context(ContextVerifyContinual, func() {
-		It("should verify continual operations completed successfully", func() {
+		It("should verify continual operations completed successfully", Label(internal.BlockingLabel), func() {
 			if prober == nil {
 				Skip("prober not initialized")
 			}
@@ -263,7 +263,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 	})
 
 	Context(ContextPostBackupControlPlane, func() {
-		It("should have control plane healthy after backup", func() {
+		It("should have control plane healthy after backup", Label(internal.BlockingLabel), func() {
 			err := internal.WaitForControlPlaneDeploymentsReadiness(testCtx, 5*time.Minute, platformCfg.excludeWorkloads)
 			Expect(err).NotTo(HaveOccurred())
 			err = internal.WaitForControlPlaneStatefulSetsReadiness(testCtx, 5*time.Minute, platformCfg.excludeWorkloads)
@@ -272,14 +272,14 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 	})
 
 	Context(ContextBreakControlPlane, func() {
-		It("should break hosted cluster", func() {
+		It("should break hosted cluster", Label(internal.BlockingLabel), func() {
 			err := backuprestore.BreakHostedClusterPreservingMachines(testCtx, GinkgoLogr.WithName("cleanup"))
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	Context(ContextRestore, func() {
-		It("should restore from backup successfully", func() {
+		It("should restore from backup successfully", Label(internal.BlockingLabel), func() {
 			By("Creating Restore")
 			restoreName := oadp.GenerateRestoreName(testCtx.ClusterName, testCtx.ClusterNamespace)
 			restoreOpts := &backuprestore.OADPRestoreOptions{
@@ -294,7 +294,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:BackupRestore] Backu
 	})
 
 	Context(ContextPostRestoreControlPlane, func() {
-		It("should have control plane healthy after restore", func() {
+		It("should have control plane healthy after restore", Label(internal.BlockingLabel), func() {
 			// TODO(mgencur): Remove this condition once https://redhat.atlassian.net/browse/MGMT-23509 is fixed
 			hc, err := testCtx.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -504,13 +504,13 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 	})
 
 	Context(ContextPreBackupControlPlane, func() {
-		It("should have control plane healthy before backup", func() {
+		It("should have control plane healthy before backup", Label(internal.BlockingLabel), func() {
 			expectedConditions = validatePreBackupControlPlane(testCtx, platformCfg.excludeWorkloads)
 		})
 	})
 
 	Context(ContextBackup, func() {
-		It("should create backup with etcd snapshot method", func() {
+		It("should create backup with etcd snapshot method", Label(internal.BlockingLabel), func() {
 			By("Waiting for BackupStorageLocation to be Available")
 			err := backuprestore.WaitForBackupStorageLocationAvailable(testCtx, testCtx.ClusterName)
 			Expect(err).NotTo(HaveOccurred())
@@ -537,13 +537,13 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 	})
 
 	Context("VerifyEtcdSnapshotBackup", func() {
-		It("should have HCPEtcdBackup with BackupCompleted=True", func() {
+		It("should have HCPEtcdBackup with BackupCompleted=True", Label(internal.BlockingLabel), func() {
 			By("Waiting for HCPEtcdBackup BackupCompleted condition to be True")
 			err := backuprestore.WaitForHCPEtcdBackupCondition(testCtx, backupName, metav1.ConditionTrue)
 			Expect(err).NotTo(HaveOccurred(), "HCPEtcdBackup %s should have BackupCompleted=True", backupName)
 		})
 
-		It("should have HCPEtcdBackup with snapshotURL matching the backup created in this run", func() {
+		It("should have HCPEtcdBackup with snapshotURL matching the backup created in this run", Label(internal.BlockingLabel), func() {
 			By("Waiting for HCPEtcdBackup to have a snapshotURL")
 			Eventually(func(g Gomega) {
 				hcpEtcdBackupList := &hyperv1.HCPEtcdBackupList{}
@@ -564,7 +564,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 			}).WithPolling(backuprestore.PollInterval).WithTimeout(backuprestore.BackupTimeout).Should(Succeed())
 		})
 
-		It("should have lastSuccessfulEtcdBackupURL on HostedCluster status matching the snapshot", func() {
+		It("should have lastSuccessfulEtcdBackupURL on HostedCluster status matching the snapshot", Label(internal.BlockingLabel), func() {
 			if snapshotURL == "" {
 				Skip("snapshotURL was not captured; the snapshotURL verification spec may have failed")
 			}
@@ -584,14 +584,14 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 	})
 
 	Context(ContextBreakControlPlane, func() {
-		It("should break hosted cluster", func() {
+		It("should break hosted cluster", Label(internal.BlockingLabel), func() {
 			err := backuprestore.BreakHostedClusterPreservingMachines(testCtx, GinkgoLogr.WithName("cleanup"))
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	Context(ContextRestore, func() {
-		It("should restore from backup successfully", func() {
+		It("should restore from backup successfully", Label(internal.BlockingLabel), func() {
 			By("Creating Restore with etcd snapshot options")
 			restoreName := oadp.GenerateRestoreName(testCtx.ClusterName, testCtx.ClusterNamespace)
 			restoreOpts := &backuprestore.OADPRestoreOptions{
@@ -610,7 +610,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 		// CPO clears restoreSnapshotURL which triggers a second StatefulSet rollout
 		// that replaces the pod without the etcd-init container. The poll-based
 		// function captures logs before that window closes.
-		It("should have etcd-init container logs showing successful snapshot restore", func() {
+		It("should have etcd-init container logs showing successful snapshot restore", Label(internal.BlockingLabel), func() {
 			By("Polling for etcd-init container completion and verifying restore logs")
 			restConfig, err := util.GetConfig()
 			Expect(err).NotTo(HaveOccurred(), "failed to get REST config for pod log access")
@@ -621,11 +621,11 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdSnapshot] Backup
 			Expect(err).NotTo(HaveOccurred(), "etcd-init container logs should confirm snapshot restore")
 		})
 
-		It("should have control plane healthy after restore", func() {
+		It("should have control plane healthy after restore", Label(internal.BlockingLabel), func() {
 			validatePostRestoreControlPlane(testCtx, platformCfg.excludeWorkloads, expectedConditions, false)
 		})
 
-		It("should have restoreSnapshotURL set on HostedCluster after restore", func() {
+		It("should have restoreSnapshotURL set on HostedCluster after restore", Label(internal.BlockingLabel), func() {
 			// RestoreSnapshotURL contains a presigned URL, which differs from the
 			// original S3 URL stored in HCPEtcdBackup.Status.SnapshotURL. We verify
 			// the field is populated rather than comparing exact values.

--- a/test/e2e/v2/tests/control_plane_infrastructure_test.go
+++ b/test/e2e/v2/tests/control_plane_infrastructure_test.go
@@ -87,7 +87,7 @@ func validateContainerResourceRequests(podNamespace, podName string, containers 
 
 func InfrastructureRegistryValidationTest(getTestCtx internal.TestContextGetter) {
 	Context("Infrastructure registry validation", func() {
-		It("should not contain any unrecognized pods", func() {
+		It("should not contain any unrecognized pods", Label(internal.BlockingLabel), func() {
 			testCtx := getTestCtx()
 
 			var podsNotBelongingToWorkloads []string
@@ -139,7 +139,7 @@ func InfrastructureResourceRequestsTest(getTestCtx internal.TestContextGetter) {
 			workload := workload // capture range variable
 
 			Context(workload.Name, func() {
-				It("should have resource requests for containers", func() {
+				It("should have resource requests for containers", Label(internal.BlockingLabel), func() {
 					testCtx := getTestCtx()
 
 					ns := &corev1.Namespace{}

--- a/test/e2e/v2/tests/control_plane_tls_operator_test.go
+++ b/test/e2e/v2/tests/control_plane_tls_operator_test.go
@@ -499,7 +499,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("control-plane-pki-operator should have control-plane-pki-operator-config ConfigMap with TLS configuration", func() {
+		It("control-plane-pki-operator should have control-plane-pki-operator-config ConfigMap with TLS configuration", Label(internal.BlockingLabel), func() {
 			// Check in management cluster's control plane namespace, not hosted cluster
 			mgmtClient := tc.MgmtClient
 			cm := &corev1.ConfigMap{}
@@ -516,7 +516,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			Expect(cm.Data["config.yaml"]).NotTo(BeEmpty(), "config.yaml should not be empty")
 		})
 
-		It("control-plane-pki-operator should have minTLSVersion set to VersionTLS12 with default/intermediate profile", func() {
+		It("control-plane-pki-operator should have minTLSVersion set to VersionTLS12 with default/intermediate profile", Label(internal.BlockingLabel), func() {
 			hostedCluster, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			requireDefaultOrIntermediateTLSProfile(hostedCluster)
@@ -534,7 +534,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 				"PKI operator config should have minTLSVersion: VersionTLS12 for intermediate profile")
 		})
 
-		It("aws-pod-identity-webhook should have --tls-min-version set to VersionTLS12 with default/intermediate profile", func() {
+		It("aws-pod-identity-webhook should have --tls-min-version set to VersionTLS12 with default/intermediate profile", Label(internal.BlockingLabel), func() {
 			hostedCluster, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			skipIfComponentNotApplicable(awsPodIdentityWebhookTLSComponent, hostedCluster)
@@ -546,7 +546,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			}, 1*time.Minute, 5*time.Second).Should(Succeed())
 		})
 
-		It("konnectivity-server should have --tls-min-version set to VersionTLS12 with default/intermediate profile", func() {
+		It("konnectivity-server should have --tls-min-version set to VersionTLS12 with default/intermediate profile", Label(internal.BlockingLabel), func() {
 			hostedCluster, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			requireDefaultOrIntermediateTLSProfile(hostedCluster)
@@ -557,7 +557,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			}, 1*time.Minute, 5*time.Second).Should(Succeed())
 		})
 
-		It("control-plane-pki-operator should accept both TLS 1.2 and TLS 1.3 connections with intermediate profile", func() {
+		It("control-plane-pki-operator should accept both TLS 1.2 and TLS 1.3 connections with intermediate profile", Label(internal.BlockingLabel), func() {
 			hostedCluster, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			requireDefaultOrIntermediateTLSProfile(hostedCluster)
@@ -569,7 +569,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 				})
 		})
 
-		It("aws-pod-identity-webhook should accept both TLS 1.2 and TLS 1.3 connections with intermediate profile", func() {
+		It("aws-pod-identity-webhook should accept both TLS 1.2 and TLS 1.3 connections with intermediate profile", Label(internal.BlockingLabel), func() {
 			hostedCluster, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			skipIfComponentNotApplicable(awsPodIdentityWebhookTLSComponent, hostedCluster)
@@ -582,7 +582,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 				})
 		})
 
-		It("konnectivity-server should accept both TLS 1.2 and TLS 1.3 connections with intermediate profile", func() {
+		It("konnectivity-server should accept both TLS 1.2 and TLS 1.3 connections with intermediate profile", Label(internal.BlockingLabel), func() {
 			hostedCluster, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			requireDefaultOrIntermediateTLSProfile(hostedCluster)
@@ -594,7 +594,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 				})
 		})
 
-		It("should update HostedCluster TLS profile to Modern", func() {
+		It("should update HostedCluster TLS profile to Modern", Label(internal.BlockingLabel), func() {
 			// Get the HostedCluster from management cluster and update its TLS profile
 			mgmtClient := tc.MgmtClient
 
@@ -643,7 +643,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			GinkgoWriter.Printf("Updated HostedCluster to Modern TLS profile, waiting for changes to propagate\n")
 		})
 
-		It("control-plane-pki-operator should propagate minTLSVersion VersionTLS13 with Modern profile", func() {
+		It("control-plane-pki-operator should propagate minTLSVersion VersionTLS13 with Modern profile", Label(internal.BlockingLabel), func() {
 			requireModernProfileSet(tc)
 
 			Eventually(func(g Gomega) {
@@ -652,7 +652,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 
-		It("aws-pod-identity-webhook should propagate --tls-min-version VersionTLS13 with Modern profile", func() {
+		It("aws-pod-identity-webhook should propagate --tls-min-version VersionTLS13 with Modern profile", Label(internal.BlockingLabel), func() {
 			hostedCluster := requireModernProfileSet(tc)
 			skipIfComponentNotApplicable(awsPodIdentityWebhookTLSComponent, hostedCluster)
 
@@ -662,7 +662,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 
-		It("konnectivity-server should propagate --tls-min-version VersionTLS13 with Modern profile", func() {
+		It("konnectivity-server should propagate --tls-min-version VersionTLS13 with Modern profile", Label(internal.BlockingLabel), func() {
 			requireModernProfileSet(tc)
 
 			Eventually(func(g Gomega) {
@@ -671,7 +671,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 
-		It("control-plane-pki-operator should accept TLS 1.3 but reject TLS 1.2 with Modern profile", func() {
+		It("control-plane-pki-operator should accept TLS 1.3 but reject TLS 1.2 with Modern profile", Label(internal.BlockingLabel), func() {
 			requireModernProfileSet(tc)
 
 			// Wait for PKI operator pod to restart and pick up the new TLS config
@@ -686,7 +686,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 				})
 		})
 
-		It("aws-pod-identity-webhook should accept TLS 1.3 but reject TLS 1.2 with Modern profile", func() {
+		It("aws-pod-identity-webhook should accept TLS 1.3 but reject TLS 1.2 with Modern profile", Label(internal.BlockingLabel), func() {
 			hostedCluster := requireModernProfileSet(tc)
 			skipIfComponentNotApplicable(awsPodIdentityWebhookTLSComponent, hostedCluster)
 
@@ -703,7 +703,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 				})
 		})
 
-		It("konnectivity-server should accept TLS 1.3 but reject TLS 1.2 with Modern profile", func() {
+		It("konnectivity-server should accept TLS 1.3 but reject TLS 1.2 with Modern profile", Label(internal.BlockingLabel), func() {
 			requireModernProfileSet(tc)
 
 			// Wait for the kube-apiserver pod (which hosts konnectivity-server) to restart
@@ -720,7 +720,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 				})
 		})
 
-		It("should downgrade HostedCluster TLS profile to default/intermediate", func() {
+		It("should downgrade HostedCluster TLS profile to default/intermediate", Label(internal.BlockingLabel), func() {
 			// First verify it currently has Modern profile (fetch fresh, not cached)
 			requireModernProfileSet(tc)
 
@@ -743,7 +743,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			GinkgoWriter.Printf("Removed Modern TLS profile from HostedCluster (downgraded to default/Intermediate), waiting for changes to propagate\n")
 		})
 
-		It("control-plane-pki-operator should propagate minTLSVersion VersionTLS12 after downgrade", func() {
+		It("control-plane-pki-operator should propagate minTLSVersion VersionTLS12 after downgrade", Label(internal.BlockingLabel), func() {
 			requireModernProfileCleared(tc)
 
 			Eventually(func(g Gomega) {
@@ -752,7 +752,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 
-		It("aws-pod-identity-webhook should propagate --tls-min-version VersionTLS12 after downgrade", func() {
+		It("aws-pod-identity-webhook should propagate --tls-min-version VersionTLS12 after downgrade", Label(internal.BlockingLabel), func() {
 			hostedCluster := requireModernProfileCleared(tc)
 			skipIfComponentNotApplicable(awsPodIdentityWebhookTLSComponent, hostedCluster)
 
@@ -762,7 +762,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 
-		It("konnectivity-server should propagate --tls-min-version VersionTLS12 after downgrade", func() {
+		It("konnectivity-server should propagate --tls-min-version VersionTLS12 after downgrade", Label(internal.BlockingLabel), func() {
 			requireModernProfileCleared(tc)
 
 			Eventually(func(g Gomega) {
@@ -771,7 +771,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 
-		It("control-plane-pki-operator should accept both TLS 1.2 and TLS 1.3 connections after downgrade to Intermediate profile", func() {
+		It("control-plane-pki-operator should accept both TLS 1.2 and TLS 1.3 connections after downgrade to Intermediate profile", Label(internal.BlockingLabel), func() {
 			requireModernProfileCleared(tc)
 
 			// Wait for PKI operator pod to restart and pick up the downgraded TLS config
@@ -786,7 +786,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 				})
 		})
 
-		It("aws-pod-identity-webhook should accept both TLS 1.2 and TLS 1.3 connections after downgrade to Intermediate profile", func() {
+		It("aws-pod-identity-webhook should accept both TLS 1.2 and TLS 1.3 connections after downgrade to Intermediate profile", Label(internal.BlockingLabel), func() {
 			hostedCluster := requireModernProfileCleared(tc)
 			skipIfComponentNotApplicable(awsPodIdentityWebhookTLSComponent, hostedCluster)
 
@@ -802,7 +802,7 @@ func VerifyPKIOperatorTLSConfigTest(getTestCtx internal.TestContextGetter) {
 				})
 		})
 
-		It("konnectivity-server should accept both TLS 1.2 and TLS 1.3 connections after downgrade to Intermediate profile", func() {
+		It("konnectivity-server should accept both TLS 1.2 and TLS 1.3 connections after downgrade to Intermediate profile", Label(internal.BlockingLabel), func() {
 			requireModernProfileCleared(tc)
 
 			// Wait for the kube-apiserver pod (which hosts konnectivity-server) to restart

--- a/test/e2e/v2/tests/control_plane_upgrade_test.go
+++ b/test/e2e/v2/tests/control_plane_upgrade_test.go
@@ -31,7 +31,7 @@ import (
 
 // ControlPlaneUpgradeTest upgrades the hosted cluster from N-1 to the latest release image.
 func ControlPlaneUpgradeTest(getTestCtx internal.TestContextGetter) {
-	It("should upgrade the control plane from N-1 to latest", func() {
+	It("should upgrade the control plane from N-1 to latest", Label(internal.BlockingLabel), func() {
 		testCtx := getTestCtx()
 		ctx := testCtx.Context
 		hc, err := testCtx.GetHostedCluster()

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -80,7 +80,7 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
 			}
 
 			Context(workload.Name, func() {
-				It("should not indicate rapid rollouts", func() {
+				It("should not indicate rapid rollouts", Label(internal.BlockingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -135,7 +135,7 @@ func SafeToEvictAnnotationsTest(getTestCtx internal.TestContextGetter) {
 		}
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
-				It("should exist for pods with emptyDir or hostPath volumes", func() {
+				It("should exist for pods with emptyDir or hostPath volumes", Label(internal.BlockingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -232,7 +232,7 @@ func ReadOnlyRootFilesystemTest(getTestCtx internal.TestContextGetter) {
 
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
-				It("should have read-only root filesystem for containers", func() {
+				It("should have read-only root filesystem for containers", Label(internal.BlockingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -307,7 +307,7 @@ func ReadOnlyRootFilesystemTmpDirMountTest(getTestCtx internal.TestContextGetter
 
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
-				It("should have /tmp mounted for containers", func() {
+				It("should have /tmp mounted for containers", Label(internal.BlockingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -351,7 +351,7 @@ func ContainerImagePullPolicyTest(getTestCtx internal.TestContextGetter) {
 		// EnsureAllContainersHavePullPolicyIfNotPresent
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
-				It("should have IfNotPresent pull policy for containers", func() {
+				It("should have IfNotPresent pull policy for containers", Label(internal.BlockingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -403,7 +403,7 @@ func ContainerTerminationMessagePolicyTest(getTestCtx internal.TestContextGetter
 
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
-				It("should have FallbackToLogsOnError termination message policy for containers", func() {
+				It("should have FallbackToLogsOnError termination message policy for containers", Label(internal.BlockingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -447,7 +447,7 @@ func ContainerResourceRequestsTest(getTestCtx internal.TestContextGetter) {
 		// EnsureHCPContainersHaveResourceRequests
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
-				It("should have resource requests for containers", func() {
+				It("should have resource requests for containers", Label(internal.BlockingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -486,7 +486,7 @@ func PodPriorityTest(getTestCtx internal.TestContextGetter) {
 		const maxAllowedPriority = 100002000
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
-				It("should not have too high priority for pods", func() {
+				It("should not have too high priority for pods", Label(internal.BlockingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -563,7 +563,7 @@ func ServiceAccountTokenMountingTest(getTestCtx internal.TestContextGetter) {
 
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
-				It("should not mount service account token unless necessary for pods", func() {
+				It("should not mount service account token unless necessary for pods", Label(internal.BlockingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -607,7 +607,7 @@ func PodAffinitiesAndTolerationsTest(getTestCtx internal.TestContextGetter) {
 
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
-				It("should have correct affinities and tolerations for pods", func() {
+				It("should have correct affinities and tolerations for pods", Label(internal.BlockingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -730,7 +730,7 @@ func PodAffinitiesAndTolerationsTest(getTestCtx internal.TestContextGetter) {
 // WorkloadRegistryValidationTest registers tests for workload registry validation
 func WorkloadRegistryValidationTest(getTestCtx internal.TestContextGetter) {
 	Context("Workload registry validation", func() {
-		It("should not contain any unrecognized pods", func() {
+		It("should not contain any unrecognized pods", Label(internal.BlockingLabel), func() {
 			testCtx := getTestCtx()
 			podList := &corev1.PodList{}
 			err := testCtx.MgmtClient.List(testCtx.Context, podList, &crclient.ListOptions{
@@ -809,7 +809,7 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
-				It("should have expected RunAsUser UID for pods", func() {
+				It("should have expected RunAsUser UID for pods", Label(internal.BlockingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -915,7 +915,7 @@ func NoCrashingPodsTest(getTestCtx internal.TestContextGetter) {
 
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
-				It("should have no crashing pods", func() {
+				It("should have no crashing pods", Label(internal.BlockingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -981,7 +981,7 @@ func NoCrashingPodsTest(getTestCtx internal.TestContextGetter) {
 
 // CustomLabelsTest registers per-workload tests for custom label propagation
 func CustomLabelsTest(getTestCtx internal.TestContextGetter) {
-	Context("Custom labels", Label("Informing"), func() {
+	Context("Custom labels", func() {
 		BeforeEach(func() {
 			getTestCtx().SkipIfVersionBelow(e2eutil.Version419)
 		})
@@ -993,7 +993,7 @@ func CustomLabelsTest(getTestCtx internal.TestContextGetter) {
 
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
-				It("should propagate custom labels to pods", func() {
+				It("should propagate custom labels to pods", Label(internal.InformingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -1022,7 +1022,7 @@ func CustomLabelsTest(getTestCtx internal.TestContextGetter) {
 
 // CustomTolerationsTest registers per-workload tests for custom toleration propagation
 func CustomTolerationsTest(getTestCtx internal.TestContextGetter) {
-	Context("Custom tolerations", Label("Informing"), func() {
+	Context("Custom tolerations", func() {
 		BeforeEach(func() {
 			getTestCtx().SkipIfVersionBelow(e2eutil.Version419)
 		})
@@ -1034,7 +1034,7 @@ func CustomTolerationsTest(getTestCtx internal.TestContextGetter) {
 
 		for _, workload := range workloads {
 			Context(workload.Name, func() {
-				It("should propagate custom tolerations to pods", func() {
+				It("should propagate custom tolerations to pods", Label(internal.InformingLabel), func() {
 					testCtx := getTestCtx()
 					hostedCluster, err := testCtx.GetHostedCluster()
 					Expect(err).NotTo(HaveOccurred())
@@ -1071,7 +1071,7 @@ func DesiredStateHashAnnotationTest(getTestCtx internal.TestContextGetter) {
 		for _, w := range workloads {
 			workload := w
 			Context(workload.Name, func() {
-				It("should carry desired-state-hash annotation if managed by control-plane-operator", func() {
+				It("should carry desired-state-hash annotation if managed by control-plane-operator", Label(internal.BlockingLabel), func() {
 					tc := getTestCtx()
 
 					deploy := &appsv1.Deployment{}

--- a/test/e2e/v2/tests/etcd_chaos_test.go
+++ b/test/e2e/v2/tests/etcd_chaos_test.go
@@ -66,7 +66,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:EtcdResilience] Etcd
 // EtcdSingleMemberRecoveryTest deletes one random etcd pod and its PVC simultaneously,
 // then verifies the pod is replaced (different UID) and the StatefulSet converges.
 func EtcdSingleMemberRecoveryTest(getTestCtx internal.TestContextGetter) {
-	It("should recover after a single member loses its data", func() {
+	It("should recover after a single member loses its data", Label(internal.BlockingLabel), func() {
 		testCtx := getTestCtx()
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
@@ -120,7 +120,7 @@ func EtcdSingleMemberRecoveryTest(getTestCtx internal.TestContextGetter) {
 // deletes random etcd pods every 5 seconds for 30 seconds, then verifies
 // StatefulSet convergence and that the marker data survived.
 func EtcdKillRandomMembersTest(getTestCtx internal.TestContextGetter) {
-	It("should preserve data when random members are repeatedly killed", func() {
+	It("should preserve data when random members are repeatedly killed", Label(internal.BlockingLabel), func() {
 		testCtx := getTestCtx()
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
@@ -170,7 +170,7 @@ func EtcdKillRandomMembersTest(getTestCtx internal.TestContextGetter) {
 // EtcdKillAllMembersTest creates a marker ConfigMap, deletes ALL etcd pods simultaneously
 // via goroutines, then verifies convergence and marker survival.
 func EtcdKillAllMembersTest(getTestCtx internal.TestContextGetter) {
-	It("should preserve data when all members are killed simultaneously", func() {
+	It("should preserve data when all members are killed simultaneously", Label(internal.BlockingLabel), func() {
 		testCtx := getTestCtx()
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
@@ -250,7 +250,7 @@ func EtcdKillAllMembersTest(getTestCtx internal.TestContextGetter) {
 // RunCommandInPod, then waits for etcd to crash in-place so the recovery
 // controller detects the failing member and creates a recovery job.
 func EtcdSingleMemberCorruptionTest(getTestCtx internal.TestContextGetter) {
-	It("should recover after a single member's data is corrupted", func() {
+	It("should recover after a single member's data is corrupted", Label(internal.BlockingLabel), func() {
 		testCtx := getTestCtx()
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
@@ -298,7 +298,7 @@ func EtcdSingleMemberCorruptionTest(getTestCtx internal.TestContextGetter) {
 // etcdctl member remove, deletes the pod, verifies the recovery job,
 // and waits for StatefulSet convergence.
 func EtcdMissingMemberRecoveryTest(getTestCtx internal.TestContextGetter) {
-	It("should recover after a member is removed from the etcd cluster", func() {
+	It("should recover after a member is removed from the etcd cluster", Label(internal.BlockingLabel), func() {
 		testCtx := getTestCtx()
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace

--- a/test/e2e/v2/tests/hosted_cluster_aws_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_aws_test.go
@@ -57,7 +57,7 @@ func RegisterHostedClusterAWSTests(getTestCtx internal.TestContextGetter) {
 
 func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 	When("[Feature:AWSSecurityGroups] a day-2 resource tag is added to the HostedCluster spec", func() {
-		It("should apply the tag to the default worker security group via AWS API", Label("AWS"), func() {
+		It("should apply the tag to the default worker security group via AWS API", Label(internal.BlockingLabel), Label("AWS"), func() {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version420)
 			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
@@ -149,7 +149,7 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 
 func EnsureInfrastructureResourceTagsTest(getTestCtx internal.TestContextGetter) {
 	When("a HostedCluster is created with additional AWS resource tags", func() {
-		It("should propagate those tags to the infrastructure resource in the hosted cluster", Label("AWS"), func() {
+		It("should propagate those tags to the infrastructure resource in the hosted cluster", Label(internal.BlockingLabel), Label("AWS"), func() {
 			tc := getTestCtx()
 			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
 			hc, err := tc.GetHostedCluster()
@@ -218,7 +218,7 @@ func AWSCCMWithCustomizationsTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		When("AWSServiceLBNetworkSecurityGroup feature gate is enabled", func() {
-			It("should have NLBSecurityGroupMode=Managed in the aws-cloud-config ConfigMap", func() {
+			It("should have NLBSecurityGroupMode=Managed in the aws-cloud-config ConfigMap", Label(internal.BlockingLabel), func() {
 				tc := getTestCtx()
 
 				Eventually(func(g Gomega) {
@@ -237,7 +237,7 @@ func AWSCCMWithCustomizationsTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		When("a LoadBalancer NLB service is created in the hosted cluster", func() {
-			It("should attach managed security groups to the NLB", func() {
+			It("should attach managed security groups to the NLB", Label(internal.BlockingLabel), func() {
 				tc := getTestCtx()
 				hc, err := tc.GetHostedCluster()
 				Expect(err).NotTo(HaveOccurred())
@@ -346,7 +346,7 @@ func AWSCCMWithCustomizationsTest(getTestCtx internal.TestContextGetter) {
 
 func AWSResourceTagOverridePolicyTest(getTestCtx internal.TestContextGetter) {
 	When("[Feature:AWSResourceTagOverrides] HostedCluster tags have mixed override policies", func() {
-		It("should block or allow NodePool tag overrides based on overridePolicy and reflect conflicts in the NodePool condition", Label("AWS"), func() {
+		It("should block or allow NodePool tag overrides based on overridePolicy and reflect conflicts in the NodePool condition", Label(internal.BlockingLabel), Label("AWS"), func() {
 			tc := getTestCtx()
 			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
 
@@ -480,7 +480,7 @@ func AWSResourceTagOverridePolicyTest(getTestCtx internal.TestContextGetter) {
 
 func EnsureDefaultSecurityGroupTagsWithSpacesTest(getTestCtx internal.TestContextGetter) {
 	When("[Feature:AWSSecurityGroups] a day-2 resource tag with spaces is added to the HostedCluster spec", func() {
-		It("should apply the tag with spaces to the default worker security group via AWS API", Label("AWS"), func() {
+		It("should apply the tag with spaces to the default worker security group via AWS API", Label(internal.BlockingLabel), Label("AWS"), func() {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version420)
 			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
@@ -593,7 +593,7 @@ func EnsureDefaultSecurityGroupTagsWithSpacesTest(getTestCtx internal.TestContex
 
 func NodePoolDay2TagsWithSpacesTest(getTestCtx internal.TestContextGetter) {
 	When("[Feature:AWSResourceTags] a day-2 NodePool tag with spaces is added", func() {
-		It("should propagate the tag with spaces to AWSMachine and EC2 instances", Label("AWS"), func() {
+		It("should propagate the tag with spaces to AWSMachine and EC2 instances", Label(internal.BlockingLabel), Label("AWS"), func() {
 			tc := getTestCtx()
 			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
 

--- a/test/e2e/v2/tests/hosted_cluster_azure_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_azure_test.go
@@ -53,7 +53,7 @@ func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
 			testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)
 		})
 
-		It("should mutate pods with workload identity federated credentials", func() {
+		It("should mutate pods with workload identity federated credentials", Label(internal.BlockingLabel), func() {
 			testCtx := getTestCtx()
 			hc, err := testCtx.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -65,7 +65,7 @@ func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
 			e2eutil.ValidateAzureWorkloadIdentityWebhookMutation(GinkgoTB(), testCtx.Context, hostedClusterClient)
 		})
 
-		It("should have expected KAS allowed CIDRs", func() {
+		It("should have expected KAS allowed CIDRs", Label(internal.BlockingLabel), func() {
 			testCtx := getTestCtx()
 			hc, err := testCtx.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -76,7 +76,7 @@ func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
 			e2eutil.ValidateKubeAPIServerAllowedCIDRs(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, restConfig, hc)
 		})
 
-		It("should have Ingress Operator configuration applied", func() {
+		It("should have Ingress Operator configuration applied", Label(internal.BlockingLabel), func() {
 			testCtx := getTestCtx()
 			hc, err := testCtx.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -111,7 +111,7 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 			Expect(controlPlaneNamespace).NotTo(BeEmpty(), "control plane namespace must be set")
 		})
 
-		It("should have Azure internal LB annotation on private-router Service", func() {
+		It("should have Azure internal LB annotation on private-router Service", Label(internal.BlockingLabel), func() {
 			ctx := testCtx.Context
 			e2eutil.EventuallyObject(GinkgoTB(), ctx, "private-router Service has Azure internal LB annotation",
 				func(ctx context.Context) (*corev1.Service, error) {
@@ -138,7 +138,7 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 			)
 		})
 
-		It("should create AzurePrivateLinkService CR with PLS alias", func() {
+		It("should create AzurePrivateLinkService CR with PLS alias", Label(internal.BlockingLabel), func() {
 			ctx := testCtx.Context
 			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "AzurePrivateLinkService CR is created with PLS alias",
 				func(ctx context.Context) ([]*hyperv1.AzurePrivateLinkService, error) {
@@ -163,7 +163,7 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 			)
 		})
 
-		It("should populate Private Endpoint IP in PLS status", func() {
+		It("should populate Private Endpoint IP in PLS status", Label(internal.BlockingLabel), func() {
 			ctx := testCtx.Context
 			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "AzurePrivateLinkService has Private Endpoint IP",
 				func(ctx context.Context) ([]*hyperv1.AzurePrivateLinkService, error) {
@@ -188,7 +188,7 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 			)
 		})
 
-		It("should populate Private DNS Zone ID in PLS status", func() {
+		It("should populate Private DNS Zone ID in PLS status", Label(internal.BlockingLabel), func() {
 			ctx := testCtx.Context
 			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "AzurePrivateLinkService has Private DNS Zone ID",
 				func(ctx context.Context) ([]*hyperv1.AzurePrivateLinkService, error) {
@@ -250,7 +250,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			})
 		})
 
-		It("should transition from Private to PublicAndPrivate", func() {
+		It("should transition from Private to PublicAndPrivate", Label(internal.BlockingLabel), func() {
 			ctx := testCtx.Context
 			hc, err := testCtx.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -359,7 +359,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			verifyAPIReachable(testCtx, "after transition to PublicAndPrivate")
 		})
 
-		It("should transition from PublicAndPrivate back to Private", func() {
+		It("should transition from PublicAndPrivate back to Private", Label(internal.BlockingLabel), func() {
 			ctx := testCtx.Context
 			hc, err := testCtx.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -447,7 +447,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			)
 		})
 
-		It("should remain available after restoring Private topology", func() {
+		It("should remain available after restoring Private topology", Label(internal.BlockingLabel), func() {
 			// Private clusters' DNS zones are linked only to the guest VNet, so the
 			// management cluster cannot resolve the KAS hostname. Validate health
 			// via HostedCluster conditions instead of direct API connectivity,
@@ -643,7 +643,7 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should create oauth-openshift Service as LoadBalancer with external IP", func() {
+		It("should create oauth-openshift Service as LoadBalancer with external IP", Label(internal.BlockingLabel), func() {
 			testCtx := getTestCtx()
 			ctx := testCtx.Context
 			controlPlaneNamespace := testCtx.ControlPlaneNamespace
@@ -680,7 +680,7 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 			)
 		})
 
-		It("should complete OAuth token flow through LoadBalancer endpoint", func() {
+		It("should complete OAuth token flow through LoadBalancer endpoint", Label(internal.BlockingLabel), func() {
 			testCtx := getTestCtx()
 			hc, err := testCtx.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/v2/tests/hosted_cluster_ccm_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ccm_test.go
@@ -54,7 +54,7 @@ func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
 				Expect(nodes.Items).NotTo(BeEmpty(), "cluster should have nodes")
 			})
 
-			It("should set providerID on all nodes", func() {
+			It("should set providerID on all nodes", Label(internal.BlockingLabel), func() {
 				testCtx := getTestCtx()
 				hc, err := testCtx.GetHostedCluster()
 				Expect(err).NotTo(HaveOccurred())
@@ -73,7 +73,7 @@ func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
 				}
 			})
 
-			It("should set zone and region topology labels on all nodes", func() {
+			It("should set zone and region topology labels on all nodes", Label(internal.BlockingLabel), func() {
 				for _, node := range nodes.Items {
 					zone, ok := node.Labels["topology.kubernetes.io/zone"]
 					Expect(ok).To(BeTrue(),
@@ -89,7 +89,7 @@ func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
 				}
 			})
 
-			It("should remove the uninitialized taint from all nodes", func() {
+			It("should remove the uninitialized taint from all nodes", Label(internal.BlockingLabel), func() {
 				for _, node := range nodes.Items {
 					for _, taint := range node.Spec.Taints {
 						Expect(taint.Key).NotTo(Equal("node.cloudprovider.kubernetes.io/uninitialized"),

--- a/test/e2e/v2/tests/hosted_cluster_compliance_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_compliance_test.go
@@ -40,7 +40,7 @@ func RegisterHostedClusterComplianceTests(getTestCtx internal.TestContextGetter)
 
 func EnsureAllRoutesUseHCPRouterTest(getTestCtx internal.TestContextGetter) {
 	When("routes are created in the control plane namespace", func() {
-		It("should label all routes for the per-HCP router", Label("routes"), func() {
+		It("should label all routes for the per-HCP router", Label(internal.BlockingLabel), Label("routes"), func() {
 			tc := getTestCtx()
 			hostedCluster, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -83,7 +83,7 @@ func EnsureAllRoutesUseHCPRouterTest(getTestCtx internal.TestContextGetter) {
 // after Azure endpoint access transition tests cycle the topology.
 func EnsureKASConnectionCheckerSpecTest(getTestCtx internal.TestContextGetter) {
 	When("kas-connection-checker deployment is reconciled", func() {
-		It("should have safe-to-evict annotation, no tolerations, and topology spread constraint", func() {
+		It("should have safe-to-evict annotation, no tolerations, and topology spread constraint", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 
 			if !tc.VersionAtLeast(e2eutil.Version423) {

--- a/test/e2e/v2/tests/hosted_cluster_cpo_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_cpo_test.go
@@ -37,7 +37,7 @@ func RegisterHostedClusterCPOTests(getTestCtx internal.TestContextGetter) {
 
 func VerifyCPOOverrideImageTest(getTestCtx internal.TestContextGetter) {
 	When("a CPO override image is configured for the platform and version", func() {
-		It("should run the control-plane-operator pod with the expected override image", func() {
+		It("should run the control-plane-operator pod with the expected override image", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/v2/tests/hosted_cluster_dns_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_dns_test.go
@@ -33,7 +33,7 @@ func RegisterHostedClusterDNSTests(getTestCtx internal.TestContextGetter) {
 
 func EnsureKubeAPIDNSNameCustomCertTest(getTestCtx internal.TestContextGetter) {
 	When("KubeAPIDNSName and custom certificate are configured", func() {
-		PIt("should make KAS reachable via the custom DNS endpoint", func() {
+		PIt("should make KAS reachable via the custom DNS endpoint", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version419)
 			tc.SkipIfPlatform(hyperv1.KubevirtPlatform)

--- a/test/e2e/v2/tests/hosted_cluster_external_oidc_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_external_oidc_test.go
@@ -92,7 +92,7 @@ func ExternalOIDCClusterConfigTest(getTestCtx internal.TestContextGetter) {
 			skipIfNotOIDC(hc)
 		})
 
-		It("should have authentication type OIDC on the hosted cluster", func() {
+		It("should have authentication type OIDC on the hosted cluster", Label(internal.BlockingLabel), func() {
 			hc, err := getTestCtx().GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hc.Spec.Configuration).NotTo(BeNil(),
@@ -105,7 +105,7 @@ func ExternalOIDCClusterConfigTest(getTestCtx internal.TestContextGetter) {
 				"hosted cluster %s/%s should have at least one OIDC provider", hc.Namespace, hc.Name)
 		})
 
-		It("should have the hosted cluster Available", func() {
+		It("should have the hosted cluster Available", Label(internal.BlockingLabel), func() {
 			hc, err := getTestCtx().GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			found := false
@@ -134,7 +134,7 @@ func ExternalOIDCOAuthNotDeployedTest(getTestCtx internal.TestContextGetter) {
 			skipIfNotOIDC(hc)
 		})
 
-		It("should not have oauth-openshift deployment in the control plane namespace", func() {
+		It("should not have oauth-openshift deployment in the control plane namespace", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			deployment := &appsv1.Deployment{}
 			err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
@@ -146,7 +146,7 @@ func ExternalOIDCOAuthNotDeployedTest(getTestCtx internal.TestContextGetter) {
 				tc.ControlPlaneNamespace)
 		})
 
-		It("should not have openshift-oauth-apiserver deployment in the control plane namespace", func() {
+		It("should not have openshift-oauth-apiserver deployment in the control plane namespace", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			deployment := &appsv1.Deployment{}
 			err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
@@ -171,7 +171,7 @@ func ExternalOIDCKASConfigTest(getTestCtx internal.TestContextGetter) {
 			skipIfNotOIDC(hc)
 		})
 
-		It("should have auth-config ConfigMap with JWT authenticator matching the OIDC provider", func() {
+		It("should have auth-config ConfigMap with JWT authenticator matching the OIDC provider", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -211,7 +211,7 @@ func ExternalOIDCKASConfigTest(getTestCtx internal.TestContextGetter) {
 			}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 		})
 
-		It("should have correct audiences in JWT config", func() {
+		It("should have correct audiences in JWT config", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -249,7 +249,7 @@ func ExternalOIDCKASConfigTest(getTestCtx internal.TestContextGetter) {
 			}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 		})
 
-		It("should not have OAuth webhook authentication config", func() {
+		It("should not have OAuth webhook authentication config", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			cm := &corev1.ConfigMap{}
 			Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
@@ -344,25 +344,25 @@ func ExternalOIDCKeycloakAuthTest(getTestCtx internal.TestContextGetter) {
 			}).WithTimeout(5 * time.Minute).WithPolling(15 * time.Second).Should(Succeed())
 		})
 
-		It("should authenticate to KAS with a Keycloak-issued token", func() {
+		It("should authenticate to KAS with a Keycloak-issued token", Label(internal.BlockingLabel), func() {
 			Expect(selfSubjectReview).NotTo(BeNil(), "SelfSubjectReview should have been created in BeforeAll")
 			Expect(selfSubjectReview.Status.UserInfo.Username).NotTo(BeEmpty(),
 				"SelfSubjectReview should return a non-empty username")
 		})
 
-		It("should map username claim correctly", func() {
+		It("should map username claim correctly", Label(internal.BlockingLabel), func() {
 			Expect(selfSubjectReview.Status.UserInfo.Username).To(ContainSubstring(extOIDCConfig.UserPrefix),
 				"username should contain the configured prefix %q", extOIDCConfig.UserPrefix)
 		})
 
-		It("should map groups claim with prefix", func() {
+		It("should map groups claim with prefix", Label(internal.BlockingLabel), func() {
 			groups := selfSubjectReview.Status.UserInfo.Groups
 			Expect(groups).NotTo(BeEmpty(), "SelfSubjectReview should return groups")
 			Expect(groups).To(ContainElement(ContainSubstring(extOIDCConfig.GroupPrefix)),
 				"at least one group should contain the configured prefix %q", extOIDCConfig.GroupPrefix)
 		})
 
-		It("should map UID claim correctly", func() {
+		It("should map UID claim correctly", Label(internal.BlockingLabel), func() {
 			Expect(selfSubjectReview.Status.UserInfo.UID).NotTo(BeEmpty(),
 				"SelfSubjectReview should return a non-empty UID")
 		})

--- a/test/e2e/v2/tests/hosted_cluster_health_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_health_test.go
@@ -49,7 +49,7 @@ func RegisterHostedClusterHealthTests(getTestCtx internal.TestContextGetter) {
 
 func ValidateHostedClusterConditionsTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster is operational", func() {
-		It("should have all expected conditions with correct status", func() {
+		It("should have all expected conditions with correct status", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			hostedCluster, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -82,7 +82,7 @@ func ValidateHostedClusterConditionsTest(getTestCtx internal.TestContextGetter) 
 
 func EnsureCAPIFinalizersTest(getTestCtx internal.TestContextGetter) {
 	When("CAPI components are deployed", func() {
-		It("should have component finalizers on all CAPI deployments", func() {
+		It("should have component finalizers on all CAPI deployments", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version422)
 			Expect(hcc.CAPIComponents).NotTo(BeEmpty(),
@@ -102,7 +102,7 @@ func EnsureCAPIFinalizersTest(getTestCtx internal.TestContextGetter) {
 
 func EnsureFeatureGateStatusTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster version is completed", func() {
-		It("should have feature gate status matching cluster version", func() {
+		It("should have feature gate status matching cluster version", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version419)
 			hc, err := tc.GetHostedCluster()
@@ -137,7 +137,7 @@ func EnsureFeatureGateStatusTest(getTestCtx internal.TestContextGetter) {
 
 func EnsurePayloadArchSetCorrectlyTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster has a release image", func() {
-		It("should set payload arch status correctly", func() {
+		It("should set payload arch status correctly", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			hostedCluster, err := getTestCtx().GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -157,7 +157,7 @@ func EnsurePayloadArchSetCorrectlyTest(getTestCtx internal.TestContextGetter) {
 
 func ValidateConfigurationStatusTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster authentication is configured", func() {
-		It("should propagate configuration status consistently", func() {
+		It("should propagate configuration status consistently", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			hostedCluster, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/v2/tests/hosted_cluster_image_registry_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_image_registry_test.go
@@ -63,7 +63,7 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should have a healthy image-registry ClusterOperator", func() {
+		It("should have a healthy image-registry ClusterOperator", Label(internal.BlockingLabel), func() {
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hostedClusterClient, err := tc.GetHostedClusterClient(hc)
@@ -95,7 +95,7 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 			}).WithTimeout(10 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
 		})
 
-		It("should have installer-cloud-credentials in the hosted cluster", func() {
+		It("should have installer-cloud-credentials in the hosted cluster", Label(internal.BlockingLabel), func() {
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hostedClusterClient, err := tc.GetHostedClusterClient(hc)
@@ -110,7 +110,7 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 				"installer-cloud-credentials secret should have data")
 		})
 
-		It("should have storage configured in the registry config", func() {
+		It("should have storage configured in the registry config", Label(internal.BlockingLabel), func() {
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hostedClusterClient, err := tc.GetHostedClusterClient(hc)
@@ -132,7 +132,7 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 				"image registry Config should have at least one storage backend configured")
 		})
 
-		It("should have a ready cluster-image-registry-operator deployment", func() {
+		It("should have a ready cluster-image-registry-operator deployment", Label(internal.BlockingLabel), func() {
 			deployment := &appsv1.Deployment{}
 			Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
 				Namespace: tc.ControlPlaneNamespace,
@@ -159,7 +159,7 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 					hc.Namespace, hc.Name)
 			})
 
-			It("should use GCS storage with a bucket name", func() {
+			It("should use GCS storage with a bucket name", Label(internal.BlockingLabel), func() {
 				hc, err := tc.GetHostedCluster()
 				Expect(err).NotTo(HaveOccurred())
 				hostedClusterClient, err := tc.GetHostedClusterClient(hc)
@@ -173,7 +173,7 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 					"GCS storage bucket name should not be empty")
 			})
 
-			It("should have valid WIF credentials in installer-cloud-credentials", func() {
+			It("should have valid WIF credentials in installer-cloud-credentials", Label(internal.BlockingLabel), func() {
 				hc, err := tc.GetHostedCluster()
 				Expect(err).NotTo(HaveOccurred())
 				hostedClusterClient, err := tc.GetHostedClusterClient(hc)
@@ -227,7 +227,7 @@ func ImageRegistryCapabilityDisabledTest(getTestCtx internal.TestContextGetter) 
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should not have the image-registry ClusterOperator", func() {
+		It("should not have the image-registry ClusterOperator", Label(internal.BlockingLabel), func() {
 			co := &configv1.ClusterOperator{}
 			err := hostedClusterClient.Get(tc.Context, crclient.ObjectKey{Name: "image-registry"}, co)
 			if err != nil && !apierrors.IsNotFound(err) {
@@ -237,7 +237,7 @@ func ImageRegistryCapabilityDisabledTest(getTestCtx internal.TestContextGetter) 
 				"image-registry ClusterOperator should not exist when ImageRegistry capability is disabled")
 		})
 
-		It("should not have the openshift-image-registry namespace", func() {
+		It("should not have the openshift-image-registry namespace", Label(internal.BlockingLabel), func() {
 			ns := &corev1.Namespace{}
 			err := hostedClusterClient.Get(tc.Context, crclient.ObjectKey{Name: "openshift-image-registry"}, ns)
 			if err != nil && !apierrors.IsNotFound(err) {
@@ -247,7 +247,7 @@ func ImageRegistryCapabilityDisabledTest(getTestCtx internal.TestContextGetter) 
 				"openshift-image-registry namespace should not exist when ImageRegistry capability is disabled")
 		})
 
-		It("should not add ImagePullSecrets to default service accounts", func() {
+		It("should not add ImagePullSecrets to default service accounts", Label(internal.BlockingLabel), func() {
 			sa := &corev1.ServiceAccount{}
 			Expect(hostedClusterClient.Get(tc.Context, crclient.ObjectKey{
 				Namespace: "default",
@@ -257,7 +257,7 @@ func ImageRegistryCapabilityDisabledTest(getTestCtx internal.TestContextGetter) 
 				"default service account in default namespace should not have ImagePullSecrets when ImageRegistry capability is disabled")
 		})
 
-		It("should not inject ImagePullSecrets into newly created service accounts", func() {
+		It("should not inject ImagePullSecrets into newly created service accounts", Label(internal.BlockingLabel), func() {
 			ns := &corev1.Namespace{}
 			ns.Name = "image-registry-test-namespace"
 			Expect(hostedClusterClient.Create(tc.Context, ns)).To(Succeed())

--- a/test/e2e/v2/tests/hosted_cluster_ingress_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ingress_test.go
@@ -36,7 +36,7 @@ func RegisterHostedClusterIngressTests(getTestCtx internal.TestContextGetter) {
 
 func ValidateIngressOperatorConfigurationTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster has IngressOperator EndpointPublishingStrategy configured", func() {
-		It("should reflect the custom strategy in the hosted cluster IngressController", func() {
+		It("should reflect the custom strategy in the hosted cluster IngressController", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version421)
 			hc, err := tc.GetHostedCluster()

--- a/test/e2e/v2/tests/hosted_cluster_metrics_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_metrics_test.go
@@ -71,7 +71,7 @@ func RegisterHostedClusterMetricsTests(getTestCtx internal.TestContextGetter) {
 
 func ValidateMetricsTest(getTestCtx internal.TestContextGetter) {
 	When("HyperShift operator is running", func() {
-		It("should expose expected metrics at the metrics endpoint", func() {
+		It("should expose expected metrics at the metrics endpoint", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			tc.SkipIfPlatform(hyperv1.NonePlatform)
 			hostedCluster, err := tc.GetHostedCluster()
@@ -142,8 +142,8 @@ func ValidateMetricsTest(getTestCtx internal.TestContextGetter) {
 }
 
 func EnsureMetricsForwarderWorkingTest(getTestCtx internal.TestContextGetter) {
-	When("metrics forwarding is enabled", Label("Informing"), func() {
-		It("should deploy the metrics pipeline and scrape kube-apiserver metrics end-to-end", func() {
+	When("metrics forwarding is enabled", func() {
+		It("should deploy the metrics pipeline and scrape kube-apiserver metrics end-to-end", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version422)
 			hostedCluster, err := tc.GetHostedCluster()
@@ -224,7 +224,7 @@ func EnsureMetricsForwarderWorkingTest(getTestCtx internal.TestContextGetter) {
 
 func EnsureNodeTuningOperatorMetricsEndpointTest(getTestCtx internal.TestContextGetter) {
 	When("cluster has worker nodes", func() {
-		It("should have a functional node-tuning-operator metrics endpoint", func() {
+		It("should have a functional node-tuning-operator metrics endpoint", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version422)
 
@@ -314,7 +314,7 @@ func EnsureNodeTuningOperatorMetricsEndpointTest(getTestCtx internal.TestContext
 
 func EnsureKubeSchedulerMetricsEndpointTest(getTestCtx internal.TestContextGetter) {
 	When("kube-scheduler is running", func() {
-		It("should have functional kube-scheduler metrics endpoints", func() {
+		It("should have functional kube-scheduler metrics endpoints", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version423)
 

--- a/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
@@ -35,7 +35,7 @@ func RegisterNodeCommunicationTests(getTestCtx internal.TestContextGetter) {
 
 func EnsureNodeCommunicationTest(getTestCtx internal.TestContextGetter) {
 	When("hosted cluster has konnectivity tunnel configured", func() {
-		It("should have konnectivity-agent pods with retrievable logs", func() {
+		It("should have konnectivity-agent pods with retrievable logs", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/v2/tests/hosted_cluster_psc_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_psc_test.go
@@ -37,7 +37,7 @@ func GCPPrivateServiceConnectTest(getTestCtx internal.TestContextGetter) {
 		// GCP enforces that the NAT subnet and the forwarding rule must belong to the same VPC
 		// when creating a Service Attachment. A True GCPServiceAttachmentAvailable condition
 		// is therefore proof that the controller selected a subnet from the correct VPC.
-		It("should have GCPServiceAttachmentAvailable condition set to True", func() {
+		It("should have GCPServiceAttachmentAvailable condition set to True", Label(internal.BlockingLabel), func() {
 			testCtx := getTestCtx()
 
 			// Find the GCPPrivateServiceConnect CR in the control plane namespace.

--- a/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
@@ -43,8 +43,8 @@ func RegisterGlobalPullSecretTests(getTestCtx internal.TestContextGetter) {
 }
 
 func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
-	When("an additional pull secret is created in the hosted cluster", Label("Informing"), func() {
-		It("should propagate it through the global pull secret pipeline and clean up on deletion", func() {
+	When("an additional pull secret is created in the hosted cluster", func() {
+		It("should propagate it through the global pull secret pipeline and clean up on deletion", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			tc.SkipIfVersionBelow(e2eutil.Version419)
 			tc.SkipIfNotPlatform(hyperv1.AWSPlatform, hyperv1.AzurePlatform)

--- a/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
@@ -47,7 +47,7 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 				}
 			})
 
-			It("should have ActiveKey fields populated", func() {
+			It("should have ActiveKey fields populated", Label(internal.BlockingLabel), func() {
 				hc, err := getTestCtx().GetHostedCluster()
 				Expect(err).NotTo(HaveOccurred())
 				azureKMS := hc.Spec.SecretEncryption.KMS.Azure
@@ -60,7 +60,7 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 					"ActiveKey.KeyVersion must be set")
 			})
 
-			It("should have KMS authentication configured", func() {
+			It("should have KMS authentication configured", Label(internal.BlockingLabel), func() {
 				hc, err := getTestCtx().GetHostedCluster()
 				Expect(err).NotTo(HaveOccurred())
 				azureKMS := hc.Spec.SecretEncryption.KMS.Azure
@@ -90,7 +90,7 @@ func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
 // via etcdctl, and asserts the k8s:enc:kms:v2 prefix. Cleans up via DeferCleanup.
 func KMSFunctionalValidationTest(getTestCtx internal.TestContextGetter) {
 	Context("KMS Functional Validation", func() {
-		It("should encrypt secrets in etcd using KMSv2", func() {
+		It("should encrypt secrets in etcd using KMSv2", Label(internal.BlockingLabel), func() {
 			testCtx := getTestCtx()
 			ctx := testCtx.Context
 

--- a/test/e2e/v2/tests/hosted_cluster_security_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_security_test.go
@@ -55,7 +55,7 @@ func RegisterHostedClusterSecurityTests(getTestCtx internal.TestContextGetter) {
 
 func EnsureHostedClusterWebhooksValidatedTest(getTestCtx internal.TestContextGetter) {
 	When("[Feature:WebhookValidation] a webhook targeting a control plane service is created in the hosted cluster", func() {
-		It("should be automatically deleted", func() {
+		It("should be automatically deleted", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -119,7 +119,7 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should find all required ValidatingAdmissionPolicies", func() {
+		It("should find all required ValidatingAdmissionPolicies", Label(internal.BlockingLabel), func() {
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hc)
@@ -150,7 +150,7 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 
-		It("should deny unauthorized config changes via VAPs", func() {
+		It("should deny unauthorized config changes via VAPs", Label(internal.BlockingLabel), func() {
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hc)
@@ -171,7 +171,7 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 			}, time.Minute, 5*time.Second).Should(Succeed())
 		})
 
-		It("should deny unauthorized deletion of kas-bootstrap RBAC bindings via VAPs", func() {
+		It("should deny unauthorized deletion of kas-bootstrap RBAC bindings via VAPs", Label(internal.BlockingLabel), func() {
 			tc.SkipIfVersionBelow(e2eutil.Version51)
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -201,7 +201,7 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should allow status modifications via VAPs", func() {
+		It("should allow status modifications via VAPs", Label(internal.BlockingLabel), func() {
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hc)
@@ -228,7 +228,7 @@ func EnsureAdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
 			}, time.Minute, 5*time.Second).Should(Succeed())
 		})
 
-		It("should allow OperatorHub config changes with guest OLM placement", func() {
+		It("should allow OperatorHub config changes with guest OLM placement", Label(internal.BlockingLabel), func() {
 			hostedCluster, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hostedCluster)
@@ -267,7 +267,7 @@ func EnsureNetworkPoliciesTest(getTestCtx internal.TestContextGetter) {
 			tc.SkipIfNotPlatform(hyperv1.AWSPlatform)
 		})
 
-		It("should find management KAS access labels on expected components", func() {
+		It("should find management KAS access labels on expected components", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 
 			podList := &corev1.PodList{}
@@ -280,7 +280,7 @@ func EnsureNetworkPoliciesTest(getTestCtx internal.TestContextGetter) {
 				suppconfig.NeedManagementKASAccessLabel, tc.ControlPlaneNamespace)
 		})
 
-		It("should block egress traffic from non-privileged pods to the management KAS", func() {
+		It("should block egress traffic from non-privileged pods to the management KAS", Label(internal.BlockingLabel), func() {
 			tc := getTestCtx()
 
 			mgmtRestConfig, err := e2eutil.GetConfig()

--- a/test/e2e/v2/tests/karpenter_control_plane_upgrade_test.go
+++ b/test/e2e/v2/tests/karpenter_control_plane_upgrade_test.go
@@ -31,7 +31,7 @@ func RegisterKarpenterControlPlaneUpgradeTests(getTestCtx internal.TestContextGe
 }
 
 var _ = Describe("[sig-hypershift][Jira:Hypershift] Karpenter",
-	Label("lifecycle", "karpenter-upgrade", internal.InformingLabel), Ordered, func() {
+	Label("lifecycle", "karpenter-upgrade"), Ordered, func() {
 		var testCtx *internal.TestContext
 
 		BeforeEach(func() {
@@ -64,7 +64,7 @@ func KarpenterUpgradeTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should upgrade the control plane and drift Karpenter nodes to the new version", func() {
+		It("should upgrade the control plane and drift Karpenter nodes to the new version", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()

--- a/test/e2e/v2/tests/karpenter_test.go
+++ b/test/e2e/v2/tests/karpenter_test.go
@@ -85,7 +85,7 @@ func RegisterKarpenterTests(getTestCtx internal.TestContextGetter) {
 }
 
 var _ = Describe("[sig-hypershift][Jira:Hypershift] Karpenter",
-	Label("lifecycle", "karpenter", internal.InformingLabel), Ordered, func() {
+	Label("lifecycle", "karpenter"), Ordered, func() {
 		var testCtx *internal.TestContext
 
 		BeforeEach(func() {
@@ -122,7 +122,7 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should expose Karpenter metrics", func() {
+		It("should expose Karpenter metrics", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()
@@ -165,14 +165,14 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 			Expect(err).NotTo(HaveOccurred(), "failed to validate Karpenter metrics")
 		})
 
-		It("should report AutoNode vCPUs status as 0 when no Karpenter nodes are provisioned", func() {
+		It("should report AutoNode vCPUs status as 0 when no Karpenter nodes are provisioned", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			waitForAutoNodeStatusVCPUs(tc.Context, tc.MgmtClient, hc, 0)
 		})
 
-		It("should have Karpenter CRDs installed in the hosted cluster", func() {
+		It("should have Karpenter CRDs installed in the hosted cluster", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()
@@ -200,7 +200,7 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should have default OpenshiftEC2NodeClass with correct subnet and security group selectors", func() {
+		It("should have default OpenshiftEC2NodeClass with correct subnet and security group selectors", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()
@@ -246,7 +246,7 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 			)
 		})
 
-		It("should have default EC2NodeClass with immutable service-owned fields", func() {
+		It("should have default EC2NodeClass with immutable service-owned fields", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()
@@ -288,7 +288,7 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 			)
 		})
 
-		It("should block direct deletion of EC2NodeClass", func() {
+		It("should block direct deletion of EC2NodeClass", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -300,7 +300,7 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 			Expect(hcClient.Delete(tc.Context, ec2NodeClass)).To(MatchError(ContainSubstring("EC2NodeClass resource can't be created/updated/deleted directly, please use OpenshiftEC2NodeClass resource instead")))
 		})
 
-		It("should block direct mutation of EC2NodeClass", func() {
+		It("should block direct mutation of EC2NodeClass", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
@@ -314,7 +314,7 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 			Expect(hcClient.Update(tc.Context, ec2NodeClassCopy)).To(MatchError(ContainSubstring("EC2NodeClass resource can't be created/updated/deleted directly, please use OpenshiftEC2NodeClass resource instead")))
 		})
 
-		It("should have AutoNodeEnabled condition set to True", func() {
+		It("should have AutoNodeEnabled condition set to True", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()
@@ -355,7 +355,7 @@ func KarpenterARM64ProvisioningTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should provision and deprovision ARM64 nodes", func() {
+		It("should provision and deprovision ARM64 nodes", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()
@@ -435,7 +435,7 @@ func KarpenterInstanceProfileTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should propagate instance profile annotation to EC2NodeClass and EC2 instances", func() {
+		It("should propagate instance profile annotation to EC2NodeClass and EC2 instances", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()
@@ -558,7 +558,7 @@ func KarpenterNodeClassVersionTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should resolve version, propagate MetadataOptions, and provision node with correct kubelet version", func() {
+		It("should resolve version, propagate MetadataOptions, and provision node with correct kubelet version", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()
@@ -885,7 +885,7 @@ func KarpenterCapacityReservationTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should provision a node into a capacity reservation", func() {
+		It("should provision a node into a capacity reservation", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()
@@ -1039,7 +1039,7 @@ func KarpenterArbitrarySubnetTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should propagate a custom subnet through the VPC endpoint and provision a node in it", func() {
+		It("should propagate a custom subnet through the VPC endpoint and provision a node in it", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()
@@ -1312,7 +1312,7 @@ func KarpenterKubeletPropagationTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should propagate kubelet config to provisioned nodes", func() {
+		It("should propagate kubelet config to provisioned nodes", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()
@@ -1530,7 +1530,7 @@ func KarpenterAutoNodeLifecycleTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should disable and re-enable AutoNode with correct condition transitions", func() {
+		It("should disable and re-enable AutoNode with correct condition transitions", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()
@@ -1626,7 +1626,7 @@ func KarpenterBillingConsolidationTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should track vCPU billing metrics and consolidate nodes when workload scales down", func() {
+		It("should track vCPU billing metrics and consolidate nodes when workload scales down", Label(internal.InformingLabel), func() {
 			tc := getTestCtx()
 			ctx := tc.Context
 			t := GinkgoTB()

--- a/test/e2e/v2/tests/nodepool_arm64_create_test.go
+++ b/test/e2e/v2/tests/nodepool_arm64_create_test.go
@@ -44,7 +44,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolArm64] NodeP
 // NodePoolArm64CreateTest creates an ARM64 NodePool, waits for the node to be ready,
 // and validates that an actual ARM64 node comes up with the correct architecture label.
 func NodePoolArm64CreateTest(getTestCtx internal.TestContextGetter) {
-	It("When creating an ARM64 NodePool, it should provision a node with ARM64 architecture", func() {
+	It("When creating an ARM64 NodePool, it should provision a node with ARM64 architecture", Label(internal.BlockingLabel), func() {
 		testCtx := getTestCtx()
 		hc, err := testCtx.GetHostedCluster()
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/v2/tests/nodepool_autoscaling_test.go
+++ b/test/e2e/v2/tests/nodepool_autoscaling_test.go
@@ -43,7 +43,7 @@ import (
 
 // AutoscalingScaleUpDownTest tests autoscaling scale-up and scale-down behavior
 func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
-	It("should scale up when workload increases and scale down when workload decreases", Label("nodepool-autoscaling-scale-up-down"), func() {
+	It("should scale up when workload increases and scale down when workload decreases", Label(internal.BlockingLabel), Label("nodepool-autoscaling-scale-up-down"), func() {
 		testCtx := getTestCtx()
 		hc, err := testCtx.GetHostedCluster()
 		Expect(err).NotTo(HaveOccurred())
@@ -108,7 +108,7 @@ func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 // It configures the HostedCluster with the Random expander so the cluster autoscaler
 // distributes scale-up events across NodePools instead of favoring one.
 func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
-	It("should balance pods across multiple autoscaling NodePools", Label("nodepool-autoscaling-balancing"), func() {
+	It("should balance pods across multiple autoscaling NodePools", Label(internal.BlockingLabel), Label("nodepool-autoscaling-balancing"), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()

--- a/test/e2e/v2/tests/nodepool_lifecycle_test.go
+++ b/test/e2e/v2/tests/nodepool_lifecycle_test.go
@@ -86,7 +86,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolLifecycle] N
 // creates a verification DaemonSet in the hosted cluster, and waits for config update
 // complete and DaemonSet rollout.
 func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
-	It("should roll out a MachineConfig change via Replace upgrade strategy", Label("nodepool-machineconfig-rollout"), func() {
+	It("should roll out a MachineConfig change via Replace upgrade strategy", Label(internal.BlockingLabel), Label("nodepool-machineconfig-rollout"), func() {
 		testCtx := getTestCtx()
 		// https://issues.redhat.com/browse/CNV-38196
 		testCtx.SkipIfPlatform(hyperv1.KubevirtPlatform)
@@ -186,7 +186,7 @@ func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 // patches the NodePool's TuningConfig, creates a verification DaemonSet,
 // and waits for rollout via Replace upgrade strategy.
 func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
-	It("should roll out an NTO Tuned config change via Replace upgrade strategy", Label("nodepool-nto-replace-rollout"), func() {
+	It("should roll out an NTO Tuned config change via Replace upgrade strategy", Label(internal.BlockingLabel), Label("nodepool-nto-replace-rollout"), func() {
 		testCtx := getTestCtx()
 
 		// https://issues.redhat.com/browse/CNV-38196, https://issues.redhat.com/browse/OSASINFRA-3566
@@ -256,7 +256,7 @@ func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 
 // NodePoolNTOInPlaceTest applies an NTO Tuned config with InPlace upgrade type.
 func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
-	It("should roll out an NTO Tuned config change via InPlace upgrade strategy", Label("nodepool-nto-inplace-rollout"), func() {
+	It("should roll out an NTO Tuned config change via InPlace upgrade strategy", Label(internal.BlockingLabel), Label("nodepool-nto-inplace-rollout"), func() {
 		testCtx := getTestCtx()
 
 		// https://issues.redhat.com/browse/CNV-38196, https://issues.redhat.com/browse/OSASINFRA-3566
@@ -321,7 +321,7 @@ func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 // NodePoolReplaceUpgradeTest creates a NodePool at previous release image, waits for nodes,
 // upgrades to latest image, and waits for version to update via Replace upgrade strategy.
 func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
-	It("should upgrade a NodePool from previous to latest release via Replace strategy", Label("nodepool-replace-version-upgrade"), func() {
+	It("should upgrade a NodePool from previous to latest release via Replace strategy", Label(internal.BlockingLabel), Label("nodepool-replace-version-upgrade"), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -409,7 +409,7 @@ func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 // NodePoolInPlaceUpgradeTest creates a NodePool at previous release image, waits for nodes,
 // upgrades to latest image via InPlace upgrade strategy.
 func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
-	It("should upgrade a NodePool from previous to latest release via InPlace strategy", Label("nodepool-inplace-version-upgrade"), func() {
+	It("should upgrade a NodePool from previous to latest release via InPlace strategy", Label(internal.BlockingLabel), Label("nodepool-inplace-version-upgrade"), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -491,7 +491,7 @@ func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 // (AWS) or VM size (Azure) to trigger a rolling upgrade, and verifies the machine specs
 // after upgrade. Only runs on AWS and Azure platforms.
 func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
-	It("should perform a rolling upgrade when instance type or VM size changes", Label("nodepool-vm-size-rollout"), func() {
+	It("should perform a rolling upgrade when instance type or VM size changes", Label(internal.BlockingLabel), Label("nodepool-vm-size-rollout"), func() {
 		testCtx := getTestCtx()
 
 		testCtx.SkipIfNotPlatform(hyperv1.AWSPlatform, hyperv1.AzurePlatform)
@@ -587,7 +587,7 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 
 // NodePoolPrevReleaseN1Test creates a NodePool at N-1 release image and waits for nodes ready.
 func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
-	It("should create a NodePool at N-1 release and have ready nodes", Label("nodepool-n1-release"), func() {
+	It("should create a NodePool at N-1 release and have ready nodes", Label(internal.BlockingLabel), Label("nodepool-n1-release"), func() {
 		testCtx := getTestCtx()
 
 		n1Image := internal.GetEnvVarValue("E2E_N1_RELEASE_IMAGE")
@@ -626,7 +626,7 @@ func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
 
 // NodePoolPrevReleaseN2Test creates a NodePool at N-2 release image and waits for nodes ready.
 func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
-	It("should create a NodePool at N-2 release and have ready nodes", Label("nodepool-n2-release"), func() {
+	It("should create a NodePool at N-2 release and have ready nodes", Label(internal.BlockingLabel), Label("nodepool-n2-release"), func() {
 		testCtx := getTestCtx()
 
 		n2Image := internal.GetEnvVarValue("E2E_N2_RELEASE_IMAGE")
@@ -667,7 +667,7 @@ func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
 // verifies the KubeletConfig gets mirrored to the hosted cluster's openshift-config-managed
 // namespace, then removes the config and verifies cleanup. Only for 4.18+.
 func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
-	It("should mirror KubeletConfig to the hosted cluster and clean up on removal", Label("nodepool-mirror-config"), func() {
+	It("should mirror KubeletConfig to the hosted cluster and clean up on removal", Label(internal.BlockingLabel), Label("nodepool-mirror-config"), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -801,7 +801,7 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 // exists in the hosted cluster, removes the trust bundle, verifies CPO deployment no longer
 // mounts it, waits for another update cycle, and verifies user-ca-bundle is deleted (4.22+).
 func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
-	It("should propagate and remove additional trust bundle to/from the hosted cluster", Label("nodepool-trust-bundle"), func() {
+	It("should propagate and remove additional trust bundle to/from the hosted cluster", Label(internal.BlockingLabel), Label("nodepool-trust-bundle"), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -1011,7 +1011,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 // patches the NodePool's TuningConfig, verifies the PerformanceProfile ConfigMap and
 // status ConfigMap are created in the control plane namespace, and verifies cleanup.
 func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
-	It("should create and manage NTO PerformanceProfile via NodePool TuningConfig", Label("nodepool-performance-profile"), func() {
+	It("should create and manage NTO PerformanceProfile via NodePool TuningConfig", Label(internal.BlockingLabel), Label("nodepool-performance-profile"), func() {
 		testCtx := getTestCtx()
 
 		// https://issues.redhat.com/browse/OSASINFRA-3566
@@ -1176,7 +1176,7 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 // NodePoolAutoRepairTest is a skeleton for platform-specific auto-repair tests.
 // The full implementation requires cloud SDK dependencies for instance termination.
 func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
-	It("should auto-repair a NodePool when a node is terminated", Label("nodepool-auto-repair"), func() {
+	It("should auto-repair a NodePool when a node is terminated", Label(internal.BlockingLabel), Label("nodepool-auto-repair"), func() {
 		Skip("auto-repair instance termination not yet implemented for v2 framework")
 
 		testCtx := getTestCtx()
@@ -1221,7 +1221,7 @@ func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
 
 // NodePoolDiskEncryptionTest is a skeleton for Azure disk encryption tests.
 func NodePoolDiskEncryptionTest(getTestCtx internal.TestContextGetter) {
-	It("should create a NodePool with Azure DiskEncryptionSet and verify it is applied", Label("nodepool-disk-encryption"), func() {
+	It("should create a NodePool with Azure DiskEncryptionSet and verify it is applied", Label(internal.BlockingLabel), Label("nodepool-disk-encryption"), func() {
 		testCtx := getTestCtx()
 
 		testCtx.SkipIfNotPlatform(hyperv1.AzurePlatform)

--- a/test/e2e/v2/tests/nodepool_osimagestream_test.go
+++ b/test/e2e/v2/tests/nodepool_osimagestream_test.go
@@ -94,7 +94,7 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:OSStreams] NodePool 
 // This test only applies to OCP >= 5.0 because on < 5.0 rhel-10 is rejected for
 // version reasons before the runc check is reached.
 func NodePoolOSImageStreamRHEL10RuncRejectionTest(getTestCtx internal.TestContextGetter) {
-	It("When osImageStream is set to rhel-10 with runc ContainerRuntimeConfig, it should set ValidMachineConfig to False", func() {
+	It("When osImageStream is set to rhel-10 with runc ContainerRuntimeConfig, it should set ValidMachineConfig to False", Label(internal.BlockingLabel), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -176,7 +176,7 @@ spec:
 // (no osImageStream set) reports a recognized RHEL stream in status.osImageStream.
 // This is a non-lifecycle test: it reads existing state without mutation.
 func NodePoolOSImageStreamDefaultStatusTest(getTestCtx internal.TestContextGetter) {
-	It("When no osImageStream is set, it should report a recognized RHEL stream in status", func() {
+	It("When no osImageStream is set, it should report a recognized RHEL stream in status", Label(internal.BlockingLabel), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -333,7 +333,7 @@ func verifyNodeOSMatchesStream(testCtx *internal.TestContext, np *hyperv1.NodePo
 // (no osImageStream set), an explicit rhel-9 NodePool, and an explicit rhel-10
 // NodePool. This is a lifecycle test because it creates additional NodePools.
 func NodePoolOSImageStreamNodeOSVerificationTest(getTestCtx internal.TestContextGetter) {
-	It("When NodePools have different osImageStream values, nodes should run the matching OS version", Label("Informing"), func() {
+	It("When NodePools have different osImageStream values, nodes should run the matching OS version", Label(internal.InformingLabel), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -493,7 +493,7 @@ func conditionMessageContains(condType string, substring string) e2eutil.Predica
 // This is a lifecycle test: it mutates spec.osImageStream on the default NodePool
 // and restores it on cleanup.
 func NodePoolOSImageStreamExplicitDefaultNoRolloutTest(getTestCtx internal.TestContextGetter) {
-	It("When osImageStream is set to the version-derived default, it should not trigger a rollout", func() {
+	It("When osImageStream is set to the version-derived default, it should not trigger a rollout", Label(internal.BlockingLabel), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -584,7 +584,7 @@ func NodePoolOSImageStreamExplicitDefaultNoRolloutTest(getTestCtx internal.TestC
 // reports the version-derived stream after upgrade. The RHEL version follows the
 // release version: upgrading to OCP 5.0+ results in rhel-10.
 func NodePoolOSImageStreamUpgradeVerificationTest(getTestCtx internal.TestContextGetter) {
-	It("When a NodePool is upgraded, it should report the correct osImageStream in status", Label("nodepool-osimagestream-upgrade"), func() {
+	It("When a NodePool is upgraded, it should report the correct osImageStream in status", Label(internal.BlockingLabel), Label("nodepool-osimagestream-upgrade"), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -687,7 +687,7 @@ func NodePoolOSImageStreamUpgradeVerificationTest(getTestCtx internal.TestContex
 // verifies that the default osImageStream switches from rhel-9 to rhel-10 and
 // that nodes run RHCOS 10 with crun-only runtime handlers post-upgrade.
 func NodePoolOSImageStreamCrossMajorUpgradeTest(getTestCtx internal.TestContextGetter) {
-	It("When a NodePool at OCP 4.23 is upgraded to 5.0+, it should switch to rhel-10 by default", func() {
+	It("When a NodePool at OCP 4.23 is upgraded to 5.0+, it should switch to rhel-10 by default", Label(internal.BlockingLabel), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()
@@ -812,7 +812,7 @@ func NodePoolOSImageStreamCrossMajorUpgradeTest(getTestCtx internal.TestContextG
 // verifies that the pin overrides the default change — nodes remain on RHEL-9
 // with runc+crun runtime handlers post-upgrade.
 func NodePoolOSImageStreamPinnedRHEL9UpgradeTest(getTestCtx internal.TestContextGetter) {
-	It("When a NodePool pinned to rhel-9 is upgraded from 4.23 to 5.0+, it should remain on RHEL-9", func() {
+	It("When a NodePool pinned to rhel-9 is upgraded from 4.23 to 5.0+, it should remain on RHEL-9", Label(internal.BlockingLabel), func() {
 		testCtx := getTestCtx()
 
 		hc, err := testCtx.GetHostedCluster()


### PR DESCRIPTION
Add a new linter enforced invariant for e2e v2 that all leaf tests (i.e. `It()`) declare explicitly whether they're informing or blocking. This will make it easier for higher level tooling to assess whether a newly introduced test is following the rules (e.g should be informing) and provide a clear atomic change process for promotion and demotion to and from the blocking path.

Existing non-informing tests are assumed to be blocking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation requiring each v2 end-to-end test case to be labeled exactly **Informing** or **Blocking**.
  * Informing tests remain non-blocking, while Blocking test failures can prevent suite progression.

* **Documentation**
  * Updated end-to-end testing guidance to explain test-state labels and their behavior.

* **Tests**
  * Classified existing v2 end-to-end tests individually for consistent CI behavior.
  * Added state-label validation to the custom linter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->