### PR TITLE
OCPBUGS-122232: Gate CAPI API version in HO upgrade test

### DIFF
--- a/test/e2e/upgrade_hypershift_operator_test.go
+++ b/test/e2e/upgrade_hypershift_operator_test.go
@@ -18,7 +18,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	capiv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -42,7 +43,7 @@ func TestUpgradeHyperShiftOperator(t *testing.T) {
 	var hostedCluster *hyperv1.HostedCluster
 	var hcpNameSpace string
 	var nodePoolsMap map[string]*hyperv1.NodePool
-	var machineDeploymentMap map[string]*capiv1.MachineDeployment
+	var machineDeploymentMap map[string]int64
 
 	hyperShiftOperatorLatestImage := globalOpts.HyperShiftOperatorLatestImage
 
@@ -82,6 +83,7 @@ func TestUpgradeHyperShiftOperator(t *testing.T) {
 	operatorImage, err := e2eutil.GetHyperShiftOperatorImage(ctx, client, globalOpts.HOInstallationOptions)
 	g.Expect(err).ToNot(gomega.HaveOccurred(), "Getting HyperShiftOperator image shouldn't return errors")
 	t.Logf("Observed pre-upgrade HyperShift Operator image %q", operatorImage)
+	useCAPIv1Beta1 := e2eutil.IsLessThan(e2eutil.Version423)
 
 	// Shared role credential reconciliation only landed on 4.21+.
 	// Check the pre-upgrade HO's advertised version, not the release image version.
@@ -134,25 +136,12 @@ func TestUpgradeHyperShiftOperator(t *testing.T) {
 				nodePoolsMap[nodepools.Items[i].Name] = &nodepools.Items[i]
 			}
 
-			// Get the MachineDeployments
-			machineDeployments := &capiv1.MachineDeploymentList{}
 			hcpNameSpace = manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
-
-			err = mgmtClient.List(ctx, machineDeployments, crclient.InNamespace(hcpNameSpace))
-
-			g.Expect(err).ToNot(gomega.HaveOccurred(),
-				"Listing MachineDeployments in namespace %s shouldn't return errors", hcpNameSpace)
-			g.Expect(machineDeployments.Items).ToNot(gomega.BeEmpty(),
-				"Should find MachineDeployments in namespace %s", hcpNameSpace)
-			g.Expect(len(machineDeployments.Items)).To(gomega.BeEquivalentTo(len(nodepools.Items)),
+			machineDeploymentMap, err = listMachineDeploymentGenerations(ctx, mgmtClient, hcpNameSpace, useCAPIv1Beta1)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(len(machineDeploymentMap)).To(gomega.BeEquivalentTo(len(nodepools.Items)),
 				"Number of MachineDeployments and NodePools should match")
-
-			machineDeploymentMap = make(map[string]*capiv1.MachineDeployment)
-			t.Logf("Found %d MachineDeployments", len(machineDeployments.Items))
-			for i := range machineDeployments.Items {
-				t.Logf("Found MachineDeployment %s", machineDeployments.Items[i].Name)
-				machineDeploymentMap[machineDeployments.Items[i].Name] = &machineDeployments.Items[i]
-			}
+			t.Logf("Found %d MachineDeployments", len(machineDeploymentMap))
 		})).To(gomega.BeTrue(), "Calculating HyperShift Operator upgrade invariants should succeed")
 
 		g.Expect(t.Run("Upgrade HyperShift Operator", func(t *testing.T) {
@@ -228,31 +217,55 @@ func TestUpgradeHyperShiftOperator(t *testing.T) {
 					}
 				}
 
-				postUpgradeMachineDeployments := &capiv1.MachineDeploymentList{}
-				err = mgmtClient.List(ctx, postUpgradeMachineDeployments, crclient.InNamespace(hcpNameSpace))
+				postUpgradeMachineDeployments, err := listMachineDeploymentGenerations(ctx, mgmtClient, hcpNameSpace, useCAPIv1Beta1)
 				if err != nil {
 					gomega.StopTrying(fmt.Sprintf("Error listing MachineDeployments: %v", err)).Now()
 				}
 
-				if len(postUpgradeMachineDeployments.Items) != len(machineDeploymentMap) {
-					gomega.StopTrying(fmt.Sprintf("Number of MachineDeployments changed from %d to %d", len(machineDeploymentMap), len(postUpgradeMachineDeployments.Items))).Now()
+				if len(postUpgradeMachineDeployments) != len(machineDeploymentMap) {
+					gomega.StopTrying(fmt.Sprintf("Number of MachineDeployments changed from %d to %d", len(machineDeploymentMap), len(postUpgradeMachineDeployments))).Now()
 				}
-				for _, machineDeployment := range postUpgradeMachineDeployments.Items {
-					t.Logf("Verifying MachineDeployment %s", machineDeployment.Name)
-					var preUpgradeMachineDeployment *capiv1.MachineDeployment
+				for name, generation := range postUpgradeMachineDeployments {
+					t.Logf("Verifying MachineDeployment %s", name)
 					var ok bool
-					if preUpgradeMachineDeployment, ok = machineDeploymentMap[machineDeployment.Name]; !ok {
-						gomega.StopTrying(fmt.Sprintf("MachineDeployment %s not found", machineDeployment.Name)).Now()
+					var preUpgradeGeneration int64
+					if preUpgradeGeneration, ok = machineDeploymentMap[name]; !ok {
+						gomega.StopTrying(fmt.Sprintf("MachineDeployment %s not found", name)).Now()
 					}
 
-					t.Logf("Generation: Got %d", machineDeployment.Generation)
+					t.Logf("Generation: Got %d", generation)
 
 					// Check if the machine deployment has been updated
-					g.Expect(machineDeployment.Generation).To(gomega.Equal(preUpgradeMachineDeployment.Generation),
+					g.Expect(generation).To(gomega.Equal(preUpgradeGeneration),
 						"Pre-upgrade and post-upgrade MachineDeployment generations should match")
 				}
 				return true
 			}, "5m", "1s").Should(gomega.BeTrue(), "Verification should consistently succeed for 5 minutes")
 		})).To(gomega.BeTrue(), "Verify upgrade invariants should succeed")
 	}).WithHOUpgrade().Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "ho-upgrade", globalOpts.ServiceAccountSigningKey)
+}
+
+func listMachineDeploymentGenerations(ctx context.Context, client crclient.Client, namespace string, useV1Beta1 bool) (map[string]int64, error) {
+	generations := make(map[string]int64)
+	if useV1Beta1 {
+		machineDeployments := &capiv1beta1.MachineDeploymentList{}
+		if err := client.List(ctx, machineDeployments, crclient.InNamespace(namespace)); err != nil {
+			return nil, fmt.Errorf("listing MachineDeployments at cluster.x-k8s.io/v1beta1 in namespace %s: %w", namespace, err)
+		}
+		for i := range machineDeployments.Items {
+			generations[machineDeployments.Items[i].Name] = machineDeployments.Items[i].Generation
+		}
+	} else {
+		machineDeployments := &capiv1beta2.MachineDeploymentList{}
+		if err := client.List(ctx, machineDeployments, crclient.InNamespace(namespace)); err != nil {
+			return nil, fmt.Errorf("listing MachineDeployments at cluster.x-k8s.io/v1beta2 in namespace %s: %w", namespace, err)
+		}
+		for i := range machineDeployments.Items {
+			generations[machineDeployments.Items[i].Name] = machineDeployments.Items[i].Generation
+		}
+	}
+	if len(generations) == 0 {
+		return nil, fmt.Errorf("no MachineDeployments found in namespace %s", namespace)
+	}
+	return generations, nil
 }


### PR DESCRIPTION
## What this PR does

Uses the CAPI API version served by the management cluster release when calculating HyperShift Operator upgrade invariants:

- OCP releases before 4.23 use `cluster.x-k8s.io/v1beta1`.
- OCP 4.23 and newer use `cluster.x-k8s.io/v1beta2`.

The same version is used for baseline and post-upgrade MachineDeployment reads.

## Why

The upgrade test runs the main-branch test binary against older management-cluster releases. Pre-4.23 release CRDs serve MachineDeployments through v1beta1; requiring v1beta2 there fails before the HO upgrade starts. Newer releases already serve v1beta2.

This keeps the test aligned with the real release environment and avoids modifying old release CRDs to synthetically serve a newer API version.

## Testing

- `GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor go test -c -tags e2e ./test/e2e -o /var/folders/zr/t9gyn09s4wq6mjn865w17jwm0000gn/T/opencode/test-e2e-upgrade.test`
- Commit hooks and push checks passed: `make verify-quick`, changed-package tests, and gitlint.
- Full AWS e2e was not run locally.

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved upgrade validation across supported cluster API versions.
  * Added checks to ensure MachineDeployments are discovered correctly, upgrade state is preserved, and expected resource counts remain consistent.
  * Enhanced error reporting for API-specific failures and cases where no MachineDeployments are found.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->