### PR TITLE
NO-JIRA: Gate GCP credential validation by control plane version

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/gcp_credentials.go
+++ b/hypershift-operator/controllers/hostedcluster/gcp_credentials.go
@@ -1,0 +1,25 @@
+package hostedcluster
+
+import (
+	"context"
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	platformgcp "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/gcp"
+	"github.com/openshift/hypershift/support/statuspatching"
+)
+
+// reconcileGCPCredentialConditions publishes the credential conditions and the
+// control plane version used to compute them in the same HC status update. Health
+// checks, metrics, and orphan cleanup therefore observe a consistent version and
+// validation result, including during deletion when later propagation is skipped.
+func (r *HostedClusterReconciler) reconcileGCPCredentialConditions(ctx context.Context, hc *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) error {
+	if err := statuspatching.PatchStatus(ctx, r.Client, hc, func() error {
+		propagateControlPlaneVersion(hc, hcp)
+		platformgcp.ComputeGCPCredentialConditions(hc, hcp)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to update GCP credential status: %w", err)
+	}
+	return nil
+}

--- a/hypershift-operator/controllers/hostedcluster/gcp_credentials_test.go
+++ b/hypershift-operator/controllers/hostedcluster/gcp_credentials_test.go
@@ -1,0 +1,269 @@
+package hostedcluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	platformgcp "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/gcp"
+	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/conditions"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestReconcileGCPCredentialConditions(t *testing.T) {
+	for _, tc := range []struct {
+		name                               string
+		hcVersion, hcpVersion              string
+		initialStatus, runtimeStatus       metav1.ConditionStatus
+		expectedStatus, expectedHealth     metav1.ConditionStatus
+		expectedCredentials                platformgcp.CredentialStatus
+		missingHCP, deleting, patchFailure bool
+		conflictingWrite                   bool
+		expectedPatches                    int
+	}{
+		{
+			name:                "When HCP upgrades to 5.1, it should publish the version and successful validation together",
+			hcVersion:           "5.0.0",
+			hcpVersion:          "5.1.0-0.ci-20260909",
+			runtimeStatus:       metav1.ConditionTrue,
+			expectedStatus:      metav1.ConditionTrue,
+			expectedHealth:      metav1.ConditionTrue,
+			expectedCredentials: platformgcp.CredentialStatusValid,
+			expectedPatches:     1,
+		},
+		{
+			name:                "When HCP is 5.0 and HC is stale 5.1, it should publish unavailable validation with version 5.0",
+			hcVersion:           "5.1.0",
+			hcpVersion:          "5.0.0",
+			initialStatus:       metav1.ConditionTrue,
+			expectedStatus:      metav1.ConditionUnknown,
+			expectedHealth:      metav1.ConditionUnknown,
+			expectedCredentials: platformgcp.CredentialStatusUnknown,
+			expectedPatches:     1,
+		},
+		{
+			name:                "When only the control plane version changes, it should still persist the new version",
+			hcVersion:           "5.1.0",
+			hcpVersion:          "5.2.0",
+			initialStatus:       metav1.ConditionTrue,
+			runtimeStatus:       metav1.ConditionTrue,
+			expectedStatus:      metav1.ConditionTrue,
+			expectedHealth:      metav1.ConditionTrue,
+			expectedCredentials: platformgcp.CredentialStatusValid,
+			expectedPatches:     1,
+		},
+		{
+			name:                "When status is unchanged, it should avoid a status patch",
+			hcVersion:           "5.1.0",
+			hcpVersion:          "5.1.0",
+			initialStatus:       metav1.ConditionTrue,
+			runtimeStatus:       metav1.ConditionTrue,
+			expectedStatus:      metav1.ConditionTrue,
+			expectedHealth:      metav1.ConditionTrue,
+			expectedCredentials: platformgcp.CredentialStatusValid,
+		},
+		{
+			name:                "When deleting with a stale HC version, it should publish the runtime failure and version together",
+			hcVersion:           "5.0.0",
+			hcpVersion:          "5.1.0",
+			runtimeStatus:       metav1.ConditionFalse,
+			deleting:            true,
+			expectedStatus:      metav1.ConditionFalse,
+			expectedHealth:      metav1.ConditionTrue,
+			expectedCredentials: platformgcp.CredentialStatusInvalid,
+			expectedPatches:     1,
+		},
+		{
+			name:                "When HCP disappears during deletion, it should preserve the persisted version and runtime failure",
+			hcVersion:           "5.1.0",
+			initialStatus:       metav1.ConditionFalse,
+			missingHCP:          true,
+			deleting:            true,
+			expectedStatus:      metav1.ConditionFalse,
+			expectedHealth:      metav1.ConditionTrue,
+			expectedCredentials: platformgcp.CredentialStatusInvalid,
+		},
+		{
+			name:                "When HCP disappears with persisted version 5.0, it should disable cleanup despite stale failures",
+			hcVersion:           "5.0.0",
+			initialStatus:       metav1.ConditionFalse,
+			missingHCP:          true,
+			deleting:            true,
+			expectedStatus:      metav1.ConditionUnknown,
+			expectedHealth:      metav1.ConditionUnknown,
+			expectedCredentials: platformgcp.CredentialStatusUnknown,
+			expectedPatches:     1,
+		},
+		{
+			name:                "When version and HCP are missing, it should report unknown without relaxing health expectations",
+			missingHCP:          true,
+			expectedStatus:      metav1.ConditionUnknown,
+			expectedHealth:      metav1.ConditionTrue,
+			expectedCredentials: platformgcp.CredentialStatusUnknown,
+			expectedPatches:     1,
+		},
+		{
+			name:                "When HCP version is empty and HC version is stale, it should persist the undetermined version",
+			hcVersion:           "5.0.0",
+			initialStatus:       metav1.ConditionTrue,
+			expectedStatus:      metav1.ConditionUnknown,
+			expectedHealth:      metav1.ConditionTrue,
+			expectedCredentials: platformgcp.CredentialStatusUnknown,
+			expectedPatches:     1,
+		},
+		{
+			name:                "When HCP version is malformed, it should report unknown without relaxing health expectations",
+			hcVersion:           "5.0.0",
+			hcpVersion:          "malformed",
+			initialStatus:       metav1.ConditionTrue,
+			expectedStatus:      metav1.ConditionUnknown,
+			expectedHealth:      metav1.ConditionTrue,
+			expectedCredentials: platformgcp.CredentialStatusUnknown,
+			expectedPatches:     1,
+		},
+		{
+			name:                "When another writer changes status, it should retry and preserve the unrelated condition",
+			hcVersion:           "5.0.0",
+			hcpVersion:          "5.1.0",
+			runtimeStatus:       metav1.ConditionTrue,
+			expectedStatus:      metav1.ConditionTrue,
+			expectedHealth:      metav1.ConditionTrue,
+			expectedCredentials: platformgcp.CredentialStatusValid,
+			conflictingWrite:    true,
+			expectedPatches:     2,
+		},
+		{
+			name:                "When the status patch fails, it should return the error without publishing partial status",
+			hcVersion:           "5.0.0",
+			hcpVersion:          "5.1.0",
+			runtimeStatus:       metav1.ConditionTrue,
+			expectedStatus:      metav1.ConditionTrue,
+			expectedHealth:      metav1.ConditionTrue,
+			expectedCredentials: platformgcp.CredentialStatusValid,
+			patchFailure:        true,
+			expectedPatches:     1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			hc := &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Name: "gcp", Namespace: "clusters", Generation: 3}}
+			hc.Spec.Platform.Type = hyperv1.GCPPlatform
+			hc.Status.ControlPlaneVersion.Desired.Version = tc.hcVersion
+			if tc.deleting {
+				hc.DeletionTimestamp = ptr.To(metav1.Now())
+				hc.Finalizers = []string{"hypershift.openshift.io/finalizer"}
+			}
+			hcp := &hyperv1.HostedControlPlane{}
+			hcp.Status.ControlPlaneVersion.Desired.Version = tc.hcpVersion
+			for _, conditionType := range []hyperv1.ConditionType{hyperv1.ValidGCPWorkloadIdentity, hyperv1.ValidGCPCredentials} {
+				for _, result := range []struct {
+					conditions *[]metav1.Condition
+					status     metav1.ConditionStatus
+				}{
+					{&hc.Status.Conditions, tc.initialStatus},
+					{&hcp.Status.Conditions, tc.runtimeStatus},
+				} {
+					if result.status == "" {
+						continue
+					}
+					reason := hyperv1.AsExpectedReason
+					if result.status == metav1.ConditionFalse {
+						reason = hyperv1.InvalidIdentityProvider
+					}
+					meta.SetStatusCondition(result.conditions, metav1.Condition{Type: string(conditionType), Status: result.status, Reason: reason, ObservedGeneration: hc.Generation})
+				}
+			}
+			expectedVersion := tc.hcpVersion
+			if tc.missingHCP {
+				hcp = nil
+				expectedVersion = tc.hcVersion
+			}
+			patches := 0
+			patchError := errors.New("status patch failed")
+			unrelatedCondition := metav1.Condition{
+				Type:               string(hyperv1.HostedClusterAvailable),
+				Status:             metav1.ConditionTrue,
+				Reason:             hyperv1.AsExpectedReason,
+				ObservedGeneration: hc.Generation,
+				LastTransitionTime: metav1.NewTime(time.Unix(1700000000, 0)),
+			}
+			c := fake.NewClientBuilder().WithScheme(api.Scheme).WithStatusSubresource(hc).WithObjects(hc).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourcePatch: func(ctx context.Context, c client.Client, subResource string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+						patches++
+						g.Expect(subResource).To(Equal("status"))
+						patchData, err := patch.Data(obj)
+						g.Expect(err).NotTo(HaveOccurred())
+						g.Expect(string(patchData)).To(ContainSubstring("\"resourceVersion\""))
+						published := obj.(*hyperv1.HostedCluster)
+						g.Expect(published.Status.ControlPlaneVersion.Desired.Version).To(Equal(expectedVersion))
+						for _, conditionType := range []hyperv1.ConditionType{hyperv1.ValidGCPWorkloadIdentity, hyperv1.ValidGCPCredentials} {
+							g.Expect(meta.FindStatusCondition(published.Status.Conditions, string(conditionType)).Status).To(Equal(tc.expectedStatus))
+						}
+						if tc.patchFailure {
+							return patchError
+						}
+						if tc.conflictingWrite && patches == 1 {
+							latest := &hyperv1.HostedCluster{}
+							g.Expect(c.Get(ctx, client.ObjectKeyFromObject(obj), latest)).To(Succeed())
+							meta.SetStatusCondition(&latest.Status.Conditions, unrelatedCondition)
+							g.Expect(c.Status().Update(ctx, latest)).To(Succeed())
+							err := c.SubResource(subResource).Patch(ctx, obj, patch, opts...)
+							g.Expect(apierrors.IsConflict(err)).To(BeTrue(), "a stale patch must conflict")
+							return err
+						}
+						return c.SubResource(subResource).Patch(ctx, obj, patch, opts...)
+					},
+				}).Build()
+			r := &HostedClusterReconciler{Client: c}
+			g.Expect(c.Get(t.Context(), client.ObjectKeyFromObject(hc), hc)).To(Succeed())
+			before := hc.DeepCopy()
+			err := r.reconcileGCPCredentialConditions(t.Context(), hc, hcp)
+			g.Expect(patches).To(Equal(tc.expectedPatches))
+			persisted := &hyperv1.HostedCluster{}
+			g.Expect(c.Get(t.Context(), client.ObjectKeyFromObject(hc), persisted)).To(Succeed())
+			if tc.patchFailure {
+				g.Expect(err).To(MatchError(ContainSubstring("failed to update GCP credential status")))
+				g.Expect(errors.Is(err, patchError)).To(BeTrue())
+				g.Expect(persisted.Status).To(Equal(before.Status))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			if tc.conflictingWrite {
+				g.Expect(meta.FindStatusCondition(persisted.Status.Conditions, unrelatedCondition.Type)).To(Equal(&unrelatedCondition))
+			}
+			g.Expect(persisted.Status.ControlPlaneVersion.Desired.Version).To(Equal(expectedVersion))
+			for _, conditionType := range []hyperv1.ConditionType{hyperv1.ValidGCPWorkloadIdentity, hyperv1.ValidGCPCredentials} {
+				condition := meta.FindStatusCondition(persisted.Status.Conditions, string(conditionType))
+				g.Expect(condition).NotTo(BeNil())
+				g.Expect(condition.Status).To(Equal(tc.expectedStatus))
+				g.Expect(conditions.ExpectedHCConditions(persisted)[conditionType]).To(Equal(tc.expectedHealth))
+			}
+			g.Expect(platformgcp.GetCredentialStatus(persisted)).To(Equal(tc.expectedCredentials))
+			g.Expect(r.reconcileGCPCredentialConditions(t.Context(), persisted, hcp)).To(Succeed())
+			g.Expect(patches).To(Equal(tc.expectedPatches), "unchanged reconciliation must not write status again")
+		})
+	}
+	t.Run("When the HostedCluster cannot be fetched, it should return the error", func(t *testing.T) {
+		g := NewWithT(t)
+		hc := &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Name: "gcp", Namespace: "clusters"}}
+		c := fake.NewClientBuilder().WithScheme(api.Scheme).WithStatusSubresource(hc).Build()
+		r := &HostedClusterReconciler{Client: c}
+		err := r.reconcileGCPCredentialConditions(t.Context(), hc, nil)
+		g.Expect(err).To(MatchError(ContainSubstring("failed to update GCP credential status")))
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -40,7 +40,6 @@ import (
 	"github.com/openshift/hypershift/control-plane-pki-operator/certificates"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform"
 	platformaws "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/aws"
-	platformgcp "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/gcp"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/proxy"
 	hcmetrics "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/metrics"
 	validations "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/validations"
@@ -492,10 +491,8 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	// We set these conditions even if the HC is being deleted so that
 	// DeleteOrphanedMachines has a fresh signal for credential validity.
 	if hcluster.Spec.Platform.Type == hyperv1.GCPPlatform {
-		if changed := platformgcp.ComputeGCPCredentialConditions(hcluster, hcp); changed {
-			if err := r.Client.Status().Update(ctx, hcluster); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
-			}
+		if err := r.reconcileGCPCredentialConditions(ctx, hcluster, hcp); err != nil {
+			return ctrl.Result{}, err
 		}
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/conditions"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/gcputil"
 	"github.com/openshift/hypershift/support/images"
@@ -455,41 +456,41 @@ func (p GCP) DeleteCredentials(ctx context.Context, c client.Client, hcluster *h
 }
 
 // GetCredentialStatus returns the GCP credential status (valid/invalid/unknown).
+// Only runtime authentication failures from a supported control plane version
+// classify credentials as invalid and authorize orphan machine cleanup.
 func GetCredentialStatus(hc *hyperv1.HostedCluster) CredentialStatus {
-	var wifStatus metav1.ConditionStatus
+	if supported, _ := conditions.SupportsGCPRuntimeCredentialValidation(hc.Status.ControlPlaneVersion.Desired.Version); !supported {
+		return CredentialStatusUnknown
+	}
 	validWIF := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPWorkloadIdentity))
-	if validWIF == nil {
-		wifStatus = metav1.ConditionUnknown
-	} else {
-		wifStatus = validWIF.Status
-	}
-
-	var credsStatus metav1.ConditionStatus
 	validCredentials := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPCredentials))
-	if validCredentials == nil {
-		credsStatus = metav1.ConditionUnknown
-	} else {
-		credsStatus = validCredentials.Status
+	for _, condition := range []*metav1.Condition{validWIF, validCredentials} {
+		if condition != nil && condition.Status == metav1.ConditionFalse && condition.Reason == hyperv1.InvalidIdentityProvider {
+			return CredentialStatusInvalid
+		}
 	}
-
-	if wifStatus == metav1.ConditionFalse || credsStatus == metav1.ConditionFalse {
-		return CredentialStatusInvalid
-	}
-	if wifStatus == metav1.ConditionTrue && credsStatus == metav1.ConditionTrue {
+	if validWIF != nil && validWIF.Status == metav1.ConditionTrue && validCredentials != nil && validCredentials.Status == metav1.ConditionTrue {
 		return CredentialStatusValid
 	}
 	return CredentialStatusUnknown
 }
 
 // ComputeGCPCredentialConditions bubbles up ValidGCPWorkloadIdentity and
-// ValidGCPCredentials from the HostedControlPlane to the HostedCluster.
+// ValidGCPCredentials from a supported HostedControlPlane to the HostedCluster.
+// Unsupported or undetermined versions report Unknown, replacing legacy results.
 // Returns whether any condition changed.
 //
-// Invalid is latched: if the HC already has a False condition and the HCP now
+// For supported versions, runtime authentication failure is latched: if the HC
+// already has a False condition with reason InvalidIdentityProvider and the HCP now
 // reports Unknown (e.g. because KAS is gone during teardown), the existing
 // False is kept so that DeleteOrphanedMachines continues to fire and teardown
 // does not get stuck again.
 func ComputeGCPCredentialConditions(hc *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) bool {
+	version := hc.Status.ControlPlaneVersion.Desired.Version
+	if hcp != nil {
+		version = hcp.Status.ControlPlaneVersion.Desired.Version
+	}
+	supported, known := conditions.SupportsGCPRuntimeCredentialValidation(version)
 	var changed bool
 	for _, condType := range []hyperv1.ConditionType{
 		hyperv1.ValidGCPWorkloadIdentity,
@@ -501,13 +502,25 @@ func ComputeGCPCredentialConditions(hc *hyperv1.HostedCluster, hcp *hyperv1.Host
 		}
 
 		var fresh metav1.Condition
-		if hcpCond == nil || hcpCond.Status == metav1.ConditionUnknown {
-			// Latch: keep an existing False on the HC rather than downgrading to
-			// Unknown. This prevents a KAS-unavailable signal during teardown from
-			// clobbering a previously confirmed Invalid state and silently stopping
-			// orphan machine cleanup.
+		if !supported {
+			fresh = metav1.Condition{
+				Type:               string(condType),
+				Status:             metav1.ConditionUnknown,
+				Reason:             hyperv1.StatusUnknownReason,
+				Message:            "The control plane version cannot be determined; runtime GCP credential validation availability is unknown",
+				ObservedGeneration: hc.Generation,
+			}
+			if known {
+				fresh.Reason = "UnsupportedControlPlaneVersion"
+				fresh.Message = "Runtime GCP credential validation requires control plane version 5.1 or later"
+			}
+		} else if hcpCond == nil || hcpCond.Status == metav1.ConditionUnknown {
+			// Latch: keep an existing False with reason InvalidIdentityProvider on
+			// the HC rather than downgrading to Unknown. This prevents a KAS-unavailable
+			// signal during teardown from clobbering a previously confirmed Invalid
+			// state and silently stopping orphan machine cleanup.
 			existing := meta.FindStatusCondition(hc.Status.Conditions, string(condType))
-			if existing != nil && existing.Status == metav1.ConditionFalse {
+			if existing != nil && existing.Status == metav1.ConditionFalse && existing.Reason == hyperv1.InvalidIdentityProvider {
 				continue // keep the latched Invalid; nothing to update
 			}
 			fresh = metav1.Condition{

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_conditions_test.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -42,6 +43,7 @@ func TestGetCredentialStatus(t *testing.T) {
 				{
 					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
 					Status: metav1.ConditionFalse,
+					Reason: hyperv1.InvalidIdentityProvider,
 				},
 				{
 					Type:   string(hyperv1.ValidGCPCredentials),
@@ -60,6 +62,7 @@ func TestGetCredentialStatus(t *testing.T) {
 				{
 					Type:   string(hyperv1.ValidGCPCredentials),
 					Status: metav1.ConditionFalse,
+					Reason: hyperv1.InvalidIdentityProvider,
 				},
 			},
 			expected: CredentialStatusInvalid,
@@ -70,10 +73,12 @@ func TestGetCredentialStatus(t *testing.T) {
 				{
 					Type:   string(hyperv1.ValidGCPWorkloadIdentity),
 					Status: metav1.ConditionFalse,
+					Reason: hyperv1.InvalidIdentityProvider,
 				},
 				{
 					Type:   string(hyperv1.ValidGCPCredentials),
 					Status: metav1.ConditionFalse,
+					Reason: hyperv1.InvalidIdentityProvider,
 				},
 			},
 			expected: CredentialStatusInvalid,
@@ -135,18 +140,35 @@ func TestGetCredentialStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-
-			hc := &hyperv1.HostedCluster{
-				Status: hyperv1.HostedClusterStatus{
-					Conditions: tt.conditions,
-				},
+			for _, version := range []string{"4.23.0", "5.0.0", "5.1.0", "5.1.0-0.ci-20260909", "6.0.0", "", "invalid"} {
+				t.Run("When control plane version is "+version+", it should enforce validation support", func(t *testing.T) {
+					hc := &hyperv1.HostedCluster{Status: hyperv1.HostedClusterStatus{Conditions: tt.conditions}}
+					hc.Status.ControlPlaneVersion.Desired.Version = version
+					expected := tt.expected
+					if version != "5.1.0" && version != "5.1.0-0.ci-20260909" && version != "6.0.0" {
+						expected = CredentialStatusUnknown
+					}
+					NewWithT(t).Expect(GetCredentialStatus(hc)).To(Equal(expected))
+				})
 			}
-
-			result := GetCredentialStatus(hc)
-			g.Expect(result).To(Equal(tt.expected))
 		})
 	}
+
+	for _, version := range []string{"4.23.0", "5.0.0", "", "invalid", "5.1.0-0.ci-20260909", "6.0.0"} {
+		for _, reason := range []string{hyperv1.InvalidIdentityProvider, hyperv1.InvalidConfigurationReason, hyperv1.ReconciliationErrorReason, ""} {
+			t.Run("When version is "+version+" and failure reason is "+reason+", it should classify only supported runtime failures as invalid", func(t *testing.T) {
+				hc := &hyperv1.HostedCluster{}
+				hc.Status.ControlPlaneVersion.Desired.Version = version
+				hc.Status.Conditions = []metav1.Condition{{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse, Reason: reason}}
+				expected := CredentialStatusUnknown
+				if (version == "5.1.0-0.ci-20260909" || version == "6.0.0") && reason == hyperv1.InvalidIdentityProvider {
+					expected = CredentialStatusInvalid
+				}
+				NewWithT(t).Expect(GetCredentialStatus(hc)).To(Equal(expected))
+			})
+		}
+	}
+
 }
 
 // TestWorkloadIdentityValidationScenarios tests additional edge cases for WIF validation.
@@ -292,138 +314,215 @@ func TestNetworkConfigAccessSafety(t *testing.T) {
 }
 
 func TestComputeGCPCredentialConditions(t *testing.T) {
-	tests := []struct {
-		name               string
-		hcConditions       []metav1.Condition
-		hcp                *hyperv1.HostedControlPlane
-		expectedChanged    bool
-		expectedWIFStatus  metav1.ConditionStatus
-		expectedWIFReason  string
-		expectedCredStatus metav1.ConditionStatus
+	const unsupportedMessage = "Runtime GCP credential validation requires control plane version 5.1 or later"
+	const unknownMessage = "The control plane version cannot be determined; runtime GCP credential validation availability is unknown"
+	for _, tc := range []struct {
+		name, hcVersion, hcpVersion                     string
+		missingHCP                                      bool
+		previousStatus, runtimeStatus, expectedStatus   metav1.ConditionStatus
+		previousReason, expectedReason, expectedMessage string
 	}{
 		{
-			name: "When HCP has True conditions, it should bubble them up to HC",
-			hcp: &hyperv1.HostedControlPlane{
-				Status: hyperv1.HostedControlPlaneStatus{
-					Conditions: []metav1.Condition{
-						{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue, Reason: hyperv1.AsExpectedReason},
-						{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue, Reason: hyperv1.AsExpectedReason},
-					},
-				},
-			},
-			expectedChanged:    true,
-			expectedWIFStatus:  metav1.ConditionTrue,
-			expectedWIFReason:  hyperv1.AsExpectedReason,
-			expectedCredStatus: metav1.ConditionTrue,
+			name:            "When HCP is 4.23, it should replace legacy success",
+			hcpVersion:      "4.23.0",
+			previousStatus:  metav1.ConditionTrue,
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  "UnsupportedControlPlaneVersion",
+			expectedMessage: unsupportedMessage,
 		},
 		{
-			name:               "When HCP is nil, it should set conditions to Unknown",
-			hcp:                nil,
-			expectedChanged:    true,
-			expectedWIFStatus:  metav1.ConditionUnknown,
-			expectedWIFReason:  hyperv1.StatusUnknownReason,
-			expectedCredStatus: metav1.ConditionUnknown,
+			name:            "When HCP is 5.0, it should replace even latched authentication failures",
+			hcpVersion:      "5.0.0",
+			previousStatus:  metav1.ConditionFalse,
+			previousReason:  hyperv1.InvalidIdentityProvider,
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  "UnsupportedControlPlaneVersion",
+			expectedMessage: unsupportedMessage,
 		},
 		{
-			name: "When HCP has no conditions, it should set conditions to Unknown",
-			hcp: &hyperv1.HostedControlPlane{
-				Status: hyperv1.HostedControlPlaneStatus{
-					Conditions: []metav1.Condition{},
-				},
-			},
-			expectedChanged:    true,
-			expectedWIFStatus:  metav1.ConditionUnknown,
-			expectedWIFReason:  hyperv1.StatusUnknownReason,
-			expectedCredStatus: metav1.ConditionUnknown,
+			name:            "When HCP is 5.0 and HC is stale 5.1, it should use HCP version",
+			hcVersion:       "5.1.0",
+			hcpVersion:      "5.0.0",
+			runtimeStatus:   metav1.ConditionTrue,
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  "UnsupportedControlPlaneVersion",
+			expectedMessage: unsupportedMessage,
 		},
 		{
-			name: "When HCP has False conditions, it should propagate them to HC",
-			hcp: &hyperv1.HostedControlPlane{
-				Status: hyperv1.HostedControlPlaneStatus{
-					Conditions: []metav1.Condition{
-						{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider},
-						{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider},
-					},
-				},
-			},
-			expectedChanged:    true,
-			expectedWIFStatus:  metav1.ConditionFalse,
-			expectedWIFReason:  hyperv1.InvalidIdentityProvider,
-			expectedCredStatus: metav1.ConditionFalse,
+			name:            "When HCP version is empty and HC is 5.1, it should report undetermined",
+			hcVersion:       "5.1.0",
+			previousStatus:  metav1.ConditionFalse,
+			previousReason:  hyperv1.InvalidIdentityProvider,
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  hyperv1.StatusUnknownReason,
+			expectedMessage: unknownMessage,
 		},
 		{
-			name: "When HC already has the same conditions, it should not report a change",
-			hcConditions: []metav1.Condition{
-				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue, Reason: hyperv1.AsExpectedReason, ObservedGeneration: 3},
-				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue, Reason: hyperv1.AsExpectedReason, ObservedGeneration: 3},
-			},
-			hcp: &hyperv1.HostedControlPlane{
-				Status: hyperv1.HostedControlPlaneStatus{
-					Conditions: []metav1.Condition{
-						{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue, Reason: hyperv1.AsExpectedReason},
-						{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue, Reason: hyperv1.AsExpectedReason},
-					},
-				},
-			},
-			expectedChanged:    false,
-			expectedWIFStatus:  metav1.ConditionTrue,
-			expectedWIFReason:  hyperv1.AsExpectedReason,
-			expectedCredStatus: metav1.ConditionTrue,
+			name:            "When HCP version is malformed, it should replace legacy success",
+			hcpVersion:      "invalid",
+			previousStatus:  metav1.ConditionTrue,
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  hyperv1.StatusUnknownReason,
+			expectedMessage: unknownMessage,
 		},
 		{
-			// Latch: during teardown KAS goes away, HCP sends Unknown. An existing
-			// False on the HC must not be clobbered so DeleteOrphanedMachines keeps firing.
-			name: "When HC has False conditions and HCP sends Unknown, it should latch False and not update",
-			hcConditions: []metav1.Condition{
-				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider, ObservedGeneration: 3},
-				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider, ObservedGeneration: 3},
-			},
-			hcp:                nil,
-			expectedChanged:    false,
-			expectedWIFStatus:  metav1.ConditionFalse,
-			expectedWIFReason:  hyperv1.InvalidIdentityProvider,
-			expectedCredStatus: metav1.ConditionFalse,
+			name:            "When HCP disappears with HC at 5.0, it should disable validation",
+			missingHCP:      true,
+			hcVersion:       "5.0.0",
+			previousStatus:  metav1.ConditionFalse,
+			previousReason:  hyperv1.InvalidIdentityProvider,
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  "UnsupportedControlPlaneVersion",
+			expectedMessage: unsupportedMessage,
 		},
 		{
-			// Partial latch: WIF is False (latched), Credentials was Unknown — HCP now
-			// sends Unknown for both. WIF stays False; Credentials stays Unknown (no change).
-			name: "When HC has False WIF and Unknown Credentials and HCP sends Unknown, it should latch False WIF only",
-			hcConditions: []metav1.Condition{
-				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider, ObservedGeneration: 3},
-				{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionUnknown, Reason: hyperv1.StatusUnknownReason, ObservedGeneration: 3},
-			},
-			hcp:                nil,
-			expectedChanged:    false,
-			expectedWIFStatus:  metav1.ConditionFalse,
-			expectedWIFReason:  hyperv1.InvalidIdentityProvider,
-			expectedCredStatus: metav1.ConditionUnknown,
+			name:            "When HCP disappears with no persisted version, it should report undetermined",
+			missingHCP:      true,
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  hyperv1.StatusUnknownReason,
+			expectedMessage: unknownMessage,
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		{
+			name:            "When HCP is a 5.1 prerelease and HC is 5.0, it should propagate success",
+			hcVersion:       "5.0.0",
+			hcpVersion:      "5.1.0-0.ci-20260909",
+			runtimeStatus:   metav1.ConditionTrue,
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  hyperv1.AsExpectedReason,
+			expectedMessage: "runtime result",
+		},
+		{
+			name:            "When supported HCP reports authentication failure, it should propagate failure",
+			hcpVersion:      "5.1.0",
+			runtimeStatus:   metav1.ConditionFalse,
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  hyperv1.InvalidIdentityProvider,
+			expectedMessage: "runtime result",
+		},
+		{
+			name:           "When supported HCP has no result, it should await validation",
+			hcpVersion:     "5.1.0",
+			expectedStatus: metav1.ConditionUnknown,
+			expectedReason: hyperv1.StatusUnknownReason,
+		},
+		{
+			name:            "When supported HCP reports Unknown, it should preserve runtime authentication failure",
+			hcpVersion:      "5.1.0",
+			previousStatus:  metav1.ConditionFalse,
+			previousReason:  hyperv1.InvalidIdentityProvider,
+			runtimeStatus:   metav1.ConditionUnknown,
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  hyperv1.InvalidIdentityProvider,
+			expectedMessage: "previous result",
+		},
+		{
+			name:            "When supported HCP disappears, it should preserve runtime authentication failure using HC version",
+			missingHCP:      true,
+			hcVersion:       "5.1.0",
+			previousStatus:  metav1.ConditionFalse,
+			previousReason:  hyperv1.InvalidIdentityProvider,
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  hyperv1.InvalidIdentityProvider,
+			expectedMessage: "previous result",
+		},
+		{
+			name:           "When supported HCP has no result after configuration failure, it should discard legacy failure",
+			hcpVersion:     "5.1.0",
+			previousStatus: metav1.ConditionFalse,
+			previousReason: hyperv1.InvalidConfigurationReason,
+			expectedStatus: metav1.ConditionUnknown,
+			expectedReason: hyperv1.StatusUnknownReason,
+		},
+		{
+			name:           "When supported HCP reports Unknown after Secret reconciliation failure, it should discard legacy failure",
+			hcpVersion:     "5.1.0",
+			previousStatus: metav1.ConditionFalse,
+			previousReason: hyperv1.ReconciliationErrorReason,
+			runtimeStatus:  metav1.ConditionUnknown,
+			expectedStatus: metav1.ConditionUnknown,
+			expectedReason: hyperv1.StatusUnknownReason,
+		},
+		{
+			name:            "When runtime validation recovers, it should replace latched failure",
+			hcpVersion:      "5.1.0",
+			previousStatus:  metav1.ConditionFalse,
+			previousReason:  hyperv1.InvalidIdentityProvider,
+			runtimeStatus:   metav1.ConditionTrue,
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  hyperv1.AsExpectedReason,
+			expectedMessage: "runtime result",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-
-			hc := &hyperv1.HostedCluster{
-				ObjectMeta: metav1.ObjectMeta{Generation: 3},
-				Status: hyperv1.HostedClusterStatus{
-					Conditions: tt.hcConditions,
-				},
+			hc := &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Generation: 3}}
+			hc.Status.ControlPlaneVersion.Desired.Version = tc.hcVersion
+			hcp := &hyperv1.HostedControlPlane{}
+			hcp.Status.ControlPlaneVersion.Desired.Version = tc.hcpVersion
+			hcp.Status.VersionStatus = &hyperv1.ClusterVersionStatus{}
+			hcp.Status.VersionStatus.Desired.Version = "5.0.0" // Data plane version must not gate management-side validation.
+			for _, conditionType := range []hyperv1.ConditionType{hyperv1.ValidGCPWorkloadIdentity, hyperv1.ValidGCPCredentials} {
+				if tc.previousStatus != "" {
+					meta.SetStatusCondition(&hc.Status.Conditions, metav1.Condition{Type: string(conditionType), Status: tc.previousStatus, Reason: tc.previousReason, Message: "previous result", ObservedGeneration: 3})
+				}
+				if tc.runtimeStatus != "" {
+					reason := hyperv1.AsExpectedReason
+					if tc.runtimeStatus == metav1.ConditionFalse {
+						reason = hyperv1.InvalidIdentityProvider
+					}
+					meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{Type: string(conditionType), Status: tc.runtimeStatus, Reason: reason, Message: "runtime result", ObservedGeneration: 99})
+				}
 			}
-
-			changed := ComputeGCPCredentialConditions(hc, tt.hcp)
-			g.Expect(changed).To(Equal(tt.expectedChanged), "changed flag mismatch")
-
-			wifCond := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPWorkloadIdentity))
-			g.Expect(wifCond).ToNot(BeNil(), "ValidGCPWorkloadIdentity condition must be set")
-			g.Expect(wifCond.Status).To(Equal(tt.expectedWIFStatus), "ValidGCPWorkloadIdentity status mismatch")
-			g.Expect(wifCond.Reason).To(Equal(tt.expectedWIFReason), "ValidGCPWorkloadIdentity reason mismatch")
-
-			credCond := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPCredentials))
-			g.Expect(credCond).ToNot(BeNil(), "ValidGCPCredentials condition must be set")
-			g.Expect(credCond.Status).To(Equal(tt.expectedCredStatus), "ValidGCPCredentials status mismatch")
+			if tc.missingHCP {
+				hcp = nil
+			}
+			before := hc.DeepCopy()
+			changed := ComputeGCPCredentialConditions(hc, hcp)
+			g.Expect(changed).To(Equal(!reflect.DeepEqual(before.Status.Conditions, hc.Status.Conditions)))
+			for _, conditionType := range []hyperv1.ConditionType{hyperv1.ValidGCPWorkloadIdentity, hyperv1.ValidGCPCredentials} {
+				condition := meta.FindStatusCondition(hc.Status.Conditions, string(conditionType))
+				g.Expect(condition).NotTo(BeNil())
+				g.Expect(condition.Status).To(Equal(tc.expectedStatus))
+				g.Expect(condition.Reason).To(Equal(tc.expectedReason))
+				g.Expect(condition.Message).To(Equal(tc.expectedMessage))
+				g.Expect(condition.ObservedGeneration).To(Equal(int64(3)))
+			}
+			before = hc.DeepCopy()
+			g.Expect(ComputeGCPCredentialConditions(hc, hcp)).To(BeFalse())
+			g.Expect(hc.Status).To(Equal(before.Status))
 		})
 	}
+	t.Run("When only WIF has a runtime failure, it should latch that failure and await credentials", func(t *testing.T) {
+		g := NewWithT(t)
+		hc := &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Generation: 3}}
+		hc.Status.ControlPlaneVersion.Desired.Version = "5.1.0"
+		hc.Status.Conditions = []metav1.Condition{
+			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider, ObservedGeneration: 3},
+			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse, Reason: hyperv1.ReconciliationErrorReason, ObservedGeneration: 2},
+		}
+		g.Expect(ComputeGCPCredentialConditions(hc, nil)).To(BeTrue())
+		g.Expect(meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPWorkloadIdentity)).Status).To(Equal(metav1.ConditionFalse))
+		credentials := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPCredentials))
+		g.Expect(credentials.Status).To(Equal(metav1.ConditionUnknown))
+		g.Expect(credentials.ObservedGeneration).To(Equal(int64(3)))
+		g.Expect(GetCredentialStatus(hc)).To(Equal(CredentialStatusInvalid))
+		g.Expect(ComputeGCPCredentialConditions(hc, nil)).To(BeFalse())
+	})
+
+	t.Run("When control plane upgrades from 5.0 to 5.1, it should accept fresh runtime results", func(t *testing.T) {
+		g := NewWithT(t)
+		hc := &hyperv1.HostedCluster{}
+		hcp := &hyperv1.HostedControlPlane{}
+		hcp.Status.ControlPlaneVersion.Desired.Version = "5.0.0"
+		g.Expect(ComputeGCPCredentialConditions(hc, hcp)).To(BeTrue())
+		hcp.Status.ControlPlaneVersion.Desired.Version = "5.1.0"
+		for _, conditionType := range []hyperv1.ConditionType{hyperv1.ValidGCPWorkloadIdentity, hyperv1.ValidGCPCredentials} {
+			meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{Type: string(conditionType), Status: metav1.ConditionTrue, Reason: hyperv1.AsExpectedReason})
+		}
+		g.Expect(ComputeGCPCredentialConditions(hc, hcp)).To(BeTrue())
+		hc.Status.ControlPlaneVersion = hcp.Status.ControlPlaneVersion
+		g.Expect(GetCredentialStatus(hc)).To(Equal(CredentialStatusValid))
+	})
 }
 
 // TestServiceAccountEmailValidation tests that the regex pattern validation for service account emails is working correctly.

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_test.go
@@ -557,14 +557,40 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 		}
 	}
 
+	for _, version := range []string{"4.23.0", "5.0.0", "", "invalid", "5.1.0"} {
+		for _, reason := range []string{hyperv1.InvalidIdentityProvider, hyperv1.InvalidConfigurationReason, hyperv1.ReconciliationErrorReason} {
+			if version == "5.1.0" && reason == hyperv1.InvalidIdentityProvider {
+				continue
+			}
+			t.Run("When version is "+version+" and failure reason is "+reason+", it should preserve finalizers without runtime evidence", func(t *testing.T) {
+				g := NewWithT(t)
+				hc := validHostedCluster()
+				hc.Status.ControlPlaneVersion.Desired.Version = version
+				hc.Status.Conditions = []metav1.Condition{
+					{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse, Reason: reason},
+					{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse, Reason: reason},
+				}
+				c := fake.NewClientBuilder().WithScheme(buildScheme(g)).WithObjects(gcpMachines()...).Build()
+				g.Expect((GCP{}).DeleteOrphanedMachines(t.Context(), c, hc, "test-control-plane-namespace")).To(Succeed())
+				machines := &capigcp.GCPMachineList{}
+				g.Expect(c.List(t.Context(), machines)).To(Succeed())
+				g.Expect(machines.Items).To(HaveLen(2))
+				for _, machine := range machines.Items {
+					g.Expect(machine.Finalizers).To(Equal([]string{capigcp.MachineFinalizer, "other-controller-finalizer"}))
+				}
+			})
+		}
+	}
+
 	t.Run("When credentials are invalid, it should strip the CAPG finalizer from deleting machines", func(t *testing.T) {
 		g := NewWithT(t)
 		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
 
 		hc := validHostedCluster()
+		hc.Status.ControlPlaneVersion.Desired.Version = "5.1.0"
 		hc.Status.Conditions = []metav1.Condition{
-			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
-			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider},
+			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider},
 		}
 
 		fakeClient := fake.NewClientBuilder().
@@ -593,6 +619,7 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
 
 		hc := validHostedCluster()
+		hc.Status.ControlPlaneVersion.Desired.Version = "5.1.0"
 		hc.Status.Conditions = []metav1.Condition{
 			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionTrue},
 			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionTrue},
@@ -619,6 +646,7 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
 
 		hc := validHostedCluster()
+		hc.Status.ControlPlaneVersion.Desired.Version = "5.1.0"
 		// No conditions set — GetCredentialStatus returns Unknown
 
 		fakeClient := fake.NewClientBuilder().
@@ -642,9 +670,10 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
 
 		hc := validHostedCluster()
+		hc.Status.ControlPlaneVersion.Desired.Version = "5.1.0"
 		hc.Status.Conditions = []metav1.Condition{
-			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
-			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider},
+			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider},
 		}
 
 		listErr := fmt.Errorf("list failed")
@@ -666,9 +695,10 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
 
 		hc := validHostedCluster()
+		hc.Status.ControlPlaneVersion.Desired.Version = "5.1.0"
 		hc.Status.Conditions = []metav1.Condition{
-			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
-			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider},
+			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider},
 		}
 
 		// Two deleted machines; Update fails for both.
@@ -712,9 +742,10 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 		platform := New("test-utilities-image", "test-capg-image", &semver.Version{Major: 4, Minor: 17, Patch: 0})
 
 		hc := validHostedCluster()
+		hc.Status.ControlPlaneVersion.Desired.Version = "5.1.0"
 		hc.Status.Conditions = []metav1.Condition{
-			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse},
-			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse},
+			{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider},
+			{Type: string(hyperv1.ValidGCPCredentials), Status: metav1.ConditionFalse, Reason: hyperv1.InvalidIdentityProvider},
 		}
 
 		// Deleted machine, but without the CAPG finalizer (already removed by another path).

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -569,6 +569,7 @@ func TestReportInvalidGcpCreds(t *testing.T) {
 	}
 
 	testCases := []struct {
+		version                            *string
 		name                               string
 		ValidGCPWorkloadIdentityCondStatus metav1.ConditionStatus
 		ValidGCPCredentialsCondStatus      metav1.ConditionStatus
@@ -616,6 +617,9 @@ func TestReportInvalidGcpCreds(t *testing.T) {
 			ValidGCPCredentialsCondStatus:      metav1.ConditionUnknown,
 			expected:                           wrapExpectedValueAsMetric(2),
 		},
+		{name: "When control plane is 5.0 with stale failures, it should report unknown", version: ptr.To("5.0.0"), ValidGCPWorkloadIdentityCondStatus: metav1.ConditionFalse, ValidGCPCredentialsCondStatus: metav1.ConditionFalse, expected: wrapExpectedValueAsMetric(2)},
+		{name: "When control plane version is empty, it should report unknown", version: ptr.To(""), ValidGCPWorkloadIdentityCondStatus: metav1.ConditionTrue, ValidGCPCredentialsCondStatus: metav1.ConditionTrue, expected: wrapExpectedValueAsMetric(2)},
+		{name: "When control plane version is malformed, it should report unknown", version: ptr.To("invalid"), ValidGCPWorkloadIdentityCondStatus: metav1.ConditionFalse, ValidGCPCredentialsCondStatus: metav1.ConditionFalse, expected: wrapExpectedValueAsMetric(2)},
 	}
 
 	for _, tc := range testCases {
@@ -630,13 +634,20 @@ func TestReportInvalidGcpCreds(t *testing.T) {
 				},
 			}
 
+			hcluster.Status.ControlPlaneVersion.Desired.Version = "5.1.0"
+			if tc.version != nil {
+				hcluster.Status.ControlPlaneVersion.Desired.Version = *tc.version
+			}
+
 			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
 				Type:   string(hyperv1.ValidGCPWorkloadIdentity),
 				Status: tc.ValidGCPWorkloadIdentityCondStatus,
+				Reason: hyperv1.InvalidIdentityProvider,
 			})
 			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
 				Type:   string(hyperv1.ValidGCPCredentials),
 				Status: tc.ValidGCPCredentialsCondStatus,
+				Reason: hyperv1.InvalidIdentityProvider,
 			})
 
 			checkMetric(t,
@@ -1774,4 +1785,39 @@ func createCa(notBefore, notAfter time.Time) (*x509.Certificate, string, error) 
 		Bytes: caBytes,
 	})
 	return ca, caPEM.String(), nil
+}
+
+func TestCollectFailureConditionCounts(t *testing.T) {
+	for _, tc := range []struct {
+		name, version string
+		status        metav1.ConditionStatus
+		expected      int
+	}{
+		{"When 5.0 reports unknown credentials, it should count no failures", "5.0.0", metav1.ConditionUnknown, 0},
+		{"When 5.1 reports unknown credentials, it should count failures", "5.1.0", metav1.ConditionUnknown, 1},
+		{"When 5.1 reports invalid credentials, it should count failures", "5.1.0", metav1.ConditionFalse, 1},
+		{"When 5.1 reports valid credentials, it should count no failures", "5.1.0", metav1.ConditionTrue, 0},
+		{"When version is missing and credentials are unknown, it should count failures", "", metav1.ConditionUnknown, 1},
+		{"When version is malformed and credentials are unknown, it should count failures", "invalid", metav1.ConditionUnknown, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hc := &hyperv1.HostedCluster{}
+			hc.Spec.Platform.Type = hyperv1.GCPPlatform
+			hc.Status.ControlPlaneVersion.Desired.Version = tc.version
+			hc.Status.Conditions = []metav1.Condition{
+				{Type: string(hyperv1.ValidGCPWorkloadIdentity), Status: tc.status},
+				{Type: string(hyperv1.ValidGCPCredentials), Status: tc.status},
+			}
+			counts := initPlatformFailureConditionCounts()
+			collectFailureConditionCounts(hc, hyperv1.GCPPlatform, counts)
+			for _, conditionType := range []hyperv1.ConditionType{hyperv1.ValidGCPWorkloadIdentity, hyperv1.ValidGCPCredentials} {
+				if got := (*counts[hyperv1.GCPPlatform])["not_"+string(conditionType)]; got != tc.expected {
+					t.Errorf("condition %s failure count = %d, want %d", conditionType, got, tc.expected)
+				}
+				if got := (*counts[hyperv1.GCPPlatform])[string(conditionType)]; got != 0 {
+					t.Errorf("unexpected condition %s failure count: %d", conditionType, got)
+				}
+			}
+		})
+	}
 }

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -67,11 +67,14 @@ func ExpectedHCConditions(hostedCluster *hyperv1.HostedCluster) map[hyperv1.Cond
 			conditions[hyperv1.ValidAzureKMSConfig] = metav1.ConditionTrue
 		}
 	case hyperv1.GCPPlatform:
-		// GCP Workload Identity Federation validation - always required
-		conditions[hyperv1.ValidGCPWorkloadIdentity] = metav1.ConditionTrue
-
-		// GCP credentials validation - indicates WIF readiness
-		conditions[hyperv1.ValidGCPCredentials] = metav1.ConditionTrue
+		// Only a known unsupported version relaxes runtime validation. An
+		// undetermined version must not make an unvalidated cluster healthy.
+		expected := metav1.ConditionTrue
+		if supported, known := SupportsGCPRuntimeCredentialValidation(hostedCluster.Status.ControlPlaneVersion.Desired.Version); known && !supported {
+			expected = metav1.ConditionUnknown
+		}
+		conditions[hyperv1.ValidGCPWorkloadIdentity] = expected
+		conditions[hyperv1.ValidGCPCredentials] = expected
 
 		// GCP Private Service Connect conditions - both GCP endpoint access modes
 		// (Private and PublicAndPrivate) use PSC, so no EndpointAccess gate is needed.

--- a/support/conditions/conditions_test.go
+++ b/support/conditions/conditions_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestExpectedHCConditions_ValidAzureKMSConfig(t *testing.T) {
+func TestExpectedHCConditions(t *testing.T) {
 	newAzureHC := func(managedIdentities bool, kms *hyperv1.KMSSpec) *hyperv1.HostedCluster {
 		authType := hyperv1.AzureAuthenticationTypeWorkloadIdentities
 		if managedIdentities {
@@ -86,4 +86,36 @@ func TestExpectedHCConditions_ValidAzureKMSConfig(t *testing.T) {
 			g.Expect(got[hyperv1.ValidAzureKMSConfig]).To(Equal(tc.expectedStatus))
 		})
 	}
+
+	for _, tc := range []struct {
+		name, version string
+		expected      metav1.ConditionStatus
+	}{
+		{"When the control plane is 4.23, it should expect unknown credentials", "4.23.0", metav1.ConditionUnknown},
+		{"When the control plane is 5.0, it should expect unknown credentials", "5.0.0", metav1.ConditionUnknown},
+		{"When the control plane is a 5.1 prerelease, it should require validation", "5.1.0-0.ci-20260909", metav1.ConditionTrue},
+		{"When the control plane is later, it should require validation", "6.0.0", metav1.ConditionTrue},
+		{"When the version is empty, it should require validation", "", metav1.ConditionTrue},
+		{"When the version is malformed, it should require validation", "invalid", metav1.ConditionTrue},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			hc := &hyperv1.HostedCluster{}
+			hc.Spec.Platform.Type = hyperv1.GCPPlatform
+			hc.Status.ControlPlaneVersion.Desired.Version = tc.version
+			expected := ExpectedHCConditions(hc)
+			g.Expect(expected[hyperv1.ValidGCPWorkloadIdentity]).To(Equal(tc.expected))
+			g.Expect(expected[hyperv1.ValidGCPCredentials]).To(Equal(tc.expected))
+			g.Expect(expected[hyperv1.GCPEndpointAvailable]).To(Equal(metav1.ConditionTrue))
+		})
+	}
+	t.Run("When the control plane upgrades from 5.0 to 5.1, it should refresh credential expectations", func(t *testing.T) {
+		g := NewWithT(t)
+		hc := &hyperv1.HostedCluster{}
+		hc.Spec.Platform.Type = hyperv1.GCPPlatform
+		hc.Status.ControlPlaneVersion.Desired.Version = "5.0.0"
+		g.Expect(ExpectedHCConditions(hc)[hyperv1.ValidGCPCredentials]).To(Equal(metav1.ConditionUnknown))
+		hc.Status.ControlPlaneVersion.Desired.Version = "5.1.0"
+		g.Expect(ExpectedHCConditions(hc)[hyperv1.ValidGCPCredentials]).To(Equal(metav1.ConditionTrue))
+	})
 }

--- a/support/conditions/gcp.go
+++ b/support/conditions/gcp.go
@@ -1,0 +1,14 @@
+package conditions
+
+import "github.com/blang/semver"
+
+// SupportsGCPRuntimeCredentialValidation reports whether the management-side control
+// plane version supports runtime GCP credential validation. An empty or malformed
+// semantic version is unknown. Patch, prerelease, and build metadata do not affect support.
+func SupportsGCPRuntimeCredentialValidation(version string) (supported bool, known bool) {
+	parsed, err := semver.Parse(version)
+	if err != nil {
+		return false, false
+	}
+	return parsed.Major > 5 || (parsed.Major == 5 && parsed.Minor >= 1), true
+}

--- a/support/conditions/gcp_test.go
+++ b/support/conditions/gcp_test.go
@@ -1,0 +1,32 @@
+package conditions
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestSupportsGCPRuntimeCredentialValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name, version    string
+		supported, known bool
+	}{
+		{"When the version is 4.23, it should be unsupported", "4.23.0", false, true},
+		{"When the version is 5.0, it should be unsupported", "5.0.99", false, true},
+		{"When the version is a 5.1 CI prerelease, it should be supported", "5.1.0-0.ci-20260909", true, true},
+		{"When the version has build metadata, it should be supported", "5.1.0-rc.1+build.42", true, true},
+		{"When the minor version is later, it should be supported", "5.2.0", true, true},
+		{"When the major version is later, it should be supported", "6.0.0", true, true},
+		{"When the version is empty, it should be unknown", "", false, false},
+		{"When the version is malformed, it should be unknown", "not-a-version", false, false},
+		{"When the version is incomplete, it should be unknown", "5.1", false, false},
+		{"When the version has an invalid suffix, it should be unknown", "5.1.0-", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			supported, known := SupportsGCPRuntimeCredentialValidation(tc.version)
+			g.Expect(supported).To(Equal(tc.supported))
+			g.Expect(known).To(Equal(tc.known))
+		})
+	}
+}

--- a/test/e2e/util/hostedcluster_conditions_test.go
+++ b/test/e2e/util/hostedcluster_conditions_test.go
@@ -1,0 +1,115 @@
+package util
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/conditions"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestHostedClusterConditionsPredicate(t *testing.T) {
+	originalVersion := releaseVersion
+	releaseVersion = Version51
+	t.Cleanup(func() { releaseVersion = originalVersion })
+	for _, tc := range []struct {
+		name            string
+		version         string
+		wrongCredential bool
+		missingIdentity bool
+	}{
+		{name: "When a 5.0 control plane has unknown credentials, it should pass", version: "5.0.0"},
+		{name: "When a 5.1 control plane has valid credentials, it should pass", version: "5.1.0"},
+		{name: "When a 5.1 credential condition is unknown, it should report the mismatch", version: "5.1.0", wrongCredential: true},
+		{name: "When a required identity condition is missing, it should report the missing condition", version: "5.1.0", missingIdentity: true},
+		{name: "When multiple conditions fail, it should report every failure", version: "5.1.0", wrongCredential: true, missingIdentity: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hc := &hyperv1.HostedCluster{}
+			hc.Spec.Platform.Type = hyperv1.GCPPlatform
+			hc.Status.ControlPlaneVersion.Desired.Version = tc.version
+			for conditionType, status := range conditions.ExpectedHCConditions(hc) {
+				hc.Status.Conditions = append(hc.Status.Conditions, metav1.Condition{Type: string(conditionType), Status: status})
+			}
+			var expectedReasons []string
+			if tc.wrongCredential {
+				meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidGCPCredentials)).Status = metav1.ConditionUnknown
+				expectedReasons = append(expectedReasons, "incorrect condition: wanted ValidGCPCredentials=True, got ValidGCPCredentials=Unknown")
+			}
+			if tc.missingIdentity {
+				meta.RemoveStatusCondition(&hc.Status.Conditions, string(hyperv1.ValidGCPWorkloadIdentity))
+				expectedReasons = append(expectedReasons, "missing condition: wanted ValidGCPWorkloadIdentity=True, did not find condition of this type")
+			}
+
+			done, reason, err := hostedClusterConditionsPredicate(true, nil)(hc)
+			if err != nil {
+				t.Fatalf("unexpected predicate error: %v", err)
+			}
+			if wantDone := len(expectedReasons) == 0; done != wantDone {
+				t.Fatalf("expected done=%t, got %t: %s", wantDone, done, reason)
+			}
+			if len(expectedReasons) == 0 {
+				if reason != "" {
+					t.Errorf("expected no failure reason, got %q", reason)
+				}
+				return
+			}
+			actualReasons := strings.Split(reason, "; ")
+			if len(actualReasons) != len(expectedReasons) {
+				t.Errorf("expected %d failure reasons, got %q", len(expectedReasons), reason)
+			}
+			for _, expectedReason := range expectedReasons {
+				if !strings.Contains(reason, expectedReason) {
+					t.Errorf("expected failure reason %q in %q", expectedReason, reason)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateHostedClusterConditions(t *testing.T) {
+	originalVersion := releaseVersion
+	releaseVersion = Version51
+	t.Cleanup(func() { releaseVersion = originalVersion })
+	for _, tc := range []struct {
+		name, initialVersion, currentVersion string
+		workers                              bool
+	}{
+		{"When a 5.0 control plane is healthy, it should accept unknown credentials", "5.0.0", "5.0.0", true},
+		{"When the fetched control plane upgrades to 5.1, it should require fresh runtime results", "5.0.0", "5.1.0", true},
+		{"When the fetched control plane is 5.0, it should refresh a stale 5.1 expectation", "5.1.0", "5.0.0", true},
+		{"When there are no workers, it should retain connection and version exceptions", "5.0.0", "5.1.0", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hc := &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Name: "gcp", Namespace: "clusters"}}
+			hc.Spec.Platform.Type = hyperv1.GCPPlatform
+			hc.Status.ControlPlaneVersion.Desired.Version = tc.initialVersion
+			fetched := hc.DeepCopy()
+			fetched.Status.ControlPlaneVersion.Desired.Version = tc.currentVersion
+			fetched.Status.ControlPlaneVersion.Desired.Image = "quay.io/openshift-release-dev/ocp-release:5.1.0-x86_64"
+			fetched.Status.ControlPlaneVersion.History = []hyperv1.ControlPlaneUpdateHistory{{State: configv1.CompletedUpdate}}
+			expected := conditions.ExpectedHCConditions(fetched)
+			if !tc.workers {
+				expected[hyperv1.ClusterVersionAvailable] = metav1.ConditionFalse
+				expected[hyperv1.ClusterVersionSucceeding] = metav1.ConditionFalse
+				expected[hyperv1.ClusterVersionProgressing] = metav1.ConditionTrue
+				expected[hyperv1.DataPlaneConnectionAvailable] = metav1.ConditionUnknown
+				expected[hyperv1.ControlPlaneConnectionAvailable] = metav1.ConditionUnknown
+			}
+			for conditionType, status := range expected {
+				fetched.Status.Conditions = append(fetched.Status.Conditions, metav1.Condition{Type: string(conditionType), Status: status, Reason: hyperv1.AsExpectedReason})
+			}
+			c := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(fetched).Build()
+			ValidateHostedClusterConditions(t, t.Context(), c, hc, tc.workers, time.Second, nil)
+		})
+	}
+}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -3192,58 +3192,9 @@ func ValidatePrivateCluster(t *testing.T, ctx context.Context, client crclient.C
 }
 
 // ValidateHostedClusterConditions checks that a HostedCluster's conditions and status fields
-// match expected values. Pass nil for uc when calling outside of an upgrade test context.
+// match expected values. Pass nil for upgradeContext when calling outside of an upgrade test context.
 func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, hasWorkerNodes bool, timeout time.Duration, upgradeContext *UpgradeContext) {
-	expectedConditions := conditions.ExpectedHCConditions(hostedCluster)
-	// OCPBUGS-59885: Ignore KubeVirtNodesLiveMigratable in e2e; CI envs may lack RWX-capable PVCs, causing false failures
-	delete(expectedConditions, hyperv1.KubeVirtNodesLiveMigratable)
-	if !hasWorkerNodes {
-		expectedConditions[hyperv1.ClusterVersionAvailable] = metav1.ConditionFalse
-		expectedConditions[hyperv1.ClusterVersionSucceeding] = metav1.ConditionFalse
-		expectedConditions[hyperv1.ClusterVersionProgressing] = metav1.ConditionTrue
-		delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkMTU)
-		delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkPolicyRBAC)
-		expectedConditions[hyperv1.DataPlaneConnectionAvailable] = metav1.ConditionUnknown
-		expectedConditions[hyperv1.ControlPlaneConnectionAvailable] = metav1.ConditionUnknown
-	}
-	if IsLessThan(Version415) {
-		// ValidKubeVirtInfraNetworkMTU condition is not present in versions < 4.15
-		delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkMTU)
-	}
-	if IsLessThan(Version421) {
-		delete(expectedConditions, hyperv1.DataPlaneConnectionAvailable)
-	}
-
-	if IsLessThan(Version422) {
-		delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
-		delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkPolicyRBAC)
-	}
-
-	// TODO: TEMPORARY - Remove this once ControlPlaneConnectionAvailable condition is merged and stable.
-	// Exclude ControlPlaneConnectionAvailable during upgrade tests as the condition
-	// may not be present in all builds during the upgrade window.
-	if upgradeContext != nil {
-		delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
-	}
-
-	if IsLessThan(Version423) {
-		delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
-	}
-
-	// TODO: TEMPORARY - Remove this once ConfigOperatorReconciliationSucceeded condition is merged and stable.
-	// Exclude ConfigOperatorReconciliationSucceeded during upgrade tests as the condition
-	// may not be present in all builds during the upgrade window.
-	if upgradeContext != nil {
-		delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
-	}
-
-	var predicates []Predicate[*hyperv1.HostedCluster]
-	for conditionType, conditionStatus := range expectedConditions {
-		predicates = append(predicates, ConditionPredicate[*hyperv1.HostedCluster](Condition{
-			Type:   string(conditionType),
-			Status: conditionStatus,
-		}))
-	}
+	predicates := []Predicate[*hyperv1.HostedCluster]{hostedClusterConditionsPredicate(hasWorkerNodes, upgradeContext)}
 
 	if IsGreaterThanOrEqualTo(Version422) {
 		cpvFieldPath := "status.controlPlaneVersion"
@@ -3265,6 +3216,68 @@ func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 			return hc, err
 		}, predicates, WithTimeout(timeout), WithoutConditionDump(),
 	)
+}
+
+// hostedClusterConditionsPredicate evaluates expectations against each freshly fetched cluster.
+func hostedClusterConditionsPredicate(hasWorkerNodes bool, upgradeContext *UpgradeContext) Predicate[*hyperv1.HostedCluster] {
+	return func(hc *hyperv1.HostedCluster) (bool, string, error) {
+		expectedConditions := conditions.ExpectedHCConditions(hc)
+		// OCPBUGS-59885: Ignore KubeVirtNodesLiveMigratable in e2e; CI envs may lack RWX-capable PVCs, causing false failures
+		delete(expectedConditions, hyperv1.KubeVirtNodesLiveMigratable)
+		if !hasWorkerNodes {
+			expectedConditions[hyperv1.ClusterVersionAvailable] = metav1.ConditionFalse
+			expectedConditions[hyperv1.ClusterVersionSucceeding] = metav1.ConditionFalse
+			expectedConditions[hyperv1.ClusterVersionProgressing] = metav1.ConditionTrue
+			delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkMTU)
+			delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkPolicyRBAC)
+			expectedConditions[hyperv1.DataPlaneConnectionAvailable] = metav1.ConditionUnknown
+			expectedConditions[hyperv1.ControlPlaneConnectionAvailable] = metav1.ConditionUnknown
+		}
+		if IsLessThan(Version415) {
+			// ValidKubeVirtInfraNetworkMTU condition is not present in versions < 4.15
+			delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkMTU)
+		}
+		if IsLessThan(Version421) {
+			delete(expectedConditions, hyperv1.DataPlaneConnectionAvailable)
+		}
+
+		if IsLessThan(Version422) {
+			delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
+			delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkPolicyRBAC)
+		}
+
+		// TODO: TEMPORARY - Remove this once ControlPlaneConnectionAvailable condition is merged and stable.
+		// Exclude ControlPlaneConnectionAvailable during upgrade tests as the condition
+		// may not be present in all builds during the upgrade window.
+		if upgradeContext != nil {
+			delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
+		}
+
+		if IsLessThan(Version423) {
+			delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
+		}
+
+		// TODO: TEMPORARY - Remove this once ConfigOperatorReconciliationSucceeded condition is merged and stable.
+		// Exclude ConfigOperatorReconciliationSucceeded during upgrade tests as the condition
+		// may not be present in all builds during the upgrade window.
+		if upgradeContext != nil {
+			delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
+		}
+		var reasons []string
+		for conditionType, conditionStatus := range expectedConditions {
+			done, reason, err := ConditionPredicate[*hyperv1.HostedCluster](Condition{
+				Type:   string(conditionType),
+				Status: conditionStatus,
+			})(hc)
+			if err != nil {
+				return false, reason, err
+			}
+			if !done {
+				reasons = append(reasons, reason)
+			}
+		}
+		return len(reasons) == 0, strings.Join(reasons, "; "), nil
+	}
 }
 
 func EnsureHCPPodsAffinitiesAndTolerations(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {

--- a/test/e2e/v2/tests/hosted_cluster_health_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_health_test.go
@@ -67,15 +67,12 @@ func ValidateHostedClusterConditionsTest(getTestCtx internal.TestContextGetter) 
 				delete(expectedConditions, hyperv1.ConfigOperatorReconciliationSucceeded)
 			}
 
-			Eventually(func(g Gomega) {
-				hc := &hyperv1.HostedCluster{}
-				g.Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKeyFromObject(hostedCluster), hc)).To(Succeed())
-				for condType, expectedStatus := range expectedConditions {
-					condition := meta.FindStatusCondition(hc.Status.Conditions, string(condType))
-					g.Expect(condition).NotTo(BeNil(), "condition %s should be present", condType)
-					g.Expect(condition.Status).To(Equal(expectedStatus), "condition %s should have status %s", condType, expectedStatus)
-				}
-			}, 10*time.Minute, 10*time.Second).Should(Succeed())
+			Expect(expectedConditions).NotTo(BeEmpty(), "expected conditions for hosted cluster %s/%s", hostedCluster.Namespace, hostedCluster.Name)
+			for condType, expectedStatus := range expectedConditions {
+				condition := meta.FindStatusCondition(hostedCluster.Status.Conditions, string(condType))
+				Expect(condition).NotTo(BeNil(), "condition %s should be present on hosted cluster %s/%s", condType, hostedCluster.Namespace, hostedCluster.Name)
+				Expect(condition.Status).To(Equal(expectedStatus), "condition %s should have status %s on hosted cluster %s/%s", condType, expectedStatus, hostedCluster.Namespace, hostedCluster.Name)
+			}
 		})
 	})
 }


### PR DESCRIPTION
## What this PR does / why we need it:

A newer HyperShift Operator paired with a pre-5.1 Control Plane Operator waits for GCP runtime credential conditions that the older CPO never produces.

Gate runtime validation using `status.controlPlaneVersion.desired.version`, preferring the HCP and falling back to the persisted HC version when the HCP disappears. Older versions report both credential conditions as `Unknown` with reason `UnsupportedControlPlaneVersion`; undetermined versions report `Unknown` with reason `StatusUnknown`. Both cases disable orphan-machine cleanup.

For 5.1 and later, propagate runtime results and allow cleanup only for `InvalidIdentityProvider` authentication failures. Preserve those failures through missing/Unknown results during teardown, and clear them on recovery. Update shared health expectations and both e2e validators so expectations follow the freshly fetched HC during upgrades; expected Unknown on 5.0 does not count as an aggregate condition failure.

## Which issue(s) this PR fixes:

Addresses the compatibility failure in the [5.0 GKE periodic](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-v2-gke/2097439212348379136) following #8884. No associated Jira issue.

## Special notes for your reviewer:

- The minimum validator version is 5.1, including prereleases. Patch and build metadata do not affect support.
- Deploying the updated HO changes older clusters' status reporting and cleanup eligibility. This adds no NodePool configuration-hash inputs or worker rollout triggers.
- Configuration validation and credential Secret reconciliation still fail reconciliation on errors. No API/schema or CPO changes are included.

Validation:
- Passed affected package tests with race detection: shared conditions, GCP platform, HostedCluster metrics, and legacy e2e utilities.
- Compiled both legacy and v2 e2e suites, built operator binaries, and compiled all repository tests.
- Passed lint, vet, staticcheck, gitlint, and the additional repository checks.
- `make pre-commit CONTAINER_ENGINE=podman` stopped during API generation because dependency synchronization left `api/go.mod` inconsistent with `api/vendor/modules.txt`. Generated changes were restored; remaining checks were run separately.
- The full race-enabled unit suite had one failure: `support/util/TestCompressDecompress` expects a different gzip byte sequence under the local Go 1.27.1 toolchain. The failure also reproduces with baseline source.
- Live validation against 5.0 and 5.1 GKE hosted clusters remains pending. Evaluate it separately from the connection-checker issue tracked by #9534.

## Checklist:

- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GCP credential and workload identity status reporting for hosted clusters.
  * Conditions now reflect whether runtime credential validation is supported, unsupported, or unknown based on the control-plane version.
  * Credential failures are marked invalid only for invalid identity-provider issues.
  * Preserved relevant invalid conditions while allowing recovered credentials to report current status.
  * Improved condition checks during version upgrades, downgrades, and status polling.
  * Reduced unnecessary status updates when conditions have not changed.
  * Improved status consistency and error reporting when control-plane information is missing or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->