### PR TITLE
OCPBUGS-120749: update Containerfile.cli runtime base image to floating tag [release-4.19]

### DIFF
--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -18,7 +18,7 @@ RUN make product-cli-release && \
     # Remove raw binaries, keep only tar.gz files \
     find ./bin -type f ! -name "*.tar.gz" -delete
 
-FROM registry.redhat.io/ubi9/nginx-124:1-1767745334
+FROM registry.redhat.io/ubi9/nginx-124:latest
 
 COPY --from=builder /hypershift/bin/ /opt/app-root/src/
 


### PR DESCRIPTION
Jira: [OCPBUGS-120749](https://redhat.atlassian.net/browse/OCPBUGS-120749)

## Summary

Updates `Containerfile.cli` on `release-4.19` to use the floating nginx runtime base image tag so rebuilds of `multicluster-engine/hypershift-cli-rhel9` (MCE 2.9) pick up current CVE-fixed layers and improve the catalog security grade.

## Changes

| Stage | Before | After |
|-------|--------|-------|
| Runtime | `registry.redhat.io/ubi9/nginx-124:1-1767745334` | `registry.redhat.io/ubi9/nginx-124:latest` |

No builder-stage changes are needed on this branch; it already uses `openshift-golang-builder:rhel_9_golang_1.24` and `COPY . .`.

## Reference

- Merged fix for 4.18: https://github.com/openshift/hypershift/pull/9044
- Related ACM work: https://redhat.atlassian.net/browse/ACM-38044

## Test plan

- [ ] Konflux build for MCE 2.9 hypershift-cli passes
- [ ] Catalog grade for hypershift-cli improves after rebuild

Made with [Cursor](https://cursor.com)