### PR TITLE
CNTRLPLANE-4209: Consolidate Azure autoscaling lifecycle cluster

### DIFF
--- a/docs/content/how-to/ci/v2-testing/ci-pipeline.md
+++ b/docs/content/how-to/ci/v2-testing/ci-pipeline.md
@@ -91,7 +91,7 @@ All v2 CI logic is implemented in Go binaries built from `test/e2e/v2/cmd/` and 
 
 Creates hosted clusters in parallel using a five-phase flow:
 
-1. **Cluster creation**: Calls `hypershift create cluster <platform>` in parallel for each `ClusterSpec` in the platform's test matrix. Cluster names are derived from `PROW_JOB_ID` via SHA-256 hashing: `{variant}-{sha256(prowJobID)[:10]}`
+1. **Cluster creation**: Calls `hypershift create cluster <platform>` in parallel for each `ClusterSpec` in the platform's test matrix. The default Azure self-managed matrix creates five variants: `private`, `public`, `oauth-lb`, `external-oidc`, and `upgrade`. Cluster names are derived from `PROW_JOB_ID` via SHA-256 hashing: `{variant}-{sha256(prowJobID)[:10]}`
 
 2. **Post-create hooks**: Runs platform-specific `PostCreate()` hooks. For example, Azure patches the `OperatorConfiguration` CRD to enable lifecycle tests
 
@@ -135,6 +135,11 @@ type TestMatrix struct {
 **`Parallel`** groups run concurrently across multiple clusters. This maximizes throughput and is the common case.
 
 **`Sequential`** groups run their `Steps` one after another on the same cluster. If any step fails, remaining steps in that group are skipped. Use sequential groups for ordered workflows like upgrade → validate → downgrade.
+
+Matrix validation rejects a variant assigned to multiple top-level lanes because
+those lanes run concurrently. Reusing a variant within one sequential group's
+steps is allowed and is how configuration-specific tests run before autoscaling
+tests on the Azure `oauth-lb` and `external-oidc` clusters.
 
 See [Labels](writing-tests.md#labels-two-layer-model) for how to control which tests run in each group.
 

--- a/docs/content/how-to/ci/v2-testing/test-flow.md
+++ b/docs/content/how-to/ci/v2-testing/test-flow.md
@@ -141,21 +141,20 @@ sequenceDiagram
     activate CG
     Note over CG: Single Go process, phases run sequentially.<br/>Phases 1, 3, and 5 use internal goroutines for parallelism.
 
-    par Phase 1: Create 6 clusters in parallel (goroutines + exec.Command)
+    par Phase 1: Create 5 clusters in parallel (goroutines + exec.Command)
         CG->>MC: Create public-{hash}
         CG->>MC: Create private-{hash} (Private endpoint access)
         CG->>MC: Create oauth-lb-{hash} (OAuth via LoadBalancer)
         CG->>MC: Create upgrade-{hash} (N-1 release, HA control plane)
-        CG->>MC: Create autoscaling-{hash}
         CG->>MC: Create external-oidc-{hash}
     end
     Note right of CG: Each calls `hypershift create cluster azure`<br/>with variant-specific flags.<br/>Hooks run between phases:<br/>PreCreate (deploy Keycloak),<br/>PostCreate (patch OperatorConfiguration),<br/>PostAvailable, PostVersionRollout (OIDC config).
 
     CG->>MC: Watch all clusters for Available condition<br/>(controller-runtime Watch, 45m timeout)
-    MC-->>CG: All 6 clusters Available
+    MC-->>CG: All 5 clusters Available
 
     CG->>MC: Watch for version rollout completion<br/>(VersionState=Completed on all history entries)
-    MC-->>CG: All 6 clusters rolled out
+    MC-->>CG: All 5 clusters rolled out
 
     CG->>CG: Write cluster names and<br/>platform-specific config to SHARED_DIR
     deactivate CG
@@ -169,12 +168,11 @@ sequenceDiagram
 
     RT->>RT: PlatformConfig.SetupTestEnv()<br/>(set env vars from SHARED_DIR files)
 
-    par Parallel test groups (each is a goroutine calling exec.Command)
-        RT->>T: public-{hash} (platform + feature tests)
+    par Test lanes (each lane is a goroutine; steps within each lane are sequential)
         RT->>T: private-{hash} (private topology + compliance)
-        RT->>T: oauth-lb-{hash} (OAuth, health, metrics, registry)
-        RT->>T: autoscaling-{hash}
-        RT->>T: external-oidc-{hash}
+        RT->>T: public-{hash} (platform, feature, then NodePool rollout tests)
+        RT->>T: oauth-lb-{hash} (OAuth/configuration, MachineConfig rollout, then autoscaling balancing)
+        RT->>T: external-oidc-{hash} (OIDC/pull-secret, then autoscaling scale-up/down)
     end
     Note right of RT: Each subprocess receives cluster name via<br/>E2E_HOSTED_CLUSTER_NAME env var and label<br/>filter via --ginkgo.label-filter
 
@@ -188,7 +186,7 @@ sequenceDiagram
         T-->>RT: exit 0 or error
     end
 
-    T-->>RT: All parallel groups return exit codes
+    T-->>RT: All test lanes return exit codes
     RT->>RT: Collect results, report pass/fail summary
     RT-->>CIO: exit code (0 if all passed)
     deactivate RT
@@ -199,7 +197,7 @@ sequenceDiagram
 
     CIO->>DG: Run destroy-selfmanaged-guests step (best_effort: true)
     activate DG
-    par Destroy all 6 clusters in parallel
+    par Destroy all 5 clusters in parallel
         DG->>MC: hypershift destroy cluster azure<br/>for each variant (--cluster-grace-period=40m)
     end
     DG-->>CIO: exit code
@@ -274,7 +272,7 @@ sequenceDiagram
 | **Step shell** | bash | One per CI step | Sets KUBECONFIG, runs Go binaries ([create][create-guests-sh], [run][run-tests-chain], [destroy][destroy-guests-chain]) |
 | **[create-guests][]** | `/hypershift/bin/create-guests` | Runs once in pre step | Forks `hypershift` CLI via `exec.Command`, writes cluster names and platform-specific config to `SHARED_DIR` |
 | **[run-tests][]** | `/hypershift/bin/run-tests` | Runs once in test step | Forks one `test-e2e-v2` process per test group via `exec.Command`. Env vars pass cluster name + config. Collects exit codes. |
-| **test-e2e-v2** | `/hypershift/bin/test-e2e-v2` | One process per test group (7 total, up to 6 concurrent) | Reads env vars for cluster identity. Talks to management + hosted cluster APIs via kubeconfig. Writes JUnit XML to `ARTIFACT_DIR`. Entry point: [`suite_test.go`][suite-test]. |
+| **test-e2e-v2** | `/hypershift/bin/test-e2e-v2` | One process per test group; sequential lanes run one group at a time | Reads env vars for cluster identity. Talks to management + hosted cluster APIs via kubeconfig. Writes JUnit XML to `ARTIFACT_DIR`. Entry point: [`suite_test.go`][suite-test]. |
 | **[destroy-guests][]** | `/hypershift/bin/destroy-guests` | Runs once in post step | Forks `hypershift` CLI via `exec.Command` for each cluster (parallel goroutines). |
 
 ## Sequencing of Mutually Exclusive Tests
@@ -285,15 +283,34 @@ Mutual exclusion between test groups is achieved through **cluster isolation** a
 ```mermaid
 flowchart TD
     subgraph TestMatrix["TestMatrix (defined by PlatformConfig)"]
-        subgraph Parallel["Parallel Groups (all run concurrently)"]
-            P1["public cluster<br/>(platform + feature tests)"]
-            P2["private cluster<br/>(private topology + compliance)"]
-            P3["oauth-lb cluster<br/>(OAuth, health, metrics, registry)"]
-            P4["autoscaling cluster"]
-            P5["external-oidc cluster"]
+        subgraph Parallel["Parallel lane"]
+            P1["private cluster<br/>(private topology + compliance)"]
         end
 
-        subgraph Sequential["Sequential Group: upgrade-and-chaos"]
+        subgraph Public["Sequential lane: public cluster"]
+            direction TB
+            PUB1["platform + feature tests"]
+            PUB2["NodePool rollout tests"]
+            PUB1 --> PUB2
+        end
+
+        subgraph OAuth["Sequential lane: oauth-lb cluster"]
+            direction TB
+            OAUTH1["OAuth, health, metrics, registry"]
+            OAUTH2["NodePool configuration tests"]
+            OAUTH3["Autoscaling balancing"]
+            OAUTH1 --> OAUTH2 --> OAUTH3
+        end
+
+        subgraph OIDC["Sequential lane: external-oidc cluster"]
+            direction TB
+            OIDC1["External OIDC + global pull-secret"]
+            OIDC2["Autoscaling scale-up/down"]
+            OIDC3["Trust bundle tests"]
+            OIDC1 --> OIDC2 --> OIDC3
+        end
+
+        subgraph Sequential["Sequential lane: upgrade cluster"]
             direction TB
             S1["Step 1: upgrade tests<br/>label: control-plane-upgrade"]
             S2["Step 2: etcd-chaos tests<br/>label: etcd-chaos"]
@@ -303,31 +320,69 @@ flowchart TD
     end
 
     RT["run-tests orchestrator"] --> Parallel
+    RT --> Public
+    RT --> OAuth
+    RT --> OIDC
     RT --> Sequential
 
 ```
 
 **Key mechanisms:**
 
-1. **Cluster-per-group isolation**: Each parallel test group targets a **different
-   HostedCluster**. Tests within a group share one cluster but different groups never
-   touch the same cluster. This eliminates inter-group interference without locks.
+1. **Cluster-per-lane isolation**: The Azure matrix provisions five HostedClusters:
+   `private`, `public`, `oauth-lb`, `external-oidc`, and `upgrade`. Each top-level
+   execution lane targets exactly one cluster. Tests within a lane share that
+   cluster, while different lanes never touch the same cluster.
 
-2. **Label-based partitioning**: Ginkgo's `--ginkgo.label-filter` ensures each
-   `test-e2e-v2` process only runs specs matching its assigned labels. The label
-   sets are [non-overlapping across groups][azure-platform], so the same spec never
-   runs in two processes.
+2. **Label-based selection**: Ginkgo's `--ginkgo.label-filter` selects the
+   intended feature specs for each process. Some labels intentionally appear in
+   multiple lanes because those lanes target different HostedClusters; lane
+   isolation prevents their processes from interfering with each other.
 
-3. **Sequential groups for ordered dependencies**: The `upgrade-and-chaos`
-   [sequential group][azure-platform] runs upgrade first, then etcd-chaos on the
-   **same cluster**. The [`run-tests` orchestrator][run-tests] enforces ordering by
-   running steps sequentially within a single goroutine. If upgrade fails, etcd-chaos
-   is skipped (the goroutine returns early).
+3. **Sequential groups for ordered dependencies**: The [Azure matrix][azure-platform]
+   runs configuration-specific tests before autoscaling tests on the `oauth-lb` and
+   `external-oidc` clusters. The `upgrade-and-chaos` lane runs upgrade first, then
+   etcd-chaos on the **same cluster**. The [`run-tests` orchestrator][run-tests]
+   enforces ordering by running steps sequentially within one goroutine. If an
+   earlier step fails, the remaining steps in that lane are skipped.
 
-4. **No in-process mutex**: Because each `test-e2e-v2` process targets exactly one
-   cluster and runs non-overlapping label sets, there is no need for mutexes or
-   other synchronization between test specs. Ginkgo runs specs within a single
+4. **Matrix validation prevents concurrent reuse**: `TestMatrix.Validate` rejects
+   any variant assigned to more than one top-level lane. This prevents
+   `run-tests` from launching two processes against the same HostedCluster while
+   retaining repeated steps within one sequential lane.
+
+5. **No in-process mutex**: Each `test-e2e-v2` process targets exactly one cluster,
+   so no mutex is needed between test specs. Ginkgo runs specs within a single
    process serially by default (no `--procs` flag is passed).
+
+## Azure Autoscaling Consolidation
+
+The dedicated Azure `autoscaling` HostedCluster was removed from the default
+matrix without removing autoscaling or NodePool lifecycle coverage. The
+scale-up/down test runs after external OIDC and global pull-secret validation
+on `external-oidc`; the multi-NodePool balancing test runs after OAuth
+LoadBalancer configuration tests on `oauth-lb`. The former autoscaling lane's
+MachineConfig rollout test also remains in the OAuth LoadBalancer configuration
+step. Both public-capable variants are isolated in their own sequential lanes,
+and each test retains its label and JUnit group coverage.
+
+The decision used five qualifying successful baseline runs, with run `#9542`
+providing supplemental timing and six-cluster readiness evidence:
+
+| Run | Total | Tests | Post | Dump | Destroy guests | Destroy management |
+|-----|-------|-------|------|------|---------------|--------------------|
+| PR #9355 | 2h40m28s | 47m16s | 57m14s | 24m46s | 13m05s | 8m36s |
+| PR #9324 | 2h42m44s | 45m53s | 56m00s | 23m09s | 13m28s | 9m52s |
+| PR #9545 | 2h51m50s | 45m10s | 54m53s | 22m34s | 12m28s | 10m41s |
+| PR #8698 | 2h57m13s | 51m27s | 55m37s | 23m27s | 14m16s | 8m31s |
+| PR #9411 | 2h51m16s | 1h06m22s | 52m36s | 20m02s | 12m37s | 9m52s |
+| PR #9542 (supplemental) | 2h35m13s | 47m20s | 52m02s | 21m08s | 11m51s | 9m00s |
+
+The available artifacts provide aggregate step timings but not standard JUnit
+suite durations or per-cluster Available transition timestamps. Post-change CI
+runs must therefore confirm that the five-cluster matrix maintains or improves
+median end-to-end runtime, keeps every lane below 60 minutes, and does not
+introduce sustained flakes, cleanup failures, or leaked Azure resources.
 
 ## Inter-Process Communication
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -14383,7 +14383,7 @@ All v2 CI logic is implemented in Go binaries built from `test/e2e/v2/cmd/` and 
 
 Creates hosted clusters in parallel using a five-phase flow:
 
-1. **Cluster creation**: Calls `hypershift create cluster <platform>` in parallel for each `ClusterSpec` in the platform's test matrix. Cluster names are derived from `PROW_JOB_ID` via SHA-256 hashing: `{variant}-{sha256(prowJobID)[:10]}`
+1. **Cluster creation**: Calls `hypershift create cluster <platform>` in parallel for each `ClusterSpec` in the platform's test matrix. The default Azure self-managed matrix creates five variants: `private`, `public`, `oauth-lb`, `external-oidc`, and `upgrade`. Cluster names are derived from `PROW_JOB_ID` via SHA-256 hashing: `{variant}-{sha256(prowJobID)[:10]}`
 
 2. **Post-create hooks**: Runs platform-specific `PostCreate()` hooks. For example, Azure patches the `OperatorConfiguration` CRD to enable lifecycle tests
 
@@ -14427,6 +14427,11 @@ type TestMatrix struct {
 **`Parallel`** groups run concurrently across multiple clusters. This maximizes throughput and is the common case.
 
 **`Sequential`** groups run their `Steps` one after another on the same cluster. If any step fails, remaining steps in that group are skipped. Use sequential groups for ordered workflows like upgrade → validate → downgrade.
+
+Matrix validation rejects a variant assigned to multiple top-level lanes because
+those lanes run concurrently. Reusing a variant within one sequential group's
+steps is allowed and is how configuration-specific tests run before autoscaling
+tests on the Azure `oauth-lb` and `external-oidc` clusters.
 
 See Labels for how to control which tests run in each group.
 
@@ -15197,21 +15202,20 @@ sequenceDiagram
     activate CG
     Note over CG: Single Go process, phases run sequentially.<br/>Phases 1, 3, and 5 use internal goroutines for parallelism.
 
-    par Phase 1: Create 6 clusters in parallel (goroutines + exec.Command)
+    par Phase 1: Create 5 clusters in parallel (goroutines + exec.Command)
         CG->>MC: Create public-{hash}
         CG->>MC: Create private-{hash} (Private endpoint access)
         CG->>MC: Create oauth-lb-{hash} (OAuth via LoadBalancer)
         CG->>MC: Create upgrade-{hash} (N-1 release, HA control plane)
-        CG->>MC: Create autoscaling-{hash}
         CG->>MC: Create external-oidc-{hash}
     end
     Note right of CG: Each calls `hypershift create cluster azure`<br/>with variant-specific flags.<br/>Hooks run between phases:<br/>PreCreate (deploy Keycloak),<br/>PostCreate (patch OperatorConfiguration),<br/>PostAvailable, PostVersionRollout (OIDC config).
 
     CG->>MC: Watch all clusters for Available condition<br/>(controller-runtime Watch, 45m timeout)
-    MC-->>CG: All 6 clusters Available
+    MC-->>CG: All 5 clusters Available
 
     CG->>MC: Watch for version rollout completion<br/>(VersionState=Completed on all history entries)
-    MC-->>CG: All 6 clusters rolled out
+    MC-->>CG: All 5 clusters rolled out
 
     CG->>CG: Write cluster names and<br/>platform-specific config to SHARED_DIR
     deactivate CG
@@ -15225,12 +15229,11 @@ sequenceDiagram
 
     RT->>RT: PlatformConfig.SetupTestEnv()<br/>(set env vars from SHARED_DIR files)
 
-    par Parallel test groups (each is a goroutine calling exec.Command)
-        RT->>T: public-{hash} (platform + feature tests)
+    par Test lanes (each lane is a goroutine; steps within each lane are sequential)
         RT->>T: private-{hash} (private topology + compliance)
-        RT->>T: oauth-lb-{hash} (OAuth, health, metrics, registry)
-        RT->>T: autoscaling-{hash}
-        RT->>T: external-oidc-{hash}
+        RT->>T: public-{hash} (platform, feature, then NodePool rollout tests)
+        RT->>T: oauth-lb-{hash} (OAuth/configuration, MachineConfig rollout, then autoscaling balancing)
+        RT->>T: external-oidc-{hash} (OIDC/pull-secret, then autoscaling scale-up/down)
     end
     Note right of RT: Each subprocess receives cluster name via<br/>E2E_HOSTED_CLUSTER_NAME env var and label<br/>filter via --ginkgo.label-filter
 
@@ -15244,7 +15247,7 @@ sequenceDiagram
         T-->>RT: exit 0 or error
     end
 
-    T-->>RT: All parallel groups return exit codes
+    T-->>RT: All test lanes return exit codes
     RT->>RT: Collect results, report pass/fail summary
     RT-->>CIO: exit code (0 if all passed)
     deactivate RT
@@ -15255,7 +15258,7 @@ sequenceDiagram
 
     CIO->>DG: Run destroy-selfmanaged-guests step (best_effort: true)
     activate DG
-    par Destroy all 6 clusters in parallel
+    par Destroy all 5 clusters in parallel
         DG->>MC: hypershift destroy cluster azure<br/>for each variant (--cluster-grace-period=40m)
     end
     DG-->>CIO: exit code
@@ -15330,7 +15333,7 @@ sequenceDiagram
 | **Step shell** | bash | One per CI step | Sets KUBECONFIG, runs Go binaries ([create][create-guests-sh], [run][run-tests-chain], [destroy][destroy-guests-chain]) |
 | **[create-guests][]** | `/hypershift/bin/create-guests` | Runs once in pre step | Forks `hypershift` CLI via `exec.Command`, writes cluster names and platform-specific config to `SHARED_DIR` |
 | **[run-tests][]** | `/hypershift/bin/run-tests` | Runs once in test step | Forks one `test-e2e-v2` process per test group via `exec.Command`. Env vars pass cluster name + config. Collects exit codes. |
-| **test-e2e-v2** | `/hypershift/bin/test-e2e-v2` | One process per test group (7 total, up to 6 concurrent) | Reads env vars for cluster identity. Talks to management + hosted cluster APIs via kubeconfig. Writes JUnit XML to `ARTIFACT_DIR`. Entry point: [`suite_test.go`][suite-test]. |
+| **test-e2e-v2** | `/hypershift/bin/test-e2e-v2` | One process per test group; sequential lanes run one group at a time | Reads env vars for cluster identity. Talks to management + hosted cluster APIs via kubeconfig. Writes JUnit XML to `ARTIFACT_DIR`. Entry point: [`suite_test.go`][suite-test]. |
 | **[destroy-guests][]** | `/hypershift/bin/destroy-guests` | Runs once in post step | Forks `hypershift` CLI via `exec.Command` for each cluster (parallel goroutines). |
 
 ## Sequencing of Mutually Exclusive Tests
@@ -15341,15 +15344,34 @@ Mutual exclusion between test groups is achieved through **cluster isolation** a
 ```mermaid
 flowchart TD
     subgraph TestMatrix["TestMatrix (defined by PlatformConfig)"]
-        subgraph Parallel["Parallel Groups (all run concurrently)"]
-            P1["public cluster<br/>(platform + feature tests)"]
-            P2["private cluster<br/>(private topology + compliance)"]
-            P3["oauth-lb cluster<br/>(OAuth, health, metrics, registry)"]
-            P4["autoscaling cluster"]
-            P5["external-oidc cluster"]
+        subgraph Parallel["Parallel lane"]
+            P1["private cluster<br/>(private topology + compliance)"]
         end
 
-        subgraph Sequential["Sequential Group: upgrade-and-chaos"]
+        subgraph Public["Sequential lane: public cluster"]
+            direction TB
+            PUB1["platform + feature tests"]
+            PUB2["NodePool rollout tests"]
+            PUB1 --> PUB2
+        end
+
+        subgraph OAuth["Sequential lane: oauth-lb cluster"]
+            direction TB
+            OAUTH1["OAuth, health, metrics, registry"]
+            OAUTH2["NodePool configuration tests"]
+            OAUTH3["Autoscaling balancing"]
+            OAUTH1 --> OAUTH2 --> OAUTH3
+        end
+
+        subgraph OIDC["Sequential lane: external-oidc cluster"]
+            direction TB
+            OIDC1["External OIDC + global pull-secret"]
+            OIDC2["Autoscaling scale-up/down"]
+            OIDC3["Trust bundle tests"]
+            OIDC1 --> OIDC2 --> OIDC3
+        end
+
+        subgraph Sequential["Sequential lane: upgrade cluster"]
             direction TB
             S1["Step 1: upgrade tests<br/>label: control-plane-upgrade"]
             S2["Step 2: etcd-chaos tests<br/>label: etcd-chaos"]
@@ -15359,31 +15381,69 @@ flowchart TD
     end
 
     RT["run-tests orchestrator"] --> Parallel
+    RT --> Public
+    RT --> OAuth
+    RT --> OIDC
     RT --> Sequential
 
 ```
 
 **Key mechanisms:**
 
-1. **Cluster-per-group isolation**: Each parallel test group targets a **different
-   HostedCluster**. Tests within a group share one cluster but different groups never
-   touch the same cluster. This eliminates inter-group interference without locks.
+1. **Cluster-per-lane isolation**: The Azure matrix provisions five HostedClusters:
+   `private`, `public`, `oauth-lb`, `external-oidc`, and `upgrade`. Each top-level
+   execution lane targets exactly one cluster. Tests within a lane share that
+   cluster, while different lanes never touch the same cluster.
 
-2. **Label-based partitioning**: Ginkgo's `--ginkgo.label-filter` ensures each
-   `test-e2e-v2` process only runs specs matching its assigned labels. The label
-   sets are [non-overlapping across groups][azure-platform], so the same spec never
-   runs in two processes.
+2. **Label-based selection**: Ginkgo's `--ginkgo.label-filter` selects the
+   intended feature specs for each process. Some labels intentionally appear in
+   multiple lanes because those lanes target different HostedClusters; lane
+   isolation prevents their processes from interfering with each other.
 
-3. **Sequential groups for ordered dependencies**: The `upgrade-and-chaos`
-   [sequential group][azure-platform] runs upgrade first, then etcd-chaos on the
-   **same cluster**. The [`run-tests` orchestrator][run-tests] enforces ordering by
-   running steps sequentially within a single goroutine. If upgrade fails, etcd-chaos
-   is skipped (the goroutine returns early).
+3. **Sequential groups for ordered dependencies**: The [Azure matrix][azure-platform]
+   runs configuration-specific tests before autoscaling tests on the `oauth-lb` and
+   `external-oidc` clusters. The `upgrade-and-chaos` lane runs upgrade first, then
+   etcd-chaos on the **same cluster**. The [`run-tests` orchestrator][run-tests]
+   enforces ordering by running steps sequentially within one goroutine. If an
+   earlier step fails, the remaining steps in that lane are skipped.
 
-4. **No in-process mutex**: Because each `test-e2e-v2` process targets exactly one
-   cluster and runs non-overlapping label sets, there is no need for mutexes or
-   other synchronization between test specs. Ginkgo runs specs within a single
+4. **Matrix validation prevents concurrent reuse**: `TestMatrix.Validate` rejects
+   any variant assigned to more than one top-level lane. This prevents
+   `run-tests` from launching two processes against the same HostedCluster while
+   retaining repeated steps within one sequential lane.
+
+5. **No in-process mutex**: Each `test-e2e-v2` process targets exactly one cluster,
+   so no mutex is needed between test specs. Ginkgo runs specs within a single
    process serially by default (no `--procs` flag is passed).
+
+## Azure Autoscaling Consolidation
+
+The dedicated Azure `autoscaling` HostedCluster was removed from the default
+matrix without removing autoscaling or NodePool lifecycle coverage. The
+scale-up/down test runs after external OIDC and global pull-secret validation
+on `external-oidc`; the multi-NodePool balancing test runs after OAuth
+LoadBalancer configuration tests on `oauth-lb`. The former autoscaling lane's
+MachineConfig rollout test also remains in the OAuth LoadBalancer configuration
+step. Both public-capable variants are isolated in their own sequential lanes,
+and each test retains its label and JUnit group coverage.
+
+The decision used five qualifying successful baseline runs, with run `#9542`
+providing supplemental timing and six-cluster readiness evidence:
+
+| Run | Total | Tests | Post | Dump | Destroy guests | Destroy management |
+|-----|-------|-------|------|------|---------------|--------------------|
+| PR #9355 | 2h40m28s | 47m16s | 57m14s | 24m46s | 13m05s | 8m36s |
+| PR #9324 | 2h42m44s | 45m53s | 56m00s | 23m09s | 13m28s | 9m52s |
+| PR #9545 | 2h51m50s | 45m10s | 54m53s | 22m34s | 12m28s | 10m41s |
+| PR #8698 | 2h57m13s | 51m27s | 55m37s | 23m27s | 14m16s | 8m31s |
+| PR #9411 | 2h51m16s | 1h06m22s | 52m36s | 20m02s | 12m37s | 9m52s |
+| PR #9542 (supplemental) | 2h35m13s | 47m20s | 52m02s | 21m08s | 11m51s | 9m00s |
+
+The available artifacts provide aggregate step timings but not standard JUnit
+suite durations or per-cluster Available transition timestamps. Post-change CI
+runs must therefore confirm that the five-cluster matrix maintains or improves
+median end-to-end runtime, keeps every lane below 60 minutes, and does not
+introduce sustained flakes, cleanup failures, or leaked Azure resources.
 
 ## Inter-Process Communication
 

--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -154,11 +154,6 @@ func (a *AzurePlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Clust
 			ExtraArgs:               append([]string{"--control-plane-availability-policy=HighlyAvailable"}, extraArgs...),
 		},
 		{
-			Variant:                 "autoscaling",
-			InitialNodePoolReplicas: &oneInitialReplica,
-			ExtraArgs:               extraArgs,
-		},
-		{
 			Variant:                 "external-oidc",
 			InitialNodePoolReplicas: &oneInitialReplica,
 			ExtraArgs:               extraArgs,
@@ -378,21 +373,6 @@ func (a *AzurePlatformConfig) TestMatrix() TestMatrix {
 				},
 			},
 			{
-				Name: "autoscaling",
-				Steps: []TestGroup{
-					{
-						Name:        "autoscaling-nodepool-machineconfig",
-						Variant:     "autoscaling",
-						LabelFilter: "nodepool-machineconfig-rollout",
-					},
-					{
-						Name:        "autoscaling-balancing",
-						Variant:     "autoscaling",
-						LabelFilter: "nodepool-autoscaling-balancing",
-					},
-				},
-			},
-			{
 				Name: "oauth-lb",
 				Steps: []TestGroup{
 					{
@@ -404,7 +384,12 @@ func (a *AzurePlatformConfig) TestMatrix() TestMatrix {
 						Name:    "oauth-lb-nodepool-config",
 						Variant: "oauth-lb",
 						LabelFilter: "nodepool-nto-replace-rollout || nodepool-nto-inplace-rollout || " +
-							"nodepool-performance-profile || nodepool-mirror-config",
+							"nodepool-performance-profile || nodepool-mirror-config || nodepool-machineconfig-rollout",
+					},
+					{
+						Name:        "oauth-lb-autoscaling",
+						Variant:     "oauth-lb",
+						LabelFilter: "nodepool-autoscaling-balancing",
 					},
 				},
 			},

--- a/test/e2e/v2/lifecycle/azure_test.go
+++ b/test/e2e/v2/lifecycle/azure_test.go
@@ -2,7 +2,10 @@
 
 package lifecycle
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestAzurePlatformConfigClusterSpecs(t *testing.T) {
 	t.Parallel()
@@ -39,11 +42,6 @@ func TestAzurePlatformConfigClusterSpecs(t *testing.T) {
 			want:    1,
 		},
 		{
-			name:    "When autoscaling Azure variant is configured, it should request one initial replica",
-			variant: "autoscaling",
-			want:    1,
-		},
-		{
 			name:    "When external OIDC Azure variant is configured, it should request one initial replica",
 			variant: "external-oidc",
 			want:    1,
@@ -70,5 +68,74 @@ func TestAzurePlatformConfigClusterSpecs(t *testing.T) {
 				t.Errorf("Azure variant %q requests %d initial replicas, want %d", tt.variant, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestAzurePlatformConfigTestMatrix(t *testing.T) {
+	t.Parallel()
+
+	matrix := (&AzurePlatformConfig{}).TestMatrix()
+	sequential := make(map[string]SequentialGroup, len(matrix.Sequential))
+	for _, group := range matrix.Sequential {
+		sequential[group.Name] = group
+	}
+
+	tests := []struct {
+		name       string
+		group      string
+		stepNames  []string
+		variants   []string
+		labelMatch []string
+	}{
+		{
+			name:       "When OAuth LoadBalancer tests run, autoscaling balancing follows configuration tests",
+			group:      "oauth-lb",
+			stepNames:  []string{"oauth-lb", "oauth-lb-nodepool-config", "oauth-lb-autoscaling"},
+			variants:   []string{"oauth-lb", "oauth-lb", "oauth-lb"},
+			labelMatch: []string{"", "", "nodepool-autoscaling-balancing"},
+		},
+		{
+			name:       "When external OIDC tests run, autoscaling scale-up/down follows configuration tests",
+			group:      "external-oidc",
+			stepNames:  []string{"external-oidc", "external-oidc-autoscaling", "external-oidc-trust-bundle"},
+			variants:   []string{"external-oidc", "external-oidc", "external-oidc"},
+			labelMatch: []string{"", "nodepool-autoscaling-scale-up-down", ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			group, ok := sequential[tt.group]
+			if !ok {
+				t.Fatalf("sequential group %q was not configured", tt.group)
+			}
+			if len(group.Steps) != len(tt.stepNames) {
+				t.Fatalf("group %q has %d steps, want %d", tt.group, len(group.Steps), len(tt.stepNames))
+			}
+			for i, step := range group.Steps {
+				if step.Name != tt.stepNames[i] {
+					t.Errorf("step %d in %q is %q, want %q", i, tt.group, step.Name, tt.stepNames[i])
+				}
+				if step.Variant != tt.variants[i] {
+					t.Errorf("step %d in %q uses variant %q, want %q", i, tt.group, step.Variant, tt.variants[i])
+				}
+				if tt.labelMatch[i] != "" && !strings.Contains(step.LabelFilter, tt.labelMatch[i]) {
+					t.Errorf("step %q in %q has label filter %q, want it to contain %q", step.Name, tt.group, step.LabelFilter, tt.labelMatch[i])
+				}
+			}
+		})
+	}
+
+	oauthConfig := sequential["oauth-lb"].Steps[1].LabelFilter
+	if !strings.Contains(oauthConfig, "nodepool-machineconfig-rollout") {
+		t.Errorf("OAuth LoadBalancer configuration step must retain nodepool machineconfig coverage, got %q", oauthConfig)
+	}
+
+	for _, group := range matrix.Sequential {
+		for _, step := range group.Steps {
+			if step.Variant == "autoscaling" {
+				t.Errorf("dedicated autoscaling variant must not be referenced by step %q", step.Name)
+			}
+		}
 	}
 }

--- a/test/e2e/v2/lifecycle/platform.go
+++ b/test/e2e/v2/lifecycle/platform.go
@@ -67,10 +67,12 @@ type TestMatrix struct {
 	Sequential []SequentialGroup `json:"sequential,omitempty"`
 }
 
-// Validate checks that all group names within the matrix are unique
-// and safe for use as JUnit filename components.
+// Validate checks that all group names within the matrix are unique and safe
+// for use as JUnit filename components. It also rejects variants assigned to
+// different top-level execution lanes, because those lanes run concurrently.
 func (m TestMatrix) Validate() error {
 	seen := make(map[string]bool)
+	variantLanes := make(map[string]string)
 	var errs []error
 	check := func(name string) {
 		if err := validateGroupName(name); err != nil {
@@ -81,12 +83,22 @@ func (m TestMatrix) Validate() error {
 		}
 		seen[name] = true
 	}
+	checkVariant := func(variant, lane string) {
+		if previousLane, ok := variantLanes[variant]; ok && previousLane != lane {
+			errs = append(errs, fmt.Errorf("variant %q is used by concurrent lanes %q and %q", variant, previousLane, lane))
+			return
+		}
+		variantLanes[variant] = lane
+	}
 	for _, g := range m.Parallel {
 		check(g.Name)
+		checkVariant(g.Variant, "parallel/"+g.Name)
 	}
-	for _, sg := range m.Sequential {
+	for i, sg := range m.Sequential {
+		lane := fmt.Sprintf("sequential/%d/%s", i, sg.Name)
 		for _, step := range sg.Steps {
 			check(step.Name)
+			checkVariant(step.Variant, lane)
 		}
 	}
 	return errors.Join(errs...)

--- a/test/e2e/v2/lifecycle/testplan_test.go
+++ b/test/e2e/v2/lifecycle/testplan_test.go
@@ -152,6 +152,45 @@ func TestTestMatrixValidate(t *testing.T) {
 			},
 			wantError: true,
 		},
+		{
+			name: "When a variant is used by concurrent lanes, it should return an error",
+			matrix: TestMatrix{
+				Parallel: []TestGroup{
+					{Name: "public", Variant: "public"},
+				},
+				Sequential: []SequentialGroup{
+					{Name: "public-follow-up", Steps: []TestGroup{
+						{Name: "public-validation", Variant: "public"},
+					}},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "When a variant is reused by steps in one sequential lane, it should succeed",
+			matrix: TestMatrix{
+				Sequential: []SequentialGroup{
+					{Name: "public-flow", Steps: []TestGroup{
+						{Name: "public", Variant: "public"},
+						{Name: "public-follow-up", Variant: "public"},
+					}},
+				},
+			},
+		},
+		{
+			name: "When same-named sequential lanes reuse a variant, it should return an error",
+			matrix: TestMatrix{
+				Sequential: []SequentialGroup{
+					{Name: "public-flow", Steps: []TestGroup{
+						{Name: "public", Variant: "public"},
+					}},
+					{Name: "public-flow", Steps: []TestGroup{
+						{Name: "public-follow-up", Variant: "public"},
+					}},
+				},
+			},
+			wantError: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/e2e/v2/tests/azure_test_matrix_test.go
+++ b/test/e2e/v2/tests/azure_test_matrix_test.go
@@ -42,13 +42,13 @@ func TestAzureTestMatrix(t *testing.T) {
 	previousSelection := selectedSpecs(g, report.SpecReports, previousFilters)
 	currentSelection := selectedSpecs(g, report.SpecReports, testMatrixFilters(matrix))
 
-	g.Expect(currentSelection).To(Equal(previousSelection),
-		"the Azure matrix must select every previously selected spec exactly once")
-	for spec, count := range previousSelection {
-		g.Expect(count).To(Equal(1), "previous Azure matrix selected spec %q more than once", spec)
+	for spec := range previousSelection {
+		g.Expect(currentSelection).To(HaveKey(spec),
+			"current Azure matrix must retain previously selected spec %q", spec)
 	}
-	for spec, count := range currentSelection {
-		g.Expect(count).To(Equal(1), "current Azure matrix selects spec %q more than once", spec)
+	for spec := range currentSelection {
+		g.Expect(previousSelection).To(HaveKey(spec),
+			"current Azure matrix must not select new spec %q", spec)
 	}
 
 	junitFiles := testMatrixJUnitFiles(matrix)
@@ -67,7 +67,6 @@ func TestAzureTestMatrix(t *testing.T) {
 	expectedVariantLanes := map[string][]string{
 		"private":       {"parallel:private"},
 		"public":        {"sequential:public"},
-		"autoscaling":   {"sequential:autoscaling"},
 		"oauth-lb":      {"sequential:oauth-lb"},
 		"external-oidc": {"sequential:external-oidc"},
 		"upgrade":       {"sequential:upgrade-and-chaos"},


### PR DESCRIPTION
## What this PR does / why we need it:

Removes the dedicated Azure `autoscaling` HostedCluster from the default v2 lifecycle matrix while preserving all coverage:

- Runs autoscaling scale-up/down sequentially on `external-oidc`.
- Runs autoscaling balancing sequentially on `oauth-lb`.
- Retains NodePool MachineConfig rollout coverage on the OAuth LoadBalancer configuration step.
- Rejects custom matrices that use one HostedCluster variant in concurrent lanes.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-4209](https://redhat.atlassian.net/browse/CNTRLPLANE-4209)

Jira: https://redhat.atlassian.net/browse/CNTRLPLANE-4209

## Special notes for your reviewer:

The issue comments establish five qualifying successful baseline runs; run `#9542` provides supplemental six-cluster and readiness evidence. The available artifacts contain aggregate timings but not standard JUnit suite durations or per-cluster Available transition timestamps. The documentation records the baseline and requires post-change CI runs to confirm median runtime, the 60-minute lane target, and cleanup/reliability criteria.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [x] This change includes unit tests.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Azure CI guidance for private, public, OAuth load balancer, external OIDC, and upgrade variants.
  - Clarified parallel lanes, sequential ordering, permitted variant reuse, teardown, availability checks, and timing criteria.
  - Documented autoscaling and node pool coverage on existing test lanes.

- **Tests**
  - Removed the dedicated autoscaling cluster variant while retaining autoscaling coverage elsewhere.
  - Added node pool machine configuration rollout coverage to the OAuth load balancer variant.
  - Strengthened validation for test matrix ordering, lane reuse, and configuration rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->