### PR TITLE
OCPBUGS-120799: fix(e2e) Make v2 E2E helpers independent of testing.TB

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,7 @@ linters:
               - vacuouspass
               - ipv6url
               - e2eutilallowlist
+              - e2eutiltestingtb
     gocyclo:
       min-complexity: 30
     govet:

--- a/hack/tools/hypershiftlinter/README.md
+++ b/hack/tools/hypershiftlinter/README.md
@@ -49,6 +49,7 @@ The plugin ships 9 analyzers, scoped so each rule only fires where it applies.
 | `ipv6url`           | Detects `fmt.Sprintf` URL patterns that break with IPv6; use `net.JoinHostPort` instead.          |
 | `sippyannotation`   | Requires the correct Sippy/Jira `[Feature:X]` annotations on Ginkgo `Describe` blocks.            |
 | `e2eutilallowlist`  | Restricts `test/e2e/v2` to an allowlist of approved symbols from `test/e2e/util`.                 |
+| `e2eutiltestingtb`  | Forbids `test/e2e/v2` from referencing `test/e2e/util` symbols whose function signatures accept `testing.TB`. |
 
 ### HostedControlPlane status patching (repo-wide, see [CNTRLPLANE-3532](https://redhat.atlassian.net/browse/CNTRLPLANE-3532))
 

--- a/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/e2eutilallowlist.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/e2eutilallowlist.go
@@ -24,9 +24,6 @@ var allowlist = map[string]map[string]bool{
 		"ConditionPredicate":           true,
 		"Conditions":                   true,
 		"WithPredicates":               true,
-		"EventuallyNotFound":           true,
-		"EventuallyObject":             true,
-		"EventuallyObjects":            true,
 		"Matches":                      true,
 		"MatchesLeaderElectionFailure": true,
 		"OSImageStreamPredicate":       true,
@@ -40,19 +37,8 @@ var allowlist = map[string]map[string]bool{
 		"WithTimeout":                  true,
 
 		// Client helpers
-		"GetClient":    true,
-		"GetConfig":    true,
-		"UpdateObject": true,
-
-		// Wait/rollout helpers
-		"WaitForControlPlaneComponentRollout":             true,
-		"WaitForControlPlaneRollout":                      true,
-		"WaitForDataPlaneRollout":                         true,
-		"WaitForGuestKubeConfig":                          true,
-		"WaitForNReadyNodesWithOptions":                   true,
-		"WaitForNodePoolConfigUpdateCompleteWithPlatform": true,
-		"WaitForReadyNodesByNodePool":                     true,
-		"WaitForReadyNodesByLabels":                       true,
+		"GetClient": true,
+		"GetConfig": true,
 
 		// Cloud provider helpers
 		"GetDefaultSecurityGroup": true,
@@ -64,12 +50,6 @@ var allowlist = map[string]map[string]bool{
 		"HasFieldInCRDSchema":            true,
 		"RunCommandInPod":                true,
 		"SimpleNameGenerator":            true,
-
-		// Validation helpers
-		"ValidateAzureWorkloadIdentityWebhookMutation":     true,
-		"ValidateIngressOperatorConfiguration":             true,
-		"ValidateKubeAPIServerAllowedCIDRs":                true,
-		"ValidateOAuthWithIdentityProviderViaLoadBalancer": true,
 
 		// OIDC helpers
 		"CliClientID":              true,

--- a/hack/tools/hypershiftlinter/analyzers/e2eutiltestingtb/e2eutiltestingtb.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eutiltestingtb/e2eutiltestingtb.go
@@ -1,0 +1,96 @@
+package e2eutiltestingtb
+
+import (
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/pathutil"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const e2eUtilPackagePath = "github.com/openshift/hypershift/test/e2e/util"
+
+var Analyzer = &analysis.Analyzer{
+	Name: "e2eutiltestingtb",
+	Doc:  "forbids test/e2e/util symbols whose function signature accepts testing.TB from test/e2e/v2",
+	Run:  run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	for _, file := range pass.Files {
+		filename := pass.Fset.File(file.Pos()).Name()
+		if !pathutil.IsV2E2ETest(filename) {
+			continue
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			ident, ok := n.(*ast.Ident)
+			if !ok || ident.Name == "_" {
+				return true
+			}
+
+			obj := pass.TypesInfo.Uses[ident]
+			if obj == nil || obj.Pkg() == nil {
+				return true
+			}
+			pkgPath := obj.Pkg().Path()
+			if pkgPath != e2eUtilPackagePath && !strings.HasPrefix(pkgPath, e2eUtilPackagePath+"/") {
+				return true
+			}
+			if !acceptsTestingTB(obj) {
+				return true
+			}
+
+			pass.Report(analysis.Diagnostic{
+				Pos: ident.Pos(),
+				End: ident.End(),
+				Message: "reference to " + pkgPath + "." + obj.Name() +
+					" is forbidden from test/e2e/v2: its function signature accepts testing.TB; port it to a v2 error-returning helper",
+			})
+			return true
+		})
+	}
+	return nil, nil
+}
+
+func acceptsTestingTB(obj types.Object) bool {
+	sig := functionSignature(obj.Type())
+	if sig == nil {
+		return false
+	}
+	for i := 0; i < sig.Params().Len(); i++ {
+		if containsTestingTB(sig.Params().At(i).Type()) {
+			return true
+		}
+	}
+	return false
+}
+
+func functionSignature(typ types.Type) *types.Signature {
+	typ = types.Unalias(typ)
+	switch typ := typ.(type) {
+	case *types.Signature:
+		return typ
+	case *types.Named:
+		return functionSignature(typ.Underlying())
+	default:
+		return nil
+	}
+}
+
+func containsTestingTB(typ types.Type) bool {
+	typ = types.Unalias(typ)
+	switch typ := typ.(type) {
+	case *types.Named:
+		obj := typ.Obj()
+		return obj.Pkg() != nil && obj.Pkg().Path() == "testing" && (obj.Name() == "TB" || obj.Name() == "T")
+	case *types.Pointer:
+		return containsTestingTB(typ.Elem())
+	case *types.Slice:
+		return containsTestingTB(typ.Elem())
+	default:
+		return false
+	}
+}

--- a/hack/tools/hypershiftlinter/analyzers/e2eutiltestingtb/e2eutiltestingtb_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eutiltestingtb/e2eutiltestingtb_test.go
@@ -1,0 +1,12 @@
+package e2eutiltestingtb
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, Analyzer, "test/e2e/v2/good", "test/e2e/v2/bad")
+}

--- a/hack/tools/hypershiftlinter/analyzers/e2eutiltestingtb/testdata/src/github.com/openshift/hypershift/test/e2e/util/util.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eutiltestingtb/testdata/src/github.com/openshift/hypershift/test/e2e/util/util.go
@@ -1,0 +1,17 @@
+package util
+
+import "testing"
+
+type AliasTB = testing.TB
+
+type TBFunc func(testing.TB)
+
+func AcceptsTB(testing.TB) {}
+
+func AcceptsAlias(AliasTB) {}
+
+func AcceptsT(*testing.T) {}
+
+var FunctionValue TBFunc
+
+func Pure() {}

--- a/hack/tools/hypershiftlinter/analyzers/e2eutiltestingtb/testdata/src/test/e2e/v2/bad/bad_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eutiltestingtb/testdata/src/test/e2e/v2/bad/bad_test.go
@@ -1,0 +1,13 @@
+package bad
+
+import (
+	aliased "github.com/openshift/hypershift/test/e2e/util"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+)
+
+func Bad() {
+	e2eutil.AcceptsTB(nil)    // want `reference to github.com/openshift/hypershift/test/e2e/util.AcceptsTB is forbidden from test/e2e/v2: its function signature accepts testing.TB; port it to a v2 error-returning helper`
+	_ = e2eutil.AcceptsAlias  // want `reference to github.com/openshift/hypershift/test/e2e/util.AcceptsAlias is forbidden from test/e2e/v2: its function signature accepts testing.TB; port it to a v2 error-returning helper`
+	_ = aliased.AcceptsT      // want `reference to github.com/openshift/hypershift/test/e2e/util.AcceptsT is forbidden from test/e2e/v2: its function signature accepts testing.TB; port it to a v2 error-returning helper`
+	_ = e2eutil.FunctionValue // want `reference to github.com/openshift/hypershift/test/e2e/util.FunctionValue is forbidden from test/e2e/v2: its function signature accepts testing.TB; port it to a v2 error-returning helper`
+}

--- a/hack/tools/hypershiftlinter/analyzers/e2eutiltestingtb/testdata/src/test/e2e/v2/good/good_test.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eutiltestingtb/testdata/src/test/e2e/v2/good/good_test.go
@@ -1,0 +1,7 @@
+package good
+
+import e2eutil "github.com/openshift/hypershift/test/e2e/util"
+
+func Good() {
+	e2eutil.Pure()
+}

--- a/hack/tools/hypershiftlinter/plugin.go
+++ b/hack/tools/hypershiftlinter/plugin.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/contextbackground"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist"
+	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/e2eutiltestingtb"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/guestcluster"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/hcpstatuspatch"
 	"github.com/openshift/hypershift/hack/tools/hypershiftlinter/analyzers/ipv6url"
@@ -68,6 +69,7 @@ func allAnalyzers() []*analysis.Analyzer {
 		vacuouspass.Analyzer,
 		ipv6url.Analyzer,
 		e2eutilallowlist.Analyzer,
+		e2eutiltestingtb.Analyzer,
 		// TODO(CNTRLPLANE-3532): add the reflect.DeepEqual rule.
 		// CNTRLPLANE-3532 also asks to warn on reflect.DeepEqual for Kubernetes
 		// API objects (use equality.Semantic.DeepEqual). That is a separate

--- a/test/e2e/v2/internal/test_context.go
+++ b/test/e2e/v2/internal/test_context.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"time"
 
 	"github.com/blang/semver"
 	. "github.com/onsi/ginkgo/v2"
@@ -34,6 +35,7 @@ import (
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -50,6 +52,11 @@ type TestContext struct {
 	ControlPlaneNamespace string
 	ArtifactDir           string
 }
+
+const (
+	hostedClusterKubeConfigPollInterval = 3 * time.Second
+	hostedClusterKubeConfigTimeout      = 10 * time.Minute
+)
 
 // GetHostedCluster fetches the HostedCluster from the management cluster.
 // Returns an error if no cluster name/namespace is configured or if the API
@@ -90,6 +97,77 @@ func (tc *TestContext) GetHostedClusterVersion() (semver.Version, error) {
 	return semver.Version{}, nil
 }
 
+// WaitForHostedClusterKubeConfig waits for the HostedCluster to publish a
+// kubeconfig reference and for the referenced Secret to contain kubeconfig
+// data. The passed HostedCluster is refreshed with the object observed during
+// the wait. It returns an error if the kubeconfig is not published before the
+// test context is canceled or the wait timeout expires.
+func (tc *TestContext) WaitForHostedClusterKubeConfig(hc *hyperv1.HostedCluster) ([]byte, error) {
+	if hc == nil {
+		return nil, fmt.Errorf("cannot wait for kubeconfig for a nil HostedCluster")
+	}
+
+	var kubeconfigSecretKey crclient.ObjectKey
+	var lastErr error
+	err := wait.PollUntilContextTimeout(tc.Context, hostedClusterKubeConfigPollInterval, hostedClusterKubeConfigTimeout, true, func(ctx context.Context) (bool, error) {
+		currentHC := &hyperv1.HostedCluster{}
+		if err := tc.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), currentHC); err != nil {
+			lastErr = fmt.Errorf("failed to get HostedCluster %s/%s: %w", hc.Namespace, hc.Name, err)
+			return false, nil
+		}
+		if currentHC.Status.KubeConfig == nil || currentHC.Status.KubeConfig.Name == "" {
+			lastErr = fmt.Errorf("HostedCluster %s/%s has not published a kubeconfig reference", hc.Namespace, hc.Name)
+			return false, nil
+		}
+		*hc = *currentHC
+		kubeconfigSecretKey = crclient.ObjectKey{Namespace: currentHC.Namespace, Name: currentHC.Status.KubeConfig.Name}
+		return true, nil
+	})
+	if err != nil {
+		if lastErr != nil {
+			return nil, fmt.Errorf("failed to wait for kubeconfig reference for HostedCluster %s/%s: %w (last observed error: %w)", hc.Namespace, hc.Name, err, lastErr)
+		}
+		return nil, fmt.Errorf("failed to wait for kubeconfig reference for HostedCluster %s/%s: %w", hc.Namespace, hc.Name, err)
+	}
+
+	var kubeconfigData []byte
+	lastErr = nil
+	err = wait.PollUntilContextTimeout(tc.Context, hostedClusterKubeConfigPollInterval, hostedClusterKubeConfigTimeout, true, func(ctx context.Context) (bool, error) {
+		kubeconfigSecret := &corev1.Secret{}
+		if err := tc.MgmtClient.Get(ctx, kubeconfigSecretKey, kubeconfigSecret); err != nil {
+			lastErr = fmt.Errorf("failed to get kubeconfig Secret %s/%s: %w", kubeconfigSecretKey.Namespace, kubeconfigSecretKey.Name, err)
+			return false, nil
+		}
+
+		data, ok := kubeconfigSecret.Data["kubeconfig"]
+		if !ok || len(data) == 0 {
+			lastErr = fmt.Errorf("kubeconfig Secret %s/%s does not contain kubeconfig data", kubeconfigSecretKey.Namespace, kubeconfigSecretKey.Name)
+			return false, nil
+		}
+
+		kubeconfigData = append([]byte(nil), data...)
+		return true, nil
+	})
+	if err != nil {
+		if lastErr != nil {
+			return nil, fmt.Errorf("failed to wait for kubeconfig Secret %s/%s: %w (last observed error: %w)", kubeconfigSecretKey.Namespace, kubeconfigSecretKey.Name, err, lastErr)
+		}
+		return nil, fmt.Errorf("failed to wait for kubeconfig Secret %s/%s: %w", kubeconfigSecretKey.Namespace, kubeconfigSecretKey.Name, err)
+	}
+
+	return kubeconfigData, nil
+}
+
+// WaitForHostedClusterRESTConfig waits for the HostedCluster kubeconfig to be
+// published and returns a REST config using the v2 client settings.
+func (tc *TestContext) WaitForHostedClusterRESTConfig(hc *hyperv1.HostedCluster) (*rest.Config, error) {
+	kubeconfigData, err := tc.WaitForHostedClusterKubeConfig(hc)
+	if err != nil {
+		return nil, err
+	}
+	return hostedClusterRESTConfigFromKubeConfig(kubeconfigData)
+}
+
 // GetHostedClusterRESTConfig returns the REST config for the hosted cluster.
 // Returns an error if the kubeconfig secret cannot be fetched or parsed.
 func (tc *TestContext) GetHostedClusterRESTConfig(hc *hyperv1.HostedCluster) (*rest.Config, error) {
@@ -110,6 +188,15 @@ func (tc *TestContext) GetHostedClusterRESTConfig(hc *hyperv1.HostedCluster) (*r
 		return nil, fmt.Errorf("kubeconfig key not found or empty in secret %s/%s", hc.Namespace, hc.Status.KubeConfig.Name)
 	}
 
+	restConfig, err := hostedClusterRESTConfigFromKubeConfig(kubeconfigData)
+	if err != nil {
+		return nil, err
+	}
+
+	return restConfig, nil
+}
+
+func hostedClusterRESTConfigFromKubeConfig(kubeconfigData []byte) (*rest.Config, error) {
 	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create REST config from kubeconfig: %w", err)

--- a/test/e2e/v2/internal/test_context_test.go
+++ b/test/e2e/v2/internal/test_context_test.go
@@ -1,0 +1,138 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hyperapi "github.com/openshift/hypershift/support/api"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestWaitForHostedClusterKubeConfig(t *testing.T) {
+	const kubeconfig = "apiVersion: v1\nkind: Config\n"
+
+	hc := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "clusters", Name: "example"},
+		Status: hyperv1.HostedClusterStatus{
+			KubeConfig: &corev1.LocalObjectReference{Name: "example-kubeconfig"},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: hc.Namespace, Name: hc.Status.KubeConfig.Name},
+		Data:       map[string][]byte{"kubeconfig": []byte(kubeconfig)},
+	}
+	client := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(hc, secret).Build()
+	testCtx := &TestContext{Context: t.Context(), MgmtClient: client}
+
+	got, err := testCtx.WaitForHostedClusterKubeConfig(hc)
+	if err != nil {
+		t.Fatalf("WaitForHostedClusterKubeConfig returned an unexpected error: %v", err)
+	}
+	if string(got) != kubeconfig {
+		t.Fatalf("WaitForHostedClusterKubeConfig returned %q, want %q", got, kubeconfig)
+	}
+}
+
+func TestWaitForHostedClusterKubeConfigRefreshesHostedCluster(t *testing.T) {
+	const kubeconfig = "apiVersion: v1\nkind: Config\n"
+
+	hc := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "clusters", Name: "example"},
+	}
+	storedHC := hc.DeepCopy()
+	storedHC.Status.KubeConfig = &corev1.LocalObjectReference{Name: "example-kubeconfig"}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: storedHC.Namespace, Name: storedHC.Status.KubeConfig.Name},
+		Data:       map[string][]byte{"kubeconfig": []byte(kubeconfig)},
+	}
+	client := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(storedHC, secret).Build()
+	testCtx := &TestContext{Context: t.Context(), MgmtClient: client}
+
+	_, err := testCtx.WaitForHostedClusterKubeConfig(hc)
+	if err != nil {
+		t.Fatalf("WaitForHostedClusterKubeConfig returned an unexpected error: %v", err)
+	}
+	if hc.Status.KubeConfig == nil || hc.Status.KubeConfig.Name != storedHC.Status.KubeConfig.Name {
+		t.Fatalf("WaitForHostedClusterKubeConfig did not refresh HostedCluster status: %#v", hc.Status.KubeConfig)
+	}
+}
+
+func TestWaitForHostedClusterRESTConfigUsesV2ClientSettings(t *testing.T) {
+	const kubeconfig = `apiVersion: v1
+clusters:
+- cluster:
+    server: https://example.com
+  name: example
+contexts:
+- context:
+    cluster: example
+    user: example
+  name: example
+current-context: example
+kind: Config
+users:
+- name: example
+  user: {}
+`
+
+	hc := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "clusters", Name: "example"},
+		Status: hyperv1.HostedClusterStatus{
+			KubeConfig: &corev1.LocalObjectReference{Name: "example-kubeconfig"},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: hc.Namespace, Name: hc.Status.KubeConfig.Name},
+		Data:       map[string][]byte{"kubeconfig": []byte(kubeconfig)},
+	}
+	client := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(hc, secret).Build()
+	testCtx := &TestContext{Context: t.Context(), MgmtClient: client}
+
+	config, err := testCtx.WaitForHostedClusterRESTConfig(hc)
+	if err != nil {
+		t.Fatalf("WaitForHostedClusterRESTConfig returned an unexpected error: %v", err)
+	}
+	if config.QPS != -1 || config.Burst != -1 {
+		t.Fatalf("WaitForHostedClusterRESTConfig settings = QPS %v, Burst %v; want QPS -1, Burst -1", config.QPS, config.Burst)
+	}
+}
+
+func TestWaitForHostedClusterKubeConfigReturnsLastError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+	defer cancel()
+
+	hc := &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Namespace: "clusters", Name: "example"}}
+	client := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(hc).Build()
+	testCtx := &TestContext{Context: ctx, MgmtClient: client}
+
+	_, err := testCtx.WaitForHostedClusterKubeConfig(hc)
+	if err == nil {
+		t.Fatal("WaitForHostedClusterKubeConfig returned nil error")
+	}
+	if !strings.Contains(err.Error(), "has not published a kubeconfig reference") {
+		t.Fatalf("WaitForHostedClusterKubeConfig error = %q, want last observed kubeconfig error", err)
+	}
+}

--- a/test/e2e/v2/tests/control_plane_upgrade_test.go
+++ b/test/e2e/v2/tests/control_plane_upgrade_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
+	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -146,7 +147,7 @@ func ControlPlaneUpgradeTest(getTestCtx internal.TestContextGetter) {
 		}
 
 		By(fmt.Sprintf("Requesting control plane upgrade from version %s to image %s", startingVersion, latestImage))
-		err = e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+		err = v2util.UpdateObject(ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 			obj.Spec.Release.Image = latestImage
 			if obj.Annotations == nil {
 				obj.Annotations = make(map[string]string)

--- a/test/e2e/v2/tests/etcd_chaos_test.go
+++ b/test/e2e/v2/tests/etcd_chaos_test.go
@@ -32,6 +32,7 @@ import (
 	etcdrecoverymanifests "github.com/openshift/hypershift/hypershift-operator/controllers/manifests/etcdrecovery"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
+	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -99,7 +100,7 @@ func EtcdSingleMemberRecoveryTest(getTestCtx internal.TestContextGetter) {
 		wg.Wait()
 
 		// Verify pod is replaced with a new UID
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, "deleted etcd pod is replaced",
+		Expect(v2util.EventuallyObject(ctx, "deleted etcd pod is replaced",
 			func(ctx context.Context) (*corev1.Pod, error) {
 				pod := &corev1.Pod{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(&randomPod), pod)
@@ -108,9 +109,9 @@ func EtcdSingleMemberRecoveryTest(getTestCtx internal.TestContextGetter) {
 			[]e2eutil.Predicate[*corev1.Pod]{func(pod *corev1.Pod) (bool, string, error) {
 				return originalUID != pod.UID, fmt.Sprintf("pod UID %s", pod.UID), nil
 			}},
-			e2eutil.WithInterval(5*time.Second),
-			e2eutil.WithTimeout(30*time.Minute),
-		)
+			v2util.WithInterval(5*time.Second),
+			v2util.WithTimeout(30*time.Minute),
+		)).To(Succeed())
 
 		waitForEtcdConvergence(ctx, testCtx.MgmtClient, cpNamespace, ptr.Deref(etcdSts.Spec.Replicas, 0))
 	})
@@ -214,7 +215,7 @@ func EtcdKillAllMembersTest(getTestCtx internal.TestContextGetter) {
 		wg.Wait()
 
 		// Verify all etcd pods are replaced with new UIDs
-		e2eutil.EventuallyObjects(GinkgoTB(), ctx, "etcd pods to be replaced",
+		Expect(v2util.EventuallyObjects(ctx, "etcd pods to be replaced",
 			func(ctx context.Context) ([]*corev1.Pod, error) {
 				pods := &corev1.PodList{}
 				err := testCtx.MgmtClient.List(ctx, pods, &crclient.ListOptions{
@@ -236,9 +237,9 @@ func EtcdKillAllMembersTest(getTestCtx internal.TestContextGetter) {
 				}
 				return false, "pod not found in previous list", nil
 			}},
-			e2eutil.WithInterval(5*time.Second),
-			e2eutil.WithTimeout(30*time.Minute),
-		)
+			v2util.WithInterval(5*time.Second),
+			v2util.WithTimeout(30*time.Minute),
+		)).To(Succeed())
 
 		waitForEtcdConvergence(ctx, testCtx.MgmtClient, cpNamespace, ptr.Deref(etcdSts.Spec.Replicas, 0))
 
@@ -276,7 +277,7 @@ func EtcdSingleMemberCorruptionTest(getTestCtx internal.TestContextGetter) {
 
 		// Etcd recovery job should be created.
 		// We don't check if the job completed because it will be deleted after completion.
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, "etcd recovery job to be active",
+		Expect(v2util.EventuallyObject(ctx, "etcd recovery job to be active",
 			func(ctx context.Context) (*batchv1.Job, error) {
 				recoveryJob := etcdrecoverymanifests.EtcdRecoveryJob(cpNamespace)
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(recoveryJob), recoveryJob)
@@ -286,9 +287,9 @@ func EtcdSingleMemberCorruptionTest(getTestCtx internal.TestContextGetter) {
 				got := job.Status.Active
 				return got == 1, fmt.Sprintf("wanted status active to be 1, got %d", got), nil
 			}},
-			e2eutil.WithInterval(5*time.Second),
-			e2eutil.WithTimeout(15*time.Minute),
-		)
+			v2util.WithInterval(5*time.Second),
+			v2util.WithTimeout(15*time.Minute),
+		)).To(Succeed())
 
 		waitForEtcdConvergence(ctx, testCtx.MgmtClient, cpNamespace, ptr.Deref(etcdSts.Spec.Replicas, 0))
 	})
@@ -343,7 +344,7 @@ func EtcdMissingMemberRecoveryTest(getTestCtx internal.TestContextGetter) {
 
 		// Etcd recovery job should be created.
 		// We don't check if the job completed because it will be deleted after completion.
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, "etcd recovery job to be active",
+		Expect(v2util.EventuallyObject(ctx, "etcd recovery job to be active",
 			func(ctx context.Context) (*batchv1.Job, error) {
 				recoveryJob := etcdrecoverymanifests.EtcdRecoveryJob(cpNamespace)
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(recoveryJob), recoveryJob)
@@ -353,9 +354,9 @@ func EtcdMissingMemberRecoveryTest(getTestCtx internal.TestContextGetter) {
 				got := job.Status.Active
 				return got == 1, fmt.Sprintf("wanted status active to be 1, got %d", got), nil
 			}},
-			e2eutil.WithInterval(5*time.Second),
-			e2eutil.WithTimeout(15*time.Minute),
-		)
+			v2util.WithInterval(5*time.Second),
+			v2util.WithTimeout(15*time.Minute),
+		)).To(Succeed())
 
 		waitForEtcdConvergence(ctx, testCtx.MgmtClient, cpNamespace, ptr.Deref(etcdSts.Spec.Replicas, 0))
 	})
@@ -383,7 +384,7 @@ func getEtcdStsAndPods(ctx context.Context, client crclient.Client, cpNamespace 
 func waitForEtcdConvergence(ctx context.Context, client crclient.Client, cpNamespace string, expectedReplicas int32) {
 	GinkgoHelper()
 
-	e2eutil.EventuallyObject(GinkgoTB(), ctx, "etcd StatefulSet replicas to converge",
+	Expect(v2util.EventuallyObject(ctx, "etcd StatefulSet replicas to converge",
 		func(ctx context.Context) (*appsv1.StatefulSet, error) {
 			sts := cpomanifests.EtcdStatefulSet(cpNamespace)
 			err := client.Get(ctx, crclient.ObjectKeyFromObject(sts), sts)
@@ -393,9 +394,9 @@ func waitForEtcdConvergence(ctx context.Context, client crclient.Client, cpNames
 			got := sts.Status.ReadyReplicas
 			return expectedReplicas != 0 && expectedReplicas == got, fmt.Sprintf("wanted %d ready replicas, got %d", expectedReplicas, got), nil
 		}},
-		e2eutil.WithInterval(5*time.Second),
-		e2eutil.WithTimeout(30*time.Minute),
-	)
+		v2util.WithInterval(5*time.Second),
+		v2util.WithTimeout(30*time.Minute),
+	)).To(Succeed())
 }
 
 // randomEtcdPods selects count random pods from the provided slice.
@@ -422,12 +423,12 @@ func createMarkerConfigMap(ctx context.Context, client crclient.Client) *corev1.
 		},
 		Data: map[string]string{"value": string(value)},
 	}
-	e2eutil.EventuallyObject(GinkgoTB(), ctx, "create marker ConfigMap",
+	Expect(v2util.EventuallyObject(ctx, "create marker ConfigMap",
 		func(ctx context.Context) (*corev1.ConfigMap, error) {
 			err := client.Create(ctx, cm)
 			return cm, err
 		}, nil,
-	)
+	)).To(Succeed())
 	GinkgoWriter.Printf("Created marker ConfigMap %s/%s\n", cm.Namespace, cm.Name)
 	return cm
 }
@@ -437,7 +438,7 @@ func createMarkerConfigMap(ctx context.Context, client crclient.Client) *corev1.
 func verifyMarkerSurvived(ctx context.Context, client crclient.Client, expected *corev1.ConfigMap) {
 	GinkgoHelper()
 
-	e2eutil.EventuallyObject(GinkgoTB(), ctx, "verify marker data survived disruption",
+	Expect(v2util.EventuallyObject(ctx, "verify marker data survived disruption",
 		func(ctx context.Context) (*corev1.ConfigMap, error) {
 			actual := &corev1.ConfigMap{}
 			err := client.Get(ctx, crclient.ObjectKeyFromObject(expected), actual)
@@ -447,7 +448,7 @@ func verifyMarkerSurvived(ctx context.Context, client crclient.Client, expected 
 			diff := cmp.Diff(expected.Data, configMap.Data)
 			return diff == "", fmt.Sprintf("incorrect data: %v", diff), nil
 		}},
-		e2eutil.WithInterval(5*time.Second),
-		e2eutil.WithTimeout(30*time.Minute),
-	)
+		v2util.WithInterval(5*time.Second),
+		v2util.WithTimeout(30*time.Minute),
+	)).To(Succeed())
 }

--- a/test/e2e/v2/tests/hosted_cluster_aws_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_aws_test.go
@@ -28,6 +28,7 @@ import (
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
+	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -106,7 +107,7 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 
 			originalTags := append([]hyperv1.AWSClusterResourceTag(nil), hc.Spec.Platform.AWS.ResourceTags...)
 
-			err = e2eutil.UpdateObject(GinkgoTB(), tc.Context, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+			err = v2util.UpdateObject(tc.Context, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.Platform.AWS.ResourceTags = append(obj.Spec.Platform.AWS.ResourceTags, hyperv1.AWSClusterResourceTag{
 					Key:   day2TagKey,
 					Value: day2TagValue,
@@ -114,7 +115,7 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to update HostedCluster with day-2 tag")
 			DeferCleanup(func() {
-				err := e2eutil.UpdateObject(GinkgoTB(), tc.Context, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+				err := v2util.UpdateObject(tc.Context, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 					obj.Spec.Platform.AWS.ResourceTags = append([]hyperv1.AWSClusterResourceTag(nil), originalTags...)
 				})
 				if err != nil && !apierrors.IsNotFound(err) {
@@ -359,7 +360,7 @@ func AWSResourceTagOverridePolicyTest(getTestCtx internal.TestContextGetter) {
 			ctx := tc.Context
 
 			originalTags := append([]hyperv1.AWSClusterResourceTag(nil), hc.Spec.Platform.AWS.ResourceTags...)
-			err = e2eutil.UpdateObject(GinkgoTB(), ctx, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+			err = v2util.UpdateObject(ctx, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.Platform.AWS.ResourceTags = append(obj.Spec.Platform.AWS.ResourceTags,
 					hyperv1.AWSClusterResourceTag{
 						Key:            "e2e-tag-deny",
@@ -375,7 +376,7 @@ func AWSResourceTagOverridePolicyTest(getTestCtx internal.TestContextGetter) {
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to update HostedCluster with override policy tags")
 			DeferCleanup(func() {
-				err := e2eutil.UpdateObject(GinkgoTB(), ctx, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+				err := v2util.UpdateObject(ctx, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 					obj.Spec.Platform.AWS.ResourceTags = append([]hyperv1.AWSClusterResourceTag(nil), originalTags...)
 				})
 				if err != nil && !apierrors.IsNotFound(err) {
@@ -402,7 +403,8 @@ func AWSResourceTagOverridePolicyTest(getTestCtx internal.TestContextGetter) {
 				cleanupNodePool(ctx, tc.MgmtClient, np)
 			})
 
-			e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+			_, err = v2util.WaitForReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
+			Expect(err).NotTo(HaveOccurred(), "failed waiting for nodes after NodePool tag update")
 
 			Eventually(func(g Gomega) {
 				fresh := &hyperv1.NodePool{}
@@ -529,7 +531,7 @@ func EnsureDefaultSecurityGroupTagsWithSpacesTest(getTestCtx internal.TestContex
 
 			originalTags := append([]hyperv1.AWSClusterResourceTag(nil), hc.Spec.Platform.AWS.ResourceTags...)
 
-			err = e2eutil.UpdateObject(GinkgoTB(), tc.Context, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+			err = v2util.UpdateObject(tc.Context, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.Platform.AWS.ResourceTags = append(obj.Spec.Platform.AWS.ResourceTags, hyperv1.AWSClusterResourceTag{
 					Key:   day2TagKey,
 					Value: day2TagValue,
@@ -537,7 +539,7 @@ func EnsureDefaultSecurityGroupTagsWithSpacesTest(getTestCtx internal.TestContex
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to update HostedCluster with day-2 tag containing spaces")
 			DeferCleanup(func() {
-				err := e2eutil.UpdateObject(GinkgoTB(), tc.Context, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+				err := v2util.UpdateObject(tc.Context, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 					obj.Spec.Platform.AWS.ResourceTags = append([]hyperv1.AWSClusterResourceTag(nil), originalTags...)
 				})
 				if err != nil && !apierrors.IsNotFound(err) {
@@ -621,7 +623,7 @@ func NodePoolDay2TagsWithSpacesTest(getTestCtx internal.TestContextGetter) {
 			day2TagValue := "e2e np space value"
 
 			originalTags := append([]hyperv1.AWSNodePoolResourceTag(nil), defaultNP.Spec.Platform.AWS.ResourceTags...)
-			err = e2eutil.UpdateObject(GinkgoTB(), ctx, tc.MgmtClient, defaultNP, func(obj *hyperv1.NodePool) {
+			err = v2util.UpdateObject(ctx, tc.MgmtClient, defaultNP, func(obj *hyperv1.NodePool) {
 				obj.Spec.Platform.AWS.ResourceTags = append(obj.Spec.Platform.AWS.ResourceTags, hyperv1.AWSNodePoolResourceTag{
 					Key:   day2TagKey,
 					Value: day2TagValue,
@@ -629,7 +631,7 @@ func NodePoolDay2TagsWithSpacesTest(getTestCtx internal.TestContextGetter) {
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to update NodePool with day-2 tag containing spaces")
 			DeferCleanup(func() {
-				err := e2eutil.UpdateObject(GinkgoTB(), ctx, tc.MgmtClient, defaultNP, func(obj *hyperv1.NodePool) {
+				err := v2util.UpdateObject(ctx, tc.MgmtClient, defaultNP, func(obj *hyperv1.NodePool) {
 					obj.Spec.Platform.AWS.ResourceTags = append([]hyperv1.AWSNodePoolResourceTag(nil), originalTags...)
 				})
 				if err != nil && !apierrors.IsNotFound(err) {

--- a/test/e2e/v2/tests/hosted_cluster_azure_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_azure_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift/hypershift/support/netutil"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
+	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -58,22 +59,22 @@ func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
 			hc, err := testCtx.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			testCtx.SkipIfVersionBelow(e2eutil.Version420)
-			e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
+			_, err = testCtx.WaitForHostedClusterKubeConfig(hc)
+			Expect(err).NotTo(HaveOccurred())
 			hostedClusterClient, err := testCtx.GetHostedClusterClient(hc)
 			Expect(err).NotTo(HaveOccurred())
 
-			e2eutil.ValidateAzureWorkloadIdentityWebhookMutation(GinkgoTB(), testCtx.Context, hostedClusterClient)
+			Expect(v2util.ValidateAzureWorkloadIdentityWebhookMutation(testCtx.Context, hostedClusterClient)).To(Succeed())
 		})
 
 		It("should have expected KAS allowed CIDRs", func() {
 			testCtx := getTestCtx()
 			hc, err := testCtx.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
-			kubeconfigData := e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
-			restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
+			restConfig, err := testCtx.WaitForHostedClusterRESTConfig(hc)
 			Expect(err).NotTo(HaveOccurred(), "failed to create hosted cluster REST config")
 
-			e2eutil.ValidateKubeAPIServerAllowedCIDRs(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, restConfig, hc)
+			Expect(v2util.ValidateKubeAPIServerAllowedCIDRs(testCtx.Context, testCtx.MgmtClient, restConfig, hc)).To(Succeed())
 		})
 
 		It("should have Ingress Operator configuration applied", func() {
@@ -81,11 +82,12 @@ func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
 			hc, err := testCtx.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			testCtx.SkipIfVersionBelow(e2eutil.Version421)
-			e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
+			_, err = testCtx.WaitForHostedClusterKubeConfig(hc)
+			Expect(err).NotTo(HaveOccurred())
 			hostedClusterClient, err := testCtx.GetHostedClusterClient(hc)
 			Expect(err).NotTo(HaveOccurred())
 
-			e2eutil.ValidateIngressOperatorConfiguration(GinkgoTB(), testCtx.Context, hostedClusterClient, hc)
+			Expect(v2util.ValidateIngressOperatorConfiguration(testCtx.Context, hostedClusterClient, hc)).To(Succeed())
 		})
 	})
 }
@@ -113,7 +115,7 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 
 		It("should have Azure internal LB annotation on private-router Service", func() {
 			ctx := testCtx.Context
-			e2eutil.EventuallyObject(GinkgoTB(), ctx, "private-router Service has Azure internal LB annotation",
+			Expect(v2util.EventuallyObject(ctx, "private-router Service has Azure internal LB annotation",
 				func(ctx context.Context) (*corev1.Service, error) {
 					svc := &corev1.Service{
 						ObjectMeta: metav1.ObjectMeta{
@@ -134,13 +136,13 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 						return true, "private-router Service has internal LB annotation", nil
 					},
 				},
-				e2eutil.WithTimeout(10*time.Minute),
-			)
+				v2util.WithTimeout(10*time.Minute),
+			)).To(Succeed())
 		})
 
 		It("should create AzurePrivateLinkService CR with PLS alias", func() {
 			ctx := testCtx.Context
-			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "AzurePrivateLinkService CR is created with PLS alias",
+			Expect(v2util.EventuallyObjects(ctx, "AzurePrivateLinkService CR is created with PLS alias",
 				func(ctx context.Context) ([]*hyperv1.AzurePrivateLinkService, error) {
 					return listPLS(ctx, testCtx.MgmtClient, controlPlaneNamespace)
 				},
@@ -158,14 +160,14 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 					},
 				},
 				nil,
-				e2eutil.WithTimeout(15*time.Minute),
-				e2eutil.WithInterval(15*time.Second),
-			)
+				v2util.WithTimeout(15*time.Minute),
+				v2util.WithInterval(15*time.Second),
+			)).To(Succeed())
 		})
 
 		It("should populate Private Endpoint IP in PLS status", func() {
 			ctx := testCtx.Context
-			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "AzurePrivateLinkService has Private Endpoint IP",
+			Expect(v2util.EventuallyObjects(ctx, "AzurePrivateLinkService has Private Endpoint IP",
 				func(ctx context.Context) ([]*hyperv1.AzurePrivateLinkService, error) {
 					return listPLS(ctx, testCtx.MgmtClient, controlPlaneNamespace)
 				},
@@ -183,14 +185,14 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 					},
 				},
 				nil,
-				e2eutil.WithTimeout(15*time.Minute),
-				e2eutil.WithInterval(15*time.Second),
-			)
+				v2util.WithTimeout(15*time.Minute),
+				v2util.WithInterval(15*time.Second),
+			)).To(Succeed())
 		})
 
 		It("should populate Private DNS Zone ID in PLS status", func() {
 			ctx := testCtx.Context
-			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "AzurePrivateLinkService has Private DNS Zone ID",
+			Expect(v2util.EventuallyObjects(ctx, "AzurePrivateLinkService has Private DNS Zone ID",
 				func(ctx context.Context) ([]*hyperv1.AzurePrivateLinkService, error) {
 					return listPLS(ctx, testCtx.MgmtClient, controlPlaneNamespace)
 				},
@@ -208,9 +210,9 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 					},
 				},
 				nil,
-				e2eutil.WithTimeout(15*time.Minute),
-				e2eutil.WithInterval(15*time.Second),
-			)
+				v2util.WithTimeout(15*time.Minute),
+				v2util.WithInterval(15*time.Second),
+			)).To(Succeed())
 		})
 	})
 }
@@ -241,7 +243,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 					GinkgoTB().Logf("WARNING: failed to fetch HostedCluster for cleanup: %v", err)
 					return
 				}
-				restoreErr := e2eutil.UpdateObject(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, freshHC, func(obj *hyperv1.HostedCluster) {
+				restoreErr := v2util.UpdateObject(testCtx.Context, testCtx.MgmtClient, freshHC, func(obj *hyperv1.HostedCluster) {
 					obj.Spec.Platform.Azure.Topology = hyperv1.AzureTopologyPrivate
 				})
 				if restoreErr != nil {
@@ -256,7 +258,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify ExternalPrivateService resources exist in Private topology before transition.
-			e2eutil.EventuallyObject(GinkgoTB(), ctx, "KAS ExternalPrivateService exists in Private topology",
+			Expect(v2util.EventuallyObject(ctx, "KAS ExternalPrivateService exists in Private topology",
 				func(ctx context.Context) (*corev1.Service, error) {
 					svc := hcpmanifests.KubeAPIServerExternalPrivateService(controlPlaneNamespace)
 					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
@@ -265,10 +267,10 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 				[]e2eutil.Predicate[*corev1.Service]{
 					serviceTypePredicate(corev1.ServiceTypeExternalName),
 				},
-				e2eutil.WithTimeout(2*time.Minute),
-			)
+				v2util.WithTimeout(2*time.Minute),
+			)).To(Succeed())
 
-			e2eutil.EventuallyObject(GinkgoTB(), ctx, "OAuth ExternalPrivateService exists in Private topology",
+			Expect(v2util.EventuallyObject(ctx, "OAuth ExternalPrivateService exists in Private topology",
 				func(ctx context.Context) (*corev1.Service, error) {
 					svc := hcpmanifests.OauthServerExternalPrivateService(controlPlaneNamespace)
 					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
@@ -277,15 +279,15 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 				[]e2eutil.Predicate[*corev1.Service]{
 					serviceTypePredicate(corev1.ServiceTypeExternalName),
 				},
-				e2eutil.WithTimeout(2*time.Minute),
-			)
+				v2util.WithTimeout(2*time.Minute),
+			)).To(Succeed())
 
-			err = e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+			err = v2util.UpdateObject(ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.Platform.Azure.Topology = hyperv1.AzureTopologyPublicAndPrivate
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to update topology to PublicAndPrivate")
 
-			e2eutil.EventuallyObject(GinkgoTB(), ctx, "KAS external public route exists after transition to PublicAndPrivate",
+			Expect(v2util.EventuallyObject(ctx, "KAS external public route exists after transition to PublicAndPrivate",
 				func(ctx context.Context) (*routev1.Route, error) {
 					route := hcpmanifests.KubeAPIServerExternalPublicRoute(controlPlaneNamespace)
 					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(route), route)
@@ -294,8 +296,8 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 				[]e2eutil.Predicate[*routev1.Route]{
 					routeHasHostPredicate(),
 				},
-				e2eutil.WithTimeout(10*time.Minute),
-			)
+				v2util.WithTimeout(10*time.Minute),
+			)).To(Succeed())
 
 			Eventually(func() error {
 				route := hcpmanifests.KubeAPIServerExternalPrivateRoute(controlPlaneNamespace)
@@ -303,7 +305,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"KAS external private route should be deleted after transition to PublicAndPrivate")
 
-			e2eutil.EventuallyObject(GinkgoTB(), ctx, "OAuth external public route exists after transition to PublicAndPrivate",
+			Expect(v2util.EventuallyObject(ctx, "OAuth external public route exists after transition to PublicAndPrivate",
 				func(ctx context.Context) (*routev1.Route, error) {
 					route := hcpmanifests.OauthServerExternalPublicRoute(controlPlaneNamespace)
 					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(route), route)
@@ -312,8 +314,8 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 				[]e2eutil.Predicate[*routev1.Route]{
 					routeHasHostPredicate(),
 				},
-				e2eutil.WithTimeout(10*time.Minute),
-			)
+				v2util.WithTimeout(10*time.Minute),
+			)).To(Succeed())
 
 			Eventually(func() error {
 				route := hcpmanifests.OauthServerExternalPrivateRoute(controlPlaneNamespace)
@@ -321,7 +323,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"OAuth external private route should be deleted after transition to PublicAndPrivate")
 
-			e2eutil.EventuallyObject(GinkgoTB(), ctx, "router-public Service is LoadBalancer after transition to PublicAndPrivate",
+			Expect(v2util.EventuallyObject(ctx, "router-public Service is LoadBalancer after transition to PublicAndPrivate",
 				func(ctx context.Context) (*corev1.Service, error) {
 					svc := hcpmanifests.RouterPublicService(controlPlaneNamespace)
 					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
@@ -330,10 +332,10 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 				[]e2eutil.Predicate[*corev1.Service]{
 					serviceTypePredicate(corev1.ServiceTypeLoadBalancer),
 				},
-				e2eutil.WithTimeout(10*time.Minute),
-			)
+				v2util.WithTimeout(10*time.Minute),
+			)).To(Succeed())
 
-			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "PLS CRs still exist after transition to PublicAndPrivate",
+			Expect(v2util.EventuallyObjects(ctx, "PLS CRs still exist after transition to PublicAndPrivate",
 				func(ctx context.Context) ([]*hyperv1.AzurePrivateLinkService, error) {
 					return listPLS(ctx, testCtx.MgmtClient, controlPlaneNamespace)
 				},
@@ -341,8 +343,8 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 					plsExistsPredicate(),
 				},
 				nil,
-				e2eutil.WithTimeout(2*time.Minute),
-			)
+				v2util.WithTimeout(2*time.Minute),
+			)).To(Succeed())
 
 			Eventually(func() error {
 				svc := hcpmanifests.KubeAPIServerExternalPrivateService(controlPlaneNamespace)
@@ -364,12 +366,12 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			hc, err := testCtx.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 
-			err = e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+			err = v2util.UpdateObject(ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.Platform.Azure.Topology = hyperv1.AzureTopologyPrivate
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to update topology to Private")
 
-			e2eutil.EventuallyObject(GinkgoTB(), ctx, "KAS external private route exists after restore to Private",
+			Expect(v2util.EventuallyObject(ctx, "KAS external private route exists after restore to Private",
 				func(ctx context.Context) (*routev1.Route, error) {
 					route := hcpmanifests.KubeAPIServerExternalPrivateRoute(controlPlaneNamespace)
 					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(route), route)
@@ -378,8 +380,8 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 				[]e2eutil.Predicate[*routev1.Route]{
 					routeHasHostPredicate(),
 				},
-				e2eutil.WithTimeout(10*time.Minute),
-			)
+				v2util.WithTimeout(10*time.Minute),
+			)).To(Succeed())
 
 			Eventually(func() error {
 				route := hcpmanifests.KubeAPIServerExternalPublicRoute(controlPlaneNamespace)
@@ -387,7 +389,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"KAS external public route should be deleted after restore to Private")
 
-			e2eutil.EventuallyObject(GinkgoTB(), ctx, "OAuth external private route exists after restore to Private",
+			Expect(v2util.EventuallyObject(ctx, "OAuth external private route exists after restore to Private",
 				func(ctx context.Context) (*routev1.Route, error) {
 					route := hcpmanifests.OauthServerExternalPrivateRoute(controlPlaneNamespace)
 					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(route), route)
@@ -396,8 +398,8 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 				[]e2eutil.Predicate[*routev1.Route]{
 					routeHasHostPredicate(),
 				},
-				e2eutil.WithTimeout(10*time.Minute),
-			)
+				v2util.WithTimeout(10*time.Minute),
+			)).To(Succeed())
 
 			Eventually(func() error {
 				route := hcpmanifests.OauthServerExternalPublicRoute(controlPlaneNamespace)
@@ -411,7 +413,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"router-public Service should be deleted after restore to Private")
 
-			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "PLS CRs still exist after restore to Private",
+			Expect(v2util.EventuallyObjects(ctx, "PLS CRs still exist after restore to Private",
 				func(ctx context.Context) ([]*hyperv1.AzurePrivateLinkService, error) {
 					return listPLS(ctx, testCtx.MgmtClient, controlPlaneNamespace)
 				},
@@ -419,10 +421,10 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 					plsExistsPredicate(),
 				},
 				nil,
-				e2eutil.WithTimeout(2*time.Minute),
-			)
+				v2util.WithTimeout(2*time.Minute),
+			)).To(Succeed())
 
-			e2eutil.EventuallyObject(GinkgoTB(), ctx, "KAS ExternalPrivateService recreated after restore to Private",
+			Expect(v2util.EventuallyObject(ctx, "KAS ExternalPrivateService recreated after restore to Private",
 				func(ctx context.Context) (*corev1.Service, error) {
 					svc := hcpmanifests.KubeAPIServerExternalPrivateService(controlPlaneNamespace)
 					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
@@ -431,10 +433,10 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 				[]e2eutil.Predicate[*corev1.Service]{
 					serviceTypePredicate(corev1.ServiceTypeExternalName),
 				},
-				e2eutil.WithTimeout(10*time.Minute),
-			)
+				v2util.WithTimeout(10*time.Minute),
+			)).To(Succeed())
 
-			e2eutil.EventuallyObject(GinkgoTB(), ctx, "OAuth ExternalPrivateService recreated after restore to Private",
+			Expect(v2util.EventuallyObject(ctx, "OAuth ExternalPrivateService recreated after restore to Private",
 				func(ctx context.Context) (*corev1.Service, error) {
 					svc := hcpmanifests.OauthServerExternalPrivateService(controlPlaneNamespace)
 					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
@@ -443,8 +445,8 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 				[]e2eutil.Predicate[*corev1.Service]{
 					serviceTypePredicate(corev1.ServiceTypeExternalName),
 				},
-				e2eutil.WithTimeout(10*time.Minute),
-			)
+				v2util.WithTimeout(10*time.Minute),
+			)).To(Succeed())
 		})
 
 		It("should remain available after restoring Private topology", func() {
@@ -452,7 +454,7 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 			// management cluster cannot resolve the KAS hostname. Validate health
 			// via HostedCluster conditions instead of direct API connectivity,
 			// matching the pattern from ValidatePrivateCluster in the v1 framework.
-			e2eutil.EventuallyObject(GinkgoTB(), testCtx.Context, "HostedCluster is Available and not Degraded after restore to Private",
+			Expect(v2util.EventuallyObject(testCtx.Context, "HostedCluster is Available and not Degraded after restore to Private",
 				func(ctx context.Context) (*hyperv1.HostedCluster, error) {
 					freshHC := &hyperv1.HostedCluster{}
 					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKey{
@@ -487,8 +489,8 @@ func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
 						return true, "HostedCluster Degraded condition not found (not degraded)", nil
 					},
 				},
-				e2eutil.WithTimeout(15*time.Minute),
-			)
+				v2util.WithTimeout(15*time.Minute),
+			)).To(Succeed())
 		})
 	})
 }
@@ -648,7 +650,7 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 			ctx := testCtx.Context
 			controlPlaneNamespace := testCtx.ControlPlaneNamespace
 
-			e2eutil.EventuallyObject(GinkgoTB(), ctx, "oauth-openshift Service is LoadBalancer with external IP",
+			Expect(v2util.EventuallyObject(ctx, "oauth-openshift Service is LoadBalancer with external IP",
 				func(ctx context.Context) (*corev1.Service, error) {
 					svc := hcpmanifests.OauthServerService(controlPlaneNamespace)
 					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
@@ -676,8 +678,8 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 						return true, fmt.Sprintf("oauth-openshift LoadBalancer has external endpoint: %s", host), nil
 					},
 				},
-				e2eutil.WithTimeout(10*time.Minute),
-			)
+				v2util.WithTimeout(10*time.Minute),
+			)).To(Succeed())
 		})
 
 		It("should complete OAuth token flow through LoadBalancer endpoint", func() {
@@ -685,7 +687,9 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 			hc, err := testCtx.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 
-			e2eutil.ValidateOAuthWithIdentityProviderViaLoadBalancer(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
+			restConfig, err := testCtx.WaitForHostedClusterRESTConfig(hc)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v2util.ValidateOAuthWithIdentityProviderViaLoadBalancer(testCtx.Context, testCtx.MgmtClient, hc, restConfig)).To(Succeed())
 		})
 	})
 }

--- a/test/e2e/v2/tests/hosted_cluster_ccm_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ccm_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
@@ -45,7 +44,8 @@ func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
 				testCtx := getTestCtx()
 				hc, err := testCtx.GetHostedCluster()
 				Expect(err).NotTo(HaveOccurred())
-				e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
+				_, err = testCtx.WaitForHostedClusterKubeConfig(hc)
+				Expect(err).NotTo(HaveOccurred())
 				hostedClusterClient, err := testCtx.GetHostedClusterClient(hc)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openshift/hypershift/support/netutil"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
+	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -113,7 +114,8 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 				"failed to update additional-pull-secret with valid data")
 
 			By("waiting for nodes to stabilize after pull secret update")
-			e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), tc.Context, hcClient, np, hc.Spec.Platform.Type)
+			_, err = v2util.WaitForReadyNodesByNodePool(tc.Context, hcClient, np, hc.Spec.Platform.Type)
+			Expect(err).NotTo(HaveOccurred(), "failed waiting for nodes after pull secret update")
 
 			By("verifying GlobalPullSecret is updated in the hosted cluster")
 			Eventually(func(g Gomega) {
@@ -149,7 +151,8 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 			}, 30*time.Second, 5*time.Second).Should(Succeed())
 
 			By("waiting for nodes to stabilize after pull secret deletion")
-			e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), tc.Context, hcClient, np, hc.Spec.Platform.Type)
+			_, err = v2util.WaitForReadyNodesByNodePool(tc.Context, hcClient, np, hc.Spec.Platform.Type)
+			Expect(err).NotTo(HaveOccurred(), "failed waiting for nodes after pull secret deletion")
 
 			By("verifying global-pull-secret-syncer DaemonSet is ready after cleanup")
 			Eventually(func(g Gomega) {

--- a/test/e2e/v2/tests/karpenter_control_plane_upgrade_test.go
+++ b/test/e2e/v2/tests/karpenter_control_plane_upgrade_test.go
@@ -16,6 +16,7 @@ import (
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
+	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -67,7 +68,6 @@ func KarpenterUpgradeTest(getTestCtx internal.TestContextGetter) {
 		It("should upgrade the control plane and drift Karpenter nodes to the new version", func() {
 			tc := getTestCtx()
 			ctx := tc.Context
-			t := GinkgoTB()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hc)
@@ -99,7 +99,8 @@ func KarpenterUpgradeTest(getTestCtx internal.TestContextGetter) {
 						Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete NodePool %s", karpenterNodePool.Name)
 					}
 				}
-				_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 0, nodeLabels)
+				_, err := v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 0, nodeLabels)
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed waiting for Karpenter nodes to terminate")
 			})
 			GinkgoWriter.Println("Created Karpenter NodePool")
 
@@ -112,7 +113,8 @@ func KarpenterUpgradeTest(getTestCtx internal.TestContextGetter) {
 			GinkgoWriter.Println("Created workloads")
 
 			By("Waiting for Karpenter nodes and pods to be ready")
-			nodes := e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, int32(replicas), nodeLabels)
+			nodes, err := v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, int32(replicas), nodeLabels)
+			Expect(err).NotTo(HaveOccurred())
 			nodeClaims := waitForReadyNodeClaims(ctx, hcClient, len(nodes))
 			waitForReadyKarpenterPods(ctx, hcClient, nodes, replicas, map[string]string{"app": "web-app"})
 
@@ -120,7 +122,7 @@ func KarpenterUpgradeTest(getTestCtx internal.TestContextGetter) {
 			GinkgoWriter.Printf("Pre-upgrade node: %s, OS image: %s\n", nodes[0].Name, preUpgradeOSImage)
 
 			By(fmt.Sprintf("Updating cluster release image to %s", latestImage))
-			err = e2eutil.UpdateObject(t, ctx, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+			err = v2util.UpdateObject(ctx, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.Release.Image = latestImage
 				if obj.Annotations == nil {
 					obj.Annotations = make(map[string]string)
@@ -165,11 +167,11 @@ func KarpenterUpgradeTest(getTestCtx internal.TestContextGetter) {
 			GinkgoWriter.Printf("Pre-upgrade RHCOS version: %s\n", preUpgradeRHCOSVersion)
 
 			By("Waiting for replacement nodes with updated RHCOS version")
-			nodes = e2eutil.WaitForNReadyNodesWithOptions(t, ctx, hcClient, int32(replicas), hyperv1.AWSPlatform, "",
-				e2eutil.WithClientOptions(
+			nodes, err = v2util.WaitForNReadyNodesWithOptions(ctx, hcClient, int32(replicas), hyperv1.AWSPlatform, "",
+				v2util.WithClientOptions(
 					crclient.MatchingLabelsSelector{Selector: labels.SelectorFromSet(labels.Set(nodeLabels))},
 				),
-				e2eutil.WithPredicates(
+				v2util.WithPredicates(
 					e2eutil.ConditionPredicate[*corev1.Node](e2eutil.Condition{
 						Type:   string(corev1.NodeReady),
 						Status: metav1.ConditionTrue,
@@ -186,6 +188,7 @@ func KarpenterUpgradeTest(getTestCtx internal.TestContextGetter) {
 					},
 				),
 			)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for Karpenter pods to schedule on the new nodes")
 			waitForReadyKarpenterPods(ctx, hcClient, nodes, replicas, map[string]string{"app": "web-app"})
@@ -234,9 +237,10 @@ func extractRHCOSVersion(osImage string) string {
 // waitForReadyNodeClaims polls until exactly n NodeClaims are present and all
 // have Launched, Registered, and Initialized conditions set to True.
 func waitForReadyNodeClaims(ctx context.Context, client crclient.Client, n int) *karpenterv1.NodeClaimList {
-	t := GinkgoTB()
+	GinkgoHelper()
+
 	nodeClaims := &karpenterv1.NodeClaimList{}
-	e2eutil.EventuallyObjects(t, ctx, "NodeClaims to be ready",
+	Expect(v2util.EventuallyObjects(ctx, "NodeClaims to be ready",
 		func(ctx context.Context) ([]*karpenterv1.NodeClaim, error) {
 			err := client.List(ctx, nodeClaims)
 			if err != nil {
@@ -279,8 +283,8 @@ func waitForReadyNodeClaims(ctx context.Context, client crclient.Client, n int) 
 				return true, "", nil
 			},
 		},
-		e2eutil.WithTimeout(5*time.Minute),
-	)
+		v2util.WithTimeout(5*time.Minute),
+	)).To(Succeed())
 
 	return nodeClaims
 }

--- a/test/e2e/v2/tests/karpenter_test.go
+++ b/test/e2e/v2/tests/karpenter_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/hypershift/support/supportedversion"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
+	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
 	dto "github.com/prometheus/client_model/go"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -125,7 +126,6 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 		It("should expose Karpenter metrics", func() {
 			tc := getTestCtx()
 			ctx := tc.Context
-			t := GinkgoTB()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -154,7 +154,8 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 					maps.Copy(combined, komf)
 				}
 				for _, metricName := range karpenterMetrics {
-					if !e2eutil.ValidateMetricPresence(t, combined, metricName, "", "", metricName, true) {
+					if err := v2util.ValidateMetricPresence(combined, metricName, "", "", metricName, true); err != nil {
+						GinkgoWriter.Printf("metric validation pending: %v", err)
 						return false, nil
 					}
 				}
@@ -175,7 +176,6 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 		It("should have Karpenter CRDs installed in the hosted cluster", func() {
 			tc := getTestCtx()
 			ctx := tc.Context
-			t := GinkgoTB()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hc)
@@ -188,22 +188,21 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 				"nodeclaims.karpenter.sh",
 			}
 			for _, crdName := range expectedCRDs {
-				e2eutil.EventuallyObject(t, ctx, fmt.Sprintf("CRD %s to exist in the hosted cluster", crdName),
+				Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("CRD %s to exist in the hosted cluster", crdName),
 					func(ctx context.Context) (*apiextensionsv1.CustomResourceDefinition, error) {
 						crd := &apiextensionsv1.CustomResourceDefinition{}
 						err := hcClient.Get(ctx, crclient.ObjectKey{Name: crdName}, crd)
 						return crd, err
 					},
 					nil,
-					e2eutil.WithTimeout(2*time.Minute),
-				)
+					v2util.WithTimeout(2*time.Minute),
+				)).To(Succeed())
 			}
 		})
 
 		It("should have default OpenshiftEC2NodeClass with correct subnet and security group selectors", func() {
 			tc := getTestCtx()
 			ctx := tc.Context
-			t := GinkgoTB()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hc)
@@ -211,7 +210,7 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 
 			GinkgoWriter.Println("Validating default OpenshiftEC2NodeClass exists with expected values")
 			infraID := hc.Spec.InfraID
-			e2eutil.EventuallyObject(t, ctx, "default OpenshiftEC2NodeClass to have expected spec",
+			Expect(v2util.EventuallyObject(ctx, "default OpenshiftEC2NodeClass to have expected spec",
 				func(ctx context.Context) (*hyperkarpenterv1.OpenshiftEC2NodeClass, error) {
 					nc := &hyperkarpenterv1.OpenshiftEC2NodeClass{}
 					err := hcClient.Get(ctx, crclient.ObjectKey{Name: karpenterassets.EC2NodeClassDefault}, nc)
@@ -242,14 +241,13 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 						return true, "default OpenshiftEC2NodeClass has expected fields set", nil
 					},
 				},
-				e2eutil.WithTimeout(1*time.Minute),
-			)
+				v2util.WithTimeout(1*time.Minute),
+			)).To(Succeed())
 		})
 
 		It("should have default EC2NodeClass with immutable service-owned fields", func() {
 			tc := getTestCtx()
 			ctx := tc.Context
-			t := GinkgoTB()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hc)
@@ -259,7 +257,7 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 			Expect(expectedTags).NotTo(BeEmpty(), "HostedCluster has no non-restricted resource tags; cluster setup must include at least one propagatable tag for this test to be meaningful")
 
 			GinkgoWriter.Println("Validating corresponding default EC2NodeClass has immutable service-owned fields set")
-			e2eutil.EventuallyObject(t, ctx, "EC2NodeClass to have service-owned fields populated",
+			Expect(v2util.EventuallyObject(ctx, "EC2NodeClass to have service-owned fields populated",
 				func(ctx context.Context) (*awskarpenterv1.EC2NodeClass, error) {
 					nc := &awskarpenterv1.EC2NodeClass{}
 					err := hcClient.Get(ctx, crclient.ObjectKey{Name: karpenterassets.EC2NodeClassDefault}, nc)
@@ -284,8 +282,8 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 						return true, "default EC2NodeClass has expected fields set", nil
 					},
 				},
-				e2eutil.WithTimeout(1*time.Minute),
-			)
+				v2util.WithTimeout(1*time.Minute),
+			)).To(Succeed())
 		})
 
 		It("should block direct deletion of EC2NodeClass", func() {
@@ -317,11 +315,10 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 		It("should have AutoNodeEnabled condition set to True", func() {
 			tc := getTestCtx()
 			ctx := tc.Context
-			t := GinkgoTB()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 
-			e2eutil.EventuallyObject(t, ctx, fmt.Sprintf("HostedCluster %s/%s to have AutoNodeEnabled condition", hc.Namespace, hc.Name),
+			Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("HostedCluster %s/%s to have AutoNodeEnabled condition", hc.Namespace, hc.Name),
 				func(ctx context.Context) (*hyperv1.HostedCluster, error) {
 					obj := &hyperv1.HostedCluster{}
 					err := tc.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), obj)
@@ -334,8 +331,8 @@ func KarpenterPlumbingTests(getTestCtx internal.TestContextGetter) {
 						Reason: hyperv1.AsExpectedReason,
 					}),
 				},
-				e2eutil.WithTimeout(2*time.Minute),
-			)
+				v2util.WithTimeout(2*time.Minute),
+			)).To(Succeed())
 		})
 	})
 }
@@ -358,7 +355,6 @@ func KarpenterARM64ProvisioningTest(getTestCtx internal.TestContextGetter) {
 		It("should provision and deprovision ARM64 nodes", func() {
 			tc := getTestCtx()
 			ctx := tc.Context
-			t := GinkgoTB()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hc)
@@ -406,7 +402,8 @@ func KarpenterARM64ProvisioningTest(getTestCtx internal.TestContextGetter) {
 					}
 					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete NodePool %s", armNodePool.Name)
 				}
-				_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 0, armNodeLabels)
+				_, err := v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 0, armNodeLabels)
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed waiting for ARM64 Karpenter nodes to terminate")
 			})
 
 			Expect(hcClient.Create(ctx, armWorkLoads)).To(Succeed())
@@ -417,7 +414,8 @@ func KarpenterARM64ProvisioningTest(getTestCtx internal.TestContextGetter) {
 			})
 			GinkgoWriter.Println("Created ARM64 workloads")
 
-			nodes := e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 1, armNodeLabels)
+			nodes, err := v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 1, armNodeLabels)
+			Expect(err).NotTo(HaveOccurred())
 			waitForReadyKarpenterPods(ctx, hcClient, nodes, 1, map[string]string{"app": "arm-app"})
 		})
 	})
@@ -438,7 +436,6 @@ func KarpenterInstanceProfileTest(getTestCtx internal.TestContextGetter) {
 		It("should propagate instance profile annotation to EC2NodeClass and EC2 instances", func() {
 			tc := getTestCtx()
 			ctx := tc.Context
-			t := GinkgoTB()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hc)
@@ -449,7 +446,7 @@ func KarpenterInstanceProfileTest(getTestCtx internal.TestContextGetter) {
 			workerInstanceProfile := hc.Spec.InfraID + "-worker"
 
 			var origInstanceProfile string
-			err = e2eutil.UpdateObject(t, ctx, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+			err = v2util.UpdateObject(ctx, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 				if obj.Annotations == nil {
 					obj.Annotations = make(map[string]string)
 				}
@@ -466,7 +463,7 @@ func KarpenterInstanceProfileTest(getTestCtx internal.TestContextGetter) {
 				current := &hyperv1.HostedCluster{}
 				Expect(tc.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), current)).To(Succeed(),
 					"cleanup: failed to get HostedCluster %s/%s", hc.Namespace, hc.Name)
-				Expect(e2eutil.UpdateObject(t, ctx, tc.MgmtClient, current, func(obj *hyperv1.HostedCluster) {
+				Expect(v2util.UpdateObject(ctx, tc.MgmtClient, current, func(obj *hyperv1.HostedCluster) {
 					if len(origInstanceProfile) > 0 {
 						if obj.Annotations == nil {
 							obj.Annotations = make(map[string]string)
@@ -519,10 +516,12 @@ func KarpenterInstanceProfileTest(getTestCtx internal.TestContextGetter) {
 					}
 					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete NodePool %s", testNodePool.Name)
 				}
-				_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 0, testNodeLabels)
+				_, err := v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 0, testNodeLabels)
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed waiting for instance-profile Karpenter nodes to terminate")
 			})
 
-			nodes := e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 1, testNodeLabels)
+			nodes, err := v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 1, testNodeLabels)
+			Expect(err).NotTo(HaveOccurred())
 
 			// Verify EC2 instances have the correct instance profile
 			ec2client := newEC2Client(awsCredsFile, awsRegion)
@@ -561,7 +560,6 @@ func KarpenterNodeClassVersionTest(getTestCtx internal.TestContextGetter) {
 		It("should resolve version, propagate MetadataOptions, and provision node with correct kubelet version", func() {
 			tc := getTestCtx()
 			ctx := tc.Context
-			t := GinkgoTB()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hc)
@@ -579,7 +577,7 @@ func KarpenterNodeClassVersionTest(getTestCtx internal.TestContextGetter) {
 
 			// Verify default OpenshiftEC2NodeClass uses control plane release image
 			GinkgoWriter.Printf("Verifying default OpenshiftEC2NodeClass uses control plane release image")
-			e2eutil.EventuallyObject(t, ctx, "default OpenshiftEC2NodeClass to have VersionResolved=True",
+			Expect(v2util.EventuallyObject(ctx, "default OpenshiftEC2NodeClass to have VersionResolved=True",
 				func(ctx context.Context) (*hyperkarpenterv1.OpenshiftEC2NodeClass, error) {
 					nc := &hyperkarpenterv1.OpenshiftEC2NodeClass{}
 					err := hcClient.Get(ctx, crclient.ObjectKey{Name: "default"}, nc)
@@ -606,8 +604,8 @@ func KarpenterNodeClassVersionTest(getTestCtx internal.TestContextGetter) {
 						return true, fmt.Sprintf("status.releaseImage matches control plane: %s", nc.Status.ReleaseImage), nil
 					},
 				},
-				e2eutil.WithTimeout(2*time.Minute),
-			)
+				v2util.WithTimeout(2*time.Minute),
+			)).To(Succeed())
 
 			// Use a previous minor version (n-2) to test a genuinely different version.
 			prevMajor, prevMinor, err := supportedversion.PreviousMinorVersion(cpVersion, 2)
@@ -644,7 +642,7 @@ func KarpenterNodeClassVersionTest(getTestCtx internal.TestContextGetter) {
 			// Wait for version resolution and get the resolved release image
 			var resolvedReleaseImage string
 			GinkgoWriter.Printf("Waiting for OpenshiftEC2NodeClass version resolution")
-			e2eutil.EventuallyObject(t, ctx, "OpenshiftEC2NodeClass version-test to resolve version",
+			Expect(v2util.EventuallyObject(ctx, "OpenshiftEC2NodeClass version-test to resolve version",
 				func(ctx context.Context) (*hyperkarpenterv1.OpenshiftEC2NodeClass, error) {
 					result := &hyperkarpenterv1.OpenshiftEC2NodeClass{}
 					err := hcClient.Get(ctx, crclient.ObjectKey{Name: nc.Name}, result)
@@ -669,12 +667,12 @@ func KarpenterNodeClassVersionTest(getTestCtx internal.TestContextGetter) {
 						return true, fmt.Sprintf("status.releaseImage resolved to: %s", nc.Status.ReleaseImage), nil
 					},
 				},
-				e2eutil.WithTimeout(5*time.Minute),
-			)
+				v2util.WithTimeout(5*time.Minute),
+			)).To(Succeed())
 
 			// Verify MetadataOptions propagated to downstream EC2NodeClass
 			GinkgoWriter.Printf("Verifying MetadataOptions propagated to EC2NodeClass")
-			e2eutil.EventuallyObject(t, ctx, "EC2NodeClass to have MetadataOptions propagated",
+			Expect(v2util.EventuallyObject(ctx, "EC2NodeClass to have MetadataOptions propagated",
 				func(ctx context.Context) (*awskarpenterv1.EC2NodeClass, error) {
 					ec2NodeClass := &awskarpenterv1.EC2NodeClass{}
 					err := hcClient.Get(ctx, crclient.ObjectKey{Name: nc.Name}, ec2NodeClass)
@@ -700,8 +698,8 @@ func KarpenterNodeClassVersionTest(getTestCtx internal.TestContextGetter) {
 						return true, "MetadataOptions propagated correctly", nil
 					},
 				},
-				e2eutil.WithTimeout(2*time.Minute),
-			)
+				v2util.WithTimeout(2*time.Minute),
+			)).To(Succeed())
 
 			// Look up expected kubelet version from the resolved release image
 			pullSecret, err := os.ReadFile(pullSecretFile)
@@ -734,7 +732,8 @@ func KarpenterNodeClassVersionTest(getTestCtx internal.TestContextGetter) {
 					}
 					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete NodePool %s", testNodePool.Name)
 				}
-				_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 0, testNodeLabels)
+				_, err := v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 0, testNodeLabels)
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed waiting for version-test Karpenter nodes to terminate")
 			})
 
 			Expect(hcClient.Create(ctx, testWorkLoads)).To(Succeed())
@@ -768,11 +767,11 @@ func KarpenterNodeClassVersionTest(getTestCtx internal.TestContextGetter) {
 			}
 
 			// Wait for node to be provisioned and verify it has the correct kubelet version
-			nodes := e2eutil.WaitForNReadyNodesWithOptions(t, ctx, hcClient, 1, hyperv1.AWSPlatform, "",
-				e2eutil.WithClientOptions(
+			nodes, err := v2util.WaitForNReadyNodesWithOptions(ctx, hcClient, 1, hyperv1.AWSPlatform, "",
+				v2util.WithClientOptions(
 					crclient.MatchingLabelsSelector{Selector: labels.SelectorFromSet(labels.Set(testNodeLabels))},
 				),
-				e2eutil.WithPredicates(
+				v2util.WithPredicates(
 					func(node *corev1.Node) (bool, string, error) {
 						kubeletVersion := node.Status.NodeInfo.KubeletVersion
 						if !strings.Contains(kubeletVersion, expectedKubeletVersion) {
@@ -782,6 +781,7 @@ func KarpenterNodeClassVersionTest(getTestCtx internal.TestContextGetter) {
 					},
 				),
 			)
+			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Printf("Node provisioned with correct kubelet version (v%s) for NodeClass version %s", expectedKubeletVersion, nodeClassVersion)
 
 			// Verify MetadataOptions on EC2 instance
@@ -803,7 +803,8 @@ func KarpenterNodeClassVersionTest(getTestCtx internal.TestContextGetter) {
 			// NodeClaims don't leak vCPUs into subsequent sequential tests.
 			Expect(hcClient.Delete(ctx, testWorkLoads)).To(Succeed())
 			Expect(hcClient.Delete(ctx, testNodePool)).To(Succeed())
-			_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 0, testNodeLabels)
+			_, err = v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 0, testNodeLabels)
+			Expect(err).NotTo(HaveOccurred(), "failed waiting for version-test Karpenter nodes to terminate")
 
 			// Verify n-4 version skew produces SupportedVersionSkew=False
 			skewMajor, skewMinor, err := supportedversion.PreviousMinorVersion(cpVersion, 4)
@@ -837,7 +838,7 @@ func KarpenterNodeClassVersionTest(getTestCtx internal.TestContextGetter) {
 			})
 
 			GinkgoWriter.Printf("Waiting for VersionResolved=True and SupportedVersionSkew=False")
-			e2eutil.EventuallyObject(t, ctx, "OpenshiftEC2NodeClass version-skew-test to have SupportedVersionSkew=False",
+			Expect(v2util.EventuallyObject(ctx, "OpenshiftEC2NodeClass version-skew-test to have SupportedVersionSkew=False",
 				func(ctx context.Context) (*hyperkarpenterv1.OpenshiftEC2NodeClass, error) {
 					result := &hyperkarpenterv1.OpenshiftEC2NodeClass{}
 					err := hcClient.Get(ctx, crclient.ObjectKey{Name: skewNC.Name}, result)
@@ -866,8 +867,8 @@ func KarpenterNodeClassVersionTest(getTestCtx internal.TestContextGetter) {
 						return false, "SupportedVersionSkew=False condition not found", nil
 					},
 				},
-				e2eutil.WithTimeout(2*time.Minute),
-			)
+				v2util.WithTimeout(2*time.Minute),
+			)).To(Succeed())
 			GinkgoWriter.Printf("OpenshiftEC2NodeClass %q has SupportedVersionSkew=False for version %s (exceeds n-3 skew from CP %s)", skewNC.Name, skewVersion, cpVersion)
 		})
 	})
@@ -888,7 +889,6 @@ func KarpenterCapacityReservationTest(getTestCtx internal.TestContextGetter) {
 		It("should provision a node into a capacity reservation", func() {
 			tc := getTestCtx()
 			ctx := tc.Context
-			t := GinkgoTB()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hc)
@@ -939,7 +939,7 @@ func KarpenterCapacityReservationTest(getTestCtx internal.TestContextGetter) {
 			GinkgoWriter.Printf("Created OpenshiftEC2NodeClass capacity-reservation-test with CapacityReservationSelectorTerms ID=%s", crID)
 
 			// Verify the downstream EC2NodeClass has the CapacityReservationSelectorTerms propagated.
-			e2eutil.EventuallyObject(t, ctx, "EC2NodeClass capacity-reservation-test to have CapacityReservationSelectorTerms set",
+			Expect(v2util.EventuallyObject(ctx, "EC2NodeClass capacity-reservation-test to have CapacityReservationSelectorTerms set",
 				func(ctx context.Context) (*awskarpenterv1.EC2NodeClass, error) {
 					ec2nc := &awskarpenterv1.EC2NodeClass{}
 					return ec2nc, hcClient.Get(ctx, crclient.ObjectKey{Name: "capacity-reservation-test"}, ec2nc)
@@ -954,11 +954,11 @@ func KarpenterCapacityReservationTest(getTestCtx internal.TestContextGetter) {
 							crID, ec2nc.Spec.CapacityReservationSelectorTerms), nil
 					},
 				},
-				e2eutil.WithTimeout(2*time.Minute), e2eutil.WithInterval(5*time.Second),
-			)
+				v2util.WithTimeout(2*time.Minute), v2util.WithInterval(5*time.Second),
+			)).To(Succeed())
 
 			// Verify karpenter resolves the capacity reservation and reflects it in the OpenshiftEC2NodeClass status.
-			e2eutil.EventuallyObject(t, ctx, fmt.Sprintf("OpenshiftEC2NodeClass capacity-reservation-test to have capacity reservation %s in status", crID),
+			Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("OpenshiftEC2NodeClass capacity-reservation-test to have capacity reservation %s in status", crID),
 				func(ctx context.Context) (*hyperkarpenterv1.OpenshiftEC2NodeClass, error) {
 					updated := &hyperkarpenterv1.OpenshiftEC2NodeClass{}
 					return updated, hcClient.Get(ctx, crclient.ObjectKey{Name: "capacity-reservation-test"}, updated)
@@ -971,8 +971,8 @@ func KarpenterCapacityReservationTest(getTestCtx internal.TestContextGetter) {
 						return false, fmt.Sprintf("expected capacity reservation %s in status, got %+v", crID, updated.Status.CapacityReservations), nil
 					},
 				},
-				e2eutil.WithTimeout(5*time.Minute), e2eutil.WithInterval(10*time.Second),
-			)
+				v2util.WithTimeout(5*time.Minute), v2util.WithInterval(10*time.Second),
+			)).To(Succeed())
 
 			// Create a dedicated NodePool that targets the capacity-reservation-test NodeClass and requires
 			// capacity-type=reserved so karpenter launches the instance into the reservation (not alongside it).
@@ -992,7 +992,8 @@ func KarpenterCapacityReservationTest(getTestCtx internal.TestContextGetter) {
 					}
 					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete NodePool %s", crNodePool.Name)
 				}
-				_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 0, crNodeLabels)
+				_, err := v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 0, crNodeLabels)
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed waiting for capacity-reservation Karpenter nodes to terminate")
 			})
 			GinkgoWriter.Printf("Created NodePool capacity-reservation-test targeting capacity reservation %s", crID)
 
@@ -1005,7 +1006,8 @@ func KarpenterCapacityReservationTest(getTestCtx internal.TestContextGetter) {
 			GinkgoWriter.Printf("Created workload capacity-reservation-web-app to trigger node provisioning")
 
 			// Wait for the node to be ready.
-			nodes := e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 1, crNodeLabels)
+			nodes, err := v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 1, crNodeLabels)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(nodes).To(HaveLen(1))
 
 			// Verify the EC2 instance was launched into the capacity reservation.
@@ -1022,7 +1024,8 @@ func KarpenterCapacityReservationTest(getTestCtx internal.TestContextGetter) {
 			// so stale NodeClaims don't leak vCPUs into subsequent sequential tests.
 			Expect(hcClient.Delete(ctx, crWorkload)).To(Succeed())
 			Expect(hcClient.Delete(ctx, crNodePool)).To(Succeed())
-			_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 0, crNodeLabels)
+			_, err = v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 0, crNodeLabels)
+			Expect(err).NotTo(HaveOccurred(), "failed waiting for capacity-reservation Karpenter nodes to terminate")
 		})
 	})
 }
@@ -1042,7 +1045,6 @@ func KarpenterArbitrarySubnetTest(getTestCtx internal.TestContextGetter) {
 		It("should propagate a custom subnet through the VPC endpoint and provision a node in it", func() {
 			tc := getTestCtx()
 			ctx := tc.Context
-			t := GinkgoTB()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hc)
@@ -1106,7 +1108,8 @@ func KarpenterArbitrarySubnetTest(getTestCtx internal.TestContextGetter) {
 			GinkgoWriter.Printf("Selected AZ %s for test subnet (supported by endpoint service, not in VPC)", az)
 
 			// Create a small test subnet in the VPC.
-			subnetID, cleanupSubnet := e2eutil.CreateTestSubnet(ctx, t, ec2client, vpcID, az, hc.Spec.InfraID, hc.Name, e2eutil.E2ETagsFromEnvironment())
+			subnetID, cleanupSubnet, err := v2util.CreateTestSubnet(ctx, ec2client, vpcID, az, hc.Spec.InfraID, hc.Name, v2util.E2ETagsFromEnvironment())
+			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func() {
 				cleanupSubnet()
 			})
@@ -1270,7 +1273,8 @@ func KarpenterArbitrarySubnetTest(getTestCtx internal.TestContextGetter) {
 					}
 					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete NodePool %s", testNodePool.Name)
 				}
-				_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 0, testNodeLabels)
+				_, err := v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 0, testNodeLabels)
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed waiting for arbitrary-subnet Karpenter nodes to terminate")
 			})
 
 			Expect(hcClient.Create(ctx, testWorkLoads)).To(Succeed())
@@ -1281,7 +1285,8 @@ func KarpenterArbitrarySubnetTest(getTestCtx internal.TestContextGetter) {
 				}
 			})
 
-			nodes := e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 1, testNodeLabels)
+			nodes, err := v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 1, testNodeLabels)
+			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Printf("Node launched in arbitrary subnet, verifying it used subnet %s", subnetID)
 
 			// Verify the launched node's EC2 instance is in the expected subnet.
@@ -1315,7 +1320,6 @@ func KarpenterKubeletPropagationTest(getTestCtx internal.TestContextGetter) {
 		It("should propagate kubelet config to provisioned nodes", func() {
 			tc := getTestCtx()
 			ctx := tc.Context
-			t := GinkgoTB()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 			hcClient, err := tc.GetHostedClusterClient(hc)
@@ -1363,7 +1367,7 @@ func KarpenterKubeletPropagationTest(getTestCtx internal.TestContextGetter) {
 
 			// Wait for the per-nodeclass KubeletConfig ConfigMap to appear in the HCP namespace.
 			kubeletCMName := karpenterutil.KarpenterNodeClassKubeletConfigName(nc.Name)
-			e2eutil.EventuallyObject(t, ctx, fmt.Sprintf("KubeletConfig ConfigMap %s/%s to appear", hcpNamespace, kubeletCMName),
+			Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("KubeletConfig ConfigMap %s/%s to appear", hcpNamespace, kubeletCMName),
 				func(ctx context.Context) (*corev1.ConfigMap, error) {
 					cm := &corev1.ConfigMap{}
 					err := tc.MgmtClient.Get(ctx, crclient.ObjectKey{Name: kubeletCMName, Namespace: hcpNamespace}, cm)
@@ -1386,14 +1390,14 @@ func KarpenterKubeletPropagationTest(getTestCtx internal.TestContextGetter) {
 						return true, "all required fields present in config", nil
 					},
 				},
-				e2eutil.WithTimeout(2*time.Minute), e2eutil.WithInterval(5*time.Second),
-			)
+				v2util.WithTimeout(2*time.Minute), v2util.WithInterval(5*time.Second),
+			)).To(Succeed())
 			GinkgoWriter.Printf("KubeletConfig ConfigMap %s is present and correct", kubeletCMName)
 
 			// Wait for the karpenterignition controller to issue the ignition token with kubelet config.
 			// The annotation is set after token.Reconcile() succeeds, guaranteeing Karpenter will use
 			// the token (with kubelet config) when provisioning new nodes.
-			e2eutil.EventuallyObject(t, ctx, fmt.Sprintf("OpenshiftEC2NodeClass %q to have ignition token annotation", nc.Name),
+			Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("OpenshiftEC2NodeClass %q to have ignition token annotation", nc.Name),
 				func(ctx context.Context) (*hyperkarpenterv1.OpenshiftEC2NodeClass, error) {
 					updated := &hyperkarpenterv1.OpenshiftEC2NodeClass{}
 					err := hcClient.Get(ctx, crclient.ObjectKey{Name: nc.Name}, updated)
@@ -1408,8 +1412,8 @@ func KarpenterKubeletPropagationTest(getTestCtx internal.TestContextGetter) {
 						return true, fmt.Sprintf("annotation set to %q", v), nil
 					},
 				},
-				e2eutil.WithTimeout(2*time.Minute), e2eutil.WithInterval(5*time.Second),
-			)
+				v2util.WithTimeout(2*time.Minute), v2util.WithInterval(5*time.Second),
+			)).To(Succeed())
 			GinkgoWriter.Printf("Ignition token annotation set on %q", nc.Name)
 
 			// Wait for the OpenshiftEC2NodeClass to be fully Ready before creating the NodePool.
@@ -1417,7 +1421,7 @@ func KarpenterKubeletPropagationTest(getTestCtx internal.TestContextGetter) {
 			// annotation above is set before AWS resource discovery (SecurityGroups, Subnets) completes,
 			// so we must wait for the Ready condition explicitly to avoid provisioning delays.
 			GinkgoWriter.Printf("Make sure OpenshiftEC2NodeClass %q is Ready before nodepool creation", nc.Name)
-			e2eutil.EventuallyObject(t, ctx, fmt.Sprintf("OpenshiftEC2NodeClass %q to be Ready", nc.Name),
+			Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("OpenshiftEC2NodeClass %q to be Ready", nc.Name),
 				func(ctx context.Context) (*hyperkarpenterv1.OpenshiftEC2NodeClass, error) {
 					updated := &hyperkarpenterv1.OpenshiftEC2NodeClass{}
 					err := hcClient.Get(ctx, crclient.ObjectKey{Name: nc.Name}, updated)
@@ -1429,8 +1433,8 @@ func KarpenterKubeletPropagationTest(getTestCtx internal.TestContextGetter) {
 						Status: metav1.ConditionTrue,
 					}),
 				},
-				e2eutil.WithTimeout(5*time.Minute),
-			)
+				v2util.WithTimeout(5*time.Minute),
+			)).To(Succeed())
 			GinkgoWriter.Printf("OpenshiftEC2NodeClass %q is Ready", nc.Name)
 
 			// Create Karpenter NodePool pointing at the custom nodeclass and workloads to provision nodes.
@@ -1449,7 +1453,8 @@ func KarpenterKubeletPropagationTest(getTestCtx internal.TestContextGetter) {
 					}
 					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete NodePool %s", testNodePool.Name)
 				}
-				_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 0, testNodeLabels)
+				_, err := v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 0, testNodeLabels)
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed waiting for kubelet-config Karpenter nodes to terminate")
 			})
 
 			Expect(hcClient.Create(ctx, testWorkLoads)).To(Succeed())
@@ -1461,10 +1466,12 @@ func KarpenterKubeletPropagationTest(getTestCtx internal.TestContextGetter) {
 			})
 
 			// Wait for nodes to be provisioned
-			e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 1, testNodeLabels)
+			_, err = v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 1, testNodeLabels)
+			Expect(err).NotTo(HaveOccurred())
 
 			// Build a clientset for the hosted cluster (needed for pod log fetching)
-			guestConfig := e2eutil.WaitForGuestRestConfig(t, ctx, tc.MgmtClient, hc)
+			guestConfig, err := tc.WaitForHostedClusterRESTConfig(hc)
+			Expect(err).NotTo(HaveOccurred())
 			guestClientset, err := kubeclient.NewForConfig(guestConfig)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1513,7 +1520,8 @@ func KarpenterKubeletPropagationTest(getTestCtx internal.TestContextGetter) {
 			// Cleanup workloads and NodePool
 			Expect(hcClient.Delete(ctx, testWorkLoads)).To(Succeed())
 			Expect(hcClient.Delete(ctx, testNodePool)).To(Succeed())
-			_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 0, testNodeLabels)
+			_, err = v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 0, testNodeLabels)
+			Expect(err).NotTo(HaveOccurred(), "failed waiting for kubelet-config Karpenter nodes to terminate")
 		})
 	})
 }
@@ -1533,7 +1541,6 @@ func KarpenterAutoNodeLifecycleTest(getTestCtx internal.TestContextGetter) {
 		It("should disable and re-enable AutoNode with correct condition transitions", func() {
 			tc := getTestCtx()
 			ctx := tc.Context
-			t := GinkgoTB()
 			hc, err := tc.GetHostedCluster()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1542,7 +1549,7 @@ func KarpenterAutoNodeLifecycleTest(getTestCtx internal.TestContextGetter) {
 
 			// Disable Karpenter.
 			GinkgoWriter.Printf("Disabling AutoNode (Karpenter) on HostedCluster")
-			err = e2eutil.UpdateObject(t, ctx, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+			err = v2util.UpdateObject(ctx, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.AutoNode = hyperv1.AutoNode{}
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to disable AutoNode")
@@ -1552,7 +1559,7 @@ func KarpenterAutoNodeLifecycleTest(getTestCtx internal.TestContextGetter) {
 			// the transient Progressing state unreliably catchable. Go straight to the final state.
 
 			// Expect fully disabled (components removed).
-			e2eutil.EventuallyObject(t, ctx, "HostedCluster to have AutoNodeEnabled=False/AutoNodeNotConfigured",
+			Expect(v2util.EventuallyObject(ctx, "HostedCluster to have AutoNodeEnabled=False/AutoNodeNotConfigured",
 				func(ctx context.Context) (*hyperv1.HostedCluster, error) {
 					obj := &hyperv1.HostedCluster{}
 					err := tc.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), obj)
@@ -1565,19 +1572,19 @@ func KarpenterAutoNodeLifecycleTest(getTestCtx internal.TestContextGetter) {
 						Reason: hyperv1.AutoNodeNotConfiguredReason,
 					}),
 				},
-				e2eutil.WithTimeout(5*time.Minute),
-			)
+				v2util.WithTimeout(5*time.Minute),
+			)).To(Succeed())
 
 			// Re-enable Karpenter.
 			GinkgoWriter.Println("Re-enabling AutoNode (Karpenter) on HostedCluster")
-			err = e2eutil.UpdateObject(t, ctx, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+			err = v2util.UpdateObject(ctx, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.AutoNode = savedAutoNode
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to re-enable AutoNode")
 
 			// Expect progressing (enable in flight — components being created/rolled out).
 			GinkgoWriter.Println("Waiting for AutoNodeEnabled=False/AutoNodeProgressing (enable in progress)")
-			e2eutil.EventuallyObject(t, ctx, "HostedCluster to have AutoNodeEnabled=False/AutoNodeProgressing",
+			Expect(v2util.EventuallyObject(ctx, "HostedCluster to have AutoNodeEnabled=False/AutoNodeProgressing",
 				func(ctx context.Context) (*hyperv1.HostedCluster, error) {
 					obj := &hyperv1.HostedCluster{}
 					err := tc.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), obj)
@@ -1590,12 +1597,12 @@ func KarpenterAutoNodeLifecycleTest(getTestCtx internal.TestContextGetter) {
 						Reason: hyperv1.AutoNodeProgressingReason,
 					}),
 				},
-				e2eutil.WithTimeout(2*time.Minute),
-			)
+				v2util.WithTimeout(2*time.Minute),
+			)).To(Succeed())
 
 			// Expect fully enabled (both components rolled out).
 			GinkgoWriter.Println("Waiting for AutoNodeEnabled=True/AsExpected (enable complete)")
-			e2eutil.EventuallyObject(t, ctx, "HostedCluster to have AutoNodeEnabled=True/AsExpected",
+			Expect(v2util.EventuallyObject(ctx, "HostedCluster to have AutoNodeEnabled=True/AsExpected",
 				func(ctx context.Context) (*hyperv1.HostedCluster, error) {
 					obj := &hyperv1.HostedCluster{}
 					err := tc.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), obj)
@@ -1608,8 +1615,8 @@ func KarpenterAutoNodeLifecycleTest(getTestCtx internal.TestContextGetter) {
 						Reason: hyperv1.AsExpectedReason,
 					}),
 				},
-				e2eutil.WithTimeout(5*time.Minute),
-			)
+				v2util.WithTimeout(5*time.Minute),
+			)).To(Succeed())
 		})
 	})
 }
@@ -1655,7 +1662,8 @@ func KarpenterBillingConsolidationTest(getTestCtx internal.TestContextGetter) {
 			Expect(hcClient.Create(ctx, workLoads)).To(Succeed())
 			GinkgoWriter.Println("Created workloads with 2 replicas")
 
-			_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 2, nodeLabels)
+			_, err = v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 2, nodeLabels)
+			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println("Both nodes ready, validating billing vCPUs")
 
 			// t3.xlarge = 4 vCPUs; 2 nodes = 8 Karpenter vCPUs on top of baseline
@@ -1664,12 +1672,13 @@ func KarpenterBillingConsolidationTest(getTestCtx internal.TestContextGetter) {
 			waitForBillingMetricVCPUs(ctx, tc.MgmtClient, hc, baseline+8)
 
 			GinkgoWriter.Println("Scaling workload to 1 replica to verify deprovisioning and consolidation")
-			err = e2eutil.UpdateObject(t, ctx, hcClient, workLoads, func(obj *appsv1.Deployment) {
+			err = v2util.UpdateObject(ctx, hcClient, workLoads, func(obj *appsv1.Deployment) {
 				obj.Spec.Replicas = ptr.To(int32(1))
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, hcClient, hc.Spec.Platform.Type, 1, nodeLabels)
+			_, err = v2util.WaitForReadyNodesByLabels(ctx, hcClient, hc.Spec.Platform.Type, 1, nodeLabels)
+			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println("Karpenter consolidated the extra node")
 
 			// t3.xlarge = 4 vCPUs; 1 node = 4 Karpenter vCPUs on top of baseline
@@ -1831,9 +1840,10 @@ func describeEC2Instance(ctx context.Context, ec2client *ec2.Client, node corev1
 }
 
 func waitForReadyKarpenterPods(ctx context.Context, client crclient.Client, nodes []corev1.Node, n int, podLabels map[string]string) {
-	t := GinkgoTB()
+	GinkgoHelper()
+
 	pods := &corev1.PodList{}
-	e2eutil.EventuallyObjects(t, ctx, "Pods to be scheduled on provisioned Karpenter nodes",
+	Expect(v2util.EventuallyObjects(ctx, "Pods to be scheduled on provisioned Karpenter nodes",
 		func(ctx context.Context) ([]*corev1.Pod, error) {
 			err := client.List(ctx, pods, crclient.InNamespace("default"), crclient.MatchingLabels(podLabels))
 			items := make([]*corev1.Pod, len(pods.Items))
@@ -1866,18 +1876,18 @@ func waitForReadyKarpenterPods(ctx context.Context, client crclient.Client, node
 				return pod.Status.Phase == corev1.PodRunning, fmt.Sprintf("pod %s is not running", pod.Name), nil
 			},
 		},
-		e2eutil.WithTimeout(20*time.Minute),
-	)
+		v2util.WithTimeout(20*time.Minute),
+	)).To(Succeed())
 }
 
 // waitForAutoNodeStatusVCPUs polls until HostedCluster.Status.AutoNode.VCPUs
 // converges to the expected value. This checks only the status field (Karpenter-only vCPUs),
 // not the billing metric.
 func waitForAutoNodeStatusVCPUs(ctx context.Context, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, expected int32) {
-	t := GinkgoTB()
+	GinkgoHelper()
 
 	GinkgoWriter.Printf("Validating AutoNode.VCPUs converges to %d", expected)
-	e2eutil.EventuallyObject(t, ctx,
+	Expect(v2util.EventuallyObject(ctx,
 		fmt.Sprintf("HostedCluster %s/%s AutoNode.VCPUs=%d", hostedCluster.Namespace, hostedCluster.Name, expected),
 		func(ctx context.Context) (*hyperv1.HostedCluster, error) {
 			hc := &hyperv1.HostedCluster{}
@@ -1896,8 +1906,8 @@ func waitForAutoNodeStatusVCPUs(ctx context.Context, mgtClient crclient.Client, 
 				return true, fmt.Sprintf("AutoNode.VCPUs=%d", actual), nil
 			},
 		},
-		e2eutil.WithTimeout(1*time.Minute),
-	)
+		v2util.WithTimeout(1*time.Minute),
+	)).To(Succeed())
 }
 
 func waitForAutoNodeStatusVCPUsStable(ctx context.Context, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, expected int32, duration time.Duration) {

--- a/test/e2e/v2/tests/nodepool_arm64_create_test.go
+++ b/test/e2e/v2/tests/nodepool_arm64_create_test.go
@@ -21,8 +21,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
+	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -96,7 +96,8 @@ func NodePoolArm64CreateTest(getTestCtx internal.TestContextGetter) {
 		}
 		GinkgoWriter.Printf("Verified ARM64 NodePool %s created with correct architecture settings\n", np.Name)
 		// Wait for the ARM64 node to become ready
-		nodes := e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		nodes, err := v2util.WaitForReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
+		Expect(err).NotTo(HaveOccurred(), "failed waiting for the ARM64 node to become ready")
 		Expect(nodes).To(HaveLen(1), "expected exactly 1 ARM64 node for NodePool %s", np.Name)
 		// Verify the node has the correct ARM64 architecture label
 		node := nodes[0]

--- a/test/e2e/v2/tests/nodepool_autoscaling_test.go
+++ b/test/e2e/v2/tests/nodepool_autoscaling_test.go
@@ -28,6 +28,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
+	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -68,12 +69,13 @@ func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, autoscalingNP)
 		})
 
-		npLabelSelector := e2eutil.WithClientOptions(crclient.MatchingLabelsSelector{
+		npLabelSelector := v2util.WithClientOptions(crclient.MatchingLabelsSelector{
 			Selector: labels.SelectorFromSet(labels.Set{hyperv1.NodePoolLabel: autoscalingNP.Name}),
 		})
 
 		// Wait for NodePool to be ready with 1 node (min replicas)
-		nodes := e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, hcClient, 1, hc.Spec.Platform.Type, fmt.Sprintf("for NodePool %s", autoscalingNP.Name), npLabelSelector)
+		nodes, err := v2util.WaitForNReadyNodesWithOptions(ctx, hcClient, 1, hc.Spec.Platform.Type, fmt.Sprintf("for NodePool %s", autoscalingNP.Name), npLabelSelector)
+		Expect(err).NotTo(HaveOccurred(), "failed waiting for initial autoscaling NodePool node")
 		Expect(nodes).To(HaveLen(1), "should have exactly 1 node initially")
 
 		// Get node capacity for workload sizing
@@ -94,13 +96,15 @@ func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		// Wait for scale-up to 3 nodes
-		e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, hcClient, 3, hc.Spec.Platform.Type, fmt.Sprintf("for NodePool %s", autoscalingNP.Name), npLabelSelector)
+		_, err = v2util.WaitForNReadyNodesWithOptions(ctx, hcClient, 3, hc.Spec.Platform.Type, fmt.Sprintf("for NodePool %s", autoscalingNP.Name), npLabelSelector)
+		Expect(err).NotTo(HaveOccurred(), "failed waiting for autoscaling NodePool scale-up")
 
 		// Delete workload to trigger scale-down
 		cleanupWorkload(ctx, hcClient, workload)
 
 		// Wait for scale-down to 1 node (min replicas)
-		e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, hcClient, 1, hc.Spec.Platform.Type, fmt.Sprintf("for NodePool %s", autoscalingNP.Name), npLabelSelector)
+		_, err = v2util.WaitForNReadyNodesWithOptions(ctx, hcClient, 1, hc.Spec.Platform.Type, fmt.Sprintf("for NodePool %s", autoscalingNP.Name), npLabelSelector)
+		Expect(err).NotTo(HaveOccurred(), "failed waiting for autoscaling NodePool scale-down")
 	})
 }
 
@@ -179,7 +183,7 @@ func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 
 		// The autoscaler is enabled only when an autoscaling NodePool exists.
 		// Create the NodePools before waiting for the configured deployment.
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, "autoscaler deployment to have balancing config",
+		Expect(v2util.EventuallyObject(ctx, "autoscaler deployment to have balancing config",
 			func(ctx context.Context) (*appsv1.Deployment, error) {
 				dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
 					Namespace: cpNamespace, Name: "cluster-autoscaler",
@@ -195,20 +199,22 @@ func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 				}
 				return false, "balancing-ignore-label not found in autoscaler args", nil
 			}},
-			e2eutil.WithInterval(10*time.Second),
-			e2eutil.WithTimeout(5*time.Minute),
-		)
+			v2util.WithInterval(10*time.Second),
+			v2util.WithTimeout(5*time.Minute),
+		)).To(Succeed())
 
-		np1LabelSelector := e2eutil.WithClientOptions(crclient.MatchingLabelsSelector{
+		np1LabelSelector := v2util.WithClientOptions(crclient.MatchingLabelsSelector{
 			Selector: labels.SelectorFromSet(labels.Set{hyperv1.NodePoolLabel: autoscalingNP1.Name}),
 		})
-		np2LabelSelector := e2eutil.WithClientOptions(crclient.MatchingLabelsSelector{
+		np2LabelSelector := v2util.WithClientOptions(crclient.MatchingLabelsSelector{
 			Selector: labels.SelectorFromSet(labels.Set{hyperv1.NodePoolLabel: autoscalingNP2.Name}),
 		})
 
 		// Wait for initial nodes (1 per NodePool at min replicas)
-		nodes := e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, hcClient, 1, hc.Spec.Platform.Type, "for NP1", np1LabelSelector)
-		e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, hcClient, 1, hc.Spec.Platform.Type, "for NP2", np2LabelSelector)
+		nodes, err := v2util.WaitForNReadyNodesWithOptions(ctx, hcClient, 1, hc.Spec.Platform.Type, "for NP1", np1LabelSelector)
+		Expect(err).NotTo(HaveOccurred(), "failed waiting for first autoscaling NodePool")
+		_, err = v2util.WaitForNReadyNodesWithOptions(ctx, hcClient, 1, hc.Spec.Platform.Type, "for NP2", np2LabelSelector)
+		Expect(err).NotTo(HaveOccurred(), "failed waiting for second autoscaling NodePool")
 
 		// Get node capacity for workload sizing
 		memCapacity := nodes[0].Status.Allocatable[corev1.ResourceMemory]
@@ -382,10 +388,10 @@ func cleanupNodePool(ctx context.Context, client crclient.Client, np *hyperv1.No
 	}
 	GinkgoWriter.Printf("Deleting NodePool %s\n", np.Name)
 
-	e2eutil.EventuallyNotFound(GinkgoTB(), ctx, client, np,
-		e2eutil.WithTimeout(nodePoolUpgradeTimeout(np.Spec.Platform.Type)),
-		e2eutil.WithInterval(15*time.Second),
-	)
+	Expect(v2util.EventuallyNotFound(ctx, client, np,
+		v2util.WithTimeout(nodePoolUpgradeTimeout(np.Spec.Platform.Type)),
+		v2util.WithInterval(15*time.Second),
+	)).To(Succeed())
 }
 
 // cleanupWorkload deletes a Job workload if it exists

--- a/test/e2e/v2/tests/nodepool_lifecycle_test.go
+++ b/test/e2e/v2/tests/nodepool_lifecycle_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/hypershift/support/podspec"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
+	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
 
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 
@@ -119,7 +120,7 @@ func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// Build MachineConfig with a custom file at /etc/custom-config
 		ignitionConfig := ignitionapi.Config{
@@ -172,9 +173,9 @@ func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 		ds := buildMachineConfigVerificationDaemonSet(np)
 		Expect(hcClient.Create(ctx, ds)).To(Succeed(), "failed to create verification DaemonSet")
 
-		e2eutil.WaitForNodePoolConfigUpdateCompleteWithPlatform(GinkgoTB(), ctx, testCtx.MgmtClient, np, hc.Spec.Platform.Type)
+		expectNodePoolConfigUpdateComplete(ctx, testCtx.MgmtClient, np, hc.Spec.Platform.Type)
 		waitForDaemonSetRollout(ctx, hcClient, ds, 1, np.Spec.Platform.Type)
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNoCrashingPods, EnsureAllContainersHavePullPolicyIfNotPresent,
 		// EnsureHCPContainersHaveResourceRequests, EnsureNoPodsWithTooHighPriority
@@ -220,7 +221,7 @@ func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		tuningCM := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -244,9 +245,9 @@ func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 		ds := buildNTOVerificationDaemonSet(np)
 		Expect(hcClient.Create(ctx, ds)).To(Succeed(), "failed to create NTO verification DaemonSet")
 
-		e2eutil.WaitForNodePoolConfigUpdateCompleteWithPlatform(GinkgoTB(), ctx, testCtx.MgmtClient, np, hc.Spec.Platform.Type)
+		expectNodePoolConfigUpdateComplete(ctx, testCtx.MgmtClient, np, hc.Spec.Platform.Type)
 		waitForDaemonSetRollout(ctx, hcClient, ds, 2, np.Spec.Platform.Type)
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNoCrashingPods, EnsureAllContainersHavePullPolicyIfNotPresent,
 		// EnsureHCPContainersHaveResourceRequests, EnsureNoPodsWithTooHighPriority
@@ -284,7 +285,7 @@ func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		tuningCM := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -308,9 +309,9 @@ func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 		ds := buildNTOVerificationDaemonSet(np)
 		Expect(hcClient.Create(ctx, ds)).To(Succeed(), "failed to create NTO verification DaemonSet")
 
-		e2eutil.WaitForNodePoolConfigUpdateCompleteWithPlatform(GinkgoTB(), ctx, testCtx.MgmtClient, np, hc.Spec.Platform.Type)
+		expectNodePoolConfigUpdateComplete(ctx, testCtx.MgmtClient, np, hc.Spec.Platform.Type)
 		waitForDaemonSetRollout(ctx, hcClient, ds, 2, np.Spec.Platform.Type)
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNoCrashingPods, EnsureAllContainersHavePullPolicyIfNotPresent,
 		// EnsureHCPContainersHaveResourceRequests, EnsureNoPodsWithTooHighPriority
@@ -360,16 +361,16 @@ func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// Update NodePool to latest release image
 		GinkgoWriter.Printf("Upgrading NodePool %s to latest release %s\n", np.Name, latestImage)
-		Expect(e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, np, func(obj *hyperv1.NodePool) {
+		Expect(v2util.UpdateObject(ctx, testCtx.MgmtClient, np, func(obj *hyperv1.NodePool) {
 			obj.Spec.Release.Image = latestImage
 		})).To(Succeed(), "failed to update NodePool release image")
 
 		// Wait for upgrade to start
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to start the upgrade", np.Namespace, np.Name),
+		Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to start the upgrade", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), pool)
@@ -381,11 +382,11 @@ func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionTrue,
 				}),
 			},
-		)
+		)).To(Succeed())
 
 		// Wait for upgrade to complete
 		upgradeTimeout := nodePoolUpgradeTimeout(hc.Spec.Platform.Type)
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to complete the upgrade", np.Namespace, np.Name),
+		Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to complete the upgrade", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), pool)
@@ -397,10 +398,10 @@ func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionFalse,
 				}),
 			},
-			e2eutil.WithTimeout(upgradeTimeout),
-		)
+			v2util.WithTimeout(upgradeTimeout),
+		)).To(Succeed())
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNodesLabelsAndTaints, EnsureNodesRuntime require *testing.T
 	})
@@ -442,15 +443,15 @@ func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		GinkgoWriter.Printf("Upgrading NodePool %s to latest release %s\n", np.Name, latestImage)
-		Expect(e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, np, func(obj *hyperv1.NodePool) {
+		Expect(v2util.UpdateObject(ctx, testCtx.MgmtClient, np, func(obj *hyperv1.NodePool) {
 			obj.Spec.Release.Image = latestImage
 		})).To(Succeed(), "failed to update NodePool release image")
 
 		// Wait for upgrade to start
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to start the upgrade", np.Namespace, np.Name),
+		Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to start the upgrade", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), pool)
@@ -462,11 +463,11 @@ func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionTrue,
 				}),
 			},
-		)
+		)).To(Succeed())
 
 		// Wait for upgrade to complete
 		upgradeTimeout := nodePoolUpgradeTimeout(hc.Spec.Platform.Type)
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to complete the upgrade", np.Namespace, np.Name),
+		Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to complete the upgrade", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), pool)
@@ -478,10 +479,10 @@ func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionFalse,
 				}),
 			},
-			e2eutil.WithTimeout(upgradeTimeout),
-		)
+			v2util.WithTimeout(upgradeTimeout),
+		)).To(Succeed())
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNodesLabelsAndTaints, EnsureNodesRuntime require *testing.T
 	})
@@ -525,7 +526,7 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, platform)
+		expectReadyNodesByNodePool(ctx, hcClient, np, platform)
 
 		// Change instance type / VM size to trigger rolling upgrade
 		var newInstanceType, newVMSize string
@@ -536,7 +537,7 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 			newVMSize = "Standard_D4s_v5"
 		}
 
-		Expect(e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, np, func(obj *hyperv1.NodePool) {
+		Expect(v2util.UpdateObject(ctx, testCtx.MgmtClient, np, func(obj *hyperv1.NodePool) {
 			switch platform {
 			case hyperv1.AWSPlatform:
 				obj.Spec.Platform.AWS.InstanceType = newInstanceType
@@ -546,7 +547,7 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 		})).To(Succeed(), "failed to update NodePool instance type / VM size")
 
 		// Wait for rolling upgrade to start
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to start the rolling upgrade", np.Namespace, np.Name),
+		Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to start the rolling upgrade", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), pool)
@@ -558,12 +559,12 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithTimeout(2*time.Minute),
-		)
+			v2util.WithTimeout(2*time.Minute),
+		)).To(Succeed())
 
 		// Wait for rolling upgrade to complete
 		rollingTimeout := nodePoolUpgradeTimeout(platform)
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to finish the rolling upgrade", np.Namespace, np.Name),
+		Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to finish the rolling upgrade", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), pool)
@@ -575,8 +576,8 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionFalse,
 				}),
 			},
-			e2eutil.WithTimeout(rollingTimeout),
-		)
+			v2util.WithTimeout(rollingTimeout),
+		)).To(Succeed())
 
 		// TODO: Verify machine specs (AWSMachineList / AzureMachineList) after upgrade.
 		// The v1 test uses capiaws.AWSMachineList and capiazure.AzureMachineList to check
@@ -618,7 +619,7 @@ func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNodesLabelsAndTaints requires *testing.T
 	})
@@ -657,7 +658,7 @@ func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNodesLabelsAndTaints requires *testing.T
 	})
@@ -694,7 +695,7 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		kcConfigMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -716,7 +717,7 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 			"failed to patch NodePool %s with KubeletConfig", np.Name)
 
 		// Verify mirrored ConfigMap appears in the hosted cluster
-		e2eutil.EventuallyObjects(GinkgoTB(), ctx, "KubeletConfig should be mirrored to the hosted cluster",
+		Expect(v2util.EventuallyObjects(ctx, "KubeletConfig should be mirrored to the hosted cluster",
 			func(ctx context.Context) ([]*corev1.ConfigMap, error) {
 				list := &corev1.ConfigMapList{}
 				err := hcClient.List(ctx, list, crclient.InNamespace(configManagedNamespace),
@@ -759,9 +760,9 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 					return true, "labels are correct", nil
 				},
 			},
-			e2eutil.WithTimeout(20*time.Minute),
-			e2eutil.WithInterval(5*time.Second),
-		)
+			v2util.WithTimeout(20*time.Minute),
+			v2util.WithInterval(5*time.Second),
+		)).To(Succeed())
 
 		// Remove KubeletConfig from NodePool and verify cleanup
 		GinkgoWriter.Printf("Removing KubeletConfig reference from NodePool %s\n", np.Name)
@@ -770,7 +771,7 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 		Expect(testCtx.MgmtClient.Patch(ctx, np, crclient.MergeFrom(baseNP))).To(Succeed(),
 			"failed to remove KubeletConfig from NodePool %s", np.Name)
 
-		e2eutil.EventuallyObjects(GinkgoTB(), ctx, "KubeletConfig ConfigMap to be deleted from hosted cluster",
+		Expect(v2util.EventuallyObjects(ctx, "KubeletConfig ConfigMap to be deleted from hosted cluster",
 			func(ctx context.Context) ([]*corev1.ConfigMap, error) {
 				list := &corev1.ConfigMapList{}
 				err := hcClient.List(ctx, list, crclient.InNamespace(configManagedNamespace),
@@ -790,9 +791,9 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 					return want == got, fmt.Sprintf("expected %d KubeletConfig ConfigMaps, got %d", want, got), nil
 				},
 			}, nil,
-			e2eutil.WithTimeout(20*time.Minute),
-			e2eutil.WithInterval(5*time.Second),
-		)
+			v2util.WithTimeout(20*time.Minute),
+			v2util.WithInterval(5*time.Second),
+		)).To(Succeed())
 	})
 }
 
@@ -834,7 +835,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// Create additional trust bundle ConfigMap
 		trustBundle := &corev1.ConfigMap{
@@ -853,7 +854,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 
 		// Update HostedCluster to reference the trust bundle
 		GinkgoWriter.Printf("Updating HostedCluster with additional trust bundle %s\n", trustBundle.Name)
-		Expect(e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+		Expect(v2util.UpdateObject(ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 			obj.Spec.AdditionalTrustBundle = &corev1.LocalObjectReference{Name: trustBundle.Name}
 		})).To(Succeed(), "failed to update HostedCluster with trust bundle")
 
@@ -866,7 +867,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 				}
 				return
 			}
-			err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, currentHC, func(obj *hyperv1.HostedCluster) {
+			err := v2util.UpdateObject(ctx, testCtx.MgmtClient, currentHC, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.AdditionalTrustBundle = nil
 			})
 			if err != nil && !apierrors.IsNotFound(err) {
@@ -874,7 +875,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to begin updating", np.Namespace, np.Name),
+		Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to begin updating", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), pool)
@@ -886,10 +887,10 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(nodePoolConfigUpdateStartTimeout),
-		)
+			v2util.WithInterval(defaultPollInterval), v2util.WithTimeout(nodePoolConfigUpdateStartTimeout),
+		)).To(Succeed())
 
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to stop updating", np.Namespace, np.Name),
+		Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to stop updating", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), pool)
@@ -905,8 +906,8 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(nodePoolConfigUpdateFinishTimeout),
-		)
+			v2util.WithInterval(defaultPollInterval), v2util.WithTimeout(nodePoolConfigUpdateFinishTimeout),
+		)).To(Succeed())
 
 		// Verify user-ca-bundle exists in the hosted cluster
 		userCAConfigMap := &corev1.ConfigMap{
@@ -915,7 +916,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 				Namespace: "openshift-config",
 			},
 		}
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, "user-ca-bundle to exist in hosted cluster",
+		Expect(v2util.EventuallyObject(ctx, "user-ca-bundle to exist in hosted cluster",
 			func(ctx context.Context) (*corev1.ConfigMap, error) {
 				cm := &corev1.ConfigMap{}
 				err := hcClient.Get(ctx, crclient.ObjectKeyFromObject(userCAConfigMap), cm)
@@ -924,12 +925,12 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 			[]e2eutil.Predicate[*corev1.ConfigMap]{
 				func(obj *corev1.ConfigMap) (bool, string, error) { return true, "exists", nil },
 			},
-			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(guestUserCABundlePropagationTimeout),
-		)
+			v2util.WithInterval(defaultPollInterval), v2util.WithTimeout(guestUserCABundlePropagationTimeout),
+		)).To(Succeed())
 
 		// Remove trust bundle from HostedCluster
 		GinkgoWriter.Printf("Removing additional trust bundle from HostedCluster\n")
-		Expect(e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+		Expect(v2util.UpdateObject(ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 			obj.Spec.AdditionalTrustBundle = nil
 		})).To(Succeed(), "failed to remove trust bundle from HostedCluster")
 
@@ -941,7 +942,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 				Namespace: cpNamespace,
 			},
 		}
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, "CPO deployment to stop mounting trust bundle",
+		Expect(v2util.EventuallyObject(ctx, "CPO deployment to stop mounting trust bundle",
 			func(ctx context.Context) (*appsv1.Deployment, error) {
 				deploy := &appsv1.Deployment{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(cpoDeployment), deploy)
@@ -960,11 +961,11 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 					return true, "trust bundle volume removed from CPO", nil
 				},
 			},
-			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(cpoDeploymentUpdateTimeout),
-		)
+			v2util.WithInterval(defaultPollInterval), v2util.WithTimeout(cpoDeploymentUpdateTimeout),
+		)).To(Succeed())
 
 		// Wait for NodePool to cycle again
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to begin updating after trust bundle removal", np.Namespace, np.Name),
+		Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to begin updating after trust bundle removal", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), pool)
@@ -976,10 +977,10 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(nodePoolConfigUpdateStartTimeout),
-		)
+			v2util.WithInterval(defaultPollInterval), v2util.WithTimeout(nodePoolConfigUpdateStartTimeout),
+		)).To(Succeed())
 
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to stop updating after trust bundle removal", np.Namespace, np.Name),
+		Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to stop updating after trust bundle removal", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), pool)
@@ -995,14 +996,14 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(nodePoolConfigUpdateFinishTimeout),
-		)
+			v2util.WithInterval(defaultPollInterval), v2util.WithTimeout(nodePoolConfigUpdateFinishTimeout),
+		)).To(Succeed())
 
 		// Verify user-ca-bundle is deleted from the hosted cluster (4.22+)
 		if version.GE(e2eutil.Version422) {
-			e2eutil.EventuallyNotFound(GinkgoTB(), ctx, hcClient, userCAConfigMap,
-				e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute),
-			)
+			Expect(v2util.EventuallyNotFound(ctx, hcClient, userCAConfigMap,
+				v2util.WithInterval(10*time.Second), v2util.WithTimeout(5*time.Minute),
+			)).To(Succeed())
 		}
 	})
 }
@@ -1038,7 +1039,7 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		ppConfigMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1062,7 +1063,7 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 		cpNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name)
 
 		// Verify PerformanceProfile ConfigMap exists in control plane namespace
-		e2eutil.EventuallyObjects(GinkgoTB(), ctx, "PerformanceProfile ConfigMap to exist with correct labels",
+		Expect(v2util.EventuallyObjects(ctx, "PerformanceProfile ConfigMap to exist with correct labels",
 			func(ctx context.Context) ([]*corev1.ConfigMap, error) {
 				list := &corev1.ConfigMapList{}
 				err := testCtx.MgmtClient.List(ctx, list, crclient.InNamespace(cpNamespace),
@@ -1102,13 +1103,13 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 					return true, "labels are correct", nil
 				},
 			},
-			e2eutil.WithTimeout(20*time.Minute),
-			e2eutil.WithInterval(5*time.Second),
-		)
+			v2util.WithTimeout(20*time.Minute),
+			v2util.WithInterval(5*time.Second),
+		)).To(Succeed())
 
 		// Verify status ConfigMap (4.17+)
 		if testCtx.VersionAtLeast(e2eutil.Version417) {
-			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "PerformanceProfile status ConfigMap to exist",
+			Expect(v2util.EventuallyObjects(ctx, "PerformanceProfile status ConfigMap to exist",
 				func(ctx context.Context) ([]*corev1.ConfigMap, error) {
 					list := &corev1.ConfigMapList{}
 					err := testCtx.MgmtClient.List(ctx, list, crclient.InNamespace(cpNamespace),
@@ -1136,9 +1137,9 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 						return true, "status ConfigMap name is as expected", nil
 					},
 				},
-				e2eutil.WithTimeout(20*time.Minute),
-				e2eutil.WithInterval(5*time.Second),
-			)
+				v2util.WithTimeout(20*time.Minute),
+				v2util.WithInterval(5*time.Second),
+			)).To(Succeed())
 		}
 
 		// Remove PerformanceProfile from NodePool and verify cleanup
@@ -1148,7 +1149,7 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 		Expect(testCtx.MgmtClient.Patch(ctx, np, crclient.MergeFrom(baseNP))).To(Succeed(),
 			"failed to remove PerformanceProfile from NodePool %s", np.Name)
 
-		e2eutil.EventuallyObjects(GinkgoTB(), ctx, "PerformanceProfile ConfigMap to be deleted",
+		Expect(v2util.EventuallyObjects(ctx, "PerformanceProfile ConfigMap to be deleted",
 			func(ctx context.Context) ([]*corev1.ConfigMap, error) {
 				list := &corev1.ConfigMapList{}
 				err := testCtx.MgmtClient.List(ctx, list, crclient.InNamespace(cpNamespace),
@@ -1167,9 +1168,9 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 					return want == got, fmt.Sprintf("expected %d PerformanceProfile ConfigMaps, got %d", want, got), nil
 				},
 			}, nil,
-			e2eutil.WithTimeout(20*time.Minute),
-			e2eutil.WithInterval(5*time.Second),
-		)
+			v2util.WithTimeout(20*time.Minute),
+			v2util.WithInterval(5*time.Second),
+		)).To(Succeed())
 	})
 }
 
@@ -1208,13 +1209,13 @@ func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, platform)
+		expectReadyNodesByNodePool(ctx, hcClient, np, platform)
 
 		// TODO: Implement cloud-specific instance termination logic.
 		// For AWS: use EC2 TerminateInstances API to terminate the node's backing instance.
 		// For Azure: delete the VMSS instance backing the node.
 		// After termination, wait for the node to be replaced using:
-		//   e2eutil.WaitForReadyNodesByNodePool with WithCollectionPredicates and WithPredicates
+		//   v2util.WaitForReadyNodesByNodePool with WithCollectionPredicates and WithPredicates
 		//   to verify the old node is replaced and the new node is healthy.
 	})
 }
@@ -1256,7 +1257,7 @@ func NodePoolDiskEncryptionTest(getTestCtx internal.TestContextGetter) {
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: Verify disk encryption is applied by checking AzureMachine specs
 		// in the control plane namespace. This requires importing CAPI Azure types
@@ -1438,7 +1439,7 @@ func waitForDaemonSetRollout(ctx context.Context, client crclient.Client, ds *ap
 		timeout = 25 * time.Minute
 	}
 
-	e2eutil.EventuallyObjects(GinkgoTB(), ctx, fmt.Sprintf("all pods in DaemonSet %s/%s to be ready", ds.Namespace, ds.Name),
+	Expect(v2util.EventuallyObjects(ctx, fmt.Sprintf("all pods in DaemonSet %s/%s to be ready", ds.Namespace, ds.Name),
 		func(ctx context.Context) ([]*corev1.Pod, error) {
 			list := &corev1.PodList{}
 			err := client.List(ctx, list, crclient.InNamespace(ds.Namespace), crclient.MatchingLabels(ds.Spec.Selector.MatchLabels))
@@ -1460,9 +1461,23 @@ func waitForDaemonSetRollout(ctx context.Context, client crclient.Client, ds *ap
 				return want == got, fmt.Sprintf("expected %d ready Pods, got %d", want, got), nil
 			},
 		}, nil,
-		e2eutil.WithTimeout(timeout),
-		e2eutil.WithInterval(5*time.Second),
-	)
+		v2util.WithTimeout(timeout),
+		v2util.WithInterval(5*time.Second),
+	)).To(Succeed())
+}
+
+func expectReadyNodesByNodePool(ctx context.Context, client crclient.Client, np *hyperv1.NodePool, platform hyperv1.PlatformType) {
+	GinkgoHelper()
+
+	_, err := v2util.WaitForReadyNodesByNodePool(ctx, client, np, platform)
+	Expect(err).NotTo(HaveOccurred(), "failed waiting for NodePool %s/%s nodes to become ready", np.Namespace, np.Name)
+}
+
+func expectNodePoolConfigUpdateComplete(ctx context.Context, client crclient.Client, np *hyperv1.NodePool, platform hyperv1.PlatformType) {
+	GinkgoHelper()
+
+	Expect(v2util.WaitForNodePoolConfigUpdateCompleteWithPlatform(ctx, client, np, platform)).To(Succeed(),
+		"failed waiting for NodePool %s/%s config update", np.Namespace, np.Name)
 }
 
 // nodePoolUpgradeTimeout returns the appropriate timeout for NodePool upgrades

--- a/test/e2e/v2/tests/nodepool_osimagestream_test.go
+++ b/test/e2e/v2/tests/nodepool_osimagestream_test.go
@@ -29,6 +29,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
+	v2util "github.com/openshift/hypershift/test/e2e/v2/util"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -150,8 +151,8 @@ spec:
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.EventuallyObject[*hyperv1.NodePool](
-			GinkgoTB(), ctx,
+		Expect(v2util.EventuallyObject[*hyperv1.NodePool](
+			ctx,
 			"NodePool to have ValidMachineConfig=False with ValidationFailed and runc message",
 			func(pollCtx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
@@ -166,9 +167,9 @@ spec:
 				}),
 				conditionMessageContains(hyperv1.NodePoolValidMachineConfigConditionType, "incompatible with runc"),
 			},
-			e2eutil.WithTimeout(5*time.Minute),
-			e2eutil.WithInterval(10*time.Second),
-		)
+			v2util.WithTimeout(5*time.Minute),
+			v2util.WithInterval(10*time.Second),
+		)).To(Succeed())
 	})
 }
 
@@ -201,8 +202,8 @@ func NodePoolOSImageStreamDefaultStatusTest(getTestCtx internal.TestContextGette
 		// will never be set.
 		GinkgoWriter.Printf("Waiting for NodePool %s/%s to have nodesInfo with node versions populated\n",
 			defaultNP.Namespace, defaultNP.Name)
-		e2eutil.EventuallyObject[*hyperv1.NodePool](
-			GinkgoTB(), ctx,
+		Expect(v2util.EventuallyObject[*hyperv1.NodePool](
+			ctx,
 			fmt.Sprintf("NodePool %s/%s to have nodesInfo.nodeVersions populated", defaultNP.Namespace, defaultNP.Name),
 			func(pollCtx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
@@ -212,16 +213,16 @@ func NodePoolOSImageStreamDefaultStatusTest(getTestCtx internal.TestContextGette
 			[]e2eutil.Predicate[*hyperv1.NodePool]{
 				nodesInfoPopulatedPredicate(),
 			},
-			e2eutil.WithTimeout(10*time.Minute),
-			e2eutil.WithInterval(15*time.Second),
-		)
+			v2util.WithTimeout(10*time.Minute),
+			v2util.WithInterval(15*time.Second),
+		)).To(Succeed())
 
 		expectedStream := hyperv1.OSImageStreamRHEL10
 
 		GinkgoWriter.Printf("Waiting for NodePool %s/%s status.osImageStream.name to be %s\n",
 			defaultNP.Namespace, defaultNP.Name, expectedStream)
-		e2eutil.EventuallyObject[*hyperv1.NodePool](
-			GinkgoTB(), ctx,
+		Expect(v2util.EventuallyObject[*hyperv1.NodePool](
+			ctx,
 			"default NodePool status to report a non-empty osImageStream",
 			func(pollCtx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
@@ -231,9 +232,9 @@ func NodePoolOSImageStreamDefaultStatusTest(getTestCtx internal.TestContextGette
 			[]e2eutil.Predicate[*hyperv1.NodePool]{
 				osImageStreamSetPredicate(),
 			},
-			e2eutil.WithTimeout(10*time.Minute),
-			e2eutil.WithInterval(15*time.Second),
-		)
+			v2util.WithTimeout(10*time.Minute),
+			v2util.WithInterval(15*time.Second),
+		)).To(Succeed())
 
 		By("verifying node OS images match the resolved osImageStream")
 		verifyNodeOSMatchesStream(testCtx, defaultNP, expectedStream)
@@ -291,8 +292,8 @@ func verifyNodeOSMatchesStream(testCtx *internal.TestContext, np *hyperv1.NodePo
 	hcClient, err := testCtx.GetHostedClusterClient(hc)
 	Expect(err).NotTo(HaveOccurred(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
 
-	e2eutil.EventuallyObject[*hyperv1.NodePool](
-		GinkgoTB(), testCtx.Context,
+	Expect(v2util.EventuallyObject[*hyperv1.NodePool](
+		testCtx.Context,
 		fmt.Sprintf("NodePool %s/%s to have all nodes ready", np.Namespace, np.Name),
 		func(pollCtx context.Context) (*hyperv1.NodePool, error) {
 			pool := &hyperv1.NodePool{}
@@ -300,9 +301,9 @@ func verifyNodeOSMatchesStream(testCtx *internal.TestContext, np *hyperv1.NodePo
 			return pool, err
 		},
 		[]e2eutil.Predicate[*hyperv1.NodePool]{allNodesReadyPredicate()},
-		e2eutil.WithTimeout(45*time.Minute),
-		e2eutil.WithInterval(30*time.Second),
-	)
+		v2util.WithTimeout(45*time.Minute),
+		v2util.WithInterval(30*time.Second),
+	)).To(Succeed())
 
 	expectedMajor, err := expectedRHELMajorForStream(expectedStream)
 	Expect(err).NotTo(HaveOccurred())
@@ -350,8 +351,8 @@ func NodePoolOSImageStreamNodeOSVerificationTest(getTestCtx internal.TestContext
 			"a non-deleting NodePool with at least one replica should exist for HostedCluster %s/%s", hc.Namespace, hc.Name)
 
 		By("waiting for the NodePool to have status.osImageStream resolved")
-		e2eutil.EventuallyObject[*hyperv1.NodePool](
-			GinkgoTB(), ctx,
+		Expect(v2util.EventuallyObject[*hyperv1.NodePool](
+			ctx,
 			fmt.Sprintf("NodePool %s/%s status.osImageStream to be set", defaultNP.Namespace, defaultNP.Name),
 			func(pollCtx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
@@ -361,9 +362,9 @@ func NodePoolOSImageStreamNodeOSVerificationTest(getTestCtx internal.TestContext
 			[]e2eutil.Predicate[*hyperv1.NodePool]{
 				osImageStreamSetPredicate(),
 			},
-			e2eutil.WithTimeout(10*time.Minute),
-			e2eutil.WithInterval(15*time.Second),
-		)
+			v2util.WithTimeout(10*time.Minute),
+			v2util.WithInterval(15*time.Second),
+		)).To(Succeed())
 
 		Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), defaultNP)).To(Succeed(),
 			"failed to get NodePool %s/%s", defaultNP.Namespace, defaultNP.Name)
@@ -520,8 +521,8 @@ func NodePoolOSImageStreamExplicitDefaultNoRolloutTest(getTestCtx internal.TestC
 		// snapshot — the controller may not have set it yet if Machines are
 		// still registering NodeInfo.
 		GinkgoWriter.Printf("Waiting for NodePool %s to have status.osImageStream set\n", defaultNP.Name)
-		e2eutil.EventuallyObject[*hyperv1.NodePool](
-			GinkgoTB(), ctx,
+		Expect(v2util.EventuallyObject[*hyperv1.NodePool](
+			ctx,
 			fmt.Sprintf("NodePool %s status.osImageStream to be set", defaultNP.Name),
 			func(pollCtx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
@@ -531,9 +532,9 @@ func NodePoolOSImageStreamExplicitDefaultNoRolloutTest(getTestCtx internal.TestC
 			[]e2eutil.Predicate[*hyperv1.NodePool]{
 				osImageStreamSetPredicate(),
 			},
-			e2eutil.WithTimeout(10*time.Minute),
-			e2eutil.WithInterval(15*time.Second),
-		)
+			v2util.WithTimeout(10*time.Minute),
+			v2util.WithInterval(15*time.Second),
+		)).To(Succeed())
 
 		// Re-read the NodePool to get the populated status for the patch below.
 		Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), defaultNP)).To(Succeed())
@@ -554,8 +555,8 @@ func NodePoolOSImageStreamExplicitDefaultNoRolloutTest(getTestCtx internal.TestC
 		// Verify the config hash does not change over time.
 		// The controller normalizes the explicit default to empty for hash computation,
 		// so both hashes should be identical — no rollout would be triggered.
-		e2eutil.EventuallyObject[*hyperv1.NodePool](
-			GinkgoTB(), ctx,
+		Expect(v2util.EventuallyObject[*hyperv1.NodePool](
+			ctx,
 			fmt.Sprintf("NodePool %s config hash to match baseline (explicit default == implicit default)", defaultNP.Name),
 			func(pollCtx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
@@ -574,9 +575,9 @@ func NodePoolOSImageStreamExplicitDefaultNoRolloutTest(getTestCtx internal.TestC
 					return true, "config hash matches baseline", nil
 				},
 			},
-			e2eutil.WithTimeout(5*time.Minute),
-			e2eutil.WithInterval(15*time.Second),
-		)
+			v2util.WithTimeout(5*time.Minute),
+			v2util.WithInterval(15*time.Second),
+		)).To(Succeed())
 	})
 }
 
@@ -623,17 +624,17 @@ func NodePoolOSImageStreamUpgradeVerificationTest(getTestCtx internal.TestContex
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// Upgrade to latest release
 		GinkgoWriter.Printf("Upgrading NodePool %s to latest release %s\n", np.Name, latestImage)
-		Expect(e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, np, func(obj *hyperv1.NodePool) {
+		Expect(v2util.UpdateObject(ctx, testCtx.MgmtClient, np, func(obj *hyperv1.NodePool) {
 			obj.Spec.Release.Image = latestImage
 		})).To(Succeed(), "failed to update NodePool release image")
 
 		// Wait for upgrade to complete
 		upgradeTimeout := nodePoolUpgradeTimeout(hc.Spec.Platform.Type)
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to complete the upgrade", np.Namespace, np.Name),
+		Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to complete the upgrade", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), pool)
@@ -645,10 +646,10 @@ func NodePoolOSImageStreamUpgradeVerificationTest(getTestCtx internal.TestContex
 					Status: metav1.ConditionFalse,
 				}),
 			},
-			e2eutil.WithTimeout(upgradeTimeout),
-		)
+			v2util.WithTimeout(upgradeTimeout),
+		)).To(Succeed())
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// Verify osImageStream status after upgrade.
 		// The RHEL version is dictated by the release version. After upgrading
@@ -663,8 +664,8 @@ func NodePoolOSImageStreamUpgradeVerificationTest(getTestCtx internal.TestContex
 			expectedStream = hyperv1.OSImageStreamRHEL10
 		}
 
-		e2eutil.EventuallyObject[*hyperv1.NodePool](
-			GinkgoTB(), ctx,
+		Expect(v2util.EventuallyObject[*hyperv1.NodePool](
+			ctx,
 			fmt.Sprintf("NodePool %s/%s status to report osImageStream=%s after upgrade", np.Namespace, np.Name, expectedStream),
 			func(pollCtx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
@@ -674,9 +675,9 @@ func NodePoolOSImageStreamUpgradeVerificationTest(getTestCtx internal.TestContex
 			[]e2eutil.Predicate[*hyperv1.NodePool]{
 				e2eutil.OSImageStreamPredicate(expectedStream),
 			},
-			e2eutil.WithTimeout(10*time.Minute),
-			e2eutil.WithInterval(15*time.Second),
-		)
+			v2util.WithTimeout(10*time.Minute),
+			v2util.WithInterval(15*time.Second),
+		)).To(Succeed())
 
 		By("verifying post-upgrade node OS and runtime handlers match the resolved stream")
 		verifyNodeOSMatchesStream(testCtx, np, expectedStream)
@@ -727,7 +728,7 @@ func NodePoolOSImageStreamCrossMajorUpgradeTest(getTestCtx internal.TestContextG
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		By("validating pre-upgrade NodePool version is OCP 4.x")
 		preUpgradeNP := &hyperv1.NodePool{}
@@ -741,8 +742,8 @@ func NodePoolOSImageStreamCrossMajorUpgradeTest(getTestCtx internal.TestContextG
 		verifyNodeOSMatchesStream(testCtx, np, hyperv1.OSImageStreamRHEL9)
 
 		By("verifying pre-upgrade status.osImageStream reports rhel-9")
-		e2eutil.EventuallyObject[*hyperv1.NodePool](
-			GinkgoTB(), ctx,
+		Expect(v2util.EventuallyObject[*hyperv1.NodePool](
+			ctx,
 			fmt.Sprintf("NodePool %s/%s status to report osImageStream=%s before upgrade", np.Namespace, np.Name, hyperv1.OSImageStreamRHEL9),
 			func(pollCtx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
@@ -752,17 +753,17 @@ func NodePoolOSImageStreamCrossMajorUpgradeTest(getTestCtx internal.TestContextG
 			[]e2eutil.Predicate[*hyperv1.NodePool]{
 				e2eutil.OSImageStreamPredicate(hyperv1.OSImageStreamRHEL9),
 			},
-			e2eutil.WithTimeout(10*time.Minute),
-			e2eutil.WithInterval(15*time.Second),
-		)
+			v2util.WithTimeout(10*time.Minute),
+			v2util.WithInterval(15*time.Second),
+		)).To(Succeed())
 
 		By(fmt.Sprintf("upgrading NodePool to latest release %s", latestImage))
-		Expect(e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, np, func(obj *hyperv1.NodePool) {
+		Expect(v2util.UpdateObject(ctx, testCtx.MgmtClient, np, func(obj *hyperv1.NodePool) {
 			obj.Spec.Release.Image = latestImage
 		})).To(Succeed(), "failed to update NodePool release image")
 
 		upgradeTimeout := nodePoolUpgradeTimeout(hc.Spec.Platform.Type)
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to complete the upgrade", np.Namespace, np.Name),
+		Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to complete the upgrade", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), pool)
@@ -774,10 +775,10 @@ func NodePoolOSImageStreamCrossMajorUpgradeTest(getTestCtx internal.TestContextG
 					Status: metav1.ConditionFalse,
 				}),
 			},
-			e2eutil.WithTimeout(upgradeTimeout),
-		)
+			v2util.WithTimeout(upgradeTimeout),
+		)).To(Succeed())
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		By("validating post-upgrade NodePool version is OCP 5.x")
 		postUpgradeNP := &hyperv1.NodePool{}
@@ -791,8 +792,8 @@ func NodePoolOSImageStreamCrossMajorUpgradeTest(getTestCtx internal.TestContextG
 		verifyNodeOSMatchesStream(testCtx, np, hyperv1.OSImageStreamRHEL10)
 
 		By("verifying status.osImageStream reports rhel-10 after cross-major upgrade")
-		e2eutil.EventuallyObject[*hyperv1.NodePool](
-			GinkgoTB(), ctx,
+		Expect(v2util.EventuallyObject[*hyperv1.NodePool](
+			ctx,
 			fmt.Sprintf("NodePool %s/%s status to report osImageStream=%s", np.Namespace, np.Name, hyperv1.OSImageStreamRHEL10),
 			func(pollCtx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
@@ -802,9 +803,9 @@ func NodePoolOSImageStreamCrossMajorUpgradeTest(getTestCtx internal.TestContextG
 			[]e2eutil.Predicate[*hyperv1.NodePool]{
 				e2eutil.OSImageStreamPredicate(hyperv1.OSImageStreamRHEL10),
 			},
-			e2eutil.WithTimeout(10*time.Minute),
-			e2eutil.WithInterval(15*time.Second),
-		)
+			v2util.WithTimeout(10*time.Minute),
+			v2util.WithInterval(15*time.Second),
+		)).To(Succeed())
 	})
 }
 
@@ -855,7 +856,7 @@ func NodePoolOSImageStreamPinnedRHEL9UpgradeTest(getTestCtx internal.TestContext
 			cleanupNodePool(ctx, testCtx.MgmtClient, np)
 		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		By("validating pre-upgrade NodePool version is OCP 4.x")
 		preUpgradeNP := &hyperv1.NodePool{}
@@ -869,8 +870,8 @@ func NodePoolOSImageStreamPinnedRHEL9UpgradeTest(getTestCtx internal.TestContext
 		verifyNodeOSMatchesStream(testCtx, np, hyperv1.OSImageStreamRHEL9)
 
 		By("verifying pre-upgrade status.osImageStream reports rhel-9")
-		e2eutil.EventuallyObject[*hyperv1.NodePool](
-			GinkgoTB(), ctx,
+		Expect(v2util.EventuallyObject[*hyperv1.NodePool](
+			ctx,
 			fmt.Sprintf("NodePool %s/%s status to report osImageStream=%s before upgrade", np.Namespace, np.Name, hyperv1.OSImageStreamRHEL9),
 			func(pollCtx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
@@ -880,17 +881,17 @@ func NodePoolOSImageStreamPinnedRHEL9UpgradeTest(getTestCtx internal.TestContext
 			[]e2eutil.Predicate[*hyperv1.NodePool]{
 				e2eutil.OSImageStreamPredicate(hyperv1.OSImageStreamRHEL9),
 			},
-			e2eutil.WithTimeout(10*time.Minute),
-			e2eutil.WithInterval(15*time.Second),
-		)
+			v2util.WithTimeout(10*time.Minute),
+			v2util.WithInterval(15*time.Second),
+		)).To(Succeed())
 
 		By(fmt.Sprintf("upgrading pinned NodePool to latest release %s", latestImage))
-		Expect(e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, np, func(obj *hyperv1.NodePool) {
+		Expect(v2util.UpdateObject(ctx, testCtx.MgmtClient, np, func(obj *hyperv1.NodePool) {
 			obj.Spec.Release.Image = latestImage
 		})).To(Succeed(), "failed to update NodePool release image")
 
 		upgradeTimeout := nodePoolUpgradeTimeout(hc.Spec.Platform.Type)
-		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to complete the upgrade", np.Namespace, np.Name),
+		Expect(v2util.EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to complete the upgrade", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
 				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), pool)
@@ -902,10 +903,10 @@ func NodePoolOSImageStreamPinnedRHEL9UpgradeTest(getTestCtx internal.TestContext
 					Status: metav1.ConditionFalse,
 				}),
 			},
-			e2eutil.WithTimeout(upgradeTimeout),
-		)
+			v2util.WithTimeout(upgradeTimeout),
+		)).To(Succeed())
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+		expectReadyNodesByNodePool(ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		By("validating post-upgrade NodePool version is OCP 5.x")
 		postUpgradeNP := &hyperv1.NodePool{}
@@ -919,8 +920,8 @@ func NodePoolOSImageStreamPinnedRHEL9UpgradeTest(getTestCtx internal.TestContext
 		verifyNodeOSMatchesStream(testCtx, np, hyperv1.OSImageStreamRHEL9)
 
 		By("verifying status.osImageStream still reports rhel-9 after upgrade")
-		e2eutil.EventuallyObject[*hyperv1.NodePool](
-			GinkgoTB(), ctx,
+		Expect(v2util.EventuallyObject[*hyperv1.NodePool](
+			ctx,
 			fmt.Sprintf("NodePool %s/%s status to report osImageStream=%s", np.Namespace, np.Name, hyperv1.OSImageStreamRHEL9),
 			func(pollCtx context.Context) (*hyperv1.NodePool, error) {
 				pool := &hyperv1.NodePool{}
@@ -930,8 +931,8 @@ func NodePoolOSImageStreamPinnedRHEL9UpgradeTest(getTestCtx internal.TestContext
 			[]e2eutil.Predicate[*hyperv1.NodePool]{
 				e2eutil.OSImageStreamPredicate(hyperv1.OSImageStreamRHEL9),
 			},
-			e2eutil.WithTimeout(10*time.Minute),
-			e2eutil.WithInterval(15*time.Second),
-		)
+			v2util.WithTimeout(10*time.Minute),
+			v2util.WithInterval(15*time.Second),
+		)).To(Succeed())
 	})
 }

--- a/test/e2e/v2/util/aws.go
+++ b/test/e2e/v2/util/aws.go
@@ -1,0 +1,190 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	supportawsutil "github.com/openshift/hypershift/support/awsutil"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	ec2v2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
+)
+
+// CreateTestSubnet creates a small (/28) subnet in the given VPC in the specified AZ,
+// associates it with an existing private route table (one with a NAT gateway route),
+// and returns the subnet ID plus a cleanup function that disassociates and deletes it.
+// The subnet CIDR is chosen dynamically to avoid overlapping with any existing subnets.
+func CreateTestSubnet(ctx context.Context, client *ec2v2.Client, vpcID, az, infraID, clusterName string, additionalTags map[string]string) (string, func(), error) {
+	existing, err := client.DescribeSubnets(ctx, &ec2v2.DescribeSubnetsInput{
+		Filters: []ec2types.Filter{{Name: awsv2.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to list subnets in VPC %s: %w", vpcID, err)
+	}
+
+	occupied := make([]*net.IPNet, 0, len(existing.Subnets))
+	for _, subnet := range existing.Subnets {
+		_, network, err := net.ParseCIDR(awsv2.ToString(subnet.CidrBlock))
+		if err != nil {
+			continue
+		}
+		occupied = append(occupied, network)
+	}
+
+	_, searchSpace, _ := net.ParseCIDR("10.0.192.0/18")
+	candidateCIDR, err := findFreeCIDR(searchSpace, 28, occupied)
+	if err != nil {
+		return "", nil, err
+	}
+
+	subnetName := fmt.Sprintf("%s-karpenter-test-subnet", infraID)
+	subnetTags := []ec2types.Tag{
+		{Key: awsv2.String("Name"), Value: awsv2.String(subnetName)},
+		{Key: awsv2.String(fmt.Sprintf("kubernetes.io/cluster/%s", infraID)), Value: awsv2.String("owned")},
+		{Key: awsv2.String(supportawsutil.HypershiftInfraIDTagKey), Value: awsv2.String(infraID)},
+		{Key: awsv2.String(supportawsutil.HypershiftClusterNameTagKey), Value: awsv2.String(clusterName)},
+	}
+	for key, value := range additionalTags {
+		subnetTags = append(subnetTags, ec2types.Tag{Key: awsv2.String(key), Value: awsv2.String(value)})
+	}
+
+	createOut, err := client.CreateSubnet(ctx, &ec2v2.CreateSubnetInput{
+		VpcId:            awsv2.String(vpcID),
+		CidrBlock:        awsv2.String(candidateCIDR),
+		AvailabilityZone: awsv2.String(az),
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeSubnet,
+			Tags:         subnetTags,
+		}},
+	})
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create subnet %s in %s: %w", candidateCIDR, az, err)
+	}
+	subnetID := awsv2.ToString(createOut.Subnet.SubnetId)
+	GinkgoWriter.Printf("CreateTestSubnet: created subnet %s (%s) in AZ %s\n", subnetID, candidateCIDR, az)
+
+	rtOut, err := client.DescribeRouteTables(ctx, &ec2v2.DescribeRouteTablesInput{
+		Filters: []ec2types.Filter{
+			{Name: awsv2.String("vpc-id"), Values: []string{vpcID}},
+			{Name: awsv2.String("route.nat-gateway-id"), Values: []string{"nat-*"}},
+		},
+	})
+	if err != nil {
+		_, _ = client.DeleteSubnet(ctx, &ec2v2.DeleteSubnetInput{SubnetId: awsv2.String(subnetID)})
+		return "", nil, fmt.Errorf("no private route table with NAT gateway found in VPC %s (err: %w); deleted subnet %s", vpcID, err, subnetID)
+	}
+	if len(rtOut.RouteTables) == 0 {
+		_, _ = client.DeleteSubnet(ctx, &ec2v2.DeleteSubnetInput{SubnetId: awsv2.String(subnetID)})
+		return "", nil, fmt.Errorf("no private route table with NAT gateway found in VPC %s; deleted subnet %s", vpcID, subnetID)
+	}
+
+	routeTableID := awsv2.ToString(rtOut.RouteTables[0].RouteTableId)
+	assocOut, err := client.AssociateRouteTable(ctx, &ec2v2.AssociateRouteTableInput{
+		RouteTableId: awsv2.String(routeTableID),
+		SubnetId:     awsv2.String(subnetID),
+	})
+	if err != nil {
+		_, _ = client.DeleteSubnet(ctx, &ec2v2.DeleteSubnetInput{SubnetId: awsv2.String(subnetID)})
+		return "", nil, fmt.Errorf("failed to associate route table %s with subnet %s: %w; deleted subnet", routeTableID, subnetID, err)
+	}
+
+	associationID := awsv2.ToString(assocOut.AssociationId)
+	GinkgoWriter.Printf("CreateTestSubnet: associated route table %s with subnet %s (association %s)\n", routeTableID, subnetID, associationID)
+
+	cleanup := func() {
+		if _, err := client.DisassociateRouteTable(ctx, &ec2v2.DisassociateRouteTableInput{AssociationId: awsv2.String(associationID)}); err != nil {
+			GinkgoWriter.Printf("CreateTestSubnet cleanup: failed to disassociate route table from subnet %s: %v\n", subnetID, err)
+		}
+		var lastErr error
+		for attempt := 0; attempt < 12; attempt++ {
+			if attempt > 0 {
+				time.Sleep(10 * time.Second)
+			}
+			_, lastErr = client.DeleteSubnet(ctx, &ec2v2.DeleteSubnetInput{SubnetId: awsv2.String(subnetID)})
+			if lastErr == nil {
+				GinkgoWriter.Printf("CreateTestSubnet cleanup: deleted subnet %s\n", subnetID)
+				return
+			}
+			var apiErr smithy.APIError
+			if errors.As(lastErr, &apiErr) && apiErr.ErrorCode() == "DependencyViolation" {
+				GinkgoWriter.Printf("CreateTestSubnet cleanup: subnet %s has dependencies (attempt %d/12), retrying in 10s\n", subnetID, attempt+1)
+				continue
+			}
+			break
+		}
+		GinkgoWriter.Printf("CreateTestSubnet cleanup: failed to delete subnet %s: %v\n", subnetID, lastErr)
+	}
+	return subnetID, cleanup, nil
+}
+
+func findFreeCIDR(searchSpace *net.IPNet, prefixLen int, occupied []*net.IPNet) (string, error) {
+	blockSize := uint32(1) << (32 - prefixLen)
+	startIP := ipToUint32(searchSpace.IP.To4())
+	_, endIP := networkRange(searchSpace)
+	for ip := startIP; ip+blockSize-1 <= endIP; ip += blockSize {
+		candidate := &net.IPNet{IP: uint32ToIP(ip), Mask: net.CIDRMask(prefixLen, 32)}
+		if !overlapsAny(candidate, occupied) {
+			return candidate.String(), nil
+		}
+	}
+	return "", fmt.Errorf("no free /%d block found in %s", prefixLen, searchSpace)
+}
+
+func overlapsAny(candidate *net.IPNet, occupied []*net.IPNet) bool {
+	for _, network := range occupied {
+		if candidate.Contains(network.IP) || network.Contains(candidate.IP) {
+			return true
+		}
+	}
+	return false
+}
+
+func ipToUint32(ip net.IP) uint32 {
+	return binary.BigEndian.Uint32(ip.To4())
+}
+
+func uint32ToIP(n uint32) net.IP {
+	ip := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip, n)
+	return ip
+}
+
+func networkRange(network *net.IPNet) (uint32, uint32) {
+	start := ipToUint32(network.IP.To4())
+	ones, bits := network.Mask.Size()
+	size := uint32(1) << uint(bits-ones)
+	return start, start + size - 1
+}
+
+func E2ETagsFromEnvironment() map[string]string {
+	tags := map[string]string{supportawsutil.HypershiftSourceTagKey: "e2e"}
+	if prowJobID := os.Getenv("PROW_JOB_ID"); prowJobID != "" {
+		tags[supportawsutil.HypershiftProwJobIDTagKey] = prowJobID
+	}
+	return tags
+}

--- a/test/e2e/v2/util/aws_test.go
+++ b/test/e2e/v2/util/aws_test.go
@@ -1,0 +1,57 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	supportawsutil "github.com/openshift/hypershift/support/awsutil"
+)
+
+func TestE2ETagsFromEnvironment(t *testing.T) {
+	tests := []struct {
+		name      string
+		prowJobID string
+		wantJobID bool
+	}{
+		{
+			name: "When PROW_JOB_ID is unset, it should return only the e2e source tag",
+		},
+		{
+			name:      "When PROW_JOB_ID is set, it should include the Prow job tag",
+			prowJobID: "job-123",
+			wantJobID: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PROW_JOB_ID", tt.prowJobID)
+			tags := E2ETagsFromEnvironment()
+			if tags[supportawsutil.HypershiftSourceTagKey] != "e2e" {
+				t.Fatalf("source tag = %q, want %q", tags[supportawsutil.HypershiftSourceTagKey], "e2e")
+			}
+			jobID, found := tags[supportawsutil.HypershiftProwJobIDTagKey]
+			if found != tt.wantJobID {
+				t.Fatalf("Prow job tag present = %t, want %t", found, tt.wantJobID)
+			}
+			if tt.wantJobID && jobID != tt.prowJobID {
+				t.Fatalf("Prow job tag = %q, want %q", jobID, tt.prowJobID)
+			}
+		})
+	}
+}

--- a/test/e2e/v2/util/azure.go
+++ b/test/e2e/v2/util/azure.go
@@ -1,0 +1,179 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ValidateAzureWorkloadIdentityWebhookMutation verifies that the Azure workload
+// identity webhook injects the projected token volume and federated-token
+// environment variable into a newly created pod.
+func ValidateAzureWorkloadIdentityWebhookMutation(ctx context.Context, guestClient crclient.Client) error {
+	nsName := fmt.Sprintf("azure-wi-e2e-%d", time.Now().UnixNano())
+	testNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+	if err := guestClient.Create(ctx, testNamespace); err != nil {
+		return fmt.Errorf("failed to create test namespace: %w", err)
+	}
+	defer func() {
+		_ = guestClient.Delete(context.Background(), testNamespace)
+	}()
+
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-wi-test-sa",
+			Namespace: nsName,
+			Annotations: map[string]string{
+				"azure.workload.identity/client-id": "00000000-0000-0000-0000-000000000000",
+			},
+		},
+	}
+	if err := guestClient.Create(ctx, serviceAccount); err != nil {
+		return fmt.Errorf("failed to create test service account: %w", err)
+	}
+
+	podTemplate := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-wi-webhook-test-pod",
+			Namespace: nsName,
+			Labels: map[string]string{
+				"azure.workload.identity/use": "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: serviceAccount.Name,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: ptr.To(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:    "app",
+					Image:   "registry.k8s.io/pause:3.10",
+					Command: []string{"/pause"},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+
+	// The WI webhook is a MutatingAdmissionWebhook with FailurePolicy: Ignore
+	// that only fires on pod CREATE. If the webhook sidecar isn't ready when
+	// the pod is created, the pod is admitted without mutation and no amount
+	// of GET polling can recover. Delete and recreate each iteration to
+	// re-trigger admission until the webhook is ready.
+	err := waitForAzureWorkloadIdentityMutation(ctx, guestClient, podTemplate)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func waitForAzureWorkloadIdentityMutation(ctx context.Context, guestClient crclient.Client, podTemplate *corev1.Pod) error {
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		existing := &corev1.Pod{}
+		err := guestClient.Get(ctx, types.NamespacedName{Name: podTemplate.Name, Namespace: podTemplate.Namespace}, existing)
+		if err == nil {
+			if err := guestClient.Delete(ctx, existing); err != nil {
+				GinkgoWriter.Printf("failed to delete pod for retry: %v\n", err)
+				return false, nil
+			}
+			if err := wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+				err := guestClient.Get(ctx, types.NamespacedName{Name: podTemplate.Name, Namespace: podTemplate.Namespace}, &corev1.Pod{})
+				return apierrors.IsNotFound(err), nil
+			}); err != nil {
+				GinkgoWriter.Printf("pod was not deleted before retry: %v\n", err)
+				return false, nil
+			}
+		} else if !apierrors.IsNotFound(err) {
+			GinkgoWriter.Printf("unexpected error getting existing pod: %v\n", err)
+			return false, nil
+		}
+
+		fresh := podTemplate.DeepCopy()
+		if err := guestClient.Create(ctx, fresh); err != nil {
+			GinkgoWriter.Printf("failed to create pod for webhook mutation test: %v\n", err)
+			return false, nil
+		}
+
+		mutated := &corev1.Pod{}
+		if err := guestClient.Get(ctx, types.NamespacedName{Name: fresh.Name, Namespace: fresh.Namespace}, mutated); err != nil {
+			GinkgoWriter.Printf("failed to get mutated pod: %v\n", err)
+			return false, nil
+		}
+		if !hasProjectedTokenVolume(mutated.Spec.Volumes) {
+			GinkgoWriter.Println("expected projected service account token volume to be injected")
+			return false, nil
+		}
+		if !hasAzureFederatedTokenEnv(mutated.Spec.Containers) {
+			GinkgoWriter.Println("expected AZURE_FEDERATED_TOKEN_FILE env var in pod containers")
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to validate Azure workload identity webhook mutation: %w", err)
+	}
+	return nil
+}
+
+func hasProjectedTokenVolume(volumes []corev1.Volume) bool {
+	for _, volume := range volumes {
+		if volume.Name != "azure-identity-token" || volume.Projected == nil {
+			continue
+		}
+		for _, source := range volume.Projected.Sources {
+			if source.ServiceAccountToken != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasAzureFederatedTokenEnv(containers []corev1.Container) bool {
+	for _, container := range containers {
+		for _, env := range container.Env {
+			if env.Name == "AZURE_FEDERATED_TOKEN_FILE" && strings.HasPrefix(env.Value, "/var/run/secrets/azure/tokens/") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/test/e2e/v2/util/azure_test.go
+++ b/test/e2e/v2/util/azure_test.go
@@ -1,0 +1,104 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestHasProjectedTokenVolume(t *testing.T) {
+	tests := []struct {
+		name    string
+		volumes []corev1.Volume
+		want    bool
+	}{
+		{
+			name: "When the Azure token volume has a projected service account token, it should return true",
+			volumes: []corev1.Volume{{
+				Name: "azure-identity-token",
+				VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{Sources: []corev1.VolumeProjection{{
+					ServiceAccountToken: &corev1.ServiceAccountTokenProjection{},
+				}}}},
+			}},
+			want: true,
+		},
+		{
+			name: "When the volume has a different name, it should return false",
+			volumes: []corev1.Volume{{
+				Name:         "other-token",
+				VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{Sources: []corev1.VolumeProjection{{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{}}}}},
+			}},
+			want: false,
+		},
+		{
+			name: "When the Azure token volume has no service account token source, it should return false",
+			volumes: []corev1.Volume{{
+				Name:         "azure-identity-token",
+				VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{Sources: []corev1.VolumeProjection{{ConfigMap: &corev1.ConfigMapProjection{}}}}},
+			}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasProjectedTokenVolume(tt.volumes); got != tt.want {
+				t.Fatalf("hasProjectedTokenVolume() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasAzureFederatedTokenEnv(t *testing.T) {
+	tests := []struct {
+		name       string
+		containers []corev1.Container
+		want       bool
+	}{
+		{
+			name: "When a container has the Azure federated token path, it should return true",
+			containers: []corev1.Container{{Env: []corev1.EnvVar{{
+				Name:  "AZURE_FEDERATED_TOKEN_FILE",
+				Value: "/var/run/secrets/azure/tokens/azure-identity-token",
+			}}}},
+			want: true,
+		},
+		{
+			name: "When the token environment variable has another path, it should return false",
+			containers: []corev1.Container{{Env: []corev1.EnvVar{{
+				Name:  "AZURE_FEDERATED_TOKEN_FILE",
+				Value: "/var/run/secrets/tokens/token",
+			}}}},
+			want: false,
+		},
+		{
+			name:       "When the container has no Azure federated token environment variable, it should return false",
+			containers: []corev1.Container{{Env: []corev1.EnvVar{{Name: "OTHER", Value: "value"}}}},
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasAzureFederatedTokenEnv(tt.containers); got != tt.want {
+				t.Fatalf("hasAzureFederatedTokenEnv() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/v2/util/cidr.go
+++ b/test/e2e/v2/util/cidr.go
@@ -1,0 +1,240 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"reflect"
+	"slices"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	cpomanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	"github.com/openshift/hypershift/support/azureutil"
+	"github.com/openshift/hypershift/support/netutil"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ValidateKubeAPIServerAllowedCIDRs verifies that HostedCluster API server
+// allowed CIDRs are reconciled to the HCP and enforcing LoadBalancer service,
+// and that reachability changes accordingly.
+func ValidateKubeAPIServerAllowedCIDRs(ctx context.Context, mgmtClient crclient.Client, guestConfig *rest.Config, hc *hyperv1.HostedCluster) (retErr error) {
+	var originalAPIServer *hyperv1.APIServerNetworking
+	if hc.Spec.Networking.APIServer != nil {
+		originalAPIServer = hc.Spec.Networking.APIServer.DeepCopy()
+	}
+	defer func() {
+		restoreErr := UpdateObject(ctx, mgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+			if originalAPIServer != nil {
+				obj.Spec.Networking.APIServer = originalAPIServer.DeepCopy()
+			} else {
+				obj.Spec.Networking.APIServer = nil
+			}
+		})
+		if restoreErr != nil {
+			retErr = combineErrors(retErr, fmt.Errorf("failed to restore HostedCluster API server CIDRs: %w", restoreErr))
+		}
+
+		// The AllowedCIDRs test uses cfg.Dial to create isolated transports, but
+		// subsequent tests share the original guestConfig transport. Wait until
+		// Azure LB propagation completes CIDR restoration before returning.
+		if err := waitForKubeAPIServerReachability(ctx, guestConfig, true, 5*time.Minute, 10*time.Second, false); err != nil {
+			retErr = combineErrors(retErr, fmt.Errorf("KAS should be reachable on original transport after CIDR cleanup: %w", err))
+		}
+	}()
+
+	if err := ensureAPIServerAllowedCIDRs(ctx, mgmtClient, guestConfig, hc, []string{"0.0.0.0/32"}, false); err != nil {
+		return err
+	}
+	return ensureAPIServerAllowedCIDRs(ctx, mgmtClient, guestConfig, hc, append([]string{"0.0.0.0/0"}, generateTestCIDRs250()...), true)
+}
+
+func ensureAPIServerAllowedCIDRs(ctx context.Context, mgmtClient crclient.Client, guestConfig *rest.Config, hc *hyperv1.HostedCluster, allowedCIDRs []string, shouldBeReachable bool) error {
+	expectedCIDRs := make([]hyperv1.CIDRBlock, len(allowedCIDRs))
+	for i, cidr := range allowedCIDRs {
+		expectedCIDRs[i] = hyperv1.CIDRBlock(cidr)
+	}
+
+	if err := UpdateObject(ctx, mgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+		if obj.Spec.Networking.APIServer == nil {
+			obj.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{}
+		}
+		obj.Spec.Networking.APIServer.AllowedCIDRBlocks = expectedCIDRs
+	}); err != nil {
+		return fmt.Errorf("failed to update HostedCluster with allowed CIDRs: %w", err)
+	}
+
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name)
+	if err := EventuallyObject(ctx, "HostedControlPlane to reflect the updated AllowedCIDRBlocks",
+		func(ctx context.Context) (*hyperv1.HostedControlPlane, error) {
+			hcp := &hyperv1.HostedControlPlane{}
+			err := mgmtClient.Get(ctx, crclient.ObjectKey{Namespace: hcpNamespace, Name: hc.Name}, hcp)
+			if err != nil {
+				return hcp, err
+			}
+			if hcp.Spec.Networking.APIServer == nil || !reflect.DeepEqual(hcp.Spec.Networking.APIServer.AllowedCIDRBlocks, expectedCIDRs) {
+				// The HO may read a stale HC cache. Touch the HC to force a new
+				// watch event and reconciliation with the current spec.
+				_ = UpdateObject(ctx, mgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+					if obj.Annotations == nil {
+						obj.Annotations = map[string]string{}
+					}
+					obj.Annotations["e2e.hypershift.openshift.io/cidr-trigger"] = time.Now().Format(time.RFC3339)
+				})
+			}
+			return hcp, nil
+		},
+		[]e2eutil.Predicate[*hyperv1.HostedControlPlane]{
+			func(hcp *hyperv1.HostedControlPlane) (bool, string, error) {
+				if hcp.Spec.Networking.APIServer == nil {
+					return false, "HCP APIServer networking should be set", nil
+				}
+				if !reflect.DeepEqual(hcp.Spec.Networking.APIServer.AllowedCIDRBlocks, expectedCIDRs) {
+					return false, "HCP AllowedCIDRBlocks do not match the HostedCluster spec", nil
+				}
+				return true, "HCP AllowedCIDRBlocks match the HostedCluster spec", nil
+			},
+		},
+		WithTimeout(3*time.Minute), WithInterval(5*time.Second),
+	); err != nil {
+		return err
+	}
+
+	// The target service depends on the API server publishing strategy:
+	// Route: the router LB service carries the CIDRs; LoadBalancer: the KAS LB
+	// service itself carries them.
+	targetSvc := allowedCIDRsTargetService(hc, hcpNamespace)
+	if targetSvc != nil {
+		expectedSourceRanges := slices.Clone(allowedCIDRs)
+		slices.Sort(expectedSourceRanges)
+		GinkgoWriter.Printf("Waiting for service %s/%s LoadBalancerSourceRanges to match %d CIDRs\n", targetSvc.Namespace, targetSvc.Name, len(expectedSourceRanges))
+		if err := EventuallyObject(ctx, fmt.Sprintf("service %s/%s LoadBalancerSourceRanges to match expected CIDRs", targetSvc.Namespace, targetSvc.Name),
+			func(ctx context.Context) (*corev1.Service, error) {
+				svc := &corev1.Service{}
+				err := mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(targetSvc), svc)
+				return svc, err
+			},
+			[]e2eutil.Predicate[*corev1.Service]{
+				func(svc *corev1.Service) (bool, string, error) {
+					actualSourceRanges := slices.Clone(svc.Spec.LoadBalancerSourceRanges)
+					slices.Sort(actualSourceRanges)
+					if reflect.DeepEqual(actualSourceRanges, expectedSourceRanges) {
+						return true, "LoadBalancerSourceRanges match expected CIDRs", nil
+					}
+					return false, fmt.Sprintf("LoadBalancerSourceRanges are %v, want %v", actualSourceRanges, expectedSourceRanges), nil
+				},
+			},
+			WithTimeout(3*time.Minute), WithInterval(5*time.Second),
+		); err != nil {
+			return err
+		}
+	} else {
+		GinkgoWriter.Println("No downstream LB service identified for this cluster configuration; skipping LoadBalancerSourceRanges wait")
+	}
+
+	if err := waitForKubeAPIServerReachability(ctx, guestConfig, shouldBeReachable, 3*time.Minute, 5*time.Second, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func waitForKubeAPIServerReachability(ctx context.Context, guestConfig *rest.Config, shouldBeReachable bool, timeout, interval time.Duration, freshTransport bool) error {
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		cfg := guestConfig
+		if freshTransport {
+			cfg = rest.CopyConfig(guestConfig)
+			cfg.Dial = (&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext
+		}
+		client, err := kubeclient.NewForConfig(cfg)
+		if err != nil {
+			GinkgoWriter.Printf("failed to create kubeclient: %v\n", err)
+			return false, nil
+		}
+		_, err = client.ServerVersion()
+		if shouldBeReachable {
+			if err == nil {
+				return true, nil
+			}
+		} else if err != nil {
+			// An error is the expected result when checking that the API is unreachable.
+			return true, nil //nolint:nilerr
+		}
+		return false, nil
+	})
+	if err != nil {
+		if shouldBeReachable {
+			return fmt.Errorf("failed waiting for kube-apiserver to be reachable: %w", err)
+		}
+		return fmt.Errorf("failed waiting for kube-apiserver to be unreachable: %w", err)
+	}
+	return nil
+}
+
+func allowedCIDRsTargetService(hc *hyperv1.HostedCluster, hcpNamespace string) *corev1.Service {
+	if !netutil.IsPublicHC(hc) {
+		return nil
+	}
+	strategy := netutil.ServicePublishingStrategyByTypeByHC(hc, hyperv1.APIServer)
+	if strategy == nil {
+		return nil
+	}
+	switch strategy.Type {
+	case hyperv1.Route:
+		if azureutil.IsAroHCP() {
+			return nil
+		}
+		return cpomanifests.RouterPublicService(hcpNamespace)
+	case hyperv1.LoadBalancer:
+		if hc.Spec.Platform.Type == hyperv1.AzurePlatform ||
+			(hc.Annotations != nil && hc.Annotations[hyperv1.ManagementPlatformAnnotation] == string(hyperv1.AzurePlatform)) {
+			return cpomanifests.KubeAPIServerServiceAzureLB(hcpNamespace)
+		}
+		return cpomanifests.KubeAPIServerService(hcpNamespace)
+	default:
+		return nil
+	}
+}
+
+func generateTestCIDRs250() []string {
+	cidrs := make([]string, 0, 250)
+	for i := 1; i <= 250; i++ {
+		cidrs = append(cidrs, fmt.Sprintf("250.250.250.%d/32", i))
+	}
+	return cidrs
+}
+
+func combineErrors(first, second error) error {
+	if first == nil {
+		return second
+	}
+	if second == nil {
+		return first
+	}
+	return fmt.Errorf("%w; %w", first, second)
+}

--- a/test/e2e/v2/util/cidr_test.go
+++ b/test/e2e/v2/util/cidr_test.go
@@ -1,0 +1,132 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestFindFreeCIDR(t *testing.T) {
+	_, searchSpace, err := net.ParseCIDR("10.0.192.0/29")
+	if err != nil {
+		t.Fatalf("failed to parse search space: %v", err)
+	}
+	_, occupiedBlock, err := net.ParseCIDR("10.0.192.0/30")
+	if err != nil {
+		t.Fatalf("failed to parse occupied block: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		occupied  []*net.IPNet
+		wantCIDR  string
+		wantError string
+	}{
+		{
+			name:     "When the first candidate overlaps an existing subnet, it should return the next free block",
+			occupied: []*net.IPNet{occupiedBlock},
+			wantCIDR: "10.0.192.4/30",
+		},
+		{
+			name:      "When every candidate overlaps an existing subnet, it should return an error",
+			occupied:  []*net.IPNet{searchSpace},
+			wantError: "no free /30 block found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findFreeCIDR(searchSpace, 30, tt.occupied)
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("findFreeCIDR() error = %v, want error containing %q", err, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("findFreeCIDR() returned an unexpected error: %v", err)
+			}
+			if got != tt.wantCIDR {
+				t.Fatalf("findFreeCIDR() = %q, want %q", got, tt.wantCIDR)
+			}
+		})
+	}
+}
+
+func TestGenerateTestCIDRs250(t *testing.T) {
+	cidrs := generateTestCIDRs250()
+	if len(cidrs) != 250 {
+		t.Fatalf("generateTestCIDRs250() returned %d CIDRs, want 250", len(cidrs))
+	}
+	if cidrs[0] != "250.250.250.1/32" {
+		t.Fatalf("first generated CIDR = %q, want %q", cidrs[0], "250.250.250.1/32")
+	}
+	if cidrs[len(cidrs)-1] != "250.250.250.250/32" {
+		t.Fatalf("last generated CIDR = %q, want %q", cidrs[len(cidrs)-1], "250.250.250.250/32")
+	}
+}
+
+func TestCombineErrors(t *testing.T) {
+	first := errors.New("first error")
+	second := errors.New("second error")
+
+	tests := []struct {
+		name       string
+		first      error
+		second     error
+		want       error
+		wantString string
+	}{
+		{
+			name:  "When only the first error exists, it should return the first error",
+			first: first,
+			want:  first,
+		},
+		{
+			name:   "When only the second error exists, it should return the second error",
+			second: second,
+			want:   second,
+		},
+		{
+			name:       "When both errors exist, it should include both error messages",
+			first:      first,
+			second:     second,
+			wantString: "first error; second error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := combineErrors(tt.first, tt.second)
+			if tt.want != nil {
+				if !errors.Is(got, tt.want) {
+					t.Fatalf("combineErrors() = %v, want %v", got, tt.want)
+				}
+				return
+			}
+			if got == nil || got.Error() != tt.wantString {
+				t.Fatalf("combineErrors() = %v, want %q", got, tt.wantString)
+			}
+			if !errors.Is(got, tt.first) || !errors.Is(got, tt.second) {
+				t.Fatalf("combineErrors() = %v, want both source errors to be discoverable", got)
+			}
+		})
+	}
+}

--- a/test/e2e/v2/util/eventually.go
+++ b/test/e2e/v2/util/eventually.go
@@ -1,0 +1,457 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func defaultEventuallyOptions() *EventuallyOptions {
+	return &EventuallyOptions{
+		interval:       3 * time.Second,
+		timeout:        10 * time.Minute,
+		immediate:      true,
+		dumpConditions: true,
+	}
+}
+
+// EventuallyOptions configure v2 asynchronous polling behavior.
+type EventuallyOptions struct {
+	interval  time.Duration
+	timeout   time.Duration
+	immediate bool
+
+	dumpConditions      bool
+	filterConditionDump []e2eutil.Condition
+}
+
+// EventuallyOption configures v2 asynchronous polling behavior.
+type EventuallyOption func(*EventuallyOptions)
+
+// WithInterval sets the polling interval for a v2 asynchronous assertion.
+func WithInterval(interval time.Duration) EventuallyOption {
+	return func(o *EventuallyOptions) {
+		o.interval = interval
+	}
+}
+
+// WithTimeout sets the polling timeout for a v2 asynchronous assertion.
+func WithTimeout(timeout time.Duration) EventuallyOption {
+	return func(o *EventuallyOptions) {
+		o.timeout = timeout
+	}
+}
+
+// WithDelayedStart configures a v2 asynchronous assertion to wait for the
+// first interval before its first poll.
+func WithDelayedStart() EventuallyOption {
+	return func(o *EventuallyOptions) {
+		o.immediate = false
+	}
+}
+
+// WithoutConditionDump disables condition logging when a v2 asynchronous
+// assertion fails.
+func WithoutConditionDump() EventuallyOption {
+	return func(o *EventuallyOptions) {
+		o.dumpConditions = false
+	}
+}
+
+// WithFilteredConditionDump limits failure condition logging to matching
+// conditions.
+func WithFilteredConditionDump(matchers ...e2eutil.Condition) EventuallyOption {
+	return func(o *EventuallyOptions) {
+		o.filterConditionDump = append(o.filterConditionDump, matchers...)
+	}
+}
+
+// EventuallyObject polls until all predicates are fulfilled for an object.
+// It returns an error instead of signaling failure through testing.TB, so the
+// caller can report the failure through the v2 Ginkgo assertion path.
+func EventuallyObject[T client.Object](ctx context.Context, objective string, getter func(context.Context) (T, error), predicates []e2eutil.Predicate[T], options ...EventuallyOption) error {
+	opts := defaultEventuallyOptions()
+	for _, option := range options {
+		option(opts)
+	}
+
+	if os.Getenv("EVENTUALLY_VERBOSE") != "false" {
+		GinkgoWriter.Printf("Waiting for %s\n", objective)
+	}
+	start := time.Now()
+	lastTimestamp := time.Now()
+	var previousError string
+	var previousResults []predicateResult
+	var object T
+	err := wait.PollUntilContextTimeout(ctx, opts.interval, opts.timeout, opts.immediate, func(ctx context.Context) (bool, error) {
+		obj, getErr := getter(ctx)
+		if getErr != nil {
+			if getErr.Error() != previousError {
+				previousError = getErr.Error()
+				GinkgoWriter.Printf("Failed to get %T: %v\n", object, getErr)
+			}
+			return false, nil
+		}
+		object = obj
+
+		currentResults, err := evaluatePredicates(object, predicates)
+		if err != nil {
+			return false, err
+		}
+		done := summarizePredicateResults(currentResults)
+		if os.Getenv("EVENTUALLY_VERBOSE") != "false" {
+			printStatus(lastTimestamp, object, done, diffPredicateResults(previousResults, currentResults))
+		}
+
+		previousResults = currentResults
+		lastTimestamp = time.Now()
+		return done, nil
+	})
+	duration := time.Since(start).Round(25 * time.Millisecond)
+
+	if err != nil {
+		failure := fmt.Errorf("failed to wait for %s in %s: %w", objective, duration, err)
+		if !isZeroObject(object) {
+			results, resultsErr := evaluatePredicates(object, predicates)
+			if resultsErr != nil {
+				return fmt.Errorf("%w; failed to evaluate predicates: %w", failure, resultsErr)
+			}
+			done := summarizePredicateResults(results)
+			if !done {
+				var reasons []string
+				for _, result := range results {
+					if !result.done {
+						reasons = append(reasons, result.reason)
+					}
+				}
+				printStatus(start, object, done, reasons)
+			}
+
+			if opts.dumpConditions {
+				if err := logConditions(object, opts.filterConditionDump); err != nil {
+					return fmt.Errorf("%w; %w", failure, err)
+				}
+			}
+		}
+		return failure
+	}
+
+	GinkgoWriter.Printf("Successfully waited for %s in %s\n", objective, duration)
+	return nil
+}
+
+// EventuallyObjects polls until the group predicates and all per-object
+// predicates are fulfilled for a collection of objects. It returns an error
+// instead of signaling failure through testing.TB.
+func EventuallyObjects[T client.Object](ctx context.Context, objective string, getter func(context.Context) ([]T, error), groupPredicates []e2eutil.Predicate[[]T], predicates []e2eutil.Predicate[T], options ...EventuallyOption) error {
+	opts := defaultEventuallyOptions()
+	for _, option := range options {
+		option(opts)
+	}
+
+	if os.Getenv("EVENTUALLY_VERBOSE") != "false" {
+		GinkgoWriter.Printf("Waiting for %s\n", objective)
+	}
+	start := time.Now()
+	lastTimestamp := time.Now()
+	var previousError string
+	previousResults := map[types.NamespacedName][]predicateResult{}
+	var objects []T
+	err := wait.PollUntilContextTimeout(ctx, opts.interval, opts.timeout, opts.immediate, func(ctx context.Context) (bool, error) {
+		objs, getErr := getter(ctx)
+		if getErr != nil {
+			if getErr.Error() != previousError {
+				previousError = getErr.Error()
+				GinkgoWriter.Printf("Failed to get %T: %v\n", new(T), getErr)
+			}
+			return false, nil
+		}
+		objects = objs
+
+		currentResults, err := evaluateCollectionPredicates(objects, groupPredicates, predicates)
+		if err != nil {
+			return false, err
+		}
+		done := summarizeCollectionPredicateResults(currentResults)
+		if diff := cmp.Diff(previousResults, currentResults, cmp.AllowUnexported(predicateResult{})); diff != "" && os.Getenv("EVENTUALLY_VERBOSE") != "false" {
+			reasons := map[types.NamespacedName]predicateReasons{}
+			for key, results := range currentResults {
+				if diff := diffPredicateResults(previousResults[key], results); len(diff) > 0 {
+					reasons[key] = predicateReasons{
+						done:    summarizePredicateResults(results),
+						reasons: diff,
+					}
+				}
+			}
+			printCollectionStatus[T](lastTimestamp, done, reasons)
+		}
+		previousResults = currentResults
+
+		lastTimestamp = time.Now()
+		return done, nil
+	})
+	duration := time.Since(start).Round(25 * time.Millisecond)
+
+	if err != nil {
+		failure := fmt.Errorf("failed to wait for %s in %s: %w", objective, duration, err)
+		finalResults, resultErr := evaluateCollectionPredicates(objects, groupPredicates, predicates)
+		if resultErr != nil {
+			return fmt.Errorf("%w; failed to evaluate predicates: %w", failure, resultErr)
+		}
+		done := summarizeCollectionPredicateResults(finalResults)
+		if !done {
+			reasons := map[types.NamespacedName]predicateReasons{}
+			for key, results := range finalResults {
+				var failingReasons []string
+				for _, result := range results {
+					if !result.done {
+						failingReasons = append(failingReasons, result.reason)
+					}
+				}
+				if len(failingReasons) > 0 {
+					reasons[key] = predicateReasons{
+						done:    false,
+						reasons: failingReasons,
+					}
+				}
+			}
+			printCollectionStatus[T](start, done, reasons)
+		}
+
+		var invalidObjects []T
+		for _, object := range objects {
+			if !summarizePredicateResults(finalResults[types.NamespacedName{Namespace: object.GetNamespace(), Name: object.GetName()}]) {
+				invalidObjects = append(invalidObjects, object)
+			}
+		}
+		if opts.dumpConditions {
+			for _, object := range invalidObjects {
+				if isZeroObject(object) {
+					continue
+				}
+				if err := logConditions(object, opts.filterConditionDump); err != nil {
+					return fmt.Errorf("%w; %w", failure, err)
+				}
+			}
+		}
+		return failure
+	}
+
+	GinkgoWriter.Printf("Successfully waited for %s in %s\n", objective, duration)
+	return nil
+}
+
+// EventuallyNotFound polls until the object is not found (deleted). It returns
+// an error instead of signaling failure through testing.TB.
+func EventuallyNotFound[T client.Object](ctx context.Context, c client.Client, obj T, options ...EventuallyOption) error {
+	opts := defaultEventuallyOptions()
+	for _, option := range options {
+		option(opts)
+	}
+
+	objective := fmt.Sprintf("%T %s/%s to be deleted", obj, obj.GetNamespace(), obj.GetName())
+	if os.Getenv("EVENTUALLY_VERBOSE") != "false" {
+		GinkgoWriter.Printf("Waiting for %s\n", objective)
+	}
+	start := time.Now()
+	err := wait.PollUntilContextTimeout(ctx, opts.interval, opts.timeout, opts.immediate, func(ctx context.Context) (bool, error) {
+		err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		if err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	})
+	duration := time.Since(start).Round(25 * time.Millisecond)
+
+	if err != nil {
+		return fmt.Errorf("failed to wait for %s in %s: %w", objective, duration, err)
+	}
+
+	GinkgoWriter.Printf("Successfully waited for %s in %s\n", objective, duration)
+	return nil
+}
+
+type predicateResult struct {
+	done   bool
+	reason string
+}
+
+func evaluatePredicates[T any](object T, predicates []e2eutil.Predicate[T]) ([]predicateResult, error) {
+	if reflect.TypeOf(object).Kind() != reflect.Slice && (reflect.ValueOf(object).IsZero() || reflect.ValueOf(object).Elem().IsZero()) {
+		panic(fmt.Sprintf("programmer error: can't evaluate predicates on empty object %#v", object))
+	}
+	results := make([]predicateResult, len(predicates))
+	for i, predicate := range predicates {
+		if predicate == nil {
+			panic(fmt.Sprintf("programmer error: can't evaluate empty predicate %d: %#v", i, object))
+		}
+		done, reason, err := predicate(object)
+		if err != nil {
+			return nil, err
+		}
+		if !done && len(reason) == 0 {
+			panic("programmer error: predicate returned false with no message")
+		}
+		results[i] = predicateResult{done: done, reason: reason}
+	}
+	return results, nil
+}
+
+func diffPredicateResults(before, after []predicateResult) []string {
+	var diff []string
+	if len(before) != 0 && len(before) != len(after) {
+		panic(fmt.Sprintf("programmer error: predicates are different lengths, before=%d, after=%d", len(before), len(after)))
+	}
+	for i := range after {
+		if len(before) == 0 || before[i].reason != after[i].reason {
+			diff = append(diff, after[i].reason)
+		}
+	}
+	return diff
+}
+
+func summarizePredicateResults(results []predicateResult) bool {
+	done := true
+	for i := range results {
+		done = done && results[i].done
+	}
+	return done
+}
+
+func printStatus[T client.Object](lastTimestamp time.Time, object T, done bool, reasons []string) {
+	if len(reasons) == 0 {
+		return
+	}
+
+	prefix := ""
+	if !done {
+		prefix = "in"
+	}
+	suffix := ""
+	if len(reasons) == 1 {
+		suffix = " " + reasons[0]
+	}
+	GinkgoWriter.Printf("observed %T %s/%s %svalid at RV %s after %s:%s\n", object, object.GetNamespace(), object.GetName(), prefix, object.GetResourceVersion(), time.Since(lastTimestamp).Round(25*time.Millisecond), suffix)
+	if len(reasons) > 1 {
+		for _, message := range reasons {
+			GinkgoWriter.Printf(" - %s\n", message)
+		}
+	}
+}
+
+func evaluateCollectionPredicates[T client.Object](objects []T, groupPredicates []e2eutil.Predicate[[]T], predicates []e2eutil.Predicate[T]) (map[types.NamespacedName][]predicateResult, error) {
+	currentResults := map[types.NamespacedName][]predicateResult{}
+	groupResults, err := evaluatePredicates(objects, groupPredicates)
+	if err != nil {
+		return nil, err
+	}
+	currentResults[types.NamespacedName{}] = groupResults
+
+	for _, object := range objects {
+		objectResults, objectError := evaluatePredicates(object, predicates)
+		if objectError != nil {
+			return nil, objectError
+		}
+		currentResults[types.NamespacedName{Namespace: object.GetNamespace(), Name: object.GetName()}] = objectResults
+	}
+	return currentResults, nil
+}
+
+func summarizeCollectionPredicateResults(results map[types.NamespacedName][]predicateResult) bool {
+	done := true
+	for _, result := range results {
+		done = done && summarizePredicateResults(result)
+	}
+	return done
+}
+
+type predicateReasons struct {
+	done    bool
+	reasons []string
+}
+
+func printCollectionStatus[T client.Object](lastTimestamp time.Time, done bool, reasons map[types.NamespacedName]predicateReasons) {
+	prefix := ""
+	if !done {
+		prefix = "in"
+	}
+	GinkgoWriter.Printf("observed %svalid %T state after %s\n", prefix, new(T), time.Since(lastTimestamp).Round(25*time.Millisecond))
+	for key, result := range reasons {
+		if len(result.reasons) == 0 {
+			continue
+		}
+		prefix := ""
+		if !result.done {
+			prefix = "in"
+		}
+		identifier := "collection"
+		if key != (types.NamespacedName{}) {
+			identifier = fmt.Sprintf("%s/%s", key.Namespace, key.Name)
+		}
+		suffix := ""
+		if len(result.reasons) == 1 {
+			suffix = " " + result.reasons[0]
+		}
+		GinkgoWriter.Printf(" - observed %T %s %svalid:%s\n", new(T), identifier, prefix, suffix)
+		if len(result.reasons) > 1 {
+			for _, message := range result.reasons {
+				GinkgoWriter.Printf("    - %s\n", message)
+			}
+		}
+	}
+}
+
+func logConditions(object client.Object, filters []e2eutil.Condition) error {
+	conditions, err := e2eutil.Conditions(object)
+	if err != nil {
+		return fmt.Errorf("failed to extract conditions from %T %s/%s: %w", object, object.GetNamespace(), object.GetName(), err)
+	}
+	GinkgoWriter.Printf("%T %s/%s conditions:\n", object, object.GetNamespace(), object.GetName())
+	for _, condition := range conditions {
+		matches := len(filters) == 0
+		for _, matcher := range filters {
+			matches = matches || matcher.Matches(condition)
+		}
+		if matches {
+			GinkgoWriter.Printf("%s\n", condition.String())
+		}
+	}
+	return nil
+}
+
+func isZeroObject[T client.Object](object T) bool {
+	value := reflect.ValueOf(object)
+	return value.IsZero() || value.Elem().IsZero()
+}

--- a/test/e2e/v2/util/eventually_test.go
+++ b/test/e2e/v2/util/eventually_test.go
@@ -1,0 +1,134 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestEventuallyObjectRetriesGetterErrors(t *testing.T) {
+	object := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "example"}}
+	attempts := 0
+
+	err := EventuallyObject(t.Context(), "ConfigMap to become available", func(context.Context) (*corev1.ConfigMap, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, errors.New("object is not available yet")
+		}
+		return object, nil
+	}, []e2eutil.Predicate[*corev1.ConfigMap]{func(obj *corev1.ConfigMap) (bool, string, error) {
+		return true, "ConfigMap is available", nil
+	}}, WithInterval(time.Millisecond), WithTimeout(time.Second))
+	if err != nil {
+		t.Fatalf("EventuallyObject returned an unexpected error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("EventuallyObject attempts = %d, want 2", attempts)
+	}
+}
+
+func TestEventuallyObjectReturnsPredicateError(t *testing.T) {
+	wantErr := errors.New("predicate failed")
+	err := EventuallyObject(t.Context(), "ConfigMap predicate", func(context.Context) (*corev1.ConfigMap, error) {
+		return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "example"}}, nil
+	}, []e2eutil.Predicate[*corev1.ConfigMap]{func(obj *corev1.ConfigMap) (bool, string, error) {
+		return false, "", wantErr
+	}}, WithoutConditionDump(), WithInterval(time.Millisecond), WithTimeout(time.Second))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("EventuallyObject error = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+func TestEventuallyObjectReturnsTimeoutError(t *testing.T) {
+	err := EventuallyObject(t.Context(), "ConfigMap to become ready", func(context.Context) (*corev1.ConfigMap, error) {
+		return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "example"}}, nil
+	}, []e2eutil.Predicate[*corev1.ConfigMap]{func(obj *corev1.ConfigMap) (bool, string, error) {
+		return false, "ConfigMap is not ready", nil
+	}}, WithoutConditionDump(), WithInterval(time.Millisecond), WithTimeout(10*time.Millisecond))
+	if err == nil {
+		t.Fatal("EventuallyObject returned nil, want timeout error")
+	}
+	if !strings.Contains(err.Error(), "failed to wait for ConfigMap to become ready") {
+		t.Fatalf("EventuallyObject error = %q, want objective in error", err)
+	}
+}
+
+func TestEventuallyObjectsEvaluatesGroupAndObjectPredicates(t *testing.T) {
+	objects := []*corev1.ConfigMap{{ObjectMeta: metav1.ObjectMeta{Name: "one"}}, {ObjectMeta: metav1.ObjectMeta{Name: "two"}}}
+	attempts := 0
+
+	err := EventuallyObjects(t.Context(), "ConfigMaps to converge", func(context.Context) ([]*corev1.ConfigMap, error) {
+		attempts++
+		if attempts == 1 {
+			return objects[:1], nil
+		}
+		return objects, nil
+	}, []e2eutil.Predicate[[]*corev1.ConfigMap]{func(items []*corev1.ConfigMap) (bool, string, error) {
+		return len(items) == 2, "expected two ConfigMaps", nil
+	}}, []e2eutil.Predicate[*corev1.ConfigMap]{func(obj *corev1.ConfigMap) (bool, string, error) {
+		return obj.Name != "", "ConfigMap has a name", nil
+	}}, WithInterval(time.Millisecond), WithTimeout(time.Second))
+	if err != nil {
+		t.Fatalf("EventuallyObjects returned an unexpected error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("EventuallyObjects attempts = %d, want 2", attempts)
+	}
+}
+
+func TestEventuallyNotFoundReturnsSuccessForMissingObject(t *testing.T) {
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "example"}}
+	client := eventuallyNotFoundClient{getErr: apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, obj.Name)}
+
+	err := EventuallyNotFound(t.Context(), client, obj, WithInterval(time.Millisecond), WithTimeout(time.Second))
+	if err != nil {
+		t.Fatalf("EventuallyNotFound returned an unexpected error: %v", err)
+	}
+}
+
+func TestEventuallyNotFoundReturnsUnexpectedClientError(t *testing.T) {
+	wantErr := errors.New("client unavailable")
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "example"}}
+	client := eventuallyNotFoundClient{getErr: wantErr}
+
+	err := EventuallyNotFound(t.Context(), client, obj, WithInterval(time.Millisecond), WithTimeout(time.Second))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("EventuallyNotFound error = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+type eventuallyNotFoundClient struct {
+	crclient.Client
+	getErr error
+}
+
+func (c eventuallyNotFoundClient) Get(context.Context, crclient.ObjectKey, crclient.Object, ...crclient.GetOption) error {
+	return c.getErr
+}

--- a/test/e2e/v2/util/ingress.go
+++ b/test/e2e/v2/util/ingress.go
@@ -1,0 +1,89 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ValidateIngressOperatorConfiguration verifies that the HostedCluster's
+// ingress publishing strategy is reflected in the hosted cluster IngressController.
+func ValidateIngressOperatorConfiguration(ctx context.Context, guestClient crclient.Client, hostedCluster *hyperv1.HostedCluster) error {
+	GinkgoWriter.Printf("Verifying HostedCluster %s/%s has custom Ingress Operator endpointPublishingStrategy\n", hostedCluster.Namespace, hostedCluster.Name)
+	if hostedCluster.Spec.OperatorConfiguration == nil {
+		return fmt.Errorf("OperatorConfiguration should be set")
+	}
+	if hostedCluster.Spec.OperatorConfiguration.IngressOperator == nil {
+		return fmt.Errorf("IngressOperator configuration should be set")
+	}
+	strategy := hostedCluster.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy
+	if strategy == nil {
+		return fmt.Errorf("EndpointPublishingStrategy should be set")
+	}
+	if strategy.Type != operatorv1.LoadBalancerServiceStrategyType {
+		return fmt.Errorf("EndpointPublishingStrategy should be LoadBalancerService, got %s", strategy.Type)
+	}
+	if strategy.LoadBalancer == nil {
+		return fmt.Errorf("LoadBalancer configuration should be set")
+	}
+	if strategy.LoadBalancer.Scope != operatorv1.InternalLoadBalancer {
+		return fmt.Errorf("LoadBalancer scope should be Internal, got %s", strategy.LoadBalancer.Scope)
+	}
+
+	GinkgoWriter.Println("Validating IngressController in hosted cluster reflects the custom endpointPublishingStrategy")
+	return EventuallyObject(ctx, "IngressController default in hosted cluster to reflect the custom endpointPublishingStrategy",
+		func(ctx context.Context) (*operatorv1.IngressController, error) {
+			ingressController := &operatorv1.IngressController{}
+			err := guestClient.Get(ctx, types.NamespacedName{
+				Namespace: "openshift-ingress-operator",
+				Name:      "default",
+			}, ingressController)
+			return ingressController, err
+		},
+		[]e2eutil.Predicate[*operatorv1.IngressController]{
+			func(ic *operatorv1.IngressController) (bool, string, error) {
+				if ic.Spec.EndpointPublishingStrategy == nil {
+					return false, "EndpointPublishingStrategy is nil in IngressController", nil
+				}
+				if ic.Spec.EndpointPublishingStrategy.Type != operatorv1.LoadBalancerServiceStrategyType {
+					return false, fmt.Sprintf("expected EndpointPublishingStrategy type LoadBalancerService, got %s", ic.Spec.EndpointPublishingStrategy.Type), nil
+				}
+				if ic.Spec.EndpointPublishingStrategy.LoadBalancer == nil {
+					return false, "LoadBalancer configuration is nil in IngressController", nil
+				}
+				if ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope != operatorv1.InternalLoadBalancer {
+					return false, fmt.Sprintf("expected LoadBalancer scope Internal, got %s", ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope), nil
+				}
+				return true, "Successfully validated custom endpointPublishingStrategy", nil
+			},
+		},
+		WithTimeout(5*time.Minute),
+	)
+}

--- a/test/e2e/v2/util/ingress_test.go
+++ b/test/e2e/v2/util/ingress_test.go
@@ -1,0 +1,103 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"strings"
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+func TestValidateIngressOperatorConfiguration(t *testing.T) {
+	loadBalancer := &operatorv1.EndpointPublishingStrategy{
+		Type: operatorv1.LoadBalancerServiceStrategyType,
+		LoadBalancer: &operatorv1.LoadBalancerStrategy{
+			Scope: operatorv1.ExternalLoadBalancer,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		hosted    *hyperv1.HostedCluster
+		wantError string
+	}{
+		{
+			name:      "When operator configuration is missing, it should return an error",
+			hosted:    &hyperv1.HostedCluster{},
+			wantError: "OperatorConfiguration should be set",
+		},
+		{
+			name: "When ingress operator configuration is missing, it should return an error",
+			hosted: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{
+				OperatorConfiguration: &hyperv1.OperatorConfiguration{},
+			}},
+			wantError: "IngressOperator configuration should be set",
+		},
+		{
+			name: "When endpoint publishing strategy is missing, it should return an error",
+			hosted: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{
+				OperatorConfiguration: &hyperv1.OperatorConfiguration{
+					IngressOperator: &hyperv1.IngressOperatorSpec{},
+				},
+			}},
+			wantError: "EndpointPublishingStrategy should be set",
+		},
+		{
+			name: "When endpoint publishing strategy is not LoadBalancerService, it should return an error",
+			hosted: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{
+				OperatorConfiguration: &hyperv1.OperatorConfiguration{
+					IngressOperator: &hyperv1.IngressOperatorSpec{EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.HostNetworkStrategyType,
+					}},
+				},
+			}},
+			wantError: "EndpointPublishingStrategy should be LoadBalancerService",
+		},
+		{
+			name: "When LoadBalancer configuration is missing, it should return an error",
+			hosted: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{
+				OperatorConfiguration: &hyperv1.OperatorConfiguration{
+					IngressOperator: &hyperv1.IngressOperatorSpec{EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+					}},
+				},
+			}},
+			wantError: "LoadBalancer configuration should be set",
+		},
+		{
+			name: "When LoadBalancer scope is external, it should return an error",
+			hosted: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{
+				OperatorConfiguration: &hyperv1.OperatorConfiguration{
+					IngressOperator: &hyperv1.IngressOperatorSpec{EndpointPublishingStrategy: loadBalancer},
+				},
+			}},
+			wantError: "LoadBalancer scope should be Internal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateIngressOperatorConfiguration(t.Context(), nil, tt.hosted)
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("ValidateIngressOperatorConfiguration() error = %v, want error containing %q", err, tt.wantError)
+			}
+		})
+	}
+}

--- a/test/e2e/v2/util/nodes.go
+++ b/test/e2e/v2/util/nodes.go
@@ -1,0 +1,187 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NodePoolPollOptions configures a v2 node-readiness wait.
+type NodePoolPollOptions struct {
+	collectionPredicates []e2eutil.Predicate[[]*corev1.Node]
+	predicates           []e2eutil.Predicate[*corev1.Node]
+	clientOpts           []crclient.ListOption
+	suffix               string
+}
+
+// NodePoolPollOption configures a v2 node-readiness wait.
+type NodePoolPollOption func(*NodePoolPollOptions)
+
+// WithCollectionPredicates adds predicates evaluated against the complete node collection.
+func WithCollectionPredicates(predicates ...e2eutil.Predicate[[]*corev1.Node]) NodePoolPollOption {
+	return func(options *NodePoolPollOptions) {
+		options.collectionPredicates = predicates
+	}
+}
+
+// WithPredicates adds predicates evaluated against each node.
+func WithPredicates(predicates ...e2eutil.Predicate[*corev1.Node]) NodePoolPollOption {
+	return func(options *NodePoolPollOptions) {
+		options.predicates = predicates
+	}
+}
+
+// WithClientOptions adds controller-runtime list options to the node getter.
+func WithClientOptions(clientOpts ...crclient.ListOption) NodePoolPollOption {
+	return func(options *NodePoolPollOptions) {
+		options.clientOpts = clientOpts
+	}
+}
+
+// WithSuffix adds text to the node-readiness objective.
+func WithSuffix(suffix string) NodePoolPollOption {
+	return func(options *NodePoolPollOptions) {
+		options.suffix = suffix
+	}
+}
+
+// WaitForNReadyNodes waits for n Ready nodes using the v2 polling path.
+func WaitForNReadyNodes(ctx context.Context, client crclient.Client, n int32, platform hyperv1.PlatformType) ([]corev1.Node, error) {
+	return WaitForNReadyNodesWithOptions(ctx, client, n, platform, "")
+}
+
+// WaitForReadyNodesByNodePool waits for the expected number of Ready nodes belonging to a NodePool.
+func WaitForReadyNodesByNodePool(ctx context.Context, client crclient.Client, np *hyperv1.NodePool, platform hyperv1.PlatformType, opts ...NodePoolPollOption) ([]corev1.Node, error) {
+	return WaitForNReadyNodesWithOptions(ctx, client, *np.Spec.Replicas, platform,
+		fmt.Sprintf("for NodePool %s/%s", np.Namespace, np.Name),
+		append(opts, WithClientOptions(crclient.MatchingLabelsSelector{Selector: labels.SelectorFromSet(labels.Set{hyperv1.NodePoolLabel: np.Name})}))...,
+	)
+}
+
+// WaitForReadyNodesByLabels waits for the expected number of Ready nodes matching nodeLabels.
+func WaitForReadyNodesByLabels(ctx context.Context, client crclient.Client, platform hyperv1.PlatformType, replicas int32, nodeLabels map[string]string) ([]corev1.Node, error) {
+	return WaitForNReadyNodesWithOptions(ctx, client, replicas, platform, "",
+		WithClientOptions(crclient.MatchingLabelsSelector{Selector: labels.SelectorFromSet(labels.Set(nodeLabels))}),
+	)
+}
+
+// WaitForNodePoolConfigUpdateComplete waits for a NodePool config update to start and finish.
+func WaitForNodePoolConfigUpdateComplete(ctx context.Context, client crclient.Client, np *hyperv1.NodePool) error {
+	return WaitForNodePoolConfigUpdateCompleteWithPlatform(ctx, client, np, hyperv1.NonePlatform)
+}
+
+// WaitForNodePoolConfigUpdateCompleteWithPlatform waits for a NodePool config update to start and finish,
+// preserving the platform-specific timeout used by the v1 helper.
+func WaitForNodePoolConfigUpdateCompleteWithPlatform(ctx context.Context, client crclient.Client, np *hyperv1.NodePool, platform hyperv1.PlatformType) error {
+	configUpdateTimeout := 25 * time.Minute
+	switch platform {
+	case hyperv1.AzurePlatform, hyperv1.KubevirtPlatform:
+		configUpdateTimeout = 45 * time.Minute
+	}
+
+	if err := EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to start config update", np.Namespace, np.Name),
+		func(ctx context.Context) (*hyperv1.NodePool, error) {
+			nodePool := &hyperv1.NodePool{}
+			err := client.Get(ctx, crclient.ObjectKeyFromObject(np), nodePool)
+			return nodePool, err
+		},
+		[]e2eutil.Predicate[*hyperv1.NodePool]{
+			e2eutil.ConditionPredicate[*hyperv1.NodePool](e2eutil.Condition{
+				Type:   hyperv1.NodePoolUpdatingConfigConditionType,
+				Status: metav1.ConditionTrue,
+			}),
+		},
+		WithTimeout(5*time.Minute),
+		WithInterval(15*time.Second),
+	); err != nil {
+		return err
+	}
+
+	return EventuallyObject(ctx, fmt.Sprintf("NodePool %s/%s to finish config update", np.Namespace, np.Name),
+		func(ctx context.Context) (*hyperv1.NodePool, error) {
+			nodePool := &hyperv1.NodePool{}
+			err := client.Get(ctx, crclient.ObjectKeyFromObject(np), nodePool)
+			return nodePool, err
+		},
+		[]e2eutil.Predicate[*hyperv1.NodePool]{
+			e2eutil.ConditionPredicate[*hyperv1.NodePool](e2eutil.Condition{
+				Type:   hyperv1.NodePoolUpdatingConfigConditionType,
+				Status: metav1.ConditionFalse,
+			}),
+		},
+		WithTimeout(configUpdateTimeout),
+		WithInterval(20*time.Second),
+	)
+}
+
+// WaitForNReadyNodesWithOptions waits for n Ready nodes using the supplied list and predicate options.
+func WaitForNReadyNodesWithOptions(ctx context.Context, client crclient.Client, n int32, platform hyperv1.PlatformType, suffix string, opts ...NodePoolPollOption) ([]corev1.Node, error) {
+	options := &NodePoolPollOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	waitTimeout := 45 * time.Minute
+	if platform == hyperv1.PowerVSPlatform {
+		waitTimeout = 60 * time.Minute
+	}
+
+	nodes := &corev1.NodeList{}
+	if suffix != "" {
+		suffix = " " + suffix
+	}
+	if options.suffix != "" {
+		suffix += " " + options.suffix
+	}
+
+	err := EventuallyObjects(ctx, fmt.Sprintf("%d nodes to become ready%s", n, suffix),
+		func(ctx context.Context) ([]*corev1.Node, error) {
+			err := client.List(ctx, nodes, options.clientOpts...)
+			items := make([]*corev1.Node, len(nodes.Items))
+			for i := range nodes.Items {
+				items[i] = &nodes.Items[i]
+			}
+			return items, err
+		},
+		append([]e2eutil.Predicate[[]*corev1.Node]{
+			func(nodes []*corev1.Node) (bool, string, error) {
+				want, got := int(n), len(nodes)
+				return want == got, fmt.Sprintf("expected %d nodes, got %d", want, got), nil
+			},
+		}, options.collectionPredicates...),
+		append([]e2eutil.Predicate[*corev1.Node]{
+			e2eutil.ConditionPredicate[*corev1.Node](e2eutil.Condition{
+				Type:   string(corev1.NodeReady),
+				Status: metav1.ConditionTrue,
+			}),
+		}, options.predicates...),
+		WithTimeout(waitTimeout),
+		WithInterval(3*time.Second),
+	)
+	return nodes.Items, err
+}

--- a/test/e2e/v2/util/nodes_test.go
+++ b/test/e2e/v2/util/nodes_test.go
@@ -1,0 +1,135 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hyperapi "github.com/openshift/hypershift/support/api"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestWaitForReadyNodesByNodePool(t *testing.T) {
+	nodePool := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "clusters", Name: "workers"},
+		Spec: hyperv1.NodePoolSpec{
+			Replicas: ptr.To[int32](1),
+		},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "worker-0",
+			Labels: map[string]string{hyperv1.NodePoolLabel: nodePool.Name},
+		},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionTrue,
+		}}},
+	}
+	client := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(node).Build()
+
+	got, err := WaitForReadyNodesByNodePool(t.Context(), client, nodePool, hyperv1.AWSPlatform)
+	if err != nil {
+		t.Fatalf("WaitForReadyNodesByNodePool returned an unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != node.Name {
+		t.Fatalf("WaitForReadyNodesByNodePool returned %#v, want node %q", got, node.Name)
+	}
+}
+
+func TestWaitForNReadyNodesWithOptions(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "worker-0",
+			Labels: map[string]string{"role": "worker"},
+		},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionTrue,
+		}}},
+	}
+	client := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(node).Build()
+
+	got, err := WaitForNReadyNodesWithOptions(t.Context(), client, 1, hyperv1.AWSPlatform, "for test",
+		WithClientOptions(crclient.MatchingLabelsSelector{Selector: labels.SelectorFromSet(labels.Set{"role": "worker"})}),
+		WithCollectionPredicates(func(nodes []*corev1.Node) (bool, string, error) {
+			return len(nodes) == 1, "expected one worker node", nil
+		}),
+		WithPredicates(func(node *corev1.Node) (bool, string, error) {
+			return node.Name == "worker-0", "expected worker-0", nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("WaitForNReadyNodesWithOptions returned an unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != node.Name {
+		t.Fatalf("WaitForNReadyNodesWithOptions returned %#v, want node %q", got, node.Name)
+	}
+}
+
+func TestWaitForNodePoolConfigUpdateComplete(t *testing.T) {
+	nodePool := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "clusters", Name: "workers"},
+	}
+	client := &transitioningNodePoolClient{
+		Client:   fake.NewClientBuilder().WithScheme(hyperapi.Scheme).Build(),
+		nodePool: nodePool,
+	}
+
+	if err := WaitForNodePoolConfigUpdateComplete(t.Context(), client, nodePool); err != nil {
+		t.Fatalf("WaitForNodePoolConfigUpdateComplete returned an unexpected error: %v", err)
+	}
+	if client.gets != 2 {
+		t.Fatalf("WaitForNodePoolConfigUpdateComplete performed %d GETs, want 2", client.gets)
+	}
+}
+
+type transitioningNodePoolClient struct {
+	crclient.Client
+	nodePool *hyperv1.NodePool
+	gets     int
+}
+
+func (c *transitioningNodePoolClient) Get(ctx context.Context, key crclient.ObjectKey, obj crclient.Object, opts ...crclient.GetOption) error {
+	if _, ok := obj.(*hyperv1.NodePool); !ok {
+		return c.Client.Get(ctx, key, obj, opts...)
+	}
+
+	c.gets++
+	updated := c.nodePool.DeepCopy()
+	status := metav1.ConditionFalse
+	if c.gets == 1 {
+		status = metav1.ConditionTrue
+	}
+	updated.Status.Conditions = []hyperv1.NodePoolCondition{{
+		Type:   hyperv1.NodePoolUpdatingConfigConditionType,
+		Status: corev1.ConditionStatus(status),
+	}}
+	obj.(*hyperv1.NodePool).ObjectMeta = *updated.ObjectMeta.DeepCopy()
+	obj.(*hyperv1.NodePool).Spec = *updated.Spec.DeepCopy()
+	obj.(*hyperv1.NodePool).Status = *updated.Status.DeepCopy()
+	return nil
+}

--- a/test/e2e/v2/util/oauth.go
+++ b/test/e2e/v2/util/oauth.go
@@ -1,0 +1,318 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hcpmanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/oauth"
+	configmanifests "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/netutil"
+
+	v1 "github.com/openshift/api/config/v1"
+	osinv1 "github.com/openshift/api/osin/v1"
+	userv1 "github.com/openshift/api/user/v1"
+	userv1client "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	restclient "k8s.io/client-go/rest"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ValidateOAuthWithIdentityProviderViaLoadBalancer validates kubeadmin and
+// htpasswd authentication through the OAuth LoadBalancer endpoint.
+func ValidateOAuthWithIdentityProviderViaLoadBalancer(ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, restConfig *restclient.Config) error {
+	oauthHost, err := waitForOAuthLoadBalancerReady(ctx, client, restConfig, hostedCluster)
+	if err != nil {
+		return err
+	}
+
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+	kubeadminPasswordSecret := configmanifests.KubeadminPasswordSecret(hcpNamespace)
+	if err := client.Get(ctx, crclient.ObjectKeyFromObject(kubeadminPasswordSecret), kubeadminPasswordSecret); err != nil {
+		return fmt.Errorf("failed to get kubeadmin password secret: %w", err)
+	}
+	password := string(kubeadminPasswordSecret.Data["password"])
+	accessToken, err := waitForOAuthTokenByHost(ctx, oauthHost, restConfig, "kubeadmin", password)
+	if err != nil {
+		return err
+	}
+	user, err := getUserForToken(ctx, restConfig, accessToken)
+	if err != nil {
+		return fmt.Errorf("failed to get user for kubeadmin token: %w", err)
+	}
+	if user.Name != "kube:admin" {
+		return fmt.Errorf("kubeadmin token authenticated as %q, want %q", user.Name, "kube:admin")
+	}
+
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "htpasswd",
+			Namespace: hostedCluster.Namespace,
+		},
+		Data: map[string][]byte{
+			"htpasswd": []byte("testuser:$2y$05$0Fk2s.0FbLy0FZ82JAqajOV/kbT/wqKX5/QFKgps6J69J2jY6r5ZG"),
+		},
+	}
+	if err := client.Create(ctx, &secret); err != nil {
+		return fmt.Errorf("failed to create htpasswd secret: %w", err)
+	}
+
+	if err := UpdateObject(ctx, client, hostedCluster, func(obj *hyperv1.HostedCluster) {
+		if obj.Spec.Configuration == nil {
+			obj.Spec.Configuration = &hyperv1.ClusterConfiguration{}
+		}
+		obj.Spec.Configuration.OAuth = &v1.OAuthSpec{
+			IdentityProviders: []v1.IdentityProvider{
+				{
+					Name:          "my_htpasswd_provider",
+					MappingMethod: v1.MappingMethodClaim,
+					IdentityProviderConfig: v1.IdentityProviderConfig{
+						Type: v1.IdentityProviderTypeHTPasswd,
+						HTPasswd: &v1.HTPasswdIdentityProvider{
+							FileData: v1.SecretNameReference{Name: secret.Name},
+						},
+					},
+				},
+			},
+		}
+	}); err != nil {
+		return fmt.Errorf("failed to update HostedCluster identity providers: %w", err)
+	}
+
+	if err := waitForOAuthConfig(ctx, client, hostedCluster); err != nil {
+		return err
+	}
+	accessToken, err = waitForOAuthTokenByHost(ctx, oauthHost, restConfig, "testuser", "password")
+	if err != nil {
+		return err
+	}
+	user, err = getUserForToken(ctx, restConfig, accessToken)
+	if err != nil {
+		return fmt.Errorf("failed to get user for testuser token: %w", err)
+	}
+	if user.Name != "testuser" {
+		return fmt.Errorf("testuser token authenticated as %q, want %q", user.Name, "testuser")
+	}
+
+	return validateClusterPostIDP(ctx, client, hostedCluster)
+}
+
+func waitForOAuthLoadBalancerReady(ctx context.Context, client crclient.Client, restConfig *restclient.Config, hostedCluster *hyperv1.HostedCluster) (string, error) {
+	oauthStrategy := netutil.ServicePublishingStrategyByTypeByHC(hostedCluster, hyperv1.OAuthServer)
+	if oauthStrategy == nil {
+		return "", fmt.Errorf("OAuth service publishing strategy not found in HostedCluster spec")
+	}
+	if oauthStrategy.LoadBalancer == nil {
+		return "", fmt.Errorf("OAuth LoadBalancer strategy not found")
+	}
+	oauthHost := oauthStrategy.LoadBalancer.Hostname
+	if oauthHost == "" {
+		return "", fmt.Errorf("OAuth LoadBalancer hostname is empty")
+	}
+	GinkgoWriter.Printf("OAuth hostname from HostedCluster spec: %s\n", oauthHost)
+
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+	svc := hcpmanifests.OauthServerService(hcpNamespace)
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+		if err := client.Get(ctx, crclient.ObjectKeyFromObject(svc), svc); err != nil {
+			return false, nil //nolint:nilerr // retry until the OAuth service is available
+		}
+		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+			GinkgoWriter.Printf("Waiting for oauth-openshift Service type to be LoadBalancer, got %s\n", svc.Spec.Type)
+			return false, nil
+		}
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			GinkgoWriter.Println("Waiting for oauth-openshift LoadBalancer to get an external endpoint")
+			return false, nil
+		}
+		ingress := svc.Status.LoadBalancer.Ingress[0]
+		if ingress.IP == "" && ingress.Hostname == "" {
+			return false, nil
+		}
+		GinkgoWriter.Printf("OAuth LoadBalancer has external endpoint: %s%s\n", ingress.IP, ingress.Hostname)
+		return true, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed waiting for oauth-openshift LoadBalancer endpoint: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodHead, fmt.Sprintf("https://%s/healthz", oauthHost), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create OAuth LoadBalancer health request: %w", err)
+	}
+	transport, err := restclient.TransportFor(restclient.AnonymousClientConfig(restConfig))
+	if err != nil {
+		return "", fmt.Errorf("error getting OAuth LoadBalancer transport: %w", err)
+	}
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		resp, err := transport.RoundTrip(request.Clone(ctx))
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+		if resp != nil && resp.StatusCode == http.StatusOK {
+			return true, nil
+		}
+		if resp != nil {
+			GinkgoWriter.Printf("Waiting for OAuth LoadBalancer %s to be ready: %v\n", oauthHost, resp.Status)
+		}
+		if err != nil {
+			GinkgoWriter.Printf("Waiting for OAuth LoadBalancer %s to be ready: %v\n", oauthHost, err)
+		}
+		return false, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed waiting for OAuth LoadBalancer %s to be healthy: %w", oauthHost, err)
+	}
+	GinkgoWriter.Printf("Observed OAuth LoadBalancer %s to be healthy\n", oauthHost)
+	return oauthHost, nil
+}
+
+func waitForOAuthTokenByHost(ctx context.Context, oauthHost string, restConfig *restclient.Config, username, password string) (string, error) {
+	oauthClient := configmanifests.OAuthServerChallengingClient().Name
+	tokenRequestURL := fmt.Sprintf("https://%s/oauth/authorize?response_type=token&client_id=%s", oauthHost, oauthClient)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenRequestURL, nil)
+	if err != nil {
+		return "", err
+	}
+	request.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+	request.Header.Set("X-CSRF-Token", "1")
+	transport, err := restclient.TransportFor(restclient.AnonymousClientConfig(restConfig))
+	if err != nil {
+		return "", fmt.Errorf("error getting OAuth token transport: %w", err)
+	}
+	httpClient := &http.Client{Transport: transport, Timeout: 15 * time.Second}
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	var accessToken string
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		resp, err := httpClient.Do(request.Clone(ctx))
+		if err != nil {
+			GinkgoWriter.Printf("Waiting for OAuth token request to succeed for user %s\n", username)
+			return false, nil
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusFound {
+			GinkgoWriter.Printf("Waiting for OAuth token request status code %v, got %v\n", http.StatusFound, resp.StatusCode)
+			return false, nil
+		}
+		accessToken, err = extractAccessToken(resp)
+		if err != nil {
+			GinkgoWriter.Printf("Failed to extract access token from redirect URL: %v\n", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to request OAuth token for user %s: %w", username, err)
+	}
+	GinkgoWriter.Printf("OAuth token retrieved successfully for user %s\n", username)
+	return accessToken, nil
+}
+
+func getUserForToken(ctx context.Context, config *restclient.Config, token string) (*userv1.User, error) {
+	userConfig := restclient.AnonymousClientConfig(config)
+	userConfig.BearerToken = token
+	userClient, err := userv1client.NewForConfig(userConfig)
+	if err != nil {
+		return nil, err
+	}
+	return userClient.Users().Get(ctx, "~", metav1.GetOptions{})
+}
+
+func waitForOAuthConfig(ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) error {
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+	oauthConfigCM := hcpmanifests.OAuthServerConfig(hcpNamespace)
+	err := wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+		if err := client.Get(ctx, crclient.ObjectKeyFromObject(oauthConfigCM), oauthConfigCM); err != nil {
+			return false, nil //nolint:nilerr // retry until the OAuth config exists
+		}
+		data, ok := oauthConfigCM.Data["config.yaml"]
+		if !ok || data == "" {
+			return false, nil
+		}
+		oauthConfig := &osinv1.OsinServerConfig{}
+		if _, _, err := api.YamlSerializer.Decode([]byte(data), nil, oauthConfig); err != nil {
+			return false, nil //nolint:nilerr // retry until the OAuth config is valid
+		}
+		return len(oauthConfig.OAuthConfig.IdentityProviders) > 0, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed validating OAuth config: %w", err)
+	}
+	return nil
+}
+
+func validateClusterPostIDP(ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) error {
+	if err := client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster); err != nil {
+		return err
+	}
+	if hostedCluster.Status.KubeadminPassword != nil {
+		return fmt.Errorf("HostedCluster status kubeadmin password should be nil after adding an identity provider")
+	}
+
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+	kubeadminPasswordSecret := configmanifests.KubeadminPasswordSecret(hcpNamespace)
+	err := client.Get(ctx, crclient.ObjectKeyFromObject(kubeadminPasswordSecret), kubeadminPasswordSecret)
+	if !apierrors.IsNotFound(err) {
+		if err == nil {
+			return fmt.Errorf("kubeadmin password secret should be deleted after adding an identity provider")
+		}
+		return fmt.Errorf("expected kubeadmin password secret to be deleted: %w", err)
+	}
+
+	oauthDeployment := configmanifests.OAuthDeployment(hcpNamespace)
+	if err := client.Get(ctx, crclient.ObjectKeyFromObject(oauthDeployment), oauthDeployment); err != nil {
+		return err
+	}
+	if _, ok := oauthDeployment.Spec.Template.ObjectMeta.Annotations[oauth.KubeadminSecretHashAnnotation]; ok {
+		return fmt.Errorf("OAuth deployment still has kubeadmin password hash annotation")
+	}
+	return nil
+}
+
+func extractAccessToken(resp *http.Response) (string, error) {
+	location, err := resp.Location()
+	if err != nil {
+		return "", err
+	}
+	fragments, err := url.ParseQuery(location.Fragment)
+	if err != nil {
+		return "", err
+	}
+	if len(fragments["access_token"]) == 0 {
+		return "", fmt.Errorf("access_token not found")
+	}
+	return fragments["access_token"][0], nil
+}

--- a/test/e2e/v2/util/oauth_test.go
+++ b/test/e2e/v2/util/oauth_test.go
@@ -1,0 +1,67 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestExtractAccessToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		location  string
+		wantToken string
+		wantError string
+	}{
+		{
+			name:      "When the redirect fragment contains an access token, it should return the token",
+			location:  "https://oauth.example/callback#access_token=token-value&state=state-value",
+			wantToken: "token-value",
+		},
+		{
+			name:      "When the redirect fragment has no access token, it should return an error",
+			location:  "https://oauth.example/callback#state=state-value",
+			wantError: "access_token not found",
+		},
+		{
+			name:      "When the redirect fragment is malformed, it should return a parse error",
+			location:  "https://oauth.example/callback#%zz",
+			wantError: "invalid URL escape",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := &http.Response{Header: http.Header{"Location": []string{tt.location}}}
+			got, err := extractAccessToken(response)
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("extractAccessToken() error = %v, want error containing %q", err, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("extractAccessToken() returned an unexpected error: %v", err)
+			}
+			if got != tt.wantToken {
+				t.Fatalf("extractAccessToken() = %q, want %q", got, tt.wantToken)
+			}
+		})
+	}
+}

--- a/test/e2e/v2/util/object.go
+++ b/test/e2e/v2/util/object.go
@@ -1,0 +1,71 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// UpdateObject refreshes an object, applies mutate to a deep copy, and patches
+// the result. Reads and resource-version conflicts are retried for up to one
+// minute; other patch errors are returned immediately.
+func UpdateObject[T crclient.Object](ctx context.Context, client crclient.Client, original T, mutate func(obj T)) error {
+	key := crclient.ObjectKeyFromObject(original)
+	var lastAttemptErr error
+	var previousError string
+	recordRetry := func(err error) {
+		lastAttemptErr = err
+		if err.Error() == previousError {
+			return
+		}
+		previousError = err.Error()
+		GinkgoWriter.Printf("UpdateObject %s/%s: %v; retrying\n", key.Namespace, key.Name, err)
+	}
+
+	err := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+		if err := client.Get(ctx, crclient.ObjectKeyFromObject(original), original); err != nil {
+			recordRetry(fmt.Errorf("failed to retrieve object: %w", err))
+			return false, nil
+		}
+
+		obj := original.DeepCopyObject().(T)
+		mutate(obj)
+
+		if err := client.Patch(ctx, obj, crclient.MergeFrom(original)); err != nil {
+			recordRetry(fmt.Errorf("failed to patch object: %w", err))
+			if apierrors.IsConflict(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		return true, nil
+	})
+	if err != nil && lastAttemptErr != nil {
+		return fmt.Errorf("failed to update object %s/%s: %w (polling error: %w)", key.Namespace, key.Name, lastAttemptErr, err)
+	}
+	return err
+}

--- a/test/e2e/v2/util/object_test.go
+++ b/test/e2e/v2/util/object_test.go
@@ -1,0 +1,124 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	hyperapi "github.com/openshift/hypershift/support/api"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestUpdateObject(t *testing.T) {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "example"},
+		Data:       map[string]string{"state": "before"},
+	}
+	client := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(configMap).Build()
+
+	err := UpdateObject(t.Context(), client, configMap, func(obj *corev1.ConfigMap) {
+		obj.Data["state"] = "after"
+	})
+	if err != nil {
+		t.Fatalf("UpdateObject returned an unexpected error: %v", err)
+	}
+
+	updated := &corev1.ConfigMap{}
+	if err := client.Get(t.Context(), crclient.ObjectKeyFromObject(configMap), updated); err != nil {
+		t.Fatalf("failed to get updated ConfigMap: %v", err)
+	}
+	if updated.Data["state"] != "after" {
+		t.Fatalf("ConfigMap state = %q, want %q", updated.Data["state"], "after")
+	}
+}
+
+func TestUpdateObjectRetriesConflict(t *testing.T) {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "example"},
+		Data:       map[string]string{"state": "before"},
+	}
+	baseClient := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(configMap).Build()
+	client := &conflictOnceClient{Client: baseClient}
+
+	err := UpdateObject(t.Context(), client, configMap, func(obj *corev1.ConfigMap) {
+		obj.Data["state"] = "after"
+	})
+	if err != nil {
+		t.Fatalf("UpdateObject returned an unexpected error: %v", err)
+	}
+	if client.patchAttempts != 2 {
+		t.Fatalf("UpdateObject patch attempts = %d, want 2", client.patchAttempts)
+	}
+}
+
+func TestUpdateObjectReturnsLastRetryError(t *testing.T) {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "example"},
+	}
+	getErr := errors.New("simulated get failure")
+	baseClient := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(configMap).Build()
+	client := &getErrorClient{Client: baseClient, err: getErr}
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+	defer cancel()
+
+	err := UpdateObject(ctx, client, configMap, func(obj *corev1.ConfigMap) {
+		obj.Data = map[string]string{"state": "after"}
+	})
+	if err == nil {
+		t.Fatal("UpdateObject returned nil error")
+	}
+	if !errors.Is(err, getErr) {
+		t.Fatalf("UpdateObject error = %v, want underlying Get error", err)
+	}
+	if !strings.Contains(err.Error(), "polling error") {
+		t.Fatalf("UpdateObject error = %q, want polling context", err)
+	}
+}
+
+type conflictOnceClient struct {
+	crclient.Client
+	patchAttempts int
+}
+
+func (c *conflictOnceClient) Patch(ctx context.Context, obj crclient.Object, patch crclient.Patch, opts ...crclient.PatchOption) error {
+	c.patchAttempts++
+	if c.patchAttempts == 1 {
+		return apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, obj.GetName(), fmt.Errorf("simulated conflict"))
+	}
+	return c.Client.Patch(ctx, obj, patch, opts...)
+}
+
+type getErrorClient struct {
+	crclient.Client
+	err error
+}
+
+func (c *getErrorClient) Get(context.Context, crclient.ObjectKey, crclient.Object, ...crclient.GetOption) error {
+	return c.err
+}

--- a/test/e2e/v2/util/pod_exec.go
+++ b/test/e2e/v2/util/pod_exec.go
@@ -83,3 +83,37 @@ func GetMetricsFromPod(ctx context.Context, clientset kubernetes.Interface, rest
 	}
 	return families, nil
 }
+
+// ValidateMetricPresence verifies whether a metric family contains a matching
+// label. It returns an error when the observed presence does not match the
+// expected state so callers can decide whether to retry or fail immediately.
+func ValidateMetricPresence(metricFamilies map[string]*dto.MetricFamily, query, labelKey, labelValue, metricName string, metricsExpectedToBePresent bool) error {
+	labelPairs := extractMetricLabels(metricFamilies, query, labelKey, labelValue)
+	if metricsExpectedToBePresent && len(labelPairs) == 0 {
+		return fmt.Errorf("expected results for metric %q, found none", metricName)
+	}
+	if !metricsExpectedToBePresent && len(labelPairs) > 0 {
+		return fmt.Errorf("expected 0 results for metric %q, found %d", metricName, len(labelPairs))
+	}
+	return nil
+}
+
+func extractMetricLabels(metricFamilies map[string]*dto.MetricFamily, metric, labelKey, labelValue string) []*dto.LabelPair {
+	family, ok := metricFamilies[metric]
+	if !ok {
+		return nil
+	}
+
+	var labelPairs []*dto.LabelPair
+	for _, metric := range family.Metric {
+		for _, label := range metric.GetLabel() {
+			if label == nil {
+				continue
+			}
+			if labelKey == "" || (label.GetName() == labelKey && label.GetValue() == labelValue) {
+				labelPairs = append(labelPairs, label)
+			}
+		}
+	}
+	return labelPairs
+}

--- a/test/e2e/v2/util/pod_exec_test.go
+++ b/test/e2e/v2/util/pod_exec_test.go
@@ -1,0 +1,90 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"strings"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestValidateMetricPresence(t *testing.T) {
+	metrics := map[string]*dto.MetricFamily{
+		"example_metric": {
+			Metric: []*dto.Metric{
+				{Label: []*dto.LabelPair{{Name: stringPtr("name"), Value: stringPtr("example")}}},
+			},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		metricName string
+		labelKey   string
+		labelValue string
+		expected   bool
+		wantErr    string
+	}{
+		{
+			name:       "matching metric is present",
+			metricName: "example_metric",
+			labelKey:   "name",
+			labelValue: "example",
+			expected:   true,
+		},
+		{
+			name:       "missing metric is reported",
+			metricName: "missing_metric",
+			expected:   true,
+			wantErr:    `expected results for metric "missing_metric", found none`,
+		},
+		{
+			name:       "unexpected metric is reported",
+			metricName: "example_metric",
+			expected:   false,
+			wantErr:    `expected 0 results for metric "example_metric", found 1`,
+		},
+		{
+			name:       "nonmatching label is reported",
+			metricName: "example_metric",
+			labelKey:   "name",
+			labelValue: "other",
+			expected:   true,
+			wantErr:    `expected results for metric "example_metric", found none`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMetricPresence(metrics, tt.metricName, tt.labelKey, tt.labelValue, tt.metricName, tt.expected)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateMetricPresence returned unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateMetricPresence error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}


### PR DESCRIPTION
 ## What Changes 
- Port the relevant v1 E2E helper behavior to v2-native helpers that do not accept or use Go's `testing.TB` testing interface.

 ## Why
- v2 tests run under Ginkgo. Reusing v1 helpers that signal failures through `testing.TB` can interfere with Ginkgo failure handling, diagnostics, cleanup, and asynchronous test behavior.

- This change keeps failures reported at the v2 test call site using Gomega/Ginkgo semantics.

 ## Changes
  - Added v2-native helpers that return errors instead of signaling failures through `testing.TB`.
  - Migrated affected v2 HostedCluster, Azure, and Karpenter test flows.
  - Added v2 REST-config and wait helpers using `TestContext` and v2 client settings.
  - Removed migrated `testing.TB`-bearing v1 symbols from the v2 allowlist.
  - Added linter coverage for direct typed references to `test/e2e/util` symbols whose signatures accept `testing.TB`, including supported aliases and function-value references.
  - Updated v2 tests to use test-scoped contexts.
  - Preserved intentional retry behavior while satisfying error-chain and polling linters.
  - Kept v1 helper implementations unchanged.

## Added v2-native test helpers
 - Generic object and collection polling with configurable intervals, timeouts, predicate evaluation, and diagnostics.
   - Node and NodePool readiness, rollout, and configuration convergence checks.
   - Conflict-aware Kubernetes object updates.
   - HostedCluster kubeconfig publication and REST configuration waiting.
   - AWS test-resource provisioning and cleanup, including temporary subnet and CIDR allocation.
   - Azure workload-identity mutation validation.
   - Kubernetes API server allowed-CIDR and reachability validation.
   - Ingress and OAuth LoadBalancer validation, including authentication-flow checks.
   - Pod command execution and metric-presence validation. 

- These helpers are test-only, return errors instead of signaling failures through testing.TB, and allow v2 tests to use Ginkgo/Gomega failure handling while retaining the original polling intervals, timeouts, cleanup behavior, and diagnostic information from v1.
- The corresponding helper implementations are under test/e2e/v2/util with unit coverage, while HostedCluster kubeconfig waiting is implemented in [test/e2e/v2/nternal/test_context.go]

## v1 behavior preserved

 The v2 implementations preserve the relevant v1 behavior, including:

  - polling intervals and timeout semantics;
  - object lookup and update ordering;
  - predicate evaluation behavior;
  - readiness and rollout waits;
  - cloud-resource cleanup;
  - error propagation and diagnostic messages.

  The v2 implementations use `TestContext`, Ginkgo/Gomega assertions, and v2 client settings where required.

## Regression assessment

  - No v1 files or v1 runtime behavior were modified.
  - No remaining direct v2 references to the migrated testing.TB-bearing v1 helpers were found.
  - Polling and cleanup semantics were preserved.
  - The AWS helper now handles route-table API errors and empty results separately while preserving subnet cleanup.
  - Intentional false, nil retry paths remain unchanged.


## Follow-up

- The current linter enforces direct typed references and allowlist violations. Complete transitive call-graph enforcement, including wrappers that indirectly invoke testing.TB-based helpers, remains a follow-up item. The current branch audit found no existing v2 violation through such a wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable end-to-end testing utilities for polling resources, updating objects, waiting for ready nodes, retrieving HostedCluster kubeconfig data, and validating AWS, Azure, networking, ingress, OAuth, and metrics behavior.
  * Added automatic validation to prevent unsupported legacy helper usage in v2 end-to-end tests.

* **Bug Fixes**
  * Improved end-to-end test error handling by explicitly checking wait, update, and polling results.

* **Tests**
  * Added comprehensive coverage for the new utilities and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->