### PR TITLE
CNTRLPLANE-3532: Enable HC and HCP status-write linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,14 +25,11 @@ linters:
     custom:
       hypershiftlinter:
         path: hack/tools/bin/hypershiftlinter.so
-        description: "Enforces HyperShift test conventions from TESTING.md and test/e2e/v2/AGENTS.md"
+        description: "Enforces HyperShift test conventions and HC/HCP status-writing rules"
         settings:
           analyzers:
-            # hcpstatuspatch is intentionally excluded here: enabling it now would fail
-            # on the last couple of HostedControlPlane status-patch call sites still being
-            # migrated to support/statuspatching in-flight PRs. Add it to this list once
-            # those land. See hack/tools/hypershiftlinter/README.md's staged rollout section.
             enable:
+              - hcpstatuspatch
               - testcasename
               - testfuncname
               - e2eteststate
@@ -64,6 +61,57 @@ linters:
       - legacy
       - std-error-handling
     rules:
+      # Temporary HC/HCP status-writing migration exceptions, not approved patterns.
+      # Match the exact file, analyzer/operation/resource diagnostic, and source line.
+      # Identical new source lines in the same file also match; review additions carefully.
+      # updateHostedClusterBackupURL.
+      # Remove when the last matching call migrates to support/statuspatching.
+      - linters: [hypershiftlinter]
+        path: '^hypershift-operator/controllers/etcdbackup/reconciler\.go$'
+        text: '^hcpstatuspatch: do not call Status\(\)\.Update\(\) on HostedCluster;'
+        source: '^\s*return\s+r\.Status\(\)\.Update\(ctx,\s+hc\)\s*$'
+      # setEtcdRecoveryCondition.
+      # Remove when the last matching call migrates to support/statuspatching.
+      - linters: [hypershiftlinter]
+        path: '^hypershift-operator/controllers/hostedcluster/etcd_recovery\.go$'
+        text: '^hcpstatuspatch: do not call Status\(\)\.Update\(\) on HostedCluster;'
+        source: '^\s*if\s+err\s+:=\s+r\.Client\.Status\(\)\.Update\(ctx,\s+hcluster\);\s+err\s+!=\s+nil\s+\{\s*$'
+      # Reconcile.
+      # Remove when the last matching call migrates to support/statuspatching.
+      - linters: [hypershiftlinter]
+        path: '^hypershift-operator/controllers/hostedcluster/hostedcluster_controller\.go$'
+        text: '^hcpstatuspatch: do not call Status\(\)\.Update\(\) on HostedCluster;'
+        source: '^\s*return\s+res,\s+utilerrors\.NewAggregate\(\[\]error\{err,\s+r\.Client\.Status\(\)\.Update\(ctx,\s+hcluster\)\}\)\s*$'
+      # reconcile, reconcileOIDCDocumentsWithStatus, reconcileRestoredFromBackupWithStatus.
+      # Remove when the last matching call migrates to support/statuspatching.
+      - linters: [hypershiftlinter]
+        path: '^hypershift-operator/controllers/hostedcluster/hostedcluster_controller\.go$'
+        text: '^hcpstatuspatch: do not call Status\(\)\.Update\(\) on HostedCluster;'
+        source: '^\s*if\s+err\s+:=\s+r\.Client\.Status\(\)\.Update\(ctx,\s+hcluster\);\s+err\s+!=\s+nil\s+\{\s*$'
+      # reconcileOIDCDocumentsWithStatus, reconcilePlatformCredentialsWithStatus.
+      # Remove when the last matching call migrates to support/statuspatching.
+      - linters: [hypershiftlinter]
+        path: '^hypershift-operator/controllers/hostedcluster/hostedcluster_controller\.go$'
+        text: '^hcpstatuspatch: do not call Status\(\)\.Update\(\) on HostedCluster;'
+        source: '^\s*if\s+statusErr\s+:=\s+r\.Client\.Status\(\)\.Update\(ctx,\s+hcluster\);\s+statusErr\s+!=\s+nil\s+\{\s*$'
+      # reconcilePublicEndpointExposedCondition.
+      # Remove when the last matching call migrates to support/statuspatching.
+      - linters: [hypershiftlinter]
+        path: '^hypershift-operator/controllers/hostedcluster/hostedcluster_controller\.go$'
+        text: '^hcpstatuspatch: do not call Status\(\)\.Update\(\) on HostedCluster;'
+        source: '^\s*if\s+err\s+:=\s+r\.Client\.Status\(\)\.Update\(ctx,\s+hc\);\s+err\s+!=\s+nil\s+\{\s*$'
+      # reconcileLegacy.
+      # Remove when the last matching call migrates to support/statuspatching.
+      - linters: [hypershiftlinter]
+        path: '^hypershift-operator/controllers/hostedcluster/reconcile_legacy\.go$'
+        text: '^hcpstatuspatch: do not call Status\(\)\.Update\(\) on HostedCluster;'
+        source: '^\s*if\s+err\s+:=\s+r\.Client\.Status\(\)\.Update\(ctx,\s+hcluster\);\s+err\s+!=\s+nil\s+\{\s*$'
+      # reconcileLegacy.
+      # Remove when the last matching call migrates to support/statuspatching.
+      - linters: [hypershiftlinter]
+        path: '^hypershift-operator/controllers/hostedcluster/reconcile_legacy\.go$'
+        text: '^hcpstatuspatch: do not call Status\(\)\.Update\(\) on HostedCluster;'
+        source: '^\s*if\s+statusErr\s+:=\s+r\.Client\.Status\(\)\.Update\(ctx,\s+hcluster\);\s+statusErr\s+!=\s+nil\s+\{\s*$'
       - linters:
           - unparam
         path: '_test\.go$'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Project documentation is published via MkDocs. The site structure and navigation
 | **API types and CRD machinery** | [api/AGENTS.md](api/AGENTS.md) |
 | **Control plane components (CPOv2)** | [support/controlplane-component/AGENTS.md](support/controlplane-component/AGENTS.md) and [support/controlplane-component/README.md](support/controlplane-component/README.md) |
 | **Control plane operator** | [control-plane-operator/AGENTS.md](control-plane-operator/AGENTS.md) |
-| **HostedControlPlane status patching** | [control-plane-operator/AGENTS.md](control-plane-operator/AGENTS.md#hostedcontrolplane-status-patching) — never `Status().Update()`/unguarded `MergeFrom()` on HCP; use `support/statuspatching` |
+| **HC/HCP status patching** | [control-plane-operator/AGENTS.md](control-plane-operator/AGENTS.md#hostedcluster-and-hostedcontrolplane-status-patching) — never `Status().Update()`/unguarded `MergeFrom()` on HC/HCP; actively enforced by `hcpstatuspatch`; use `support/statuspatching` |
 | **E2E v2 test framework** | [test/e2e/v2/AGENTS.md](test/e2e/v2/AGENTS.md) |
 | **Envtest (CEL validation tests)** | [test/envtest/README.md](test/envtest/README.md) — YAML-driven, runs across k8s 1.30–1.36, supports feature gate filtering |
 | **CEL over webhooks** | [.claude/rules/webhook-validation.md](.claude/rules/webhook-validation.md) |

--- a/control-plane-operator/AGENTS.md
+++ b/control-plane-operator/AGENTS.md
@@ -25,20 +25,20 @@ HCCO is a **separate binary in the same image**, invoked as `control-plane-opera
 
 HCCO controllers are in `hostedclusterconfigoperator/controllers/`. They do **not** use the v2 component framework today — this is a migration opportunity.
 
-## HostedControlPlane Status Patching
+## HostedCluster and HostedControlPlane Status Patching
 
-CPO, HCCO, and the hypershift-operator (karpenter) all write to the same
-`HostedControlPlane.Status` concurrently. Never patch HCP status with a raw
-`Status().Update()` or an unguarded `client.MergeFrom()` — both can silently
-overwrite a concurrent writer's changes (`Update()` replaces the whole status
-subresource; `MergeFrom()` without an optimistic lock lets a stale
-`resourceVersion` succeed silently instead of conflicting).
+CPO, HCCO, and the hypershift-operator (karpenter) write to
+`HostedControlPlane.Status` concurrently. The same status-writing rules apply to
+`HostedCluster`. Use the shared helper for HC/HCP status instead of raw
+`Status().Update()` or unguarded `client.MergeFrom()` / `MergeFromWithOptions()`.
+`Update()` conflicts on stale resource versions; merge patches without an
+optimistic lock can silently overwrite concurrent changes.
 
 Use `support/statuspatching` instead:
 
 - `statuspatching.PatchStatus(ctx, c, obj, mutate)` — general case. Re-fetches
   the object, applies `mutate`, patches with `MergeFromWithOptimisticLock`, and
-  retries automatically on conflict.
+  skips no-op changes, and retries automatically on conflict.
 - `statuspatching.PatchStatusCondition(ctx, c, obj, conditions, condition)` —
   single-condition updates. Uses `meta.SetStatusCondition`'s own change
   detection to skip no-ops without a false positive from `LastTransitionTime`.
@@ -56,10 +56,15 @@ it's derived from a fresh external probe performed immediately before the patch
 call, where no concurrent writer can invalidate the value between the probe and
 the patch, not from an earlier `Status` snapshot.
 
-The `hcpstatuspatch` static analyzer (`hack/tools/hypershiftlinter`) flags
-direct `Status().Update()`/unguarded `MergeFrom()` on `HostedControlPlane` —
-see [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532) for
-migration status.
+The `hcpstatuspatch` static analyzer (`hack/tools/hypershiftlinter`) actively
+checks both HC and HCP in normal lint runs. It flags direct `Status().Update()`
+and unguarded `MergeFrom()` / `MergeFromWithOptions()` status patches, while
+accepting explicitly optimistic-locked patches. Existing call sites have narrow
+migration exceptions in `.golangci.yml`, not approval to repeat these patterns.
+Remove each exception when its last matching call site is migrated. An identical
+new source line in the same file will also match an exception; reviewers must
+watch for this limitation. See the [analyzer README](../hack/tools/hypershiftlinter/README.md#status-writing-enforcement-and-migration-exceptions)
+for detection boundaries and exception maintenance.
 
 ## Key Directories
 

--- a/hack/tools/hypershiftlinter/README.md
+++ b/hack/tools/hypershiftlinter/README.md
@@ -1,8 +1,8 @@
 # hypershiftlinter
 
 `hypershiftlinter` is a custom [golangci-lint](https://golangci-lint.run/) plugin
-that automatically enforces HyperShift's testing conventions through static
-analysis.
+that enforces HyperShift's testing conventions and HC/HCP status-writing rules
+through static analysis.
 
 ## Why this exists
 
@@ -51,11 +51,11 @@ The plugin ships 10 analyzers, scoped so each rule only fires where it applies.
 | `sippyannotation`   | Requires the correct Sippy/Jira `[Feature:X]` annotations on Ginkgo `Describe` blocks.            |
 | `e2eutilallowlist`  | Restricts `test/e2e/v2` to an allowlist of approved symbols from `test/e2e/util`.                 |
 
-### HostedControlPlane status patching (repo-wide, see [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532))
+### HostedCluster and HostedControlPlane status patching (repo-wide, see [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532))
 
 | Analyzer          | Enforces                                                                                                    |
 | ----------------- | ------------------------------------------------------------------------------------------------------------- |
-| `hcpstatuspatch`  | Bans `Status().Update()` and unguarded `MergeFrom()` status patches on `HostedControlPlane`; use `support/statuspatching` instead. **Not yet enabled in `.golangci.yml`** — see below. |
+| `hcpstatuspatch`  | Bans `Status().Update()` and unguarded `MergeFrom()` status patches on `HostedCluster` and `HostedControlPlane`; use `support/statuspatching` instead. Enabled in `.golangci.yml`. |
 
 ## How it's built and run
 
@@ -67,32 +67,49 @@ mismatch causes `plugin.Open()` to fail at runtime.
 Relevant Makefile targets:
 
 - `make hypershiftlinter.so` — build the plugin shared library.
-- `make hypershift-lint-all` — opt-in target to run the analyzers against the
+- `make hypershift-lint-all` — run the enabled custom analyzers against the
   current tree.
+- `make lint` — run normal lint checks, including these analyzers.
 - `make test-linter` — run the analyzers' own unit tests
   (`go test ./hypershiftlinter/analyzers/...`).
 
 Each analyzer has [`analysistest`](https://pkg.go.dev/golang.org/x/tools/go/analysis/analysistest)-based
 unit tests with good/bad `testdata/` fixtures.
 
-## Staged rollout
+## Status-writing enforcement and migration exceptions
 
-Enablement is intentionally staged. The initial change lands the plugin, the
-analyzers, and their unit tests only — **it does not enable enforcement**. A
-follow-up wires the plugin into `.golangci.yml` / `make lint` and fixes the
-existing violations in the tree.
+`hcpstatuspatch` retains its identifier for compatibility and covers both
+`HostedCluster` and `HostedControlPlane` from HyperShift's `hypershift/v1beta1`
+package, including pointers and type aliases. It flags direct `Status().Update()`
+and status patches built with `MergeFrom()` or `MergeFromWithOptions()` without
+`MergeFromWithOptimisticLock`. Diagnostics name the actual resource type.
 
-Splitting it this way keeps the review surface small and lets CI actually run the
-analyzers' own tests before enforcement is turned on. (A brand-new reusable
-workflow can't get a green pre-merge run on the PR that introduces it, because
-GitHub resolves `uses: ...@main` and the `pull_request` trigger from the base
-branch — so the foundational plumbing has to land on `main` first.)
+`Update()` conflicts when the resource version is stale. An unguarded merge
+patch can silently overwrite concurrent changes. Prefer `support/statuspatching`
+to standardize fetching, mutation, no-op detection, and conflict retries;
+explicitly optimistic-locked patches are also accepted.
 
-The same staging applies per-analyzer when a new rule would fail on violations
-still being fixed in other in-flight PRs: `hcpstatuspatch` lands with its own
-tests but is deliberately left out of `linters.settings.custom.hypershiftlinter.settings.analyzers.enable`
-in `.golangci.yml` until the last HostedControlPlane status-patch call sites it
-would flag are migrated to `support/statuspatching` elsewhere.
+The analyzer ignores `_test.go` files, unrelated types (including namesakes in
+other packages), and non-status patches. It follows local patch assignments and
+aliases within a function, without interprocedural analysis: patches passed as
+function parameters or returned by other functions are outside its scope.
+Unguarded merge-patch diagnostics point to the constructor, even when the patch
+is later passed to `Status().Patch()` through a variable.
+
+Enforcement is active in normal lint runs. Existing findings have temporary
+migration exceptions in `.golangci.yml`; these are migration debt, not approved
+status-writing patterns. Each exception combines the `hypershiftlinter` linter,
+an anchored exact file path, diagnostic text identifying `hcpstatuspatch`, the
+operation and resource type, and an anchored source-line expression with
+whitespace tolerance. These filters are combined as described in the
+[golangci-lint configuration reference](https://golangci-lint.run/docs/configuration/file/).
+
+Comments name the affected functions and removal condition. Remove an exception
+when its last matching call site migrates to `support/statuspatching` (or an
+explicitly optimistic-locked patch); `warn-unused: true` helps detect obsolete
+rules. An accepted limitation is that an identical new source line in the same
+file also matches the exception. A different source line, the same line in
+another file, or a diagnostic from another analyzer remains enforced.
 
 [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532) also asks
 the linter to warn on `reflect.DeepEqual` for Kubernetes API objects (use

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch.go
@@ -1,13 +1,12 @@
 // Package hcpstatuspatch bans direct Status().Update() calls and unguarded
-// client.MergeFrom() status patches on HostedControlPlane. Multiple controllers
-// (CPO, HCCO, HO/karpenter) write to the same HostedControlPlane.Status
-// concurrently — Status().Update() replaces the whole status subresource and
-// silently overwrites concurrent changes, and MergeFrom() without an optimistic
-// lock lets a stale resourceVersion succeed silently. See
-// support/statuspatching for the safe pattern.
+// client.MergeFrom() status patches on HostedCluster and HostedControlPlane.
+// Update() conflicts on stale resource versions; unguarded merge patches can
+// silently overwrite concurrent changes. Use support/statuspatching to standardize
+// fetching, mutation, no-op detection, and conflict retries.
 package hcpstatuspatch
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
@@ -18,14 +17,13 @@ import (
 
 const (
 	controllerRuntimeClientPkg = "sigs.k8s.io/controller-runtime/pkg/client"
-	hostedControlPlanePkg      = "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	hostedControlPlaneType     = "HostedControlPlane"
+	hypershiftAPIPkg           = "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	optimisticLockType         = "MergeFromWithOptimisticLock"
 )
 
 var Analyzer = &analysis.Analyzer{
 	Name: "hcpstatuspatch",
-	Doc:  "bans Status().Update() and unguarded MergeFrom() status patches on HostedControlPlane; use support/statuspatching instead",
+	Doc:  "bans Status().Update() and unguarded MergeFrom() status patches on HostedCluster and HostedControlPlane; use support/statuspatching instead",
 	Run:  run,
 }
 
@@ -44,14 +42,14 @@ func run(pass *analysis.Pass) (any, error) {
 			if !ok {
 				return true
 			}
-			if isHCPStatusUpdate(pass, call) {
+			if isClusterStatusUpdate(pass, call) {
 				pass.Report(analysis.Diagnostic{
 					Pos:     call.Pos(),
 					End:     call.End(),
-					Message: "do not call Status().Update() on HostedControlPlane; use statuspatching.PatchStatus instead — Update() replaces the whole status subresource and silently overwrites concurrent writers",
+					Message: fmt.Sprintf("do not call Status().Update() on %s; use support/statuspatching.PatchStatus instead — Update() conflicts on stale resource versions; the helper standardizes fetching, mutation, no-op detection, and conflict retries", clusterResourceType(pass.TypesInfo.TypeOf(call.Args[1]))),
 				})
 			}
-			if isHCPStatusPatch(pass, call) {
+			if isClusterStatusPatch(pass, call) {
 				reportUnguardedPatchConstructors(pass, call)
 			}
 			return true
@@ -60,9 +58,9 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-// isHCPStatusUpdate matches `<expr>.Status().Update(ctx, obj, ...)` where obj is
-// a HyperShift HostedControlPlane.
-func isHCPStatusUpdate(pass *analysis.Pass, call *ast.CallExpr) bool {
+// isClusterStatusUpdate matches `<expr>.Status().Update(ctx, obj, ...)` where obj is
+// a HyperShift HostedCluster or HostedControlPlane.
+func isClusterStatusUpdate(pass *analysis.Pass, call *ast.CallExpr) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok || sel.Sel.Name != "Update" {
 		return false
@@ -78,12 +76,12 @@ func isHCPStatusUpdate(pass *analysis.Pass, call *ast.CallExpr) bool {
 	if len(call.Args) < 2 {
 		return false
 	}
-	return isHostedControlPlane(pass.TypesInfo.TypeOf(call.Args[1]))
+	return clusterResourceType(pass.TypesInfo.TypeOf(call.Args[1])) != ""
 }
 
-// isHCPStatusPatch matches `<expr>.Status().Patch(ctx, obj, patch)` where obj is
-// a HyperShift HostedControlPlane.
-func isHCPStatusPatch(pass *analysis.Pass, call *ast.CallExpr) bool {
+// isClusterStatusPatch matches `<expr>.Status().Patch(ctx, obj, patch)` where obj is
+// a HyperShift HostedCluster or HostedControlPlane.
+func isClusterStatusPatch(pass *analysis.Pass, call *ast.CallExpr) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok || sel.Sel.Name != "Patch" {
 		return false
@@ -99,7 +97,7 @@ func isHCPStatusPatch(pass *analysis.Pass, call *ast.CallExpr) bool {
 	if len(call.Args) < 2 {
 		return false
 	}
-	return isHostedControlPlane(pass.TypesInfo.TypeOf(call.Args[1]))
+	return clusterResourceType(pass.TypesInfo.TypeOf(call.Args[1])) != ""
 }
 
 func reportUnguardedPatchConstructors(pass *analysis.Pass, statusPatch *ast.CallExpr) {
@@ -118,22 +116,23 @@ func reportUnguardedPatchConstructors(pass *analysis.Pass, statusPatch *ast.Call
 		if !isControllerRuntime {
 			continue
 		}
-		if len(call.Args) < 1 || !isHostedControlPlane(pass.TypesInfo.TypeOf(call.Args[0])) {
+		if len(call.Args) < 1 || clusterResourceType(pass.TypesInfo.TypeOf(call.Args[0])) == "" {
 			continue
 		}
+		resourceType := clusterResourceType(pass.TypesInfo.TypeOf(statusPatch.Args[1]))
 		switch name {
 		case "MergeFrom":
 			pass.Report(analysis.Diagnostic{
 				Pos:     call.Pos(),
 				End:     call.End(),
-				Message: "do not use MergeFrom() on HostedControlPlane without an optimistic lock; use statuspatching.PatchStatus/PatchStatusCondition, or MergeFromWithOptions(..., MergeFromWithOptimisticLock{}) at minimum",
+				Message: fmt.Sprintf("do not use MergeFrom() on %s without an optimistic lock; use support/statuspatching.PatchStatus/PatchStatusCondition, or MergeFromWithOptions(..., MergeFromWithOptimisticLock{}) at minimum", resourceType),
 			})
 		case "MergeFromWithOptions":
 			if !hasOptimisticLockOption(pass, call) {
 				pass.Report(analysis.Diagnostic{
 					Pos:     call.Pos(),
 					End:     call.End(),
-					Message: "do not use MergeFromWithOptions() on HostedControlPlane without MergeFromWithOptimisticLock{}; use statuspatching.PatchStatus/PatchStatusCondition instead",
+					Message: fmt.Sprintf("do not use MergeFromWithOptions() on %s without MergeFromWithOptimisticLock{}; use support/statuspatching.PatchStatus/PatchStatusCondition instead", resourceType),
 				})
 			}
 		}
@@ -676,15 +675,19 @@ func isFromPackage(obj types.Object, path string) bool {
 	return obj != nil && obj.Pkg() != nil && obj.Pkg().Path() == path
 }
 
-// isHostedControlPlane reports whether t is (a pointer to) HyperShift's
-// HostedControlPlane type. Matching requires both the type name and the
-// hypershift/v1beta1 package path so a local or third-party type of the same
-// name does not trigger the rule.
-func isHostedControlPlane(t types.Type) bool {
+// clusterResourceType returns the HyperShift resource name for t, including
+// pointers and aliases. Matching the package path excludes unrelated namesakes.
+func clusterResourceType(t types.Type) string {
 	named := namedType(t)
 	if named == nil {
-		return false
+		return ""
 	}
 	obj := named.Obj()
-	return obj.Name() == hostedControlPlaneType && isFromPackage(obj, hostedControlPlanePkg)
+	if isFromPackage(obj, hypershiftAPIPkg) {
+		switch obj.Name() {
+		case "HostedCluster", "HostedControlPlane":
+			return obj.Name()
+		}
+	}
+	return ""
 }

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/hcpstatuspatch_test.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
-func TestAnalyzer(t *testing.T) {
+func TestRun(t *testing.T) {
 	t.Parallel()
 
 	testdata := analysistest.TestData()
@@ -16,11 +16,11 @@ func TestAnalyzer(t *testing.T) {
 		pattern string
 	}{
 		{
-			name:    "When patches use statuspatching, optimistic lock, or non-HCP types, it should produce no diagnostics",
+			name:    "When patches use statuspatching, optimistic lock, or unrelated types, it should produce no diagnostics",
 			pattern: "a/good",
 		},
 		{
-			name:    "When HostedControlPlane status is updated or patched without an optimistic lock, it should produce diagnostics",
+			name:    "When HostedCluster or HostedControlPlane status is updated or patched without an optimistic lock, it should produce diagnostics",
 			pattern: "a/bad",
 		},
 		{

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/bad/hostedcluster.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/bad/hostedcluster.go
@@ -1,0 +1,63 @@
+package bad
+
+import (
+	"context"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Both resources appear in the controller signature; diagnose the update target.
+func updateHostedCluster(ctx context.Context, c client.Client, hc *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) error {
+	return c.Status().Update(ctx, hc) // want `do not call Status\(\)\.Update\(\) on HostedCluster;`
+}
+
+func inlineHostedCluster(c client.Client, hc *hyperv1.HostedCluster) error {
+	return c.Status().Patch(nil, hc, client.MergeFrom(hc)) // want `do not use MergeFrom\(\) on HostedCluster without an optimistic lock`
+}
+
+func variableHostedCluster(c client.Client, hc *hyperv1.HostedCluster) error {
+	original := hc
+	var patch = client.MergeFrom(original) // want `do not use MergeFrom\(\) on HostedCluster without an optimistic lock`
+	return c.Status().Patch(nil, hc, patch)
+}
+
+func optionsHostedCluster(c client.Client, hc *hyperv1.HostedCluster) error {
+	return c.Status().Patch(nil, hc, client.MergeFromWithOptions(hc)) // want `do not use MergeFromWithOptions\(\) on HostedCluster without MergeFromWithOptimisticLock`
+}
+
+func spoofedLockHostedCluster(c client.Client, hc *hyperv1.HostedCluster) error {
+	return c.Status().Patch(nil, hc, client.MergeFromWithOptions(hc, MergeFromWithOptimisticLock{})) // want `do not use MergeFromWithOptions\(\) on HostedCluster without MergeFromWithOptimisticLock`
+}
+
+type ClusterAlias = hyperv1.HostedCluster
+type ControlPlaneAlias = hyperv1.HostedControlPlane
+type ClusterPointerAlias = *ClusterAlias
+
+func updateAliases(c client.Client, hc ClusterPointerAlias, hcp *ControlPlaneAlias) {
+	_ = c.Status().Update(nil, hc)  // want `do not call Status\(\)\.Update\(\) on HostedCluster;`
+	_ = c.Status().Update(nil, hcp) // want `do not call Status\(\)\.Update\(\) on HostedControlPlane;`
+}
+
+func patchAlias(c client.Client, hc *ClusterAlias) error {
+	unsafe := client.MergeFrom(hc) // want `do not use MergeFrom\(\) on HostedCluster without an optimistic lock`
+	alias := unsafe
+	patch := alias
+	return c.Status().Patch(nil, hc, patch)
+}
+
+func reassignHostedCluster(c client.Client, hc *hyperv1.HostedCluster) error {
+	patch := client.MergeFromWithOptions(hc, client.MergeFromWithOptimisticLock{})
+	{
+		patch = client.MergeFrom(hc) // want `do not use MergeFrom\(\) on HostedCluster without an optimistic lock`
+	}
+	return c.Status().Patch(nil, hc, patch)
+}
+
+func conditionalHostedCluster(c client.Client, hc *hyperv1.HostedCluster) error {
+	patch := client.MergeFrom(hc) // want `do not use MergeFrom\(\) on HostedCluster without an optimistic lock`
+	if hc.Status.Ready {
+		patch = client.MergeFromWithOptions(hc, client.MergeFromWithOptimisticLock{})
+	}
+	return c.Status().Patch(nil, hc, patch)
+}

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/good_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/good_test.go
@@ -10,3 +10,12 @@ import (
 func seedFixtureStatus(c client.Client, hcp *hyperv1.HostedControlPlane) error {
 	return c.Status().Update(nil, hcp)
 }
+
+func seedHostedCluster(c client.Client, hc *hyperv1.HostedCluster) error {
+	return c.Status().Update(nil, hc)
+}
+
+func patchFixtureStatus(c client.Client, hc *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) {
+	_ = c.Status().Patch(nil, hc, client.MergeFrom(hc))
+	_ = c.Status().Patch(nil, hcp, client.MergeFromWithOptions(hcp))
+}

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/hostedcluster.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/a/good/hostedcluster.go
@@ -1,0 +1,47 @@
+package good
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/statuspatching"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func sharedHelpers(c client.Client, hc *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) {
+	_ = statuspatching.PatchStatus(nil, c, hc, func(current *hyperv1.HostedCluster) error {
+		current.Status.Ready = true
+		return nil
+	})
+	_ = statuspatching.PatchStatus(nil, c, hcp, func(current *hyperv1.HostedControlPlane) error {
+		current.Status.Ready = true
+		return nil
+	})
+}
+
+func guardedHostedCluster(c client.Client, hc *hyperv1.HostedCluster) error {
+	return c.Status().Patch(nil, hc, client.MergeFromWithOptions(hc, client.MergeFromWithOptimisticLock{}))
+}
+
+func reassignGuardedHostedCluster(c client.Client, hc *hyperv1.HostedCluster) error {
+	patch := client.MergeFrom(hc)
+	patch = client.MergeFromWithOptions(hc, client.MergeFromWithOptimisticLock{})
+	alias := patch
+	return c.Status().Patch(nil, hc, alias)
+}
+
+func objectPatchHostedCluster(c client.Client, hc *hyperv1.HostedCluster) error {
+	return c.Patch(nil, hc, client.MergeFrom(hc))
+}
+
+type HostedCluster struct{}
+
+func unrelatedHostedCluster(c client.Client, hc *HostedCluster) {
+	_ = c.Status().Update(nil, hc)
+	_ = c.Status().Patch(nil, hc, client.MergeFrom(hc))
+}
+
+func lockOptions(c client.Client, hc *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) {
+	type LockAlias = client.MergeFromWithOptimisticLock
+	lock := LockAlias{}
+	_ = c.Status().Patch(nil, hc, client.MergeFromWithOptions(hc, lock))
+	_ = c.Status().Patch(nil, hcp, client.MergeFromWithOptions(hcp, &lock))
+}

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/github.com/openshift/hypershift/api/hypershift/v1beta1/hosted_controlplane.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/github.com/openshift/hypershift/api/hypershift/v1beta1/hosted_controlplane.go
@@ -1,5 +1,9 @@
 package v1beta1
 
+type HostedCluster struct {
+	Status Status
+}
+
 type HostedControlPlane struct {
 	Status Status
 }

--- a/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/github.com/openshift/hypershift/support/statuspatching/statuspatching.go
+++ b/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch/testdata/src/github.com/openshift/hypershift/support/statuspatching/statuspatching.go
@@ -1,0 +1,7 @@
+package statuspatching
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+func PatchStatus[T any](ctx any, c client.Client, obj T, mutate func(T) error) error {
+	return nil
+}

--- a/hack/tools/hypershiftlinter/plugin_test.go
+++ b/hack/tools/hypershiftlinter/plugin_test.go
@@ -4,8 +4,25 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch"
+
 	"golang.org/x/tools/go/analysis"
 )
+
+func TestBuildAnalyzers(t *testing.T) {
+	t.Run("When hcpstatuspatch is enabled, it should select the HC and HCP analyzer", func(t *testing.T) {
+		raw := map[string]any{
+			"analyzers": map[string]any{"enable": []any{"hcpstatuspatch"}},
+		}
+		got, err := BuildAnalyzers(raw)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0] != hcpstatuspatch.Analyzer {
+			t.Fatalf("expected only the HC and HCP status analyzer, got %v", analyzerNames(got))
+		}
+	})
+}
 
 func TestBuildAnalyzersRejectsUnknownTopLevelField(t *testing.T) {
 	raw := map[string]any{


### PR DESCRIPTION
## What this PR does / why we need it:

Extend `hcpstatuspatch` to cover both `HostedCluster` and `HostedControlPlane`, and enable it in normal lint runs. Direct `Status().Update()` calls and merge status patches without optimistic locking now produce resource-specific diagnostics recommending `support/statuspatching`.

The full main-module inventory, with all configured build tags and issue limits disabled, found 25 existing HC updates across four files. Eight temporary exceptions combine an exact file path, analyzer/operation/resource diagnostic, and anchored source-line expression so controller migrations can proceed independently. Add HC fixtures, preserve HCP regression coverage, verify plugin selection, and document enforcement and exception maintenance.

## Which issue(s) this PR fixes:

Related to [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532). The separate `reflect.DeepEqual` analyzer remains follow-up work.

## Special notes for your reviewer:

This changes lint tooling, configuration, tests, and guidance; controller behavior, the shared helper implementation, and public APIs are unchanged. `Status().Update()` conflicts on stale resource versions; unguarded merge patches can overwrite concurrent changes.

Exceptions are migration debt, not approved patterns. Remove each when its last matching call site is migrated. An identical new source line in the same file also matches an exception; this limitation is documented. `warn-unused: true` remains enabled.

Validation passed:
- `make test-linter`
- `go test ./hypershiftlinter -count=1` from `hack/tools`
- `golangci-lint config verify --config .golangci.yml`
- `make hypershift-lint-all`
- `make lint`
- Temporary exclusion smoke fixtures: an existing pattern is suppressed; a different source line, the same line in another file, HCP violations, unguarded merge constructors, and an unrelated analyzer diagnostic remain visible.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The HyperShift linter now checks status updates for both HostedCluster and HostedControlPlane resources.
  * Diagnostics identify affected resources and recommend supported status-patching approaches.
  * Additional unsafe merge-patch patterns, aliases, and pointer types are detected.

* **Documentation**
  * Updated guidance explains status-patching requirements, migration exceptions, and analyzer coverage.
  * Linting instructions now describe the checks as actively enforced rather than opt-in.

* **Bug Fixes**
  * Existing status-update call sites are temporarily excluded while they are migrated to the supported approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->