### PR TITLE
OCPBUGS-120748: update Containerfile.cli base images to floating tags [release-4.16]

### DIFF
--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -1,8 +1,8 @@
-FROM registry.redhat.io/rhel9/go-toolset:1.24.6-1763548439 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24 AS builder
 
 WORKDIR /hypershift
 
-COPY --chown=default . .
+COPY . .
 
 RUN make product-cli-release && \
     # Create tar.gz files for Linux architectures \
@@ -16,9 +16,9 @@ RUN make product-cli-release && \
       done; \
     done
 
-FROM registry.redhat.io/ubi9/nginx-124:1-1767745334
+FROM registry.redhat.io/ubi9/nginx-124:latest
 
-COPY --from=builder /hypershift/bin/ /opt/app-root/src/
+COPY --chown=1001:0 --from=builder /hypershift/bin/ /opt/app-root/src/
 RUN find /opt/app-root/src/ -type f ! -name "*.tar.gz" -delete
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Jira: [OCPBUGS-120748](https://redhat.atlassian.net/browse/OCPBUGS-120748)

## Summary

Backports the `Containerfile.cli` base image refresh from OCP 4.18 (PR #9044) to `release-4.16` so rebuilds of `multicluster-engine/hypershift-cli-rhel9` (MCE 2.6) pick up current CVE-fixed layers and improve the catalog security grade.

## Changes

| Stage | Before | After |
|-------|--------|-------|
| Builder | `registry.redhat.io/rhel9/go-toolset:1.24.6-1763548439` | `brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24` |
| Runtime | `registry.redhat.io/ubi9/nginx-124:1-1767745334` | `registry.redhat.io/ubi9/nginx-124:latest` |
| Builder COPY | `COPY --chown=default . .` | `COPY . .` |
| Runtime COPY | `COPY --from=builder /hypershift/bin/ ...` | `COPY --chown=1001:0 --from=builder /hypershift/bin/ ...` |

## Why `COPY . .` (no `--chown=default`)

The `openshift-golang-builder` image does not define a `default` user, so `--chown=default` fails at build time.

## Why `--chown=1001:0` on the runtime COPY

Without ownership transfer, the nginx process (uid 1001) cannot delete binaries during the runtime cleanup step (`find ... -delete`).

## Reference

- Merged fix for 4.18: https://github.com/openshift/hypershift/pull/9044
- Related ACM work: https://redhat.atlassian.net/browse/ACM-38044

## Test plan

- [ ] Konflux build for MCE 2.6 hypershift-cli passes without permission errors
- [ ] Catalog grade for hypershift-cli improves after rebuild

Made with [Cursor](https://cursor.com)