### PR TITLE
MULTIARCH-5567: Added support to create multi-arch (s390x & x86) NodePools with KubeVirt platform on heterogeneous management clusters

### DIFF
--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
@@ -170,19 +170,35 @@ func virtualMachineTemplateBase(nodePool *hyperv1.NodePool, bootImage BootImage)
 		guaranteedResources = kvPlatform.Compute.QosClass != nil && *kvPlatform.Compute.QosClass == hyperv1.QoSClassGuaranteed
 	}
 
+	vmiSpec := kubevirtv1.VirtualMachineInstanceSpec{
+		Domain: kubevirtv1.DomainSpec{
+			Devices: kubevirtv1.Devices{
+				Interfaces: virtualMachineInterfaces(kvPlatform),
+			},
+		},
+		EvictionStrategy: ptr.To(kubevirtv1.EvictionStrategyExternal),
+		Networks:         virtualMachineNetworks(kvPlatform),
+	}
+
+	// Set Architecture from nodePool.Spec.Arch so that VMs are always created
+	// with the correct arch on multi-arch infra clusters. Without this, KubeVirt
+	// inherits the cluster's compiled-in default (e.g. s390x on an s390x cluster)
+	// for every VM regardless of the NodePool arch.
+	//
+	// Machine.Type is intentionally left unset here. When Architecture is
+	// explicitly provided, the KubeVirt admission webhook automatically resolves
+	// the correct machine type from the cluster's ArchitectureConfiguration
+	// (e.g. amd64 → pc-q35-rhel9.x.x, s390x → s390-ccw-virtio-rhel9.x.x).
+	// Hardcoding Machine.Type would bypass the cluster admin's configuration.
+	if nodePool.Spec.Arch != "" {
+		vmiSpec.Architecture = nodePool.Spec.Arch
+	}
+
 	template := &capikubevirt.VirtualMachineTemplateSpec{
 		Spec: kubevirtv1.VirtualMachineSpec{
 			RunStrategy: ptr.To(kubevirtv1.RunStrategyAlways),
 			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
-				Spec: kubevirtv1.VirtualMachineInstanceSpec{
-					Domain: kubevirtv1.DomainSpec{
-						Devices: kubevirtv1.Devices{
-							Interfaces: virtualMachineInterfaces(kvPlatform),
-						},
-					},
-					EvictionStrategy: ptr.To(kubevirtv1.EvictionStrategyExternal),
-					Networks:         virtualMachineNetworks(kvPlatform),
-				},
+				Spec: vmiSpec,
 			},
 		},
 	}
@@ -280,8 +296,22 @@ func virtualMachineTemplateBase(nodePool *hyperv1.NodePool, bootImage BootImage)
 		template.Spec.Template.Spec.Domain.Devices.NetworkInterfaceMultiQueue = ptr.To(true)
 	}
 
-	if len(kvPlatform.NodeSelector) > 0 {
-		template.Spec.Template.Spec.NodeSelector = kvPlatform.NodeSelector
+	// Build the node selector from any user-supplied entries and always inject
+	// kubernetes.io/arch so the virt-launcher pod is scheduled on an infra
+	// node of the matching architecture. On a multi-arch infra cluster this
+	// prevents an amd64 VM from landing on an s390x node (or vice versa).
+	// A user-supplied kubernetes.io/arch entry in NodeSelector takes precedence.
+	nodeSelector := make(map[string]string, len(kvPlatform.NodeSelector)+1)
+	for k, v := range kvPlatform.NodeSelector {
+		nodeSelector[k] = v
+	}
+	if nodePool.Spec.Arch != "" {
+		if _, alreadySet := nodeSelector["kubernetes.io/arch"]; !alreadySet {
+			nodeSelector["kubernetes.io/arch"] = nodePool.Spec.Arch
+		}
+	}
+	if len(nodeSelector) > 0 {
+		template.Spec.Template.Spec.NodeSelector = nodeSelector
 	}
 
 	if len(kvPlatform.KubevirtHostDevices) > 0 {

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
@@ -579,6 +579,148 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 			},
 			expectedValidationError: "host device count must be greater than or equal to 1. received: -7",
 		},
+		{
+			// amd64 nodepool on a multi-arch cluster: verifies that Architecture
+			// and the auto-injected kubernetes.io/arch NodeSelector are set correctly.
+			name: "When arch is amd64, it should set Architecture=amd64 and inject kubernetes.io/arch=amd64 NodeSelector",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      poolName,
+					Namespace: namespace,
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: clusterName,
+					Arch:        hyperv1.ArchitectureAMD64,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: generateKubevirtPlatform(
+							memoryNPOption("8Gi"),
+							coresNPOption(4),
+							imageNPOption("testimage"),
+							volumeNPOption("32Gi"),
+						),
+					},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-hostedcluster",
+					Namespace: "clusters",
+				},
+				Spec: hyperv1.HostedClusterSpec{InfraID: "1234"},
+			},
+			expected: &capikubevirt.KubevirtMachineTemplateSpec{
+				Template: capikubevirt.KubevirtMachineTemplateResource{
+					Spec: capikubevirt.KubevirtMachineSpec{
+						BootstrapCheckSpec: capikubevirt.VirtualMachineBootstrapCheckSpec{CheckStrategy: "none"},
+						VirtualMachineTemplate: *generateNodeTemplate(
+							memoryTmpltOpt("8Gi"),
+							cpuTmpltOpt(4),
+							storageTmpltOpt("32Gi"),
+							archTmpltOpt(hyperv1.ArchitectureAMD64),
+							nodeSelectorTmpltOpt(map[string]string{"kubernetes.io/arch": hyperv1.ArchitectureAMD64}),
+						),
+					},
+				},
+			},
+		},
+		{
+			// s390x nodepool: verifies that Architecture and the auto-injected
+			// kubernetes.io/arch NodeSelector are set correctly for s390x.
+			name: "When arch is s390x, it should set Architecture=s390x and inject kubernetes.io/arch=s390x NodeSelector",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      poolName,
+					Namespace: namespace,
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: clusterName,
+					Arch:        hyperv1.ArchitectureS390X,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: generateKubevirtPlatform(
+							memoryNPOption("8Gi"),
+							coresNPOption(4),
+							imageNPOption("testimage"),
+							volumeNPOption("32Gi"),
+						),
+					},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-hostedcluster",
+					Namespace: "clusters",
+				},
+				Spec: hyperv1.HostedClusterSpec{InfraID: "1234"},
+			},
+			expected: &capikubevirt.KubevirtMachineTemplateSpec{
+				Template: capikubevirt.KubevirtMachineTemplateResource{
+					Spec: capikubevirt.KubevirtMachineSpec{
+						BootstrapCheckSpec: capikubevirt.VirtualMachineBootstrapCheckSpec{CheckStrategy: "none"},
+						VirtualMachineTemplate: *generateNodeTemplate(
+							memoryTmpltOpt("8Gi"),
+							cpuTmpltOpt(4),
+							storageTmpltOpt("32Gi"),
+							archTmpltOpt(hyperv1.ArchitectureS390X),
+							nodeSelectorTmpltOpt(map[string]string{"kubernetes.io/arch": hyperv1.ArchitectureS390X}),
+						),
+					},
+				},
+			},
+		},
+		{
+			// A user-supplied kubernetes.io/arch in kvPlatform.NodeSelector must
+			// take precedence over the automatically injected value.
+			name: "When user supplies kubernetes.io/arch in NodeSelector, it should not be overwritten by the auto-injected arch value",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      poolName,
+					Namespace: namespace,
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: clusterName,
+					Arch:        hyperv1.ArchitectureAMD64,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: generateKubevirtPlatform(
+							memoryNPOption("8Gi"),
+							coresNPOption(4),
+							imageNPOption("testimage"),
+							volumeNPOption("32Gi"),
+							nodeSelectorNPOption(map[string]string{
+								"kubernetes.io/arch": hyperv1.ArchitectureAMD64,
+								"custom-label":       "custom-value",
+							}),
+						),
+					},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-hostedcluster",
+					Namespace: "clusters",
+				},
+				Spec: hyperv1.HostedClusterSpec{InfraID: "1234"},
+			},
+			expected: &capikubevirt.KubevirtMachineTemplateSpec{
+				Template: capikubevirt.KubevirtMachineTemplateResource{
+					Spec: capikubevirt.KubevirtMachineSpec{
+						BootstrapCheckSpec: capikubevirt.VirtualMachineBootstrapCheckSpec{CheckStrategy: "none"},
+						VirtualMachineTemplate: *generateNodeTemplate(
+							memoryTmpltOpt("8Gi"),
+							cpuTmpltOpt(4),
+							storageTmpltOpt("32Gi"),
+							archTmpltOpt(hyperv1.ArchitectureAMD64),
+							nodeSelectorTmpltOpt(map[string]string{
+								"kubernetes.io/arch": hyperv1.ArchitectureAMD64,
+								"custom-label":       "custom-value",
+							}),
+						),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1386,6 +1528,27 @@ func addNetworkOpt(nw kubevirtv1.Network) nodeTemplateOption {
 func annotationsTmpltOpt(annotations map[string]string) nodeTemplateOption {
 	return func(template *capikubevirt.VirtualMachineTemplateSpec) {
 		template.Spec.Template.ObjectMeta.Annotations = annotations
+	}
+}
+
+// archTmpltOpt sets the VMI Architecture field — verifies Change 1.
+func archTmpltOpt(arch string) nodeTemplateOption {
+	return func(template *capikubevirt.VirtualMachineTemplateSpec) {
+		template.Spec.Template.Spec.Architecture = arch
+	}
+}
+
+// nodeSelectorTmpltOpt sets the NodeSelector on the VMI template — verifies Change 2.
+func nodeSelectorTmpltOpt(nodeSelector map[string]string) nodeTemplateOption {
+	return func(template *capikubevirt.VirtualMachineTemplateSpec) {
+		template.Spec.Template.Spec.NodeSelector = nodeSelector
+	}
+}
+
+// nodeSelectorNPOption sets a user-supplied NodeSelector on the KubevirtNodePoolPlatform.
+func nodeSelectorNPOption(nodeSelector map[string]string) nodePoolOption {
+	return func(kvNodePool *hyperv1.KubevirtNodePoolPlatform) {
+		kvNodePool.NodeSelector = nodeSelector
 	}
 }
 


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
On a multi-architecture KubeVirt management cluster (s390x and amd64 nodes), KubeVirt inherits the cluster's compiled-in default architecture for every VirtualMachineInstance regardless of the NodePool's requested arch. This causes two problems:

1. VMs are created with the wrong architecture (e.g. an amd64 NodePool on an s390x-default cluster produces VMs with architecture=s390x), resulting in VMs that fail to boot or join the HCP as the wrong arch workers.

2. The virt-launcher pod has no arch affinity, so it can be scheduled on any infra node regardless of architecture, leading to VMs landing on the wrong physical host.

This PR fixes both problems by:

- Setting VMI.Architecture from nodePool.Spec.Arch so KubeVirt creates the VM
with the correct instruction set. The KubeVirt admission webhook then
automatically resolves the correct machine type from the cluster's
ArchitectureConfiguration.

- Auto-injecting kubernetes.io/arch=<nodePool.Spec.Arch> into the VMI
NodeSelector so the virt-launcher pod is always scheduled on an infra node
of the matching architecture. A user-supplied kubernetes.io/arch in
NodeSelector takes precedence over the auto-injected value.
## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * KubeVirt virtual machines now use the NodePool’s specified architecture on multi-architecture infrastructure.
  * Automatically applies the corresponding architecture node selector when one is not provided.
  * Preserves user-specified architecture node selectors when configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->