### PR TITLE
OCPBUGS-115468: fix NodePool: truncate oversized machine messages instead of dropping them

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1338,8 +1338,10 @@ func aggregateMachineMessages(msgs []string) string {
 			// If nothing has been written yet, truncate the oversized message
 			// rather than dropping it entirely (OCPBUGS-115468).
 			if builder.Len() == 0 {
-				remaining := maxMessageLength - len(endOfMessage)
+				remaining := maxMessageLength - len(endOfGlobalMessage)
 				builder.WriteString(msg[:remaining])
+				builder.WriteString(endOfGlobalMessage)
+				break
 			}
 			builder.WriteString(endOfMessage)
 			break

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1335,6 +1335,12 @@ func aggregateMachineMessages(msgs []string) string {
 	builder := strings.Builder{}
 	for _, msg := range msgs {
 		if builder.Len()+len(msg) > maxMessageLength {
+			// If nothing has been written yet, truncate the oversized message
+			// rather than dropping it entirely (OCPBUGS-115468).
+			if builder.Len() == 0 {
+				remaining := maxMessageLength - len(endOfMessage)
+				builder.WriteString(msg[:remaining])
+			}
 			builder.WriteString(endOfMessage)
 			break
 		}

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -2354,12 +2354,12 @@ func TestAggregateMachineMessages(t *testing.T) {
 		{
 			name:   "When a single message exceeds the limit it should truncate the message preserving the prefix",
 			msgs:   []string{strings.Repeat("a", maxMessageLength+1)},
-			expect: strings.Repeat("a", maxMessageLength-len(endOfMessage)) + endOfMessage,
+			expect: strings.Repeat("a", maxMessageLength-len(endOfGlobalMessage)) + endOfGlobalMessage,
 		},
 		{
 			// Regression test for OCPBUGS-115468: a single Azure Policy denial message
 			// (RequestDisallowedByPolicy) exceeds 1000 chars. The old code dropped it
-			// entirely, returning only the "... too many similar errors" placeholder.
+			// entirely, returning only the "... message truncated" placeholder.
 			// The fix should truncate the message, preserving the actionable prefix
 			// (error code, policy name, denied location).
 			name: "When a single long Azure RequestDisallowedByPolicy error exceeds the limit it should truncate preserving the actionable prefix",
@@ -2410,7 +2410,7 @@ func TestAggregateMachineMessages(t *testing.T) {
 					`"policyDefinitionEffect":"deny","policyAssignmentId":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/oshr-mrg/providers/Microsoft.Authorization/policyAssignments/deny-vm-regions-test-assign-mrg",` +
 					`"policyAssignmentName":"deny-vm-regions-test-assign-mrg","policyAssignmentScope":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/oshr-mrg",` +
 					`"policyAssignmentParameters":{},"policyExemptionIds":[],"policyEnrollmentIds":[]}}}]}}` + "\n"
-				return msg[:maxMessageLength-len(endOfMessage)] + endOfMessage
+				return msg[:maxMessageLength-len(endOfGlobalMessage)] + endOfGlobalMessage
 			}(),
 		},
 	} {

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -2352,9 +2352,66 @@ func TestAggregateMachineMessages(t *testing.T) {
 			expect: strings.Repeat("z", maxMessageLength),
 		},
 		{
-			name:   "When a single message exceeds the limit it should return only the truncation suffix",
+			name:   "When a single message exceeds the limit it should truncate the message preserving the prefix",
 			msgs:   []string{strings.Repeat("a", maxMessageLength+1)},
-			expect: endOfMessage,
+			expect: strings.Repeat("a", maxMessageLength-len(endOfMessage)) + endOfMessage,
+		},
+		{
+			// Regression test for OCPBUGS-115468: a single Azure Policy denial message
+			// (RequestDisallowedByPolicy) exceeds 1000 chars. The old code dropped it
+			// entirely, returning only the "... too many similar errors" placeholder.
+			// The fix should truncate the message, preserving the actionable prefix
+			// (error code, policy name, denied location).
+			name: "When a single long Azure RequestDisallowedByPolicy error exceeds the limit it should truncate preserving the actionable prefix",
+			msgs: []string{
+				"Machine oshr-cluster-oshr-new-den-mr7p4-5vslw: Failed: " +
+					"virtualmachine failed to create or update. err: failed to create or update resource " +
+					"oshr-mrg/oshr-cluster-oshr-new-den-mr7p4-5vslw (service: virtualmachine): " +
+					"PUT https://management.azure.com/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/oshr-mrg/providers/Microsoft.Compute/virtualMachines/oshr-cluster-oshr-new-den-mr7p4-5vslw\n" +
+					"--------------------------------------------------------------------------------\n" +
+					"RESPONSE 403: 403 Forbidden\n" +
+					"ERROR CODE: RequestDisallowedByPolicy\n" +
+					"--------------------------------------------------------------------------------\n" +
+					`{"error":{"code":"RequestDisallowedByPolicy","target":"oshr-cluster-oshr-new-den-mr7p4-5vslw",` +
+					`"message":"Resource 'oshr-cluster-oshr-new-den-mr7p4-5vslw' was disallowed by policy. ` +
+					`Policy identifiers: '[{\"policyAssignment\":{\"name\":\"deny-vm-regions-test-assign-mrg\",` +
+					`\"id\":\"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/oshr-mrg/providers/Microsoft.Authorization/policyAssignments/deny-vm-regions-test-assign-mrg\"},` +
+					`\"policyDefinition\":{\"name\":\"Deny VMs outside allowed regions (test)\",` +
+					`\"id\":\"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/providers/Microsoft.Authorization/policyDefinitions/deny-vm-regions-test\",\"version\":\"1.0.0\"}}]'.","additionalInfo":` +
+					`[{"type":"PolicyViolation","info":{"evaluationDetails":{"evaluatedExpressions":[{"result":"True","expressionKind":"Field","expression":"type","path":"type",` +
+					`"expressionValue":"Microsoft.Compute/virtualMachines","targetValue":"Microsoft.Compute/virtualMachines","operator":"Equals"},` +
+					`{"result":"True","expressionKind":"Field","expression":"location","path":"location","expressionValue":"westus3","targetValue":["eastus"],"operator":"NotIn"}]},` +
+					`"policyDefinitionId":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/providers/Microsoft.Authorization/policyDefinitions/deny-vm-regions-test",` +
+					`"policyDefinitionName":"deny-vm-regions-test","policyDefinitionDisplayName":"Deny VMs outside allowed regions (test)","policyDefinitionVersion":"1.0.0",` +
+					`"policyDefinitionEffect":"deny","policyAssignmentId":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/oshr-mrg/providers/Microsoft.Authorization/policyAssignments/deny-vm-regions-test-assign-mrg",` +
+					`"policyAssignmentName":"deny-vm-regions-test-assign-mrg","policyAssignmentScope":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/oshr-mrg",` +
+					`"policyAssignmentParameters":{},"policyExemptionIds":[],"policyEnrollmentIds":[]}}}]}}` + "\n",
+			},
+			expect: func() string {
+				msg := "Machine oshr-cluster-oshr-new-den-mr7p4-5vslw: Failed: " +
+					"virtualmachine failed to create or update. err: failed to create or update resource " +
+					"oshr-mrg/oshr-cluster-oshr-new-den-mr7p4-5vslw (service: virtualmachine): " +
+					"PUT https://management.azure.com/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/oshr-mrg/providers/Microsoft.Compute/virtualMachines/oshr-cluster-oshr-new-den-mr7p4-5vslw\n" +
+					"--------------------------------------------------------------------------------\n" +
+					"RESPONSE 403: 403 Forbidden\n" +
+					"ERROR CODE: RequestDisallowedByPolicy\n" +
+					"--------------------------------------------------------------------------------\n" +
+					`{"error":{"code":"RequestDisallowedByPolicy","target":"oshr-cluster-oshr-new-den-mr7p4-5vslw",` +
+					`"message":"Resource 'oshr-cluster-oshr-new-den-mr7p4-5vslw' was disallowed by policy. ` +
+					`Policy identifiers: '[{\"policyAssignment\":{\"name\":\"deny-vm-regions-test-assign-mrg\",` +
+					`\"id\":\"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/oshr-mrg/providers/Microsoft.Authorization/policyAssignments/deny-vm-regions-test-assign-mrg\"},` +
+					`\"policyDefinition\":{\"name\":\"Deny VMs outside allowed regions (test)\",` +
+					`\"id\":\"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/providers/Microsoft.Authorization/policyDefinitions/deny-vm-regions-test\",\"version\":\"1.0.0\"}}]'.","additionalInfo":` +
+					`[{"type":"PolicyViolation","info":{"evaluationDetails":{"evaluatedExpressions":[{"result":"True","expressionKind":"Field","expression":"type","path":"type",` +
+					`"expressionValue":"Microsoft.Compute/virtualMachines","targetValue":"Microsoft.Compute/virtualMachines","operator":"Equals"},` +
+					`{"result":"True","expressionKind":"Field","expression":"location","path":"location","expressionValue":"westus3","targetValue":["eastus"],"operator":"NotIn"}]},` +
+					`"policyDefinitionId":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/providers/Microsoft.Authorization/policyDefinitions/deny-vm-regions-test",` +
+					`"policyDefinitionName":"deny-vm-regions-test","policyDefinitionDisplayName":"Deny VMs outside allowed regions (test)","policyDefinitionVersion":"1.0.0",` +
+					`"policyDefinitionEffect":"deny","policyAssignmentId":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/oshr-mrg/providers/Microsoft.Authorization/policyAssignments/deny-vm-regions-test-assign-mrg",` +
+					`"policyAssignmentName":"deny-vm-regions-test-assign-mrg","policyAssignmentScope":"/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/oshr-mrg",` +
+					`"policyAssignmentParameters":{},"policyExemptionIds":[],"policyEnrollmentIds":[]}}}]}}` + "\n"
+				return msg[:maxMessageLength-len(endOfMessage)] + endOfMessage
+			}(),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- When a single Machine condition message exceeds `maxMessageLength` (1000 chars) — e.g. an Azure `RequestDisallowedByPolicy` denial — `aggregateMachineMessages` dropped it entirely, returning only the generic `"... too many similar errors"` placeholder.
- Fix: truncate the first oversized message at the character limit, preserving the actionable prefix (error code, policy name, machine name) before appending the truncation suffix.
- Added regression tests using the actual Azure Policy error from the bug report.

Closes: https://issues.redhat.com/browse/OCPBUGS-115468

## Test plan
- [x] `TestAggregateMachineMessages` — new cases verify truncation of oversized messages (generic + real Azure `RequestDisallowedByPolicy`)
- [x] `TestAggregateMachineReasonsAndMessages` — existing cases still pass (no regressions)
- [x] `make test` passes
- [x] `make lint-fix` passes (0 issues)
- [x] `make verify` passes (only pre-existing `_artifacts/` codespell noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling so oversized messages retain their initial actionable details before the truncation marker.
  * Preserved useful context from long infrastructure policy errors instead of returning only the truncation suffix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->