### PR TITLE
GCP-958: test(e2e/v2): register gcp-pd-csi-driver control plane workloads

### DIFF
--- a/test/e2e/v2/internal/workload_registry.go
+++ b/test/e2e/v2/internal/workload_registry.go
@@ -73,6 +73,22 @@ func GetControlPlaneWorkloads() []WorkloadSpec {
 			},
 		},
 		{
+			Type:     "Deployment",
+			Name:     "gcp-pd-csi-driver-controller",
+			Platform: &gcpPlatform,
+			PodSelector: map[string]string{
+				"app": "gcp-pd-csi-driver-controller",
+			},
+		},
+		{
+			Type:     "Deployment",
+			Name:     "gcp-pd-csi-driver-operator",
+			Platform: &gcpPlatform,
+			PodSelector: map[string]string{
+				"name": "gcp-pd-csi-driver-operator",
+			},
+		},
+		{
 			Type: "Deployment",
 			Name: "capi-provider",
 			PodSelector: map[string]string{

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -260,6 +260,8 @@ func SafeToEvictAnnotationsTest(getTestCtx internal.TestContextGetter) {
 			"azure-disk-csi-driver-controller",
 			"azure-file-csi-driver-operator",
 			"azure-file-csi-driver-controller",
+			"gcp-pd-csi-driver-controller",
+			"gcp-pd-csi-driver-operator",
 			"openstack-cinder-csi-driver-operator",
 			"openstack-cinder-csi-driver-controller",
 			"openstack-manila-csi-driver-operator",
@@ -344,6 +346,8 @@ func ReadOnlyRootFilesystemTest(getTestCtx internal.TestContextGetter) {
 			"azure-file-csi-driver-operator",
 			"aws-ebs-csi-driver-controller",
 			"aws-ebs-csi-driver-operator",
+			"gcp-pd-csi-driver-controller",
+			"gcp-pd-csi-driver-operator",
 			"openstack-cinder-csi-driver-controller",
 			"openstack-manila-csi-controller",
 			"csi-snapshot-controller",
@@ -420,6 +424,8 @@ func ReadOnlyRootFilesystemTmpDirMountTest(getTestCtx internal.TestContextGetter
 			"azure-file-csi-driver-operator",
 			"aws-ebs-csi-driver-controller",
 			"aws-ebs-csi-driver-operator",
+			"gcp-pd-csi-driver-controller",
+			"gcp-pd-csi-driver-operator",
 			"openstack-cinder-csi-driver-controller",
 			"openstack-manila-csi",
 			"csi-snapshot-controller",
@@ -678,6 +684,10 @@ func ServiceAccountTokenMountingTest(getTestCtx internal.TestContextGetter) {
 			// AWS-specific exemptions
 			"aws-ebs-csi-driver-controller",
 			"aws-ebs-csi-driver-operator",
+
+			// GCP-specific exemptions
+			"gcp-pd-csi-driver-controller",
+			"gcp-pd-csi-driver-operator",
 
 			// Azure-specific exemptions
 			"azure-cloud-controller-manager",


### PR DESCRIPTION
The GCP PD CSI driver controller and operator run in the hosted control plane namespace but were not present in the control-plane workload registry, causing the "Workload registry validation / should not contain any unrecognized pods" test to fail on GCP hosted clusters.

Register both deployments (GCP-platform-gated) and add them to the safe-to-evict, read-only-root-filesystem, read-only-rootfs /tmp mount, and service-account-token-mounting exemption lists, matching the treatment of the AWS/Azure/OpenStack CSI drivers.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for GCP-specific persistent disk CSI driver controller and operator workloads.
  - Updated control plane workload validation to recognize these workloads for eviction, filesystem, temporary-directory, and service-account checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->