### PR TITLE
PERFSCALE-5529: Instrument e2e timings and add CI tracking

### DIFF
--- a/hack/track-perf-baselines.py
+++ b/hack/track-perf-baselines.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Track HostedCluster bring-up and NodePool node-join performance baselines.
+
+The e2e suite emits one structured timing record per measurement (see
+test/e2e/util/perftiming.go). Records land in $ARTIFACT_DIR/perf-timings/timings.json as JSON
+Lines, and are also echoed to the test log prefixed with "PERF_TIMING ".
+
+This script aggregates those records into P50/P95/P99 distributions grouped by platform and
+metric, compares them against a committed baseline, and exits non-zero when a metric regresses
+beyond the allowed threshold (20% by default).
+
+Usage:
+
+  # Summarize a run
+  ./hack/track-perf-baselines.py --input $ARTIFACT_DIR/perf-timings/timings.json
+
+  # Capture the v1 baseline for a platform
+  ./hack/track-perf-baselines.py --input timings.json --platform AWS \\
+      --write-baseline hack/perf-baselines/aws.json
+
+  # Gate CI on regressions against the committed baseline
+  ./hack/track-perf-baselines.py --input $ARTIFACT_DIR/perf-timings/timings.json \\
+      --baseline hack/perf-baselines/aws.json --threshold 20
+
+The platform can also be supplied via the HYPERSHIFT_PERF_PLATFORM environment variable, and the
+input via HYPERSHIFT_PERF_TIMING_DIR (the directory the e2e suite writes to).
+
+Baseline file format:
+
+  {
+    "schemaVersion": 1,
+    "generatedAt": "2026-01-01T00:00:00Z",
+    "baselines": {
+      "AWS": {
+        "hosted_control_plane_bring_up": {
+          "sampleCount": 25,
+          "p50": 610.2, "p95": 812.5, "p99": 905.0,
+          "subPhases": {"EtcdAvailable": {"p50": 120.0, "p95": 150.0, "p99": 180.0}}
+        }
+      }
+    }
+  }
+
+Exit codes: 0 = no regression, 1 = regression detected, 2 = usage or input error.
+"""
+
+import argparse
+import glob
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+SCHEMA_VERSION = 1
+LOG_PREFIX = "PERF_TIMING "
+PERCENTILES = (50, 95, 99)
+DEFAULT_THRESHOLD_PERCENT = 20.0
+# Statistic compared against the baseline. P50 is the default because it is stable at the sample
+# counts a single CI run produces; tail percentiles need many more runs to be meaningful.
+DEFAULT_COMPARE_STAT = "p50"
+
+EXIT_OK = 0
+EXIT_REGRESSION = 1
+EXIT_ERROR = 2
+
+
+def percentile(sorted_values, pct):
+    """Linear-interpolated percentile, matching the numpy default method."""
+    if not sorted_values:
+        raise ValueError("percentile of empty sample")
+    if len(sorted_values) == 1:
+        return float(sorted_values[0])
+    rank = (len(sorted_values) - 1) * (pct / 100.0)
+    low = int(rank)
+    high = min(low + 1, len(sorted_values) - 1)
+    weight = rank - low
+    return float(sorted_values[low] * (1.0 - weight) + sorted_values[high] * weight)
+
+
+def distribution(values):
+    """Summarize a list of durations into the percentiles we track."""
+    ordered = sorted(float(value) for value in values)
+    summary = {
+        "sampleCount": len(ordered),
+        "min": ordered[0],
+        "max": ordered[-1],
+        "mean": sum(ordered) / len(ordered),
+    }
+    for pct in PERCENTILES:
+        summary["p{}".format(pct)] = percentile(ordered, pct)
+    return summary
+
+
+def iter_record_lines(text):
+    """Yield JSON payloads from JSON Lines content, a JSON array, or raw test log output."""
+    stripped = text.strip()
+    if stripped.startswith("["):
+        for record in json.loads(stripped):
+            yield record
+        return
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if LOG_PREFIX in line:
+            # Test logs prefix each record with a timestamp and the marker.
+            line = line[line.index(LOG_PREFIX) + len(LOG_PREFIX):].strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+
+def load_records(paths):
+    """Read timing records from files, directories or glob patterns."""
+    records = []
+    for path in paths:
+        matches = sorted(glob.glob(path)) if any(c in path for c in "*?[") else [path]
+        if not matches:
+            raise SystemExit("no input matched {}".format(path))
+        for match in matches:
+            if os.path.isdir(match):
+                files = sorted(glob.glob(os.path.join(match, "**", "*.json"), recursive=True))
+                files += sorted(glob.glob(os.path.join(match, "**", "*.jsonl"), recursive=True))
+            else:
+                files = [match]
+            for file_path in files:
+                with open(file_path, "r", encoding="utf-8") as handle:
+                    records.extend(iter_record_lines(handle.read()))
+    return records
+
+
+def group_records(records, platform_filter, metric_filter):
+    """Group durations by platform then metric, keeping sub-phase samples alongside."""
+    grouped = {}
+    for record in records:
+        if not isinstance(record, dict) or "metric" not in record:
+            continue
+        platform = record.get("platform") or "unknown"
+        metric = record["metric"]
+        if platform_filter and platform.lower() != platform_filter.lower():
+            continue
+        if metric_filter and metric != metric_filter:
+            continue
+        duration = record.get("durationSeconds")
+        if duration is None:
+            continue
+        entry = grouped.setdefault(platform, {}).setdefault(metric, {"durations": [], "subPhases": {}})
+        entry["durations"].append(float(duration))
+        for phase, elapsed in (record.get("subPhases") or {}).items():
+            entry["subPhases"].setdefault(phase, []).append(float(elapsed))
+    return grouped
+
+
+def summarize(grouped):
+    """Turn grouped samples into the nested distribution structure used by baseline files."""
+    summary = {}
+    for platform, metrics in sorted(grouped.items()):
+        summary[platform] = {}
+        for metric, samples in sorted(metrics.items()):
+            metric_summary = distribution(samples["durations"])
+            sub_phases = {
+                phase: distribution(values)
+                for phase, values in sorted(samples["subPhases"].items())
+            }
+            if sub_phases:
+                metric_summary["subPhases"] = sub_phases
+            summary[platform][metric] = metric_summary
+    return summary
+
+
+def print_summary(summary):
+    for platform, metrics in summary.items():
+        print("platform: {}".format(platform))
+        for metric, stats in metrics.items():
+            print(
+                "  {metric}: n={n} p50={p50:.1f}s p95={p95:.1f}s p99={p99:.1f}s "
+                "(min={min:.1f}s max={max:.1f}s)".format(
+                    metric=metric,
+                    n=stats["sampleCount"],
+                    p50=stats["p50"],
+                    p95=stats["p95"],
+                    p99=stats["p99"],
+                    min=stats["min"],
+                    max=stats["max"],
+                )
+            )
+            for phase, phase_stats in stats.get("subPhases", {}).items():
+                print(
+                    "    {phase}: p50={p50:.1f}s p95={p95:.1f}s p99={p99:.1f}s".format(
+                        phase=phase,
+                        p50=phase_stats["p50"],
+                        p95=phase_stats["p95"],
+                        p99=phase_stats["p99"],
+                    )
+                )
+
+
+def load_baseline(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        baseline = json.load(handle)
+    version = baseline.get("schemaVersion")
+    if version != SCHEMA_VERSION:
+        raise SystemExit(
+            "baseline {} has schemaVersion {}, expected {}".format(path, version, SCHEMA_VERSION)
+        )
+    if "baselines" not in baseline:
+        raise SystemExit("baseline {} is missing the 'baselines' key".format(path))
+    return baseline
+
+
+def compare(summary, baseline, threshold_percent, compare_stat):
+    """Compare a run summary against a baseline, returning (comparisons, regressions)."""
+    comparisons = []
+    regressions = []
+    baselines = baseline.get("baselines", {})
+    for platform, metrics in summary.items():
+        platform_baseline = baselines.get(platform, {})
+        for metric, stats in metrics.items():
+            metric_baseline = platform_baseline.get(metric)
+            if metric_baseline is None:
+                comparisons.append(
+                    {
+                        "platform": platform,
+                        "metric": metric,
+                        "phase": None,
+                        "status": "no-baseline",
+                        "current": stats[compare_stat],
+                    }
+                )
+                continue
+            targets = [(None, stats, metric_baseline)]
+            for phase, phase_stats in stats.get("subPhases", {}).items():
+                phase_baseline = (metric_baseline.get("subPhases") or {}).get(phase)
+                if phase_baseline is not None:
+                    targets.append((phase, phase_stats, phase_baseline))
+            for phase, current_stats, expected_stats in targets:
+                current = current_stats.get(compare_stat)
+                expected = expected_stats.get(compare_stat)
+                if current is None or expected is None:
+                    continue
+                if expected <= 0:
+                    continue
+                delta_percent = ((current - expected) / expected) * 100.0
+                regressed = delta_percent > threshold_percent
+                comparison = {
+                    "platform": platform,
+                    "metric": metric,
+                    "phase": phase,
+                    "status": "regression" if regressed else "ok",
+                    "stat": compare_stat,
+                    "current": current,
+                    "baseline": expected,
+                    "deltaPercent": delta_percent,
+                    "sampleCount": current_stats.get("sampleCount"),
+                }
+                comparisons.append(comparison)
+                if regressed:
+                    regressions.append(comparison)
+    return comparisons, regressions
+
+
+def print_comparisons(comparisons, threshold_percent):
+    for comparison in comparisons:
+        label = comparison["metric"]
+        if comparison.get("phase"):
+            label = "{}/{}".format(label, comparison["phase"])
+        if comparison["status"] == "no-baseline":
+            print(
+                "NO BASELINE {platform} {label}: current={current:.1f}s".format(
+                    platform=comparison["platform"], label=label, current=comparison["current"]
+                )
+            )
+            continue
+        print(
+            "{status} {platform} {label}: {stat} current={current:.1f}s baseline={baseline:.1f}s "
+            "delta={delta:+.1f}% (threshold {threshold:+.1f}%)".format(
+                status="REGRESSION" if comparison["status"] == "regression" else "OK        ",
+                platform=comparison["platform"],
+                label=label,
+                stat=comparison["stat"],
+                current=comparison["current"],
+                baseline=comparison["baseline"],
+                delta=comparison["deltaPercent"],
+                threshold=threshold_percent,
+            )
+        )
+
+
+def default_inputs():
+    timing_dir = os.getenv("HYPERSHIFT_PERF_TIMING_DIR")
+    if timing_dir:
+        return [timing_dir]
+    artifact_dir = os.getenv("ARTIFACT_DIR")
+    if artifact_dir:
+        return [os.path.join(artifact_dir, "perf-timings")]
+    return []
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--input",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="timing records file, directory or glob; repeatable. Defaults to "
+        "$HYPERSHIFT_PERF_TIMING_DIR or $ARTIFACT_DIR/perf-timings",
+    )
+    parser.add_argument(
+        "--platform",
+        default=os.getenv("HYPERSHIFT_PERF_PLATFORM", ""),
+        help="only consider records for this platform, e.g. AWS, Azure, KubeVirt "
+        "(env: HYPERSHIFT_PERF_PLATFORM)",
+    )
+    parser.add_argument("--metric", default="", help="only consider this metric")
+    parser.add_argument("--baseline", default="", help="baseline file to compare against")
+    parser.add_argument(
+        "--write-baseline",
+        default="",
+        metavar="PATH",
+        help="write the computed distributions to PATH as a new baseline",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=float(os.getenv("HYPERSHIFT_PERF_THRESHOLD", DEFAULT_THRESHOLD_PERCENT)),
+        help="percent regression tolerated before failing (default: {:.0f})".format(
+            DEFAULT_THRESHOLD_PERCENT
+        ),
+    )
+    parser.add_argument(
+        "--compare-stat",
+        default=DEFAULT_COMPARE_STAT,
+        choices=["p{}".format(pct) for pct in PERCENTILES] + ["mean"],
+        help="statistic compared against the baseline (default: {})".format(DEFAULT_COMPARE_STAT),
+    )
+    parser.add_argument(
+        "--min-samples",
+        type=int,
+        default=1,
+        help="minimum records required per metric before comparing (default: 1)",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        metavar="PATH",
+        help="write the JSON summary and comparison report to PATH",
+    )
+    parser.add_argument(
+        "--fail-on-missing-baseline",
+        action="store_true",
+        help="treat metrics without a baseline entry as a failure",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+
+    inputs = args.input or default_inputs()
+    if not inputs:
+        print(
+            "no input specified: pass --input or set HYPERSHIFT_PERF_TIMING_DIR / ARTIFACT_DIR",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    try:
+        records = load_records(inputs)
+    except OSError as err:
+        print("failed to read timing records: {}".format(err), file=sys.stderr)
+        return EXIT_ERROR
+
+    grouped = group_records(records, args.platform, args.metric)
+    if not grouped:
+        print("no timing records found in {}".format(", ".join(inputs)), file=sys.stderr)
+        return EXIT_ERROR
+
+    summary = summarize(grouped)
+    print_summary(summary)
+
+    if args.write_baseline:
+        baseline = {
+            "schemaVersion": SCHEMA_VERSION,
+            "generatedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "thresholdPercent": args.threshold,
+            "baselines": summary,
+        }
+        directory = os.path.dirname(os.path.abspath(args.write_baseline))
+        os.makedirs(directory, exist_ok=True)
+        with open(args.write_baseline, "w", encoding="utf-8") as handle:
+            json.dump(baseline, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        print("wrote baseline to {}".format(args.write_baseline))
+
+    if not args.baseline:
+        return EXIT_OK
+
+    baseline = load_baseline(args.baseline)
+    comparisons, regressions = compare(summary, baseline, args.threshold, args.compare_stat)
+    print("")
+    print_comparisons(comparisons, args.threshold)
+
+    if args.report:
+        directory = os.path.dirname(os.path.abspath(args.report))
+        os.makedirs(directory, exist_ok=True)
+        with open(args.report, "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "schemaVersion": SCHEMA_VERSION,
+                    "generatedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "thresholdPercent": args.threshold,
+                    "compareStat": args.compare_stat,
+                    "summary": summary,
+                    "comparisons": comparisons,
+                    "regressions": regressions,
+                },
+                handle,
+                indent=2,
+                sort_keys=True,
+            )
+            handle.write("\n")
+        print("wrote report to {}".format(args.report))
+
+    underpowered = [
+        comparison
+        for comparison in comparisons
+        if comparison.get("sampleCount") is not None
+        and comparison["sampleCount"] < args.min_samples
+    ]
+    for comparison in underpowered:
+        print(
+            "skipping {} {}: only {} samples, {} required".format(
+                comparison["platform"],
+                comparison["metric"],
+                comparison["sampleCount"],
+                args.min_samples,
+            )
+        )
+    regressions = [
+        regression
+        for regression in regressions
+        if regression.get("sampleCount") is None or regression["sampleCount"] >= args.min_samples
+    ]
+
+    missing = [c for c in comparisons if c["status"] == "no-baseline"]
+    if missing and args.fail_on_missing_baseline:
+        print(
+            "{} metric(s) have no baseline entry and --fail-on-missing-baseline is set".format(
+                len(missing)
+            ),
+            file=sys.stderr,
+        )
+        return EXIT_REGRESSION
+
+    if regressions:
+        print(
+            "{} metric(s) regressed more than {:.1f}% against {}".format(
+                len(regressions), args.threshold, args.baseline
+            ),
+            file=sys.stderr,
+        )
+        return EXIT_REGRESSION
+
+    print("no regressions beyond {:.1f}% against {}".format(args.threshold, args.baseline))
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/test/e2e/util/perftiming.go
+++ b/test/e2e/util/perftiming.go
@@ -1,0 +1,229 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	// PerfTimingLogPrefix prefixes every structured timing record emitted to stdout so that
+	// CI log scrapers can recover the records even when no artifact directory is available.
+	PerfTimingLogPrefix = "PERF_TIMING "
+
+	// perfTimingSchemaVersion is bumped whenever the shape of PerfTimingRecord changes in a way
+	// that is not backwards compatible with previously published baselines.
+	perfTimingSchemaVersion = 1
+
+	// perfTimingArtifactSubdir is the directory under the artifact dir where timing records are written.
+	perfTimingArtifactSubdir = "perf-timings"
+
+	// perfTimingArtifactFile is the JSON Lines file collecting all timing records of a test run.
+	perfTimingArtifactFile = "timings.json"
+
+	// PerfTimingDirEnvVar overrides the directory timing records are written to. When unset, the
+	// records are written under $ARTIFACT_DIR/perf-timings.
+	PerfTimingDirEnvVar = "HYPERSHIFT_PERF_TIMING_DIR"
+)
+
+// Metric names tracked for bring-up and node join baselines. These are the keys the baseline
+// tracking tooling (hack/track-perf-baselines.py) groups measurements by.
+const (
+	// MetricHostedControlPlaneBringUp measures the time from HostedCluster creation until all
+	// HostedControlPlane readiness conditions are true.
+	MetricHostedControlPlaneBringUp = "hosted_control_plane_bring_up"
+
+	// MetricNodePoolNodeJoin measures the time from NodePool creation until all desired nodes joined.
+	MetricNodePoolNodeJoin = "nodepool_node_join"
+)
+
+// PerfTimingRecord is a single structured timing measurement emitted by an e2e test. Records are
+// written as JSON Lines so that repeated CI runs can be concatenated and fed to the baseline
+// tracking tooling without any further parsing.
+type PerfTimingRecord struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Timestamp     string `json:"timestamp"`
+	// Metric is one of the Metric* constants above.
+	Metric string `json:"metric"`
+	// Test is the name of the Go test that produced the measurement.
+	Test string `json:"test"`
+	// Platform is the HostedCluster platform, e.g. AWS, Azure or KubeVirt. Infrastructure
+	// provisioning times differ enough between platforms that baselines must be grouped by it.
+	Platform  string `json:"platform"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	// DurationSeconds is the total elapsed time of the measured phase.
+	DurationSeconds float64 `json:"durationSeconds"`
+	// WaitDurationSeconds is the time the test itself spent waiting. It differs from
+	// DurationSeconds when the wait started after the resource was created.
+	WaitDurationSeconds float64 `json:"waitDurationSeconds"`
+	// SubPhases breaks the total duration down into milestones, keyed by milestone name with the
+	// number of seconds elapsed between resource creation and that milestone being reached.
+	SubPhases map[string]float64 `json:"subPhases,omitempty"`
+	// Metadata carries contextual information used to slice baselines, e.g. release image or
+	// node count.
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// perfTimingMu serializes appends to the shared timing file across parallel tests.
+var perfTimingMu sync.Mutex
+
+// RecordPerfTiming emits a structured timing record to stdout and, when an artifact directory is
+// configured, appends it to the timings JSON Lines file. Failures to persist a record are logged
+// but never fail the test: timing collection is best effort and must not affect e2e outcomes.
+func RecordPerfTiming(t testing.TB, record PerfTimingRecord) {
+	t.Helper()
+
+	record.SchemaVersion = perfTimingSchemaVersion
+	if record.Timestamp == "" {
+		record.Timestamp = time.Now().UTC().Format(time.RFC3339)
+	}
+	if record.Test == "" {
+		record.Test = t.Name()
+	}
+	if record.Metadata == nil {
+		record.Metadata = map[string]string{}
+	}
+	for key, envVar := range map[string]string{
+		"jobName": "JOB_NAME",
+		"buildID": "BUILD_ID",
+		"prowJob": "PROW_JOB_ID",
+	} {
+		if _, alreadySet := record.Metadata[key]; alreadySet {
+			continue
+		}
+		if value := os.Getenv(envVar); value != "" {
+			record.Metadata[key] = value
+		}
+	}
+
+	serialized, err := json.Marshal(record)
+	if err != nil {
+		t.Logf("failed to serialize perf timing record for %s: %v", record.Metric, err)
+		return
+	}
+
+	// Always log to stdout so the measurement survives even without an artifact directory.
+	t.Logf("%s%s", PerfTimingLogPrefix, serialized)
+
+	dir := perfTimingDir()
+	if dir == "" {
+		return
+	}
+
+	perfTimingMu.Lock()
+	defer perfTimingMu.Unlock()
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Logf("failed to create perf timing directory %s: %v", dir, err)
+		return
+	}
+	path := filepath.Join(dir, perfTimingArtifactFile)
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Logf("failed to open perf timing file %s: %v", path, err)
+		return
+	}
+	defer file.Close()
+	if _, err := file.Write(append(serialized, '\n')); err != nil {
+		t.Logf("failed to write perf timing record to %s: %v", path, err)
+	}
+}
+
+// perfTimingDir resolves the directory timing records are written to, preferring the explicit
+// override over the CI-provided artifact directory. An empty return value disables persistence.
+func perfTimingDir() string {
+	if dir := os.Getenv(PerfTimingDirEnvVar); dir != "" {
+		return dir
+	}
+	if dir := os.Getenv("ARTIFACT_DIR"); dir != "" {
+		return filepath.Join(dir, perfTimingArtifactSubdir)
+	}
+	return ""
+}
+
+// hostedControlPlaneBringUpMilestones are the conditions broken out as sub-phases of control plane
+// bring-up, in the order they are expected to be reached.
+var hostedControlPlaneBringUpMilestones = []hyperv1.ConditionType{
+	hyperv1.InfrastructureReady,
+	hyperv1.EtcdAvailable,
+	hyperv1.KubeAPIServerAvailable,
+	hyperv1.HostedControlPlaneAvailable,
+}
+
+// bringUpSubPhases computes, for each bring-up milestone, the number of seconds between the
+// HostedControlPlane creation and the condition last transitioning to true. Conditions that are
+// missing or not true are omitted rather than reported as zero, so that a partial record is never
+// mistaken for a fast one.
+func bringUpSubPhases(creation time.Time, conditions []metav1.Condition) map[string]float64 {
+	subPhases := map[string]float64{}
+	for _, milestone := range hostedControlPlaneBringUpMilestones {
+		for _, condition := range conditions {
+			if condition.Type != string(milestone) || condition.Status != metav1.ConditionTrue {
+				continue
+			}
+			elapsed := condition.LastTransitionTime.Time.Sub(creation).Seconds()
+			if elapsed < 0 {
+				elapsed = 0
+			}
+			subPhases[string(milestone)] = elapsed
+			break
+		}
+	}
+	return subPhases
+}
+
+// nodePoolTimingMetadata summarizes the NodePool shape so that node join baselines can be compared
+// across equivalent scales, e.g. a 10 node pool against a 10 node baseline.
+func nodePoolTimingMetadata(nodePools []*hyperv1.NodePool) map[string]string {
+	var replicas int32
+	names := make([]string, 0, len(nodePools))
+	instanceTypes := make([]string, 0, len(nodePools))
+	for _, nodePool := range nodePools {
+		replicas += ptr.Deref(nodePool.Spec.Replicas, 0)
+		names = append(names, nodePool.Name)
+		if instanceType := nodePoolInstanceType(nodePool); instanceType != "" {
+			instanceTypes = append(instanceTypes, instanceType)
+		}
+	}
+	metadata := map[string]string{
+		"nodeCount":     fmt.Sprintf("%d", replicas),
+		"nodePoolCount": fmt.Sprintf("%d", len(nodePools)),
+		"nodePools":     strings.Join(names, ","),
+	}
+	if len(instanceTypes) > 0 {
+		metadata["instanceTypes"] = strings.Join(instanceTypes, ",")
+	}
+	return metadata
+}
+
+// nodePoolInstanceType returns the platform specific machine size of the NodePool, when the
+// platform exposes one. Instance type materially changes provisioning time, so baselines are only
+// comparable when it matches.
+func nodePoolInstanceType(nodePool *hyperv1.NodePool) string {
+	switch nodePool.Spec.Platform.Type {
+	case hyperv1.AWSPlatform:
+		if nodePool.Spec.Platform.AWS != nil {
+			return nodePool.Spec.Platform.AWS.InstanceType
+		}
+	case hyperv1.AzurePlatform:
+		if nodePool.Spec.Platform.Azure != nil {
+			return nodePool.Spec.Platform.Azure.VMSize
+		}
+	case hyperv1.OpenStackPlatform:
+		if nodePool.Spec.Platform.OpenStack != nil {
+			return nodePool.Spec.Platform.OpenStack.Flavor
+		}
+	}
+	return ""
+}

--- a/test/e2e/util/perftiming_test.go
+++ b/test/e2e/util/perftiming_test.go
@@ -1,0 +1,233 @@
+package util
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestBringUpSubPhases(t *testing.T) {
+	creation := time.Date(2026, 9, 9, 10, 0, 0, 0, time.UTC)
+	condition := func(conditionType hyperv1.ConditionType, status metav1.ConditionStatus, offset time.Duration) metav1.Condition {
+		return metav1.Condition{
+			Type:               string(conditionType),
+			Status:             status,
+			LastTransitionTime: metav1.NewTime(creation.Add(offset)),
+		}
+	}
+
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		expected   map[string]float64
+	}{
+		{
+			name: "When all bring-up conditions are true, it should report every milestone",
+			conditions: []metav1.Condition{
+				condition(hyperv1.InfrastructureReady, metav1.ConditionTrue, 3*time.Minute),
+				condition(hyperv1.EtcdAvailable, metav1.ConditionTrue, 5*time.Minute),
+				condition(hyperv1.KubeAPIServerAvailable, metav1.ConditionTrue, 7*time.Minute),
+				condition(hyperv1.HostedControlPlaneAvailable, metav1.ConditionTrue, 10*time.Minute),
+			},
+			expected: map[string]float64{
+				string(hyperv1.InfrastructureReady):         180,
+				string(hyperv1.EtcdAvailable):               300,
+				string(hyperv1.KubeAPIServerAvailable):      420,
+				string(hyperv1.HostedControlPlaneAvailable): 600,
+			},
+		},
+		{
+			name: "When a condition is false, it should omit that milestone",
+			conditions: []metav1.Condition{
+				condition(hyperv1.EtcdAvailable, metav1.ConditionTrue, 5*time.Minute),
+				condition(hyperv1.KubeAPIServerAvailable, metav1.ConditionFalse, 7*time.Minute),
+			},
+			expected: map[string]float64{
+				string(hyperv1.EtcdAvailable): 300,
+			},
+		},
+		{
+			name: "When a condition transitioned before creation, it should clamp the elapsed time to zero",
+			conditions: []metav1.Condition{
+				condition(hyperv1.EtcdAvailable, metav1.ConditionTrue, -1*time.Minute),
+			},
+			expected: map[string]float64{
+				string(hyperv1.EtcdAvailable): 0,
+			},
+		},
+		{
+			name:       "When no conditions are reported, it should return an empty breakdown",
+			conditions: nil,
+			expected:   map[string]float64{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(bringUpSubPhases(creation, test.conditions)).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestNodePoolTimingMetadata(t *testing.T) {
+	awsNodePool := func(name string, replicas int32, instanceType string) *hyperv1.NodePool {
+		return &hyperv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: hyperv1.NodePoolSpec{
+				Replicas: ptr.To(replicas),
+				Platform: hyperv1.NodePoolPlatform{
+					Type: hyperv1.AWSPlatform,
+					AWS:  &hyperv1.AWSNodePoolPlatform{InstanceType: instanceType},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		nodePools []*hyperv1.NodePool
+		expected  map[string]string
+	}{
+		{
+			name:      "When a single NodePool is measured, it should report its scale and instance type",
+			nodePools: []*hyperv1.NodePool{awsNodePool("workers", 10, "m5.large")},
+			expected: map[string]string{
+				"nodeCount":     "10",
+				"nodePoolCount": "1",
+				"nodePools":     "workers",
+				"instanceTypes": "m5.large",
+			},
+		},
+		{
+			name: "When multiple NodePools are measured, it should sum the replicas",
+			nodePools: []*hyperv1.NodePool{
+				awsNodePool("workers-1", 30, "m5.large"),
+				awsNodePool("workers-2", 20, "m5.xlarge"),
+			},
+			expected: map[string]string{
+				"nodeCount":     "50",
+				"nodePoolCount": "2",
+				"nodePools":     "workers-1,workers-2",
+				"instanceTypes": "m5.large,m5.xlarge",
+			},
+		},
+		{
+			name: "When the platform exposes no instance type, it should omit it",
+			nodePools: []*hyperv1.NodePool{{
+				ObjectMeta: metav1.ObjectMeta{Name: "workers"},
+				Spec: hyperv1.NodePoolSpec{
+					Replicas: ptr.To(int32(3)),
+					Platform: hyperv1.NodePoolPlatform{Type: hyperv1.KubevirtPlatform},
+				},
+			}},
+			expected: map[string]string{
+				"nodeCount":     "3",
+				"nodePoolCount": "1",
+				"nodePools":     "workers",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(nodePoolTimingMetadata(test.nodePools)).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestRecordPerfTiming(t *testing.T) {
+	g := NewWithT(t)
+
+	dir := t.TempDir()
+	t.Setenv(PerfTimingDirEnvVar, dir)
+	t.Setenv("JOB_NAME", "e2e-aws")
+
+	RecordPerfTiming(t, PerfTimingRecord{
+		Metric:          MetricHostedControlPlaneBringUp,
+		Platform:        string(hyperv1.AWSPlatform),
+		Namespace:       "e2e-clusters",
+		Name:            "example",
+		DurationSeconds: 612.5,
+		SubPhases:       map[string]float64{string(hyperv1.EtcdAvailable): 120},
+	})
+	RecordPerfTiming(t, PerfTimingRecord{
+		Metric:          MetricNodePoolNodeJoin,
+		Platform:        string(hyperv1.AWSPlatform),
+		Namespace:       "e2e-clusters",
+		Name:            "example",
+		DurationSeconds: 420,
+	})
+
+	file, err := os.Open(filepath.Join(dir, perfTimingArtifactFile))
+	g.Expect(err).ToNot(HaveOccurred())
+	defer file.Close()
+
+	var records []PerfTimingRecord
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		var record PerfTimingRecord
+		g.Expect(json.Unmarshal(scanner.Bytes(), &record)).To(Succeed())
+		records = append(records, record)
+	}
+	g.Expect(scanner.Err()).ToNot(HaveOccurred())
+
+	g.Expect(records).To(HaveLen(2), "each record should be appended as its own JSON line")
+	g.Expect(records[0].Metric).To(Equal(MetricHostedControlPlaneBringUp))
+	g.Expect(records[0].SchemaVersion).To(Equal(perfTimingSchemaVersion))
+	g.Expect(records[0].Test).To(Equal(t.Name()), "the test name should be filled in automatically")
+	g.Expect(records[0].Timestamp).ToNot(BeEmpty())
+	g.Expect(records[0].Metadata).To(HaveKeyWithValue("jobName", "e2e-aws"))
+	g.Expect(records[0].SubPhases).To(HaveKeyWithValue(string(hyperv1.EtcdAvailable), 120.0))
+	g.Expect(records[1].Metric).To(Equal(MetricNodePoolNodeJoin))
+}
+
+func TestPerfTimingDir(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         map[string]string
+		expected    func(base string) string
+		expectEmpty bool
+	}{
+		{
+			name:     "When the override is set, it should take precedence over the artifact dir",
+			env:      map[string]string{PerfTimingDirEnvVar: "/tmp/override", "ARTIFACT_DIR": "/tmp/artifacts"},
+			expected: func(string) string { return "/tmp/override" },
+		},
+		{
+			name:     "When only the artifact dir is set, it should nest the timings under it",
+			env:      map[string]string{PerfTimingDirEnvVar: "", "ARTIFACT_DIR": "/tmp/artifacts"},
+			expected: func(string) string { return filepath.Join("/tmp/artifacts", perfTimingArtifactSubdir) },
+		},
+		{
+			name:        "When no directory is configured, it should disable persistence",
+			env:         map[string]string{PerfTimingDirEnvVar: "", "ARTIFACT_DIR": ""},
+			expectEmpty: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			for key, value := range test.env {
+				t.Setenv(key, value)
+			}
+			if test.expectEmpty {
+				g.Expect(perfTimingDir()).To(BeEmpty())
+				return
+			}
+			g.Expect(perfTimingDir()).To(Equal(test.expected("")))
+		})
+	}
+}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -760,16 +760,66 @@ func WaitForConditionsOnHostedControlPlane(t *testing.T, ctx context.Context, cl
 	}
 
 	namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+	var readyHCP *hyperv1.HostedControlPlane
+	waitStart := time.Now()
 	EventuallyObject(t, ctx, fmt.Sprintf("HostedControlPlane %s/%s to be ready", namespace, hostedCluster.Name),
 		func(ctx context.Context) (*hyperv1.HostedControlPlane, error) {
 			hcp := &hyperv1.HostedControlPlane{}
 			err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: hostedCluster.Name}, hcp)
+			readyHCP = hcp
 			return hcp, err
 		}, predicates, WithTimeout(30*time.Minute),
 	)
+
+	// EventuallyObject fails the test on timeout, so reaching this point means bring-up succeeded
+	// and the elapsed time is a valid data point for the bring-up baseline.
+	recordHostedControlPlaneBringUpTiming(t, hostedCluster, readyHCP, waitStart, image)
+}
+
+// recordHostedControlPlaneBringUpTiming emits a structured timing record for control plane
+// bring-up, broken down into the InfrastructureReady, EtcdAvailable, KubeAPIServerAvailable and
+// Available milestones. Milestone timings are derived from condition transition times relative to
+// HostedControlPlane creation, so they measure the control plane itself rather than when the test
+// happened to start waiting.
+func recordHostedControlPlaneBringUpTiming(t testing.TB, hostedCluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, waitStart time.Time, image string) {
+	t.Helper()
+	if hcp == nil {
+		return
+	}
+
+	creation := hcp.CreationTimestamp.Time
+	if !hostedCluster.CreationTimestamp.IsZero() {
+		// Prefer the HostedCluster creation timestamp: the user visible bring-up time starts when
+		// the HostedCluster is created, not when the operator creates the HostedControlPlane.
+		creation = hostedCluster.CreationTimestamp.Time
+	}
+
+	subPhases := bringUpSubPhases(creation, hcp.Status.Conditions)
+	duration := time.Since(creation).Seconds()
+	if available, ok := subPhases[string(hyperv1.HostedControlPlaneAvailable)]; ok {
+		duration = available
+	}
+
+	metadata := map[string]string{}
+	if image != "" {
+		metadata["releaseImage"] = image
+	}
+
+	RecordPerfTiming(t, PerfTimingRecord{
+		Metric:              MetricHostedControlPlaneBringUp,
+		Platform:            string(hostedCluster.Spec.Platform.Type),
+		Namespace:           hostedCluster.Namespace,
+		Name:                hostedCluster.Name,
+		DurationSeconds:     duration,
+		WaitDurationSeconds: time.Since(waitStart).Seconds(),
+		SubPhases:           subPhases,
+		Metadata:            metadata,
+	})
 }
 
 func WaitForNodePoolDesiredNodes(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	var readyNodePools []*hyperv1.NodePool
+	waitStart := time.Now()
 	EventuallyObjects(t, ctx, fmt.Sprintf("NodePools for HostedCluster %s/%s to have all of their desired nodes", hostedCluster.Namespace, hostedCluster.Name),
 		func(ctx context.Context) ([]*hyperv1.NodePool, error) {
 			list := &hyperv1.NodePoolList{}
@@ -778,6 +828,7 @@ func WaitForNodePoolDesiredNodes(t testing.TB, ctx context.Context, client crcli
 			for i := range list.Items {
 				nodePools[i] = &list.Items[i]
 			}
+			readyNodePools = nodePools
 			return nodePools, err
 		}, nil,
 		[]Predicate[*hyperv1.NodePool]{
@@ -788,6 +839,37 @@ func WaitForNodePoolDesiredNodes(t testing.TB, ctx context.Context, client crcli
 		},
 		WithTimeout(30*time.Minute),
 	)
+
+	// EventuallyObjects fails the test on timeout, so all desired nodes joined by this point.
+	recordNodeJoinTiming(t, hostedCluster, readyNodePools, waitStart)
+}
+
+// recordNodeJoinTiming emits a structured timing record for the time it took every NodePool of the
+// HostedCluster to reach its desired number of nodes. The duration is measured from the earliest
+// NodePool creation so that it is comparable across runs regardless of when the test started
+// waiting; the observed wait is reported alongside it.
+func recordNodeJoinTiming(t testing.TB, hostedCluster *hyperv1.HostedCluster, nodePools []*hyperv1.NodePool, waitStart time.Time) {
+	t.Helper()
+	if len(nodePools) == 0 {
+		return
+	}
+
+	creation := waitStart
+	for _, nodePool := range nodePools {
+		if !nodePool.CreationTimestamp.IsZero() && nodePool.CreationTimestamp.Time.Before(creation) {
+			creation = nodePool.CreationTimestamp.Time
+		}
+	}
+
+	RecordPerfTiming(t, PerfTimingRecord{
+		Metric:              MetricNodePoolNodeJoin,
+		Platform:            string(hostedCluster.Spec.Platform.Type),
+		Namespace:           hostedCluster.Namespace,
+		Name:                hostedCluster.Name,
+		DurationSeconds:     time.Since(creation).Seconds(),
+		WaitDurationSeconds: time.Since(waitStart).Seconds(),
+		Metadata:            nodePoolTimingMetadata(nodePools),
+	})
 }
 
 func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
Modify util.go to measure and emit structured JSON timing data for HostedCluster bring-up and NodePool node-join phases. This captures milestones like EtcdAvailable, KubeAPIServerAvailable, and InfrastructureReady to establish initial performance baselines.

Introduce hack/track-perf-baselines.sh to parse CI results, calculate P50/P95/P99 distributions, and trigger alerts if bring-up or node-join times regress by more than 20% compared to baseline configurations.

- Instrument WaitForConditionsOnHostedControlPlane and WaitForNodePoolDesiredNodes
- Emit JSON timing metrics for CI collection per cloud provider
- Add automated regression threshold detection script

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 
https://redhat.atlassian.net/browse/PERFSCALE-5530
https://redhat.atlassian.net/browse/PERFSCALE-5531

## Special notes for your reviewer:

Three files:

1. `test/e2e/util/perftiming.go` — timing emission

- `PerfTimingRecord` (schema v1): metric, test, platform, namespace/name, `durationSeconds`, `waitDurationSeconds`, `subPhases`, metadata (release image, node count, instance types, Prow `JOB_NAME`/`BUILD_ID`/`PROW_JOB_ID`).
- `RecordPerfTiming` logs one JSON line prefixed `PERF_TIMING` and appends to `$ARTIFACT_DIR/perf-timings/timings.json` (JSONL, mutex-guarded; override dir with `HYPERSHIFT_PERF_TIMING_DIR`). Persistence failures log but never fail a test.
- Metric names `hosted_control_plane_bring_up` and `nodepool_node_join`.

2. `test/e2e/util/util.go` — instrumentation

- `WaitForConditionsOnHostedControlPlane` captures the ready HCP and calls `recordHostedControlPlaneBringUpTiming`. Sub-phases are derived from each condition's `LastTransitionTime` relative to HostedCluster creation (not wait start), so `InfrastructureReady`/`EtcdAvailable`/`KubeAPIServerAvailable`/`Available` are real milestones rather than poll artifacts — that's what makes a "machine creation got slower" signal separable from "etcd got slower". Negative offsets clamp to 0.
- `WaitForNodePoolDesiredNodes` records join time from the earliest NodePool creation, plus observed wait, with node count / pool count / instance types as metadata.
- Both run only after the `Eventually*` helper returns, which `t.FailNow()`s on timeout — so records exist only for successful runs.

3. `hack/track-perf-baselines.py` — regression gate

- Reads JSONL files, directories, globs, JSON arrays, or raw test logs (strips the `PERF_TIMING` prefix).
- Groups by platform → metric, computes P50/P95/P99 (linear interpolation, numpy default) plus min/max/mean, including per-sub-phase.
- `--baseline` compares P50 by default (`--compare-stat` for p95/p99/mean); exits 1 when any metric or sub-phase exceeds `--threshold` (default 20, env `HYPERSHIFT_PERF_THRESHOLD`).
- `--platform` / `HYPERSHIFT_PERF_PLATFORM` groups by provider; `--write-baseline` captures the v1 baseline; `--report` emits a JSON report for dashboards; `--min-samples` skips underpowered metrics; `--fail-on-missing-baseline` for strict mode.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added performance timing collection for end-to-end tests, including control-plane readiness and node-joining milestones.
  - Timing records now include platform, test, resource, duration, and sub-phase details, with optional artifact output.
  - Added a command-line workflow for loading timing data, generating statistical summaries, creating baselines, and detecting performance regressions.
  - Supports filtering by platform and metric, configurable thresholds, minimum sample sizes, JSON reports, and status codes for automation.

- **Tests**
  - Added coverage for timing calculations, metadata collection, record persistence, and artifact configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->