### PR TITLE
OCPBUGS-122232: Use CAPI v1beta1 for HO upgrade invariants

### DIFF
--- a/test/e2e/upgrade_hypershift_operator_test.go
+++ b/test/e2e/upgrade_hypershift_operator_test.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -42,7 +42,7 @@ func TestUpgradeHyperShiftOperator(t *testing.T) {
 	var hostedCluster *hyperv1.HostedCluster
 	var hcpNameSpace string
 	var nodePoolsMap map[string]*hyperv1.NodePool
-	var machineDeploymentMap map[string]*capiv1.MachineDeployment
+	var machineDeploymentMap map[string]*capiv1beta1.MachineDeployment
 
 	hyperShiftOperatorLatestImage := globalOpts.HyperShiftOperatorLatestImage
 
@@ -134,8 +134,10 @@ func TestUpgradeHyperShiftOperator(t *testing.T) {
 				nodePoolsMap[nodepools.Items[i].Name] = &nodepools.Items[i]
 			}
 
-			// Get the MachineDeployments
-			machineDeployments := &capiv1.MachineDeploymentList{}
+			// The release-4.21 operator is installed before this test upgrades it and
+			// serves CAPI MachineDeployments through v1beta1. Use that compatibility
+			// version for both sides of the invariant check during migration.
+			machineDeployments := &capiv1beta1.MachineDeploymentList{}
 			hcpNameSpace = manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 
 			err = mgmtClient.List(ctx, machineDeployments, crclient.InNamespace(hcpNameSpace))
@@ -147,7 +149,7 @@ func TestUpgradeHyperShiftOperator(t *testing.T) {
 			g.Expect(len(machineDeployments.Items)).To(gomega.BeEquivalentTo(len(nodepools.Items)),
 				"Number of MachineDeployments and NodePools should match")
 
-			machineDeploymentMap = make(map[string]*capiv1.MachineDeployment)
+			machineDeploymentMap = make(map[string]*capiv1beta1.MachineDeployment)
 			t.Logf("Found %d MachineDeployments", len(machineDeployments.Items))
 			for i := range machineDeployments.Items {
 				t.Logf("Found MachineDeployment %s", machineDeployments.Items[i].Name)
@@ -228,7 +230,7 @@ func TestUpgradeHyperShiftOperator(t *testing.T) {
 					}
 				}
 
-				postUpgradeMachineDeployments := &capiv1.MachineDeploymentList{}
+				postUpgradeMachineDeployments := &capiv1beta1.MachineDeploymentList{}
 				err = mgmtClient.List(ctx, postUpgradeMachineDeployments, crclient.InNamespace(hcpNameSpace))
 				if err != nil {
 					gomega.StopTrying(fmt.Sprintf("Error listing MachineDeployments: %v", err)).Now()
@@ -239,7 +241,7 @@ func TestUpgradeHyperShiftOperator(t *testing.T) {
 				}
 				for _, machineDeployment := range postUpgradeMachineDeployments.Items {
 					t.Logf("Verifying MachineDeployment %s", machineDeployment.Name)
-					var preUpgradeMachineDeployment *capiv1.MachineDeployment
+					var preUpgradeMachineDeployment *capiv1beta1.MachineDeployment
 					var ok bool
 					if preUpgradeMachineDeployment, ok = machineDeploymentMap[machineDeployment.Name]; !ok {
 						gomega.StopTrying(fmt.Sprintf("MachineDeployment %s not found", machineDeployment.Name)).Now()


### PR DESCRIPTION
## What this PR does

Uses the CAPI v1beta1 MachineDeployment API for baseline and post-upgrade invariant checks in the HyperShift Operator upgrade e2e test.

## Why

The release-4.21 upgrade workflow installs the previous release HyperShift CLI before the test captures its baseline. That CLI serves MachineDeployments through CAPI v1beta1. The test was requesting v1beta2 before the PR operator upgrade began, causing discovery to fail with `NoKindMatch`.

The release workflow is intentionally left unchanged because installing the PR CLI initially would remove the upgrade scenario under test.

## Testing

- `GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor go test -c -tags e2e ./test/e2e -o /var/folders/zr/t9gyn09s4wq6mjn865w17jwm0000gn/T/opencode/test-e2e-upgrade.test`
- Commit hooks: `make verify-quick`, changed-package tests, and gitlint passed.
- Full e2e execution was not run locally because the current Kubernetes context cannot list cluster-scoped ConfigMaps.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated upgrade end-to-end test coverage to use the supported Cluster API `v1beta1` MachineDeployment version.
  - Added compatibility documentation for operators serving the `v1beta1` API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->