### PR TITLE
[release-4.22] OCPBUGS-120746: Move packageserver PDB from guest cluster to management cluster

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -154,6 +154,7 @@ spec:
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.service.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+          rm -f /var/payload/release-manifests/0000_50_olm_00-packageserver.pdb.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -191,6 +191,15 @@ spec:
           rm -f /var/payload/release-manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
           cat > /var/payload/release-manifests/0000_01_cleanup.yaml <<EOF
           ---
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: packageserver-pdb
+            namespace: openshift-operator-lifecycle-manager
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
           apiVersion: apiextensions.k8s.io/v1
           kind: CustomResourceDefinition
           metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 343eb4fe99317dbd5db12f5cca9b09ae87cf9162e656b7cca4835e16334abac9
+    hypershift.openshift.io/desired-state-hash: 457143913f2443ab596cef6361ea86500a833c04cae6475daf0ed368156fd147
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: cluster-version-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -202,6 +202,15 @@ spec:
           rm -f /var/payload/release-manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
           cat > /var/payload/release-manifests/0000_01_cleanup.yaml <<EOF
           ---
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: packageserver-pdb
+            namespace: openshift-operator-lifecycle-manager
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
           apiVersion: apiextensions.k8s.io/v1
           kind: CustomResourceDefinition
           metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -165,6 +165,7 @@ spec:
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.service.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+          rm -f /var/payload/release-manifests/0000_50_olm_00-packageserver.pdb.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: b894aed43d1d5cb0b69dc45b8e777804d8fe29922fe7c45358f7623d965695ef
+    hypershift.openshift.io/desired-state-hash: e3f7570a231101110ca21e1f15a50133d0691b5ee5e4ebdbffd8ddabf08143ee
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: cluster-version-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -154,6 +154,7 @@ spec:
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.service.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+          rm -f /var/payload/release-manifests/0000_50_olm_00-packageserver.pdb.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -189,6 +189,15 @@ spec:
           rm -f /var/payload/release-manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
           cat > /var/payload/release-manifests/0000_01_cleanup.yaml <<EOF
           ---
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: packageserver-pdb
+            namespace: openshift-operator-lifecycle-manager
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
           apiVersion: apps/v1
           kind: Deployment
           metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: a884fa098566be0125fc765254a27e11c39acdb235585d25e8e179fa4d26f7b6
+    hypershift.openshift.io/desired-state-hash: 263b6da9fa1808c2cfd3dfb4f6ce7aa80c4462fdecf8ef666ecdac3de138ac69
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: cluster-version-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -154,6 +154,7 @@ spec:
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.service.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+          rm -f /var/payload/release-manifests/0000_50_olm_00-packageserver.pdb.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -191,6 +191,15 @@ spec:
           rm -f /var/payload/release-manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
           cat > /var/payload/release-manifests/0000_01_cleanup.yaml <<EOF
           ---
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: packageserver-pdb
+            namespace: openshift-operator-lifecycle-manager
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
           apiVersion: apiextensions.k8s.io/v1
           kind: CustomResourceDefinition
           metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: d4a04bf2f4a5d20e677d755efd645268060b753aea5c55ce6fbe96ad030679f9
+    hypershift.openshift.io/desired-state-hash: 7cfccda116bef057ddb812b83507e970ec563143888df1b7ec5418aec44ec552
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: cluster-version-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -154,6 +154,7 @@ spec:
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.service.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+          rm -f /var/payload/release-manifests/0000_50_olm_00-packageserver.pdb.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -191,6 +191,15 @@ spec:
           rm -f /var/payload/release-manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
           cat > /var/payload/release-manifests/0000_01_cleanup.yaml <<EOF
           ---
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: packageserver-pdb
+            namespace: openshift-operator-lifecycle-manager
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
           apiVersion: apiextensions.k8s.io/v1
           kind: CustomResourceDefinition
           metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    hypershift.openshift.io/desired-state-hash: 343eb4fe99317dbd5db12f5cca9b09ae87cf9162e656b7cca4835e16334abac9
+    hypershift.openshift.io/desired-state-hash: 457143913f2443ab596cef6361ea86500a833c04cae6475daf0ed368156fd147
   labels:
     hypershift.openshift.io/managed-by: control-plane-operator
   name: cluster-version-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
@@ -18,3 +18,7 @@ status:
     reason: WaitingForRolloutComplete
     status: "False"
     type: RolloutComplete
+  resources:
+  - group: policy
+    kind: PodDisruptionBudget
+    name: packageserver-pdb

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: packageserver-pdb
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  selector:
+    matchLabels:
+      app: packageserver
+  unhealthyPodEvictionPolicy: AlwaysAllow
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,6 +1,8 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: de8f46663c4397416ab6007558d35826dd6e3ff158cee96f9bbc54a82d8fa9fc
   name: packageserver-pdb
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
@@ -18,3 +18,7 @@ status:
     reason: WaitingForRolloutComplete
     status: "False"
     type: RolloutComplete
+  resources:
+  - group: policy
+    kind: PodDisruptionBudget
+    name: packageserver-pdb

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: packageserver-pdb
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  selector:
+    matchLabels:
+      app: packageserver
+  unhealthyPodEvictionPolicy: AlwaysAllow
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,6 +1,8 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: de8f46663c4397416ab6007558d35826dd6e3ff158cee96f9bbc54a82d8fa9fc
   name: packageserver-pdb
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
@@ -18,3 +18,7 @@ status:
     reason: WaitingForRolloutComplete
     status: "False"
     type: RolloutComplete
+  resources:
+  - group: policy
+    kind: PodDisruptionBudget
+    name: packageserver-pdb

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: packageserver-pdb
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  selector:
+    matchLabels:
+      app: packageserver
+  unhealthyPodEvictionPolicy: AlwaysAllow
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,6 +1,8 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: de8f46663c4397416ab6007558d35826dd6e3ff158cee96f9bbc54a82d8fa9fc
   name: packageserver-pdb
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
@@ -18,3 +18,7 @@ status:
     reason: WaitingForRolloutComplete
     status: "False"
     type: RolloutComplete
+  resources:
+  - group: policy
+    kind: PodDisruptionBudget
+    name: packageserver-pdb

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: packageserver-pdb
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  selector:
+    matchLabels:
+      app: packageserver
+  unhealthyPodEvictionPolicy: AlwaysAllow
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,6 +1,8 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: de8f46663c4397416ab6007558d35826dd6e3ff158cee96f9bbc54a82d8fa9fc
   name: packageserver-pdb
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
@@ -18,3 +18,7 @@ status:
     reason: WaitingForRolloutComplete
     status: "False"
     type: RolloutComplete
+  resources:
+  - group: policy
+    kind: PodDisruptionBudget
+    name: packageserver-pdb

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: packageserver-pdb
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  selector:
+    matchLabels:
+      app: packageserver
+  unhealthyPodEvictionPolicy: AlwaysAllow
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,6 +1,8 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  annotations:
+    hypershift.openshift.io/desired-state-hash: de8f46663c4397416ab6007558d35826dd6e3ff158cee96f9bbc54a82d8fa9fc
   name: packageserver-pdb
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/packageserver/pdb.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/packageserver/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: packageserver-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: packageserver

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
@@ -21,6 +21,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -147,6 +148,7 @@ var (
 		"0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml",
 		"0000_50_olm_06-psm-operator.service.yaml",
 		"0000_50_olm_06-psm-operator.servicemonitor.yaml",
+		"0000_50_olm_00-packageserver.pdb.yaml",
 		"0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml",
 		"0000_50_olm_07-olm-operator.deployment.yaml",
 		"0000_50_olm_07-collect-profiles.cronjob.yaml",
@@ -265,6 +267,7 @@ func resourcesToRemove(platformType hyperv1.PlatformType) []client.Object {
 	switch platformType {
 	case hyperv1.IBMCloudPlatform, hyperv1.PowerVSPlatform:
 		return []client.Object{
+			&policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "packageserver-pdb", Namespace: "openshift-operator-lifecycle-manager"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "network-operator", Namespace: "openshift-network-operator"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "default-account-cluster-network-operator"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "cluster-node-tuning-operator", Namespace: "openshift-cluster-node-tuning-operator"}},
@@ -272,6 +275,7 @@ func resourcesToRemove(platformType hyperv1.PlatformType) []client.Object {
 		}
 	default:
 		return []client.Object{
+			&policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "packageserver-pdb", Namespace: "openshift-operator-lifecycle-manager"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "machineconfigs.machineconfiguration.openshift.io"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "machineconfigpools.machineconfiguration.openshift.io"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "network-operator", Namespace: "openshift-network-operator"}},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment_test.go
@@ -110,6 +110,15 @@ func TestPreparePayloadScript(t *testing.T) {
 				g.Expect(script).To(ContainSubstring("0000_01_cleanup.yaml"))
 			},
 		},
+		{
+			name:         "When called, it should omit the packageserver PDB manifest from the payload",
+			platformType: hyperv1.AWSPlatform,
+			oauthEnabled: true,
+			featureSet:   configv1.Default,
+			assertions: func(g Gomega, script string) {
+				g.Expect(script).To(ContainSubstring("rm -f /var/payload/release-manifests/0000_50_olm_00-packageserver.pdb.yaml"))
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -135,6 +144,7 @@ func TestResourcesToRemove(t *testing.T) {
 			name:         "When platform is IBMCloud, it should return IBM-specific resources without CRDs",
 			platformType: hyperv1.IBMCloudPlatform,
 			assertions: func(g Gomega, resources []string) {
+				g.Expect(resources).To(ContainElement("packageserver-pdb"))
 				g.Expect(resources).To(ContainElement("network-operator"))
 				g.Expect(resources).To(ContainElement("default-account-cluster-network-operator"))
 				g.Expect(resources).To(ContainElement("cluster-node-tuning-operator"))
@@ -158,6 +168,7 @@ func TestResourcesToRemove(t *testing.T) {
 			name:         "When platform is AWS (default), it should return the full list including CRDs and storage operators",
 			platformType: hyperv1.AWSPlatform,
 			assertions: func(g Gomega, resources []string) {
+				g.Expect(resources).To(ContainElement("packageserver-pdb"))
 				g.Expect(resources).To(ContainElement("machineconfigs.machineconfiguration.openshift.io"))
 				g.Expect(resources).To(ContainElement("machineconfigpools.machineconfiguration.openshift.io"))
 				g.Expect(resources).To(ContainElement("network-operator"))

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/component.go
@@ -33,6 +33,10 @@ func (r *packageServer) NeedsManagementKASAccess() bool {
 func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &packageServer{}).
 		WithAdaptFunction(adaptDeployment).
+		WithManifestAdapter(
+			"pdb.yaml",
+			component.AdaptPodDisruptionBudget(),
+		).
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{
 			Mode: component.Socks5,
 		}).

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/component_test.go
@@ -1,0 +1,16 @@
+package packageserver
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestNewComponent(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	component := NewComponent()
+	g.Expect(component).ToNot(BeNil())
+	g.Expect(component.Name()).To(Equal("packageserver"))
+}


### PR DESCRIPTION
## Summary

This PR supersedes #9520 (opened by `openshift-cherrypick-robot`), the cherry-pick of #8459 (`OCPBUGS-54790`) to `release-4.22`.

The original cherry-pick failed the **Unit Tests** job (`TestControlPlaneComponents`). The failure was **not** a source-code bug — the test fixtures cherry-picked from `main` are stale on the `release-4.22` base. The only differences were the CPOv2 `hypershift.openshift.io/desired-state-hash` annotations:

- **cluster-version-operator deployment fixtures (5):** hash value changed, because the PR omits the packageserver PDB from the CVO payload.
- **packageserver PDB fixtures (5):** gain the `desired-state-hash` annotation now that the PDB is a CPOv2-managed resource on `release-4.22`.

This PR contains the two original commits plus one commit regenerating those 10 fixtures (`UPDATE=true go test ./...`). The full `hostedcontrolplane` package test tree now passes locally.

## Commits

1. `fix(CPO): move packageserver PDB from guest cluster to management cluster` (from #8459)
2. `test(CPO): update test fixtures for packageserver PDB changes` (from #8459)
3. `test(CPO): regenerate packageserver PDB and CVO fixtures for release-4.22`

**Supersedes:** #9520
**Original cherry-pick source:** #8459
