### PR TITLE
CNTRLPLANE-4209: Reject shared variants in concurrent e2e lanes

### DIFF
--- a/test/e2e/v2/lifecycle/platform.go
+++ b/test/e2e/v2/lifecycle/platform.go
@@ -67,10 +67,12 @@ type TestMatrix struct {
 	Sequential []SequentialGroup `json:"sequential,omitempty"`
 }
 
-// Validate checks that all group names within the matrix are unique
-// and safe for use as JUnit filename components.
+// Validate checks that all group names within the matrix are unique and safe
+// for use as JUnit filename components. It also rejects variants assigned to
+// different top-level execution lanes, because those lanes run concurrently.
 func (m TestMatrix) Validate() error {
 	seen := make(map[string]bool)
+	variantLanes := make(map[string]string)
 	var errs []error
 	check := func(name string) {
 		if err := validateGroupName(name); err != nil {
@@ -81,12 +83,22 @@ func (m TestMatrix) Validate() error {
 		}
 		seen[name] = true
 	}
+	checkVariant := func(variant, lane string) {
+		if previousLane, ok := variantLanes[variant]; ok && previousLane != lane {
+			errs = append(errs, fmt.Errorf("variant %q is used by concurrent lanes %q and %q", variant, previousLane, lane))
+			return
+		}
+		variantLanes[variant] = lane
+	}
 	for _, g := range m.Parallel {
 		check(g.Name)
+		checkVariant(g.Variant, "parallel/"+g.Name)
 	}
-	for _, sg := range m.Sequential {
+	for i, sg := range m.Sequential {
+		lane := fmt.Sprintf("sequential/%d/%s", i, sg.Name)
 		for _, step := range sg.Steps {
 			check(step.Name)
+			checkVariant(step.Variant, lane)
 		}
 	}
 	return errors.Join(errs...)

--- a/test/e2e/v2/lifecycle/testplan_test.go
+++ b/test/e2e/v2/lifecycle/testplan_test.go
@@ -152,6 +152,45 @@ func TestTestMatrixValidate(t *testing.T) {
 			},
 			wantError: true,
 		},
+		{
+			name: "When a variant is used by concurrent lanes, it should return an error",
+			matrix: TestMatrix{
+				Parallel: []TestGroup{
+					{Name: "public", Variant: "public"},
+				},
+				Sequential: []SequentialGroup{
+					{Name: "public-follow-up", Steps: []TestGroup{
+						{Name: "public-validation", Variant: "public"},
+					}},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "When a variant is reused by steps in one sequential lane, it should succeed",
+			matrix: TestMatrix{
+				Sequential: []SequentialGroup{
+					{Name: "public-flow", Steps: []TestGroup{
+						{Name: "public", Variant: "public"},
+						{Name: "public-follow-up", Variant: "public"},
+					}},
+				},
+			},
+		},
+		{
+			name: "When same-named sequential lanes reuse a variant, it should return an error",
+			matrix: TestMatrix{
+				Sequential: []SequentialGroup{
+					{Name: "public-flow", Steps: []TestGroup{
+						{Name: "public", Variant: "public"},
+					}},
+					{Name: "public-flow", Steps: []TestGroup{
+						{Name: "public-follow-up", Variant: "public"},
+					}},
+				},
+			},
+			wantError: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What this PR does / why we need it:

Adds lifecycle test-matrix validation that rejects a HostedCluster variant assigned to multiple concurrent execution lanes while allowing repeated steps within one sequential lane.

This prevents concurrent test processes from targeting the same HostedCluster and keeps the validation independent from the Azure-specific matrix change.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-4209](https://redhat.atlassian.net/browse/CNTRLPLANE-4209)

## Testing:

- `GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor go test -tags e2ev2 ./test/e2e/v2/lifecycle`

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded lifecycle test coverage for variant reuse across parallel and sequential execution lanes.
  - Added validation checks to reject conflicting reuse across different lanes while allowing reuse within the same sequential lane.
  - Preserved existing validation for variant names and paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->