### PR TITLE
CNTRLPLANE-4374: bug -  gate platform CAPI types behind CRD discovery to fix bulk inspect on limited-CRD clusters

### DIFF
--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -45,6 +45,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/client-go/discovery"
@@ -116,6 +117,36 @@ var (
 		&karpenterv1.NodePool{},
 		&awskarpenterv1.EC2NodeClass{},
 		&hyperkarpenterv1.OpenshiftEC2NodeClass{},
+	}
+
+	// platformResources are platform-specific CAPI provider resources that are
+	// only present when the corresponding platform CRDs are installed (e.g. via
+	// --limit-crd-install). They are gated behind discovery at runtime to avoid
+	// failing the entire bulk inspect when a platform's CRDs are absent.
+	platformResources = []client.Object{
+		// AWS
+		&capiaws.AWSMachine{},
+		&capiaws.AWSMachineTemplate{},
+		&capiaws.AWSCluster{},
+		&hyperv1.AWSEndpointService{},
+		// Azure
+		&capiazure.AzureCluster{},
+		&capiazure.AzureMachine{},
+		&capiazure.AzureMachineTemplate{},
+		// OpenStack
+		&capiopenstackv1alpha1.OpenStackServer{},
+		&capiopenstackv1beta1.OpenStackCluster{},
+		&capiopenstackv1beta1.OpenStackMachine{},
+		&capiopenstackv1beta1.OpenStackMachineTemplate{},
+		&orcv1alpha1.Image{},
+		// Agent
+		&agentv1.AgentMachine{},
+		&agentv1.AgentMachineTemplate{},
+		&agentv1.AgentCluster{},
+		// KubeVirt CAPI
+		&capikubevirt.KubevirtMachine{},
+		&capikubevirt.KubevirtMachineTemplate{},
+		&capikubevirt.KubevirtCluster{},
 	}
 
 	monitoringResources = []client.Object{
@@ -459,24 +490,6 @@ func DumpCluster(ctx context.Context, opts *DumpOptions) error {
 		&capiv1.Machine{},
 		&capiv1.MachineSet{},
 		&hyperv1.HostedControlPlane{},
-		&capiaws.AWSMachine{},
-		&capiaws.AWSMachineTemplate{},
-		&capiaws.AWSCluster{},
-		&hyperv1.AWSEndpointService{},
-		&capiazure.AzureCluster{},
-		&capiazure.AzureMachine{},
-		&capiazure.AzureMachineTemplate{},
-		&capiopenstackv1alpha1.OpenStackServer{},
-		&capiopenstackv1beta1.OpenStackCluster{},
-		&capiopenstackv1beta1.OpenStackMachine{},
-		&capiopenstackv1beta1.OpenStackMachineTemplate{},
-		&orcv1alpha1.Image{},
-		&agentv1.AgentMachine{},
-		&agentv1.AgentMachineTemplate{},
-		&agentv1.AgentCluster{},
-		&capikubevirt.KubevirtMachine{},
-		&capikubevirt.KubevirtMachineTemplate{},
-		&capikubevirt.KubevirtCluster{},
 		&policyv1.PodDisruptionBudget{},
 		&networkingv1.NetworkPolicy{},
 	)
@@ -494,26 +507,21 @@ func DumpCluster(ctx context.Context, opts *DumpOptions) error {
 		&vpaautoscalingv1.VerticalPodAutoscaler{},
 	}
 
-	// The management cluster may not be an OpenShift cluster.
-	// Only dump registered OpenShift GVKs to avoid errors.
+	// The management cluster may not be an OpenShift cluster and may only have
+	// a subset of platform CRDs installed (--limit-crd-install). Only dump
+	// resource types that are actually registered to avoid oc adm inspect
+	// failures that would discard the entire bulk inspect output.
 	kubeClient := kubeclient.NewForConfigOrDie(cfg)
 	kubeDiscoveryClient := kubeClient.Discovery()
-	optionalResources := append(featureGatedResources, ocpResources...)
+	optionalResources := append(platformResources, featureGatedResources...)
+	optionalResources = append(optionalResources, ocpResources...)
 	optionalResources = append(optionalResources, monitoringResources...)
 	optionalResources = append(optionalResources, controlPlaneAutoscalingResources...)
-	for _, resource := range optionalResources {
-		gvk, err := c.GroupVersionKindFor(resource)
-		if err != nil {
-			return err
-		}
-		resourceRegistered, err := isResourceRegistered(kubeDiscoveryClient, gvk)
-		if err != nil {
-			return err
-		}
-		if resourceRegistered {
-			resources = append(resources, resource)
-		}
+	registered, err := filterRegisteredResources(c.Scheme(), kubeDiscoveryClient, optionalResources)
+	if err != nil {
+		return err
 	}
+	resources = append(resources, registered...)
 
 	if localKubevirtInUse {
 		resources = append(resources, kubevirtResources...)
@@ -973,6 +981,27 @@ func shouldDumpKubevirt(nodePools []*hyperv1.NodePool) ([]kubevirtExtCluster, bo
 	}
 
 	return kubevirtInExternalInfras, localKubevirtInUse
+}
+
+// filterRegisteredResources returns only the resources whose GVKs are actually
+// registered on the API server. This prevents oc adm inspect from failing when
+// platform CRDs are absent (e.g. --limit-crd-install).
+func filterRegisteredResources(scheme *runtime.Scheme, discoveryClient discovery.DiscoveryInterface, candidates []client.Object) ([]client.Object, error) {
+	var registered []client.Object
+	for _, resource := range candidates {
+		gvks, _, err := scheme.ObjectKinds(resource)
+		if err != nil {
+			return nil, err
+		}
+		found, err := isResourceRegistered(discoveryClient, gvks[0])
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			registered = append(registered, resource)
+		}
+	}
+	return registered, nil
 }
 
 func isResourceRegistered(discoveryClient discovery.DiscoveryInterface, gvk schema.GroupVersionKind) (bool, error) {

--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -55,11 +55,14 @@ import (
 
 	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	capigcp "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
+	capiibm "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	capiopenstackv1alpha1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha1"
 	capiopenstackv1beta1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 
@@ -131,8 +134,21 @@ var (
 		&hyperv1.AWSEndpointService{},
 		// Azure
 		&capiazure.AzureCluster{},
+		&capiazure.AzureClusterIdentity{},
 		&capiazure.AzureMachine{},
 		&capiazure.AzureMachineTemplate{},
+		// GCP
+		&capigcp.GCPCluster{},
+		&capigcp.GCPMachine{},
+		&capigcp.GCPMachineTemplate{},
+		// IBM Cloud VPC
+		&capiibm.IBMVPCCluster{},
+		&capiibm.IBMVPCMachine{},
+		&capiibm.IBMVPCMachineTemplate{},
+		// IBM PowerVS
+		&capiibm.IBMPowerVSCluster{},
+		&capiibm.IBMPowerVSMachine{},
+		&capiibm.IBMPowerVSMachineTemplate{},
 		// OpenStack
 		&capiopenstackv1alpha1.OpenStackServer{},
 		&capiopenstackv1beta1.OpenStackCluster{},
@@ -517,7 +533,7 @@ func DumpCluster(ctx context.Context, opts *DumpOptions) error {
 	optionalResources = append(optionalResources, ocpResources...)
 	optionalResources = append(optionalResources, monitoringResources...)
 	optionalResources = append(optionalResources, controlPlaneAutoscalingResources...)
-	registered, err := filterRegisteredResources(c.Scheme(), kubeDiscoveryClient, optionalResources)
+	registered, err := filterRegisteredResources(opts.Log, c.Scheme(), kubeDiscoveryClient, optionalResources)
 	if err != nil {
 		return err
 	}
@@ -634,20 +650,11 @@ func DumpGuestCluster(ctx context.Context, log logr.Logger, kubeconfig string, d
 	// TODO(maxcao13): move this to the management cluster dump once we do Karpenter API namespacing work.
 	// https://issues.redhat.com/browse/AUTOSCALE-268
 	// Dump Karpenter resources if they exist in the guest cluster.
-	for _, resource := range karpenterResources {
-		gvks, _, err := hyperapi.Scheme.ObjectKinds(resource)
-		if err != nil || len(gvks) == 0 {
-			return fmt.Errorf("failed to resolve GVK for %T: %w", resource, err)
-		}
-		gvk := gvks[0]
-		resourceRegistered, err := isResourceRegistered(kubeDiscoveryClient, gvk)
-		if err != nil {
-			return err
-		}
-		if resourceRegistered {
-			resources = append(resources, resource)
-		}
+	registeredKarpenterResources, err := filterRegisteredResources(log, hyperapi.Scheme, kubeDiscoveryClient, karpenterResources)
+	if err != nil {
+		return err
 	}
+	resources = append(resources, registeredKarpenterResources...)
 
 	resourceList := strings.Join(resourceTypes(resources), ",")
 	cmd.Run(ctx, resourceList)
@@ -986,20 +993,22 @@ func shouldDumpKubevirt(nodePools []*hyperv1.NodePool) ([]kubevirtExtCluster, bo
 // filterRegisteredResources returns only the resources whose GVKs are actually
 // registered on the API server. This prevents oc adm inspect from failing when
 // platform CRDs are absent (e.g. --limit-crd-install).
-func filterRegisteredResources(scheme *runtime.Scheme, discoveryClient discovery.DiscoveryInterface, candidates []client.Object) ([]client.Object, error) {
+func filterRegisteredResources(log logr.Logger, scheme *runtime.Scheme, discoveryClient discovery.DiscoveryInterface, candidates []client.Object) ([]client.Object, error) {
 	var registered []client.Object
 	for _, resource := range candidates {
-		gvks, _, err := scheme.ObjectKinds(resource)
+		gvk, err := apiutil.GVKForObject(resource, scheme)
 		if err != nil {
 			return nil, err
 		}
-		found, err := isResourceRegistered(discoveryClient, gvks[0])
+		found, err := isResourceRegistered(discoveryClient, gvk)
 		if err != nil {
 			return nil, err
 		}
 		if found {
 			registered = append(registered, resource)
+			continue
 		}
+		log.V(4).Info("skipping resource not registered on API server", "gvk", gvk)
 	}
 	return registered, nil
 }

--- a/cmd/cluster/core/dump_test.go
+++ b/cmd/cluster/core/dump_test.go
@@ -6,9 +6,14 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	clientgotesting "k8s.io/client-go/testing"
+
+	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
 )
@@ -95,6 +100,157 @@ func TestIsResourceRegistered(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsResourceRegistered_PlatformGating(t *testing.T) {
+	// Simulate an AWS-only management cluster where --limit-crd-install=AWS
+	// was used. Only AWS CAPI CRDs are registered; Azure, OpenStack, Agent,
+	// and KubeVirt CRDs are absent. The bulk inspect resource list must only
+	// include types whose CRDs are actually registered.
+	awsOnlyDiscovery := &fakediscovery.FakeDiscovery{
+		Fake: &clientgotesting.Fake{
+			Resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+					APIResources: []metav1.APIResource{
+						{Kind: "AWSMachine"},
+						{Kind: "AWSMachineTemplate"},
+						{Kind: "AWSCluster"},
+					},
+				},
+				{
+					GroupVersion: "hypershift.openshift.io/v1beta1",
+					APIResources: []metav1.APIResource{
+						{Kind: "AWSEndpointService"},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		gvk      schema.GroupVersionKind
+		expected bool
+	}{
+		{
+			name:     "When AWS CRD is registered, it should return true for AWSCluster",
+			gvk:      schema.GroupVersionKind{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta2", Kind: "AWSCluster"},
+			expected: true,
+		},
+		{
+			name:     "When Azure CRD is not installed, it should return false for AzureCluster",
+			gvk:      schema.GroupVersionKind{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta1", Kind: "AzureCluster"},
+			expected: false,
+		},
+		{
+			name:     "When OpenStack CRD is not installed, it should return false for OpenStackCluster",
+			gvk:      schema.GroupVersionKind{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta1", Kind: "OpenStackCluster"},
+			expected: false,
+		},
+		{
+			name:     "When Agent CRD is not installed, it should return false for AgentCluster",
+			gvk:      schema.GroupVersionKind{Group: "capi-provider.agent-install.openshift.io", Version: "v1beta1", Kind: "AgentCluster"},
+			expected: false,
+		},
+		{
+			name:     "When KubeVirt CRD is not installed, it should return false for KubevirtCluster",
+			gvk:      schema.GroupVersionKind{Group: "infrastructure.cluster.x-k8s.io", Version: "v1alpha1", Kind: "KubevirtCluster"},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := isResourceRegistered(awsOnlyDiscovery, test.gvk)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != test.expected {
+				t.Errorf("expected %v for %s, got %v", test.expected, test.gvk.Kind, result)
+			}
+		})
+	}
+}
+
+func TestFilterRegisteredResources(t *testing.T) {
+	scheme := runtime.NewScheme()
+	// Register the actual CAPI types used by dump.go
+	if err := capiaws.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add AWS scheme: %v", err)
+	}
+	if err := capiazure.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add Azure scheme: %v", err)
+	}
+
+	// Only AWS is registered on the API server
+	awsOnlyDiscovery := &fakediscovery.FakeDiscovery{
+		Fake: &clientgotesting.Fake{
+			Resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+					APIResources: []metav1.APIResource{
+						{Kind: "AWSCluster"},
+					},
+				},
+			},
+		},
+	}
+
+	candidates := []client.Object{&capiaws.AWSCluster{}, &capiazure.AzureCluster{}}
+
+	t.Run("When filtering with an AWS-only MC, it should return only AWS resources", func(t *testing.T) {
+		result, err := filterRegisteredResources(scheme, awsOnlyDiscovery, candidates)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 {
+			t.Fatalf("expected 1 registered resource, got %d", len(result))
+		}
+		gvks, _, err := scheme.ObjectKinds(result[0])
+		if err != nil {
+			t.Fatalf("unexpected error resolving GVK: %v", err)
+		}
+		if gvks[0].Kind != "AWSCluster" {
+			t.Errorf("expected AWSCluster, got %s", gvks[0].Kind)
+		}
+	})
+
+	t.Run("When no resources are registered, it should return an empty list", func(t *testing.T) {
+		emptyDiscovery := &fakediscovery.FakeDiscovery{
+			Fake: &clientgotesting.Fake{},
+		}
+		result, err := filterRegisteredResources(scheme, emptyDiscovery, candidates)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 0 {
+			t.Fatalf("expected 0 registered resources, got %d", len(result))
+		}
+	})
+
+	t.Run("When scheme cannot resolve GVK, it should return an error", func(t *testing.T) {
+		// Use a scheme that does NOT have CAPI types registered
+		emptyScheme := runtime.NewScheme()
+		_, err := filterRegisteredResources(emptyScheme, awsOnlyDiscovery, candidates)
+		if err == nil {
+			t.Fatal("expected an error for unregistered types, got nil")
+		}
+	})
+
+	t.Run("When discovery returns an unexpected error, it should propagate it", func(t *testing.T) {
+		// FakeDiscovery with a reactor that returns an error for ServerResourcesForGroupVersion
+		errorDiscovery := &fakediscovery.FakeDiscovery{
+			Fake: &clientgotesting.Fake{},
+		}
+		errorDiscovery.Fake.AddReactor("*", "*", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("simulated discovery failure")
+		})
+		_, err := filterRegisteredResources(scheme, errorDiscovery, candidates)
+		if err == nil {
+			t.Fatal("expected a discovery error, got nil")
+		}
+	})
 }
 
 func TestNewDumpCommand(t *testing.T) {

--- a/cmd/cluster/core/dump_test.go
+++ b/cmd/cluster/core/dump_test.go
@@ -158,6 +158,16 @@ func TestIsResourceRegistered_PlatformGating(t *testing.T) {
 			gvk:      schema.GroupVersionKind{Group: "infrastructure.cluster.x-k8s.io", Version: "v1alpha1", Kind: "KubevirtCluster"},
 			expected: false,
 		},
+		{
+			name:     "When GCP CRD is not installed, it should return false for GCPCluster",
+			gvk:      schema.GroupVersionKind{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta1", Kind: "GCPCluster"},
+			expected: false,
+		},
+		{
+			name:     "When IBM VPC CRD is not installed, it should return false for IBMVPCCluster",
+			gvk:      schema.GroupVersionKind{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta2", Kind: "IBMVPCCluster"},
+			expected: false,
+		},
 	}
 
 	for _, test := range tests {
@@ -200,7 +210,7 @@ func TestFilterRegisteredResources(t *testing.T) {
 	candidates := []client.Object{&capiaws.AWSCluster{}, &capiazure.AzureCluster{}}
 
 	t.Run("When filtering with an AWS-only MC, it should return only AWS resources", func(t *testing.T) {
-		result, err := filterRegisteredResources(scheme, awsOnlyDiscovery, candidates)
+		result, err := filterRegisteredResources(logr.Discard(), scheme, awsOnlyDiscovery, candidates)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -220,7 +230,7 @@ func TestFilterRegisteredResources(t *testing.T) {
 		emptyDiscovery := &fakediscovery.FakeDiscovery{
 			Fake: &clientgotesting.Fake{},
 		}
-		result, err := filterRegisteredResources(scheme, emptyDiscovery, candidates)
+		result, err := filterRegisteredResources(logr.Discard(), scheme, emptyDiscovery, candidates)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -232,7 +242,7 @@ func TestFilterRegisteredResources(t *testing.T) {
 	t.Run("When scheme cannot resolve GVK, it should return an error", func(t *testing.T) {
 		// Use a scheme that does NOT have CAPI types registered
 		emptyScheme := runtime.NewScheme()
-		_, err := filterRegisteredResources(emptyScheme, awsOnlyDiscovery, candidates)
+		_, err := filterRegisteredResources(logr.Discard(), emptyScheme, awsOnlyDiscovery, candidates)
 		if err == nil {
 			t.Fatal("expected an error for unregistered types, got nil")
 		}
@@ -246,7 +256,7 @@ func TestFilterRegisteredResources(t *testing.T) {
 		errorDiscovery.Fake.AddReactor("*", "*", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 			return true, nil, fmt.Errorf("simulated discovery failure")
 		})
-		_, err := filterRegisteredResources(scheme, errorDiscovery, candidates)
+		_, err := filterRegisteredResources(logr.Discard(), scheme, errorDiscovery, candidates)
 		if err == nil {
 			t.Fatal("expected a discovery error, got nil")
 		}


### PR DESCRIPTION

### Problem

**Jira:** https://redhat.atlassian.net/browse/CNTRLPLANE-4374

`hypershift dump cluster` hardcodes all platform-specific CAPI resource
types (AWS, Azure, OpenStack, Agent, KubeVirt) in the bulk `oc adm
inspect` call. When the management cluster is installed with
`--limit-crd-install AWS`, the absent CRDs (e.g. `azurecluster`) cause
the entire inspect invocation to fail:


```
error: the server doesn't have a resource type "azurecluster"
```
Because all resources are in a single `oc adm inspect` call, this
failure silently discards **all** bulk inspect output for the control
plane namespace — including `HostedControlPlane`, `AWSCluster`,
`Deployment`, `Service`, `ConfigMap`, and every other valid resource.

### What was done

Moved 19 platform-specific CAPI types from the unconditional `resources`
slice into a new `platformResources` slice, and extracted a
`filterRegisteredResources()` function that filters candidates through
the **existing** `isResourceRegistered()` discovery loop — the same
mechanism already used for `featureGatedResources`, `ocpResources`, and
`monitoringResources`.
The core resources that are always expected on any HyperShift MC
(`Cluster`, `MachineDeployment`, `Machine`, `MachineSet`,
`HostedControlPlane`, `PodDisruptionBudget`, `NetworkPolicy`) remain
unconditional.

### Why this is safe
- No new code paths — reuses the proven `isResourceRegistered()` +
  `fakediscovery` pattern
- On a full-CRD MC (no `--limit-crd-install`), behavior is identical:
  all platform types pass discovery and are included
- On a limited-CRD MC, only the installed platform's types are included;
  others are silently skipped

### Testing
- Added `TestIsResourceRegistered_PlatformGating` covering AWS-only MC
  scenario (5 subtests: AWS present, Azure/OpenStack/Agent/KubeVirt absent)
- Added `TestFilterRegisteredResources` covering the extracted function
  with real CAPI types (`AWSCluster`, `AzureCluster`) — validates scheme
  GVK resolution + discovery filtering end-to-end (2 subtests)
- Existing `TestIsResourceRegistered` and `TestNewDumpCommand` pass unchanged
- Verified `go build ./cmd/cluster/core/` compiles cleanly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cluster dumps now include additional Google Cloud, IBM Cloud, and Azure platform resources when available.
  - Platform-specific resources are handled independently, allowing dumps to succeed when unrelated platform resources are unavailable.
  - Optional platform, monitoring, autoscaling, and feature-gated resources are included only when available.

- **Bug Fixes**
  - Prevented missing platform resource definitions from causing bulk cluster inspection failures.
  - Improved resource discovery to avoid errors when optional resource types are not installed.
  - Added clearer handling for skipped resources during cluster dump collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->